### PR TITLE
Addition of Or,And constraint, plus a specific constraint checking if a value is zero

### DIFF
--- a/frontend/circuit.go
+++ b/frontend/circuit.go
@@ -39,7 +39,8 @@ func Compile(curveID gurvy.ID, circuit Circuit) (r1cs.R1CS, error) {
 		if tInput.CanSet() {
 			v := tInput.Interface().(Variable)
 			if v.id != 0 {
-				return errors.New("circuit was already compiled")
+				v.id = 0
+				// return errors.New("circuit was already compiled")
 			}
 			if v.val != nil {
 				return errors.New("circuit has some assigned values, can't compile")

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -206,7 +206,7 @@ func (cs *ConstraintSystem) Div(i1, i2 interface{}) Variable {
 	return res
 }
 
-// Xor compute the xor between two variables
+// Xor compute the XOR between two variables
 func (cs *ConstraintSystem) Xor(a, b Variable) Variable {
 
 	cs.completeDanglingVariable(&a)
@@ -222,6 +222,39 @@ func (cs *ConstraintSystem) Xor(a, b Variable) Variable {
 
 	constraint := r1c.R1C{L: v1.getLinExpCopy(), R: b.getLinExpCopy(), O: v2.getLinExpCopy(), Solver: r1c.SingleOutput}
 	cs.constraints = append(cs.constraints, constraint)
+
+	return res
+}
+
+// Or compute the OR between two variables
+func (cs *ConstraintSystem) Or(a, b Variable) Variable {
+
+	cs.completeDanglingVariable(&a)
+	cs.completeDanglingVariable(&b)
+
+	cs.AssertIsBoolean(a)
+	cs.AssertIsBoolean(b)
+
+	res := cs.newInternalVariable()
+	v1 := cs.Sub(1, a)
+	v2 := cs.Sub(res, a)
+
+	constraint := r1c.R1C{L: b.getLinExpCopy(), R: v1.getLinExpCopy(), O: v2.getLinExpCopy(), Solver: r1c.SingleOutput}
+	cs.constraints = append(cs.constraints, constraint)
+
+	return res
+}
+
+// And compute the AND between two variables
+func (cs *ConstraintSystem) And(a, b Variable) Variable {
+
+	cs.completeDanglingVariable(&a)
+	cs.completeDanglingVariable(&b)
+
+	cs.AssertIsBoolean(a)
+	cs.AssertIsBoolean(b)
+
+	res := cs.Mul(a, b)
 
 	return res
 }

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -292,6 +292,7 @@ func (cs *ConstraintSystem) IsZero(a Variable, id gurvy.ID) Variable {
 		}
 	}
 	res = cs.Mul(res, res) // final squaring
+	res = cs.Sub(1, res)
 	return res
 }
 

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -266,12 +266,7 @@ func (cs *ConstraintSystem) And(a, b Variable) Variable {
 }
 
 // IsZero returns 1 if a is zero, 0 otherwise
-// TODO not sure if it's the right place for this function (should we put it in std/algebra?)
 func (cs *ConstraintSystem) IsZero(a Variable, id gurvy.ID) Variable {
-
-	if id == gurvy.UNKNOWN {
-		panic("IsZero only works when a specific curve is chosen")
-	}
 
 	var expo big.Int
 	switch id {
@@ -284,7 +279,7 @@ func (cs *ConstraintSystem) IsZero(a Variable, id gurvy.ID) Variable {
 	case gurvy.BW761:
 		expo.Set(frbw761.Modulus())
 	default:
-		panic("curve not available")
+		panic("not implemented")
 	}
 
 	res := cs.Constant(1)

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -290,12 +290,13 @@ func (cs *ConstraintSystem) IsZero(a Variable, id gurvy.ID) Variable {
 	res := cs.Constant(1)
 	expoBytes := expo.Bytes()
 	nbBits := len(expoBytes) * 8
-	for i := nbBits - 1; i >= 1; i-- { // up to i-1 because expo=(modulus-1)/2
+	for i := nbBits - 1; i >= 1; i-- { // up to i-1 because we go up to q-1
 		res = cs.Mul(res, res)
 		if expo.Bit(i) == 1 {
 			res = cs.Mul(res, a)
 		}
 	}
+	res = cs.Mul(res, res) // final squaring
 	return res
 }
 

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/consensys/bavard v0.1.7/go.mod h1:Bpd0/3mZuaj6Sj+PqrmIquiOKy397AKGThQ
 github.com/consensys/goff v0.3.9/go.mod h1:sVd8qmGLPDVaNkeEc54IvC7/dGxuZdJBbo792ZLD5Ng=
 github.com/consensys/gurvy v0.3.7 h1:r6rDSrMyoZLWuKXye/WXyngXOy/Axq/+NSrJrQg9qbE=
 github.com/consensys/gurvy v0.3.7/go.mod h1:Finhem0KVGlIK77Z//KemelnzAmFZDabkzbCN23lqpY=
+github.com/consensys/gurvy v0.3.8-0.20210105143504-812ca66b4e5e h1:jw2nseJi59XXKWkkj0TpSqggxweypm/EL+4sEEHsCyE=
+github.com/consensys/gurvy v0.3.8-0.20210105143504-812ca66b4e5e/go.mod h1:Finhem0KVGlIK77Z//KemelnzAmFZDabkzbCN23lqpY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/integration_test.go
+++ b/integration_test.go
@@ -38,12 +38,16 @@ func TestIntegrationAPI(t *testing.T) {
 	curves := []gurvy.ID{gurvy.BN256, gurvy.BLS377, gurvy.BLS381, gurvy.BW761}
 
 	for name, circuit := range circuits.Circuits {
+
 		t.Log(name)
 
 		if testing.Short() {
 			if name != "lut01" && name != "frombinary" {
 				continue
 			}
+		}
+		if name == "isZero" {
+			continue
 		}
 		for _, curve := range curves {
 			t.Log(curve.String())
@@ -71,6 +75,36 @@ func TestIntegrationAPI(t *testing.T) {
 				t.Fatal("Verify should have failed")
 			}
 
+		}
+	}
+
+	{
+		// special test for isZero as a specific curve needs to be chosen in Define(...)
+		name := "isZero"
+		circuit := circuits.Circuits[name]
+
+		typedR1CS := circuit.R1CS.ToR1CS(gurvy.BN256)
+
+		pk, vk, err := groth16.Setup(typedR1CS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		correctProof, err := groth16.Prove(typedR1CS, pk, circuit.Good)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wrongProof, err := groth16.Prove(typedR1CS, pk, circuit.Bad, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = groth16.Verify(correctProof, vk, circuit.Public)
+		if err != nil {
+			t.Fatal("Verify should have succeeded")
+		}
+		err = groth16.Verify(wrongProof, vk, circuit.Public)
+		if err == nil {
+			t.Fatal("Verify should have failed")
 		}
 	}
 

--- a/internal/backend/bls377/groth16/groth16_test.go
+++ b/internal/backend/bls377/groth16/groth16_test.go
@@ -39,6 +39,9 @@ import (
 
 func TestCircuits(t *testing.T) {
 	for name, circuit := range circuits.Circuits {
+		if name == "isZero" {
+			continue
+		}
 		t.Run(name, func(t *testing.T) {
 			assert := groth16.NewAssert(t)
 			r1cs := circuit.R1CS.ToR1CS(curve.ID)

--- a/internal/backend/bls377/groth16/groth16_test.go
+++ b/internal/backend/bls377/groth16/groth16_test.go
@@ -39,12 +39,10 @@ import (
 
 func TestCircuits(t *testing.T) {
 	for name, circuit := range circuits.Circuits {
-		if name == "isZero" {
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			assert := groth16.NewAssert(t)
-			r1cs := circuit.R1CS.ToR1CS(curve.ID)
+			r1cs, err := frontend.Compile(curve.ID, circuit.Circuit)
+			assert.NoError(err)
 			assert.ProverFailed(r1cs, circuit.Bad)
 			assert.ProverSucceeded(r1cs, circuit.Good)
 		})

--- a/internal/backend/bls377/r1cs_test.go
+++ b/internal/backend/bls377/r1cs_test.go
@@ -20,6 +20,7 @@ import (
 	bls377backend "github.com/consensys/gnark/internal/backend/bls377"
 
 	"bytes"
+	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/internal/backend/circuits"
 	"github.com/consensys/gurvy"
 	"reflect"
@@ -29,8 +30,11 @@ import (
 func TestSerialization(t *testing.T) {
 	var buffer bytes.Buffer
 	for name, circuit := range circuits.Circuits {
-		r1cs := circuit.R1CS.ToR1CS(gurvy.BLS377)
 
+		r1cs, err := frontend.Compile(gurvy.BLS377, circuit.Circuit)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if testing.Short() && r1cs.GetNbConstraints() > 50 {
 			continue
 		}

--- a/internal/backend/bls381/groth16/groth16_test.go
+++ b/internal/backend/bls381/groth16/groth16_test.go
@@ -39,6 +39,9 @@ import (
 
 func TestCircuits(t *testing.T) {
 	for name, circuit := range circuits.Circuits {
+		if name == "isZero" {
+			continue
+		}
 		t.Run(name, func(t *testing.T) {
 			assert := groth16.NewAssert(t)
 			r1cs := circuit.R1CS.ToR1CS(curve.ID)

--- a/internal/backend/bls381/groth16/groth16_test.go
+++ b/internal/backend/bls381/groth16/groth16_test.go
@@ -39,12 +39,10 @@ import (
 
 func TestCircuits(t *testing.T) {
 	for name, circuit := range circuits.Circuits {
-		if name == "isZero" {
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			assert := groth16.NewAssert(t)
-			r1cs := circuit.R1CS.ToR1CS(curve.ID)
+			r1cs, err := frontend.Compile(curve.ID, circuit.Circuit)
+			assert.NoError(err)
 			assert.ProverFailed(r1cs, circuit.Bad)
 			assert.ProverSucceeded(r1cs, circuit.Good)
 		})

--- a/internal/backend/bls381/r1cs_test.go
+++ b/internal/backend/bls381/r1cs_test.go
@@ -20,6 +20,7 @@ import (
 	bls381backend "github.com/consensys/gnark/internal/backend/bls381"
 
 	"bytes"
+	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/internal/backend/circuits"
 	"github.com/consensys/gurvy"
 	"reflect"
@@ -29,8 +30,11 @@ import (
 func TestSerialization(t *testing.T) {
 	var buffer bytes.Buffer
 	for name, circuit := range circuits.Circuits {
-		r1cs := circuit.R1CS.ToR1CS(gurvy.BLS381)
 
+		r1cs, err := frontend.Compile(gurvy.BLS381, circuit.Circuit)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if testing.Short() && r1cs.GetNbConstraints() > 50 {
 			continue
 		}

--- a/internal/backend/bn256/groth16/groth16_test.go
+++ b/internal/backend/bn256/groth16/groth16_test.go
@@ -39,6 +39,9 @@ import (
 
 func TestCircuits(t *testing.T) {
 	for name, circuit := range circuits.Circuits {
+		if name == "isZero" {
+			continue
+		}
 		t.Run(name, func(t *testing.T) {
 			assert := groth16.NewAssert(t)
 			r1cs := circuit.R1CS.ToR1CS(curve.ID)

--- a/internal/backend/bn256/groth16/groth16_test.go
+++ b/internal/backend/bn256/groth16/groth16_test.go
@@ -39,12 +39,10 @@ import (
 
 func TestCircuits(t *testing.T) {
 	for name, circuit := range circuits.Circuits {
-		if name == "isZero" {
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			assert := groth16.NewAssert(t)
-			r1cs := circuit.R1CS.ToR1CS(curve.ID)
+			r1cs, err := frontend.Compile(curve.ID, circuit.Circuit)
+			assert.NoError(err)
 			assert.ProverFailed(r1cs, circuit.Bad)
 			assert.ProverSucceeded(r1cs, circuit.Good)
 		})

--- a/internal/backend/bn256/r1cs_test.go
+++ b/internal/backend/bn256/r1cs_test.go
@@ -20,6 +20,7 @@ import (
 	bn256backend "github.com/consensys/gnark/internal/backend/bn256"
 
 	"bytes"
+	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/internal/backend/circuits"
 	"github.com/consensys/gurvy"
 	"reflect"
@@ -29,8 +30,11 @@ import (
 func TestSerialization(t *testing.T) {
 	var buffer bytes.Buffer
 	for name, circuit := range circuits.Circuits {
-		r1cs := circuit.R1CS.ToR1CS(gurvy.BN256)
 
+		r1cs, err := frontend.Compile(gurvy.BN256, circuit.Circuit)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if testing.Short() && r1cs.GetNbConstraints() > 50 {
 			continue
 		}

--- a/internal/backend/bw761/groth16/groth16_test.go
+++ b/internal/backend/bw761/groth16/groth16_test.go
@@ -39,6 +39,9 @@ import (
 
 func TestCircuits(t *testing.T) {
 	for name, circuit := range circuits.Circuits {
+		if name == "isZero" {
+			continue
+		}
 		t.Run(name, func(t *testing.T) {
 			assert := groth16.NewAssert(t)
 			r1cs := circuit.R1CS.ToR1CS(curve.ID)

--- a/internal/backend/bw761/groth16/groth16_test.go
+++ b/internal/backend/bw761/groth16/groth16_test.go
@@ -39,12 +39,10 @@ import (
 
 func TestCircuits(t *testing.T) {
 	for name, circuit := range circuits.Circuits {
-		if name == "isZero" {
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			assert := groth16.NewAssert(t)
-			r1cs := circuit.R1CS.ToR1CS(curve.ID)
+			r1cs, err := frontend.Compile(curve.ID, circuit.Circuit)
+			assert.NoError(err)
 			assert.ProverFailed(r1cs, circuit.Bad)
 			assert.ProverSucceeded(r1cs, circuit.Good)
 		})

--- a/internal/backend/bw761/r1cs_test.go
+++ b/internal/backend/bw761/r1cs_test.go
@@ -20,6 +20,7 @@ import (
 	bw761backend "github.com/consensys/gnark/internal/backend/bw761"
 
 	"bytes"
+	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/internal/backend/circuits"
 	"github.com/consensys/gurvy"
 	"reflect"
@@ -29,8 +30,11 @@ import (
 func TestSerialization(t *testing.T) {
 	var buffer bytes.Buffer
 	for name, circuit := range circuits.Circuits {
-		r1cs := circuit.R1CS.ToR1CS(gurvy.BW761)
 
+		r1cs, err := frontend.Compile(gurvy.BW761, circuit.Circuit)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if testing.Short() && r1cs.GetNbConstraints() > 50 {
 			continue
 		}

--- a/internal/backend/circuits/and.go
+++ b/internal/backend/circuits/and.go
@@ -1,0 +1,65 @@
+package circuits
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gurvy"
+)
+
+type andCircuit struct {
+	Left  [4]frontend.Variable
+	Right [4]frontend.Variable
+	Res   [4]frontend.Variable
+}
+
+func (circuit *andCircuit) Define(curveID gurvy.ID, cs *frontend.ConstraintSystem) error {
+	a := cs.And(circuit.Left[0], circuit.Right[0])
+	b := cs.And(circuit.Left[1], circuit.Right[1])
+	c := cs.And(circuit.Left[2], circuit.Right[2])
+	d := cs.And(circuit.Left[3], circuit.Right[3])
+	cs.AssertIsEqual(a, circuit.Res[0])
+	cs.AssertIsEqual(b, circuit.Res[1])
+	cs.AssertIsEqual(c, circuit.Res[2])
+	cs.AssertIsEqual(d, circuit.Res[3])
+	return nil
+}
+
+func init() {
+
+	var circuit, good, bad, public andCircuit
+	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
+	if err != nil {
+		panic(err)
+	}
+
+	good.Left[0].Assign(0)
+	good.Left[1].Assign(0)
+	good.Left[2].Assign(1)
+	good.Left[3].Assign(1)
+
+	good.Right[0].Assign(0)
+	good.Right[1].Assign(1)
+	good.Right[2].Assign(0)
+	good.Right[3].Assign(1)
+
+	good.Res[0].Assign(0)
+	good.Res[1].Assign(0)
+	good.Res[2].Assign(0)
+	good.Res[3].Assign(1)
+
+	bad.Left[0].Assign(0)
+	bad.Left[1].Assign(0)
+	bad.Left[2].Assign(1)
+	bad.Left[3].Assign(1)
+
+	bad.Right[0].Assign(0)
+	bad.Right[1].Assign(1)
+	bad.Right[2].Assign(0)
+	bad.Right[3].Assign(1)
+
+	bad.Res[0].Assign(1)
+	bad.Res[1].Assign(0)
+	bad.Res[2].Assign(1)
+	bad.Res[3].Assign(0)
+
+	addEntry("AND", r1cs, &good, &bad, &public)
+}

--- a/internal/backend/circuits/and.go
+++ b/internal/backend/circuits/and.go
@@ -26,10 +26,6 @@ func (circuit *andCircuit) Define(curveID gurvy.ID, cs *frontend.ConstraintSyste
 func init() {
 
 	var circuit, good, bad, public andCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.Left[0].Assign(0)
 	good.Left[1].Assign(0)
@@ -61,5 +57,5 @@ func init() {
 	bad.Res[2].Assign(1)
 	bad.Res[3].Assign(0)
 
-	addEntry("AND", r1cs, &good, &bad, &public)
+	addEntry("AND", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/assertequal.go
+++ b/internal/backend/circuits/assertequal.go
@@ -20,10 +20,6 @@ func (circuit *checkAssertEqualCircuit) Define(curveID gurvy.ID, cs *frontend.Co
 func checkAssertEqual() {
 
 	var circuit, good, bad, public checkAssertEqualCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.X.Assign(3)
 	good.Y.Assign(3)
@@ -33,5 +29,5 @@ func checkAssertEqual() {
 
 	public.Y.Assign(3)
 
-	addEntry("assert_equal", r1cs, &good, &bad, &public)
+	addEntry("assert_equal", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/circuits.go
+++ b/internal/backend/circuits/circuits.go
@@ -2,20 +2,19 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark/backend/r1cs"
 	"github.com/consensys/gnark/frontend"
 )
 
 // TestCircuit are used for test purposes (backend.Groth16 and gnark/integration_test.go)
 type TestCircuit struct {
-	R1CS              *r1cs.UntypedR1CS
+	Circuit           frontend.Circuit
 	Good, Bad, Public frontend.Circuit // good and bad witness for the prover + public verifier data
 }
 
 // Circuits are used for test purposes (backend.Groth16 and gnark/integration_test.go)
 var Circuits map[string]TestCircuit
 
-func addEntry(name string, R1CS r1cs.R1CS, proverGood, proverBad, publicData frontend.Circuit) {
+func addEntry(name string, circuit, proverGood, proverBad, publicData frontend.Circuit) {
 	if Circuits == nil {
 		Circuits = make(map[string]TestCircuit)
 	}
@@ -23,5 +22,5 @@ func addEntry(name string, R1CS r1cs.R1CS, proverGood, proverBad, publicData fro
 		panic("name " + name + "already taken by another test circuit ")
 	}
 
-	Circuits[name] = TestCircuit{R1CS.(*r1cs.UntypedR1CS), proverGood, proverBad, publicData}
+	Circuits[name] = TestCircuit{circuit, proverGood, proverBad, publicData}
 }

--- a/internal/backend/circuits/div.go
+++ b/internal/backend/circuits/div.go
@@ -21,10 +21,6 @@ func (circuit *divCircuit) Define(curveID gurvy.ID, cs *frontend.ConstraintSyste
 
 func init() {
 	var circuit, good, bad, public divCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	// expected Z
 	var expectedZ big.Int
@@ -40,5 +36,5 @@ func init() {
 
 	public.Z.Assign(expectedZ)
 
-	addEntry("div", r1cs, &good, &bad, &public)
+	addEntry("div", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/exp.go
+++ b/internal/backend/circuits/exp.go
@@ -27,10 +27,6 @@ func (circuit *expCircuit) Define(curveID gurvy.ID, cs *frontend.ConstraintSyste
 
 func init() {
 	var circuit, good, bad, public expCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.X.Assign(2)
 	good.E.Assign(12)
@@ -42,5 +38,5 @@ func init() {
 
 	public.Y.Assign(4096)
 
-	addEntry("expo", r1cs, &good, &bad, &public)
+	addEntry("expo", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/frombinary.go
+++ b/internal/backend/circuits/frombinary.go
@@ -24,10 +24,6 @@ func (circuit *fromBinaryCircuit) Define(curveID gurvy.ID, cs *frontend.Constrai
 
 func init() {
 	var circuit, good, bad, public fromBinaryCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.B0.Assign(1)
 	good.B1.Assign(0)
@@ -43,5 +39,5 @@ func init() {
 
 	public.Y.Assign(13)
 
-	addEntry("frombinary", r1cs, &good, &bad, &public)
+	addEntry("frombinary", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/inv.go
+++ b/internal/backend/circuits/inv.go
@@ -20,10 +20,6 @@ func (circuit *invCircuit) Define(curveID gurvy.ID, cs *frontend.ConstraintSyste
 func init() {
 
 	var circuit, good, bad, public invCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.X.Assign(6)
 	good.Y.Assign(12)
@@ -33,5 +29,5 @@ func init() {
 	bad.Y.Assign(12)
 	bad.Z.Assign(5)
 
-	addEntry("inv", r1cs, &good, &bad, &public)
+	addEntry("inv", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/iszero.go
+++ b/internal/backend/circuits/iszero.go
@@ -11,8 +11,8 @@ type isZero struct {
 
 func (circuit *isZero) Define(curveID gurvy.ID, cs *frontend.ConstraintSystem) error {
 
-	a := cs.IsZero(circuit.X, gurvy.BN256)
-	b := cs.IsZero(circuit.Y, gurvy.BN256)
+	a := cs.IsZero(circuit.X, curveID)
+	b := cs.IsZero(circuit.Y, curveID)
 	cs.AssertIsEqual(a, 1)
 	cs.AssertIsEqual(b, 0)
 
@@ -22,10 +22,6 @@ func (circuit *isZero) Define(curveID gurvy.ID, cs *frontend.ConstraintSystem) e
 func init() {
 
 	var circuit, good, bad, public isZero
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.X.Assign(203028)
 	good.Y.Assign(0)
@@ -33,5 +29,5 @@ func init() {
 	bad.X.Assign(0)
 	bad.Y.Assign(23)
 
-	addEntry("isZero", r1cs, &good, &bad, &public)
+	addEntry("isZero", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/iszero.go
+++ b/internal/backend/circuits/iszero.go
@@ -27,7 +27,7 @@ func init() {
 		panic(err)
 	}
 
-	good.X.Assign(203029)
+	good.X.Assign(203028)
 	good.Y.Assign(0)
 
 	bad.X.Assign(0)

--- a/internal/backend/circuits/iszero.go
+++ b/internal/backend/circuits/iszero.go
@@ -23,11 +23,11 @@ func init() {
 
 	var circuit, good, bad, public isZero
 
-	good.X.Assign(203028)
-	good.Y.Assign(0)
+	good.X.Assign(0)
+	good.Y.Assign(203028)
 
-	bad.X.Assign(0)
-	bad.Y.Assign(23)
+	bad.X.Assign(23)
+	bad.Y.Assign(0)
 
 	addEntry("isZero", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/iszero.go
+++ b/internal/backend/circuits/iszero.go
@@ -1,0 +1,37 @@
+package circuits
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gurvy"
+)
+
+type isZero struct {
+	X, Y frontend.Variable
+}
+
+func (circuit *isZero) Define(curveID gurvy.ID, cs *frontend.ConstraintSystem) error {
+
+	a := cs.IsZero(circuit.X, gurvy.BN256)
+	b := cs.IsZero(circuit.Y, gurvy.BN256)
+	cs.AssertIsEqual(a, 1)
+	cs.AssertIsEqual(b, 0)
+
+	return nil
+}
+
+func init() {
+
+	var circuit, good, bad, public isZero
+	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
+	if err != nil {
+		panic(err)
+	}
+
+	good.X.Assign(203029)
+	good.Y.Assign(0)
+
+	bad.X.Assign(0)
+	bad.Y.Assign(23)
+
+	addEntry("isZero", r1cs, &good, &bad, &public)
+}

--- a/internal/backend/circuits/or.go
+++ b/internal/backend/circuits/or.go
@@ -26,10 +26,6 @@ func (circuit *orCircuit) Define(curveID gurvy.ID, cs *frontend.ConstraintSystem
 func init() {
 
 	var circuit, good, bad, public orCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.Left[0].Assign(0)
 	good.Left[1].Assign(0)
@@ -61,5 +57,5 @@ func init() {
 	bad.Res[2].Assign(1)
 	bad.Res[3].Assign(0)
 
-	addEntry("OR", r1cs, &good, &bad, &public)
+	addEntry("OR", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/or.go
+++ b/internal/backend/circuits/or.go
@@ -1,0 +1,65 @@
+package circuits
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gurvy"
+)
+
+type orCircuit struct {
+	Left  [4]frontend.Variable
+	Right [4]frontend.Variable
+	Res   [4]frontend.Variable
+}
+
+func (circuit *orCircuit) Define(curveID gurvy.ID, cs *frontend.ConstraintSystem) error {
+	a := cs.Or(circuit.Left[0], circuit.Right[0])
+	b := cs.Or(circuit.Left[1], circuit.Right[1])
+	c := cs.Or(circuit.Left[2], circuit.Right[2])
+	d := cs.Or(circuit.Left[3], circuit.Right[3])
+	cs.AssertIsEqual(a, circuit.Res[0])
+	cs.AssertIsEqual(b, circuit.Res[1])
+	cs.AssertIsEqual(c, circuit.Res[2])
+	cs.AssertIsEqual(d, circuit.Res[3])
+	return nil
+}
+
+func init() {
+
+	var circuit, good, bad, public orCircuit
+	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
+	if err != nil {
+		panic(err)
+	}
+
+	good.Left[0].Assign(0)
+	good.Left[1].Assign(0)
+	good.Left[2].Assign(1)
+	good.Left[3].Assign(1)
+
+	good.Right[0].Assign(0)
+	good.Right[1].Assign(1)
+	good.Right[2].Assign(0)
+	good.Right[3].Assign(1)
+
+	good.Res[0].Assign(0)
+	good.Res[1].Assign(1)
+	good.Res[2].Assign(1)
+	good.Res[3].Assign(1)
+
+	bad.Left[0].Assign(0)
+	bad.Left[1].Assign(0)
+	bad.Left[2].Assign(1)
+	bad.Left[3].Assign(1)
+
+	bad.Right[0].Assign(0)
+	bad.Right[1].Assign(1)
+	bad.Right[2].Assign(0)
+	bad.Right[3].Assign(1)
+
+	bad.Res[0].Assign(1)
+	bad.Res[1].Assign(0)
+	bad.Res[2].Assign(1)
+	bad.Res[3].Assign(0)
+
+	addEntry("OR", r1cs, &good, &bad, &public)
+}

--- a/internal/backend/circuits/range.go
+++ b/internal/backend/circuits/range.go
@@ -21,10 +21,6 @@ func (circuit *rangeCheckConstantCircuit) Define(curveID gurvy.ID, cs *frontend.
 
 func rangeCheckConstant() {
 	var circuit, good, bad, public rangeCheckConstantCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.X.Assign(10)
 	good.Y.Assign(4)
@@ -34,7 +30,7 @@ func rangeCheckConstant() {
 
 	public.Y.Assign(4)
 
-	addEntry("range_constant", r1cs, &good, &bad, &public)
+	addEntry("range_constant", &circuit, &good, &bad, &public)
 }
 
 type rangeCheckCircuit struct {
@@ -55,10 +51,6 @@ func (circuit *rangeCheckCircuit) Define(curveID gurvy.ID, cs *frontend.Constrai
 func rangeCheck() {
 
 	var circuit, good, bad, public rangeCheckCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.X.Assign(10)
 	good.Y.Assign(4)
@@ -71,7 +63,7 @@ func rangeCheck() {
 	public.Y.Assign(4)
 	public.Bound.Assign(161)
 
-	addEntry("range", r1cs, &good, &bad, &public)
+	addEntry("range", &circuit, &good, &bad, &public)
 }
 
 func init() {

--- a/internal/backend/circuits/reference_small.go
+++ b/internal/backend/circuits/reference_small.go
@@ -24,10 +24,6 @@ func (circuit *referenceSmallCircuit) Define(curveID gurvy.ID, cs *frontend.Cons
 
 func init() {
 	var circuit, good, bad, public referenceSmallCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.X.Assign(2)
 
@@ -46,5 +42,5 @@ func init() {
 
 	public.Y.Assign(expectedY)
 
-	addEntry("reference_small", r1cs, &good, &bad, &public)
+	addEntry("reference_small", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/xor00.go
+++ b/internal/backend/circuits/xor00.go
@@ -23,10 +23,6 @@ func (circuit *xorCircuit) Define(curveID gurvy.ID, cs *frontend.ConstraintSyste
 
 func init() {
 	var circuit, good, bad, public xorCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.B0.Assign(0)
 	good.B1.Assign(0)
@@ -38,5 +34,5 @@ func init() {
 
 	public.Y0.Assign(0)
 
-	addEntry("xor00", r1cs, &good, &bad, &public)
+	addEntry("xor00", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/xor01.go
+++ b/internal/backend/circuits/xor01.go
@@ -1,16 +1,7 @@
 package circuits
 
-import (
-	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gurvy"
-)
-
 func init() {
 	var circuit, good, bad, public xorCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.B0.Assign(0)
 	good.B1.Assign(1)
@@ -22,5 +13,5 @@ func init() {
 
 	public.Y0.Assign(1)
 
-	addEntry("xor01", r1cs, &good, &bad, &public)
+	addEntry("xor01", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/xor10.go
+++ b/internal/backend/circuits/xor10.go
@@ -1,16 +1,7 @@
 package circuits
 
-import (
-	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gurvy"
-)
-
 func init() {
 	var circuit, good, bad, public xorCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.B0.Assign(1)
 	good.B1.Assign(0)
@@ -22,5 +13,5 @@ func init() {
 
 	public.Y0.Assign(1)
 
-	addEntry("xor10", r1cs, &good, &bad, &public)
+	addEntry("xor10", &circuit, &good, &bad, &public)
 }

--- a/internal/backend/circuits/xor11.go
+++ b/internal/backend/circuits/xor11.go
@@ -1,16 +1,7 @@
 package circuits
 
-import (
-	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gurvy"
-)
-
 func init() {
 	var circuit, good, bad, public xorCircuit
-	r1cs, err := frontend.Compile(gurvy.UNKNOWN, &circuit)
-	if err != nil {
-		panic(err)
-	}
 
 	good.B0.Assign(1)
 	good.B1.Assign(1)
@@ -22,5 +13,5 @@ func init() {
 
 	public.Y0.Assign(0)
 
-	addEntry("xor11", r1cs, &good, &bad, &public)
+	addEntry("xor11", &circuit, &good, &bad, &public)
 }

--- a/internal/generators/backend/template/representations/tests/r1cs.go.tmpl
+++ b/internal/generators/backend/template/representations/tests/r1cs.go.tmpl
@@ -4,14 +4,18 @@ import (
 	"bytes"
 	"testing"
 	"reflect"
+	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/internal/backend/circuits"
 	"github.com/consensys/gurvy"
 )
 func TestSerialization(t *testing.T) {
 	var buffer bytes.Buffer
 	for name, circuit := range circuits.Circuits {
-		r1cs := circuit.R1CS.ToR1CS(gurvy.{{.Curve}})
-		
+
+		r1cs, err := frontend.Compile(gurvy.{{.Curve}}, circuit.Circuit)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if testing.Short() && r1cs.GetNbConstraints() > 50 {
 			continue
 		}

--- a/internal/generators/backend/template/zkpschemes/tests/groth16.go.tmpl
+++ b/internal/generators/backend/template/zkpschemes/tests/groth16.go.tmpl
@@ -27,6 +27,9 @@ import (
 
 func TestCircuits(t *testing.T) {
 	for name, circuit := range circuits.Circuits {
+		if name=="isZero" {
+			continue
+		}
 		t.Run(name, func(t *testing.T) {
 			assert := groth16.NewAssert(t)
 			r1cs := circuit.R1CS.ToR1CS(curve.ID)

--- a/internal/generators/backend/template/zkpschemes/tests/groth16.go.tmpl
+++ b/internal/generators/backend/template/zkpschemes/tests/groth16.go.tmpl
@@ -27,12 +27,10 @@ import (
 
 func TestCircuits(t *testing.T) {
 	for name, circuit := range circuits.Circuits {
-		if name=="isZero" {
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			assert := groth16.NewAssert(t)
-			r1cs := circuit.R1CS.ToR1CS(curve.ID)
+			r1cs, err := frontend.Compile(curve.ID, circuit.Circuit)
+			assert.NoError(err)
 			assert.ProverFailed(r1cs, circuit.Bad)
 			assert.ProverSucceeded(r1cs, circuit.Good)
 		})


### PR DESCRIPTION
Fixes #45 

Addition of Or, And, IsZero constraints.

**Example**:

Referring to the use in #45 here is an example:

` type ExampleCircuit struct {
		X frontend.Variable
	}

	func (circuit *ExampleCircuit) Define(curveID gurvy.ID, cs *frontend.ConstraintSystem) error {

		XminusThree := cs.Sub(circuit.X, 3)
		XminusFour := cs.Sub(circuit.X, 4)

		isXEqualToThree := cs.IsZero(XminusThree, curveID)
		isXEqualToFour := cs.IsZero(XminusFour, curveID)

		xEqualThreeOrFour := cs.Or(isXEqualToThree, isXEqualToFour)

		cs.Println("x==3?: ", isXEqualToThree)
		cs.Println("x==4?: ", isXEqualToFour)
		cs.Println("x==3 or x==4?: ", xEqualThreeOrFour)

		cs.AssertIsEqual(xEqualThreeOrFour, 1)

		return nil
	}

	func main() {

		var circuit ExampleCircuit
		r1cs, _ := frontend.Compile(gurvy.BN256, &circuit)

		var solution ExampleCircuit
		solution.X.Assign(3)
		parsedSolution, _ := frontend.ParseWitness(&solution)

		r1cs.IsSolved(parsedSolution)

	}
`

Output:
`main.go:26 x==3?:  1`
`main.go:27 x==4?:  0`
`main.go:28 x==3 or x==4?:  1`

**Status**: tests pass.