### PR TITLE
only halve as many roots need to be precomputed for fft

### DIFF
--- a/internal/backend/bls377/fft/domain.go
+++ b/internal/backend/bls377/fft/domain.go
@@ -114,7 +114,7 @@ func (d *Domain) preComputeTwiddles() {
 	// for each fft stage, we pre compute the twiddle factors
 	twiddles := func(t [][]fr.Element, omega fr.Element) {
 		for i := uint(0); i < nbStages; i++ {
-			t[i] = make([]fr.Element, 1+(1<<(nbStages-i)))
+			t[i] = make([]fr.Element, 1+(1<<(nbStages-i-1)))
 			var w fr.Element
 			if i == 0 {
 				w = omega

--- a/internal/backend/bls381/fft/domain.go
+++ b/internal/backend/bls381/fft/domain.go
@@ -114,7 +114,7 @@ func (d *Domain) preComputeTwiddles() {
 	// for each fft stage, we pre compute the twiddle factors
 	twiddles := func(t [][]fr.Element, omega fr.Element) {
 		for i := uint(0); i < nbStages; i++ {
-			t[i] = make([]fr.Element, 1+(1<<(nbStages-i)))
+			t[i] = make([]fr.Element, 1+(1<<(nbStages-i-1)))
 			var w fr.Element
 			if i == 0 {
 				w = omega

--- a/internal/backend/bn256/fft/domain.go
+++ b/internal/backend/bn256/fft/domain.go
@@ -114,7 +114,7 @@ func (d *Domain) preComputeTwiddles() {
 	// for each fft stage, we pre compute the twiddle factors
 	twiddles := func(t [][]fr.Element, omega fr.Element) {
 		for i := uint(0); i < nbStages; i++ {
-			t[i] = make([]fr.Element, 1+(1<<(nbStages-i)))
+			t[i] = make([]fr.Element, 1+(1<<(nbStages-i-1)))
 			var w fr.Element
 			if i == 0 {
 				w = omega

--- a/internal/backend/bw761/fft/domain.go
+++ b/internal/backend/bw761/fft/domain.go
@@ -114,7 +114,7 @@ func (d *Domain) preComputeTwiddles() {
 	// for each fft stage, we pre compute the twiddle factors
 	twiddles := func(t [][]fr.Element, omega fr.Element) {
 		for i := uint(0); i < nbStages; i++ {
-			t[i] = make([]fr.Element, 1+(1<<(nbStages-i)))
+			t[i] = make([]fr.Element, 1+(1<<(nbStages-i-1)))
 			var w fr.Element
 			if i == 0 {
 				w = omega


### PR DESCRIPTION
during the pre-computation of the roots of unity for the FFT domain,
the algorithm prepares two times as many elements, as actually needed.
This fix approximately halves the required storage space and runtime of the function.