### PR TITLE
docs: added comments for the splitting of S in eddsa

### DIFF
--- a/std/signature/eddsa/eddsa.go
+++ b/std/signature/eddsa/eddsa.go
@@ -31,9 +31,13 @@ type PublicKey struct {
 }
 
 // Signature stores a signature  (to be used in gnark circuit)
+// An EdDSA signature is a tuple (R,S) where R is a point on the twisted Edwards curve
+// and S a scalar. S can be greater than r, the size of the zk snark field, and must
+// not be reduced modulo r. Therefore it is split in S1 and S2, such that if r is n-bits long,
+// S = 2^(n/2)*S1 + S2. In other words, S is written S1S2 in basis 2^(n/2).
 type Signature struct {
 	R      twistededwards.Point
-	S1, S2 frontend.Variable // S = S1*basis + S2, where basis if 1/2 log r (ex 128 in case of bn256)
+	S1, S2 frontend.Variable
 }
 
 // Verify verifies an eddsa signature

--- a/std/signature/eddsa/eddsa_test.go
+++ b/std/signature/eddsa/eddsa_test.go
@@ -55,27 +55,27 @@ func parseSignature(id ecc.ID, buf []byte) ([]byte, []byte, []byte, []byte) {
 	case ecc.BN254:
 		pointbn254.SetBytes(buf[:32])
 		a, b := parsePoint(id, buf)
-		c1 := buf[32:48]
-		c2 := buf[48:]
-		return a[:], b[:], c1, c2
+		s1 := buf[32:48] // r is 256 bits, so s = 2^128*s1 + s2
+		s2 := buf[48:]
+		return a[:], b[:], s1, s2
 	case ecc.BLS12_381:
 		pointbls12381.SetBytes(buf[:32])
 		a, b := parsePoint(id, buf)
-		c1 := buf[32:48]
-		c2 := buf[48:]
-		return a[:], b[:], c1, c2
+		s1 := buf[32:48]
+		s2 := buf[48:]
+		return a[:], b[:], s1, s2
 	case ecc.BLS12_377:
 		pointbls12377.SetBytes(buf[:32])
 		a, b := parsePoint(id, buf)
-		c1 := buf[32:48]
-		c2 := buf[48:]
-		return a[:], b[:], c1, c2
+		s1 := buf[32:48]
+		s2 := buf[48:]
+		return a[:], b[:], s1, s2
 	case ecc.BW6_761:
-		pointbw6761.SetBytes(buf[:48])
+		pointbw6761.SetBytes(buf[:48]) // r is 384 bits, so s = 2^192*s1 + s2
 		a, b := parsePoint(id, buf)
-		c1 := buf[48:72]
-		c2 := buf[72:]
-		return a[:], b[:], c1, c2
+		s1 := buf[48:72]
+		s2 := buf[72:]
+		return a[:], b[:], s1, s2
 	default:
 		return buf, buf, buf, buf
 	}


### PR DESCRIPTION
In EdDSA, the `S` scalar in the signature is now split in 2, to prevent overflowing --> S should NOT be reduced modulo r, the size of the snark field. So if n is the bit length of r, S is split in S1, S2 such that S = 2^(n/2)S1+S2, so S1 and S2 are the digits of S in basis 2^(n/2).

## Breaking changes

The signature struct is now
```
type Signature struct {
	R      twistededwards.Point
	S1, S2 frontend.Variable // --> instead of: S frontend.Variable
}
```
 Examples of how to properly split S given a signature is in std/signature/eddsa/eddsa_test.go. If r is n-bits long, splitting S amounts to take the first n/2 bits of the part of the signature corresponding to S for S1, and the last n/2 bits of the part of the signature corresponding to S for S2 (the signature is a byte slice point||S, the first n-bits chunk is the compressed point, the last bits are S).