### PR TITLE
fix: inverse and div in frontend had some variable ID offset issues

### DIFF
--- a/frontend/variable.go
+++ b/frontend/variable.go
@@ -49,11 +49,3 @@ func (v *Variable) Assign(value interface{}) {
 	}
 	v.val = value
 }
-
-// getCopyLinExp returns a copy of the linear expression
-// to avoid sharing same data, leading to bugs when updating the variables id
-func (v *Variable) getLinExpCopy() compiled.LinearExpression {
-	res := make(compiled.LinearExpression, len(v.linExp))
-	copy(res, v.linExp)
-	return res
-}

--- a/internal/backend/bls377/cs/r1cs.go
+++ b/internal/backend/bls377/cs/r1cs.go
@@ -139,7 +139,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			panic("error solving r1c: " + a[i].String() + "*" + b[i].String() + "=" + c[i].String())
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
 		}
 	}
 

--- a/internal/backend/bls381/cs/r1cs.go
+++ b/internal/backend/bls381/cs/r1cs.go
@@ -139,7 +139,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			panic("error solving r1c: " + a[i].String() + "*" + b[i].String() + "=" + c[i].String())
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
 		}
 	}
 

--- a/internal/backend/bn256/cs/r1cs.go
+++ b/internal/backend/bn256/cs/r1cs.go
@@ -139,7 +139,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			panic("error solving r1c: " + a[i].String() + "*" + b[i].String() + "=" + c[i].String())
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
 		}
 	}
 

--- a/internal/backend/bw761/cs/r1cs.go
+++ b/internal/backend/bw761/cs/r1cs.go
@@ -139,7 +139,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			panic("error solving r1c: " + a[i].String() + "*" + b[i].String() + "=" + c[i].String())
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
 		}
 	}
 

--- a/internal/backend/compiled/r1c.go
+++ b/internal/backend/compiled/r1c.go
@@ -17,6 +17,13 @@ package compiled
 // LinearExpression represent a linear expression of variables
 type LinearExpression []Term
 
+// Clone returns a copy of the underlying slice
+func (l LinearExpression) Clone() LinearExpression {
+	res := make(LinearExpression, len(l))
+	copy(res, l)
+	return res
+}
+
 // R1C used to compute the wires
 type R1C struct {
 	L      LinearExpression

--- a/internal/generators/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generators/backend/template/representations/r1cs.go.tmpl
@@ -124,7 +124,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			panic("error solving r1c: " + a[i].String() + "*" + b[i].String() + "=" + c[i].String())
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
 		}
 	}
 


### PR DESCRIPTION
Inverse and Div were adding constraints without cloning the underlying linear expressions, resulting in multiple offsetting of the variable IDs when building a R1CS. 