### PR TITLE
MillerLoops and goroutine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/consensys/bavard v0.1.7-0.20201221223155-01abca91228c
-	github.com/consensys/gurvy v0.3.6-0.20201221225431-77a67616d105
+	github.com/consensys/gurvy v0.3.6-0.20201221235200-4237132b7526
 	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/leanovate/gopter v0.2.8
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/consensys/bavard v0.1.7-0.20201221223155-01abca91228c/go.mod h1:Bpd0/
 github.com/consensys/goff v0.3.7/go.mod h1:61ZNiCXkJ/ufIRXQ9YyQ6iiTkp5d1A3aFVRzw2U+om0=
 github.com/consensys/gurvy v0.3.6-0.20201221225431-77a67616d105 h1:n/dBNhRfVPguxBIrI4Ueo1ngySBOJ5kGfRJ5hnjF/Fg=
 github.com/consensys/gurvy v0.3.6-0.20201221225431-77a67616d105/go.mod h1:VI97axxnhASpjltQyk8DNbt0jsgeI/WCicCHYj3Ntyw=
+github.com/consensys/gurvy v0.3.6-0.20201221235200-4237132b7526 h1:sV3bQ0dnJSvByOoXsT+3pjdIwqmXgoNM0KFcGPtq0t0=
+github.com/consensys/gurvy v0.3.6-0.20201221235200-4237132b7526/go.mod h1:VI97axxnhASpjltQyk8DNbt0jsgeI/WCicCHYj3Ntyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/internal/generators/backend/template/zkpschemes/groth16.verify.go.tmpl
+++ b/internal/generators/backend/template/zkpschemes/groth16.verify.go.tmpl
@@ -10,30 +10,42 @@ var errCorrectSubgroupCheckFailed = errors.New("points in the proof are not in t
 
 // Verify verifies a proof
 func Verify(proof *Proof, vk *VerifyingKey, inputs map[string]interface{}) error {
-	
+
 	// check that the points in the proof are in the correct subgroup
 	if !proof.isValid() {
 		return errCorrectSubgroupCheckFailed
 	}
 
+	var doubleML curve.GT
+	var err error
+	ch := make(chan bool, 1)
+	go func() {
+		doubleML, err = curve.MillerLoop([]curve.G1Affine{proof.Krs, proof.Ar}, []curve.G2Affine{vk.G2.DeltaNeg, proof.Bs})
+		ch <- true
+	}()
+	if err != nil {
+		return err
+	}
+
 	var kSum curve.G1Jac
-
-
 	kInputs, err := ParsePublicInput(vk.PublicInputs, inputs)
 	if err != nil {
 		return err
 	}
-	kSum.MultiExp( vk.G1.K, kInputs)
+	kSum.MultiExp(vk.G1.K, kInputs)
 
 	// e(Σx.[Kvk(t)]1, -[γ]2)
 	var kSumAff curve.G1Affine
 	kSumAff.FromJacobian(&kSum)
 
-
-	right, err := curve.Pair([]curve.G1Affine{proof.Krs, proof.Ar, kSumAff}, []curve.G2Affine{vk.G2.DeltaNeg, proof.Bs, vk.G2.GammaNeg})
+	right, err := curve.MillerLoop([]curve.G1Affine{kSumAff}, []curve.G2Affine{vk.G2.GammaNeg})
 	if err != nil {
-		return err 
+		return err
 	}
+
+	<-ch
+	right = curve.FinalExponentiation(right.Mul(&right, &doubleML))
+
 	if !vk.E.Equal(&right) {
 		return errPairingCheckFailed
 	}


### PR DESCRIPTION
`Pair([a,c,e],[b,d,f])` is slower than `FE( ML(a,b) * ML(c,d) * ML(e,f)` when used with goroutines (concurrent to `mulExp`).

instead of using `Pair([a,c,e],[b,d,f])` , this PR uses `tmp = ML([a,c],[b,d])` in a goroutine and then `FE( tmp * ML(e,f) )` after the `mulExp` is done.