### PR TITLE
feat: added Fiat Shamir for plonk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572
-	github.com/consensys/gnark-crypto v0.4.1-0.20210413004505-7c6275f1e3a9
+	github.com/consensys/gnark-crypto v0.4.1-0.20210420210015-d7ee8fef4587
 	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572 h1:+R8G1+Ftumd0
 github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572/go.mod h1:Bpd0/3mZuaj6Sj+PqrmIquiOKy397AKGThQPaGzNXAQ=
 github.com/consensys/gnark-crypto v0.4.1-0.20210413004505-7c6275f1e3a9 h1:cgA17xtezKnYOpcYiZvda21Y6mjii2Xf3l9RwFJgcSE=
 github.com/consensys/gnark-crypto v0.4.1-0.20210413004505-7c6275f1e3a9/go.mod h1:lnwZ2dJfim9gnyN9hSRW52un1bLFx0S4k/g4L+OOVhY=
+github.com/consensys/gnark-crypto v0.4.1-0.20210420210015-d7ee8fef4587 h1:wHrUR1q/U/sJAYIPv6rFTI06rt9u1xFcpHqX4TylSOc=
+github.com/consensys/gnark-crypto v0.4.1-0.20210420210015-d7ee8fef4587/go.mod h1:lnwZ2dJfim9gnyN9hSRW52un1bLFx0S4k/g4L+OOVhY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/backend/bls12-377/plonk/verify.go
+++ b/internal/backend/bls12-377/plonk/verify.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
+
 	bls12_377witness "github.com/consensys/gnark/internal/backend/bls12-377/witness"
 )
 
@@ -30,11 +32,40 @@ var (
 )
 
 // VerifyRaw verifies a PLONK proof
-// TODO use Fiat Shamir to derive the challenges
 func VerifyRaw(proof *ProofRaw, publicData *PublicRaw, publicWitness bls12_377witness.Witness) error {
 
+	// create a transcript manager to apply Fiat Shamir and get the challenges
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma", "alpha", "zeta")
+	fs.Bind("gamma", proof.CommitmentsLROZH[0].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[1].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[2].Bytes())
+	bgamma, err := fs.ComputeChallenge("gamma")
+	if err != nil {
+		return err
+	}
+	var gamma fr.Element
+	gamma.SetBytes(bgamma)
+
+	fs.Bind("alpha", proof.CommitmentsLROZH[3].Bytes())
+	balpha, err := fs.ComputeChallenge("alpha")
+	if err != nil {
+		return err
+	}
+	var alpha fr.Element
+	alpha.SetBytes(balpha)
+
+	fs.Bind("zeta", proof.CommitmentsLROZH[4].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[5].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[6].Bytes())
+	bzeta, err := fs.ComputeChallenge("zeta")
+	if err != nil {
+		return err
+	}
+	var zeta fr.Element
+	zeta.SetBytes(bzeta)
+
 	// checks the opening proofs
-	err := publicData.CommitmentScheme.BatchVerifySinglePoint(&zeta, proof.LROZH, proof.CommitmentsLROZH, proof.BatchOpenings)
+	err = publicData.CommitmentScheme.BatchVerifySinglePoint(&zeta, proof.LROZH, proof.CommitmentsLROZH, proof.BatchOpenings)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bls12-381/plonk/prove.go
+++ b/internal/backend/bls12-381/plonk/prove.go
@@ -29,19 +29,9 @@ import (
 	bls12_381witness "github.com/consensys/gnark/internal/backend/bls12-381/witness"
 
 	"github.com/consensys/gnark/internal/backend/bls12-381/cs"
+
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
-
-// TODO derive those random values using Fiat Shamir
-// zeta: value at which l, r, o, h are evaluated
-// gamma: used in (l+X+gamma)*(r+u.X+gamma).(o+u**2X+gamma)
-// alpha: used in qlL+qrR+qmL.R+qoO+k + alpha.(Z(uX)g1g2g3-Z(X)f1f2f3) + alpha**2L1(Z-1) = HZ
-var zeta, gamma, alpha fr.Element
-
-func init() {
-	zeta.SetString("2938092839238274283")
-	gamma.SetString("82782638268278263826")
-	alpha.SetString("2567832343425678323434")
-}
 
 // ProofRaw PLONK proofs, consisting of opening proofs
 type ProofRaw struct {
@@ -114,7 +104,7 @@ func ComputeLRO(spr *cs.SparseR1CS, publicData *PublicRaw, solution []fr.Element
 //								     (l_i+s1+gamma)*(r_i+s2+gamma)*(o_i+s3+gamma)
 //
 //	* l, r, o are the solution in Lagrange basis
-func ComputeZ(l, r, o bls12381.Polynomial, publicData *PublicRaw) bls12381.Polynomial {
+func ComputeZ(l, r, o bls12381.Polynomial, publicData *PublicRaw, gamma fr.Element) bls12381.Polynomial {
 
 	z := make(bls12381.Polynomial, publicData.DomainNum.Cardinality)
 	nbElmts := int(publicData.DomainNum.Cardinality)
@@ -244,7 +234,7 @@ func evalIDCosets(publicData *PublicRaw) (id, uid, uuid bls12381.Polynomial) {
 //
 // z: permutation accumulator polynomial in canonical form
 // l, r, o: solution, in canonical form
-func evalConstraintOrdering(publicData *PublicRaw, evalZ, evalZu, evalL, evalR, evalO bls12381.Polynomial) bls12381.Polynomial {
+func evalConstraintOrdering(publicData *PublicRaw, evalZ, evalZu, evalL, evalR, evalO bls12381.Polynomial, gamma fr.Element) bls12381.Polynomial {
 
 	// evaluation of z, zu, s1, s2, s3, on the odd cosets of (Z/8mZ)/(Z/mZ)
 	evalS1 := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
@@ -375,7 +365,7 @@ func shiftZ(z bls12381.Polynomial) bls12381.Polynomial {
 //    constraintsInd			    constraintOrdering					startsAtOne
 //
 // constraintInd, constraintOrdering are evaluated on the odd cosets of (Z/8mZ)/(Z/mZ)
-func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsAtOne bls12381.Polynomial) (bls12381.Polynomial, bls12381.Polynomial, bls12381.Polynomial) {
+func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsAtOne bls12381.Polynomial, alpha fr.Element) (bls12381.Polynomial, bls12381.Polynomial, bls12381.Polynomial) {
 
 	h := make(bls12381.Polynomial, publicData.DomainH.Cardinality)
 
@@ -433,35 +423,59 @@ func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsA
 // TODO add a parameter to force the resolution of the system even if a constraint does not hold
 func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness bls12_381witness.Witness) *ProofRaw {
 
+	// create a transcript manager to apply Fiat Shamir
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma", "alpha", "zeta")
+
+	// result
+	proof := &ProofRaw{}
+
 	// compute the solution
 	solution, _ := spr.Solve(fullWitness)
 
 	// query l, r, o in Lagrange basis
-	l, r, o, partialL := ComputeLRO(spr, publicData, solution)
+	ll, lr, lo, partialL := ComputeLRO(spr, publicData, solution)
+
+	// save ll, lr, lo, and make a copy of them in canonical basis.
+	// We commit them and derive gamma from them.
+	cl := make(bls12381.Polynomial, len(ll))
+	cr := make(bls12381.Polynomial, len(lr))
+	co := make(bls12381.Polynomial, len(lo))
+	copy(cl, ll)
+	copy(cr, lr)
+	copy(co, lo)
+	publicData.DomainNum.FFTInverse(cl, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(cr, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(co, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(partialL, fft.DIF, 0)
+	fft.BitReverse(cl)
+	fft.BitReverse(cr)
+	fft.BitReverse(co)
+	fft.BitReverse(partialL)
+
+	// derive gamma from the Comm(l), Comm(r), Comm(o)
+	proof.CommitmentsLROZH[0] = publicData.CommitmentScheme.Commit(cl)
+	proof.CommitmentsLROZH[1] = publicData.CommitmentScheme.Commit(cr)
+	proof.CommitmentsLROZH[2] = publicData.CommitmentScheme.Commit(co)
+	fs.Bind("gamma", proof.CommitmentsLROZH[0].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[1].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[2].Bytes())
+	bgamma, _ := fs.ComputeChallenge("gamma")
+	var gamma fr.Element
+	gamma.SetBytes(bgamma)
 
 	// compute Z, the permutation accumulator polynomial, in Lagrange basis
-	z := ComputeZ(l, r, o, publicData)
+	z := ComputeZ(ll, lr, lo, publicData, gamma)
 
 	// compute Z(uX), in Lagrange basis
 	zu := shiftZ(z)
-
-	// put l, r, o, partialL  in canonical basis
-	publicData.DomainNum.FFTInverse(l, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(r, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(o, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(partialL, fft.DIF, 0)
-	fft.BitReverse(l)
-	fft.BitReverse(r)
-	fft.BitReverse(o)
-	fft.BitReverse(partialL)
 
 	// compute the evaluations of l, r, o on odd cosets of (Z/8mZ)/(Z/mZ)
 	evalL := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
 	evalR := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
 	evalO := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
-	evaluateCosets(l, evalL, publicData.DomainNum)
-	evaluateCosets(r, evalR, publicData.DomainNum)
-	evaluateCosets(o, evalO, publicData.DomainNum)
+	evaluateCosets(cl, evalL, publicData.DomainNum)
+	evaluateCosets(cr, evalR, publicData.DomainNum)
+	evaluateCosets(co, evalO, publicData.DomainNum)
 
 	// compute the evaluation of qlL+qrR+qmL.R+qoO+k on the odd cosets of (Z/8mZ)/(Z/mZ)
 	constraintsInd := evalConstraints(publicData, evalL, evalR, evalO)
@@ -479,21 +493,42 @@ func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness bls12_381wi
 	evaluateCosets(zu, evalZu, publicData.DomainNum)
 
 	// compute zu*g1*g2*g3-z*f1*f2*f3 on the odd cosets of (Z/8mZ)/(Z/mZ)
-	constraintsOrdering := evalConstraintOrdering(publicData, evalZ, evalZu, evalL, evalR, evalO)
+	constraintsOrdering := evalConstraintOrdering(publicData, evalZ, evalZu, evalL, evalR, evalO, gamma)
 
 	// compute L1*(z-1) on the odd cosets of (Z/8mZ)/(Z/mZ)
 	startsAtOne := evalStartsAtOne(publicData, evalZ)
 
+	// commit to Z
+	proof.CommitmentsLROZH[3] = publicData.CommitmentScheme.Commit(z)
+
+	// derive alpha from the Comm(l), Comm(r), Comm(o), Com(Z)
+	fs.Bind("alpha", proof.CommitmentsLROZH[3].Bytes())
+	balpha, _ := fs.ComputeChallenge("alpha")
+	var alpha fr.Element
+	alpha.SetBytes(balpha)
+
 	// compute h in canonical form
-	h1, h2, h3 := computeH(publicData, constraintsInd, constraintsOrdering, startsAtOne)
+	h1, h2, h3 := computeH(publicData, constraintsInd, constraintsOrdering, startsAtOne, alpha)
+
+	// commit to h (3 commitments h1 + x*h2 + x**2*h3)
+	proof.CommitmentsLROZH[4] = publicData.CommitmentScheme.Commit(h1)
+	proof.CommitmentsLROZH[5] = publicData.CommitmentScheme.Commit(h2)
+	proof.CommitmentsLROZH[6] = publicData.CommitmentScheme.Commit(h3)
+
+	// derive zeta, the point of evaluation
+	fs.Bind("zeta", proof.CommitmentsLROZH[4].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[5].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[6].Bytes())
+	bzeta, _ := fs.ComputeChallenge("zeta")
+	var zeta fr.Element
+	zeta.SetBytes(bzeta)
 
 	// compute evaluations of l, r, o, z at zeta
-	proof := &ProofRaw{}
 	tmp := partialL.Eval(&zeta)
 	proof.LROZH[0].Set(tmp.(*fr.Element))
-	tmp = r.Eval(&zeta)
+	tmp = cr.Eval(&zeta)
 	proof.LROZH[1].Set(tmp.(*fr.Element))
-	tmp = o.Eval(&zeta)
+	tmp = co.Eval(&zeta)
 	proof.LROZH[2].Set(tmp.(*fr.Element))
 	tmp = z.Eval(&zeta)
 	proof.LROZH[3].Set(tmp.(*fr.Element))
@@ -512,18 +547,8 @@ func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness bls12_381wi
 	tmp = z.Eval(&zzeta)
 	proof.ZShift.Set(tmp.(*fr.Element))
 
-	// compute commitments of l,r,o,z,h
-	// TODO when using Fiat Shamir, commitments need to be re ordered
-	proof.CommitmentsLROZH[0] = publicData.CommitmentScheme.Commit(l)
-	proof.CommitmentsLROZH[1] = publicData.CommitmentScheme.Commit(r)
-	proof.CommitmentsLROZH[2] = publicData.CommitmentScheme.Commit(o)
-	proof.CommitmentsLROZH[3] = publicData.CommitmentScheme.Commit(z)
-	proof.CommitmentsLROZH[4] = publicData.CommitmentScheme.Commit(h1)
-	proof.CommitmentsLROZH[5] = publicData.CommitmentScheme.Commit(h2)
-	proof.CommitmentsLROZH[6] = publicData.CommitmentScheme.Commit(h3)
-
 	// compute batch opening proof for l, r, o, h, z at zeta
-	polynomialsToOpenAtZeta := []bls12381.Polynomial{l, r, o, z, h1, h2, h3}
+	polynomialsToOpenAtZeta := []bls12381.Polynomial{cl, cr, co, z, h1, h2, h3}
 	proof.BatchOpenings = publicData.CommitmentScheme.BatchOpenSinglePoint(&zeta, polynomialsToOpenAtZeta)
 
 	// compute opening proof for z at z*zeta

--- a/internal/backend/bls12-381/plonk/verify.go
+++ b/internal/backend/bls12-381/plonk/verify.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
+
 	bls12_381witness "github.com/consensys/gnark/internal/backend/bls12-381/witness"
 )
 
@@ -30,11 +32,40 @@ var (
 )
 
 // VerifyRaw verifies a PLONK proof
-// TODO use Fiat Shamir to derive the challenges
 func VerifyRaw(proof *ProofRaw, publicData *PublicRaw, publicWitness bls12_381witness.Witness) error {
 
+	// create a transcript manager to apply Fiat Shamir and get the challenges
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma", "alpha", "zeta")
+	fs.Bind("gamma", proof.CommitmentsLROZH[0].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[1].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[2].Bytes())
+	bgamma, err := fs.ComputeChallenge("gamma")
+	if err != nil {
+		return err
+	}
+	var gamma fr.Element
+	gamma.SetBytes(bgamma)
+
+	fs.Bind("alpha", proof.CommitmentsLROZH[3].Bytes())
+	balpha, err := fs.ComputeChallenge("alpha")
+	if err != nil {
+		return err
+	}
+	var alpha fr.Element
+	alpha.SetBytes(balpha)
+
+	fs.Bind("zeta", proof.CommitmentsLROZH[4].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[5].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[6].Bytes())
+	bzeta, err := fs.ComputeChallenge("zeta")
+	if err != nil {
+		return err
+	}
+	var zeta fr.Element
+	zeta.SetBytes(bzeta)
+
 	// checks the opening proofs
-	err := publicData.CommitmentScheme.BatchVerifySinglePoint(&zeta, proof.LROZH, proof.CommitmentsLROZH, proof.BatchOpenings)
+	err = publicData.CommitmentScheme.BatchVerifySinglePoint(&zeta, proof.LROZH, proof.CommitmentsLROZH, proof.BatchOpenings)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bn254/plonk/prove.go
+++ b/internal/backend/bn254/plonk/prove.go
@@ -29,19 +29,9 @@ import (
 	bn254witness "github.com/consensys/gnark/internal/backend/bn254/witness"
 
 	"github.com/consensys/gnark/internal/backend/bn254/cs"
+
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
-
-// TODO derive those random values using Fiat Shamir
-// zeta: value at which l, r, o, h are evaluated
-// gamma: used in (l+X+gamma)*(r+u.X+gamma).(o+u**2X+gamma)
-// alpha: used in qlL+qrR+qmL.R+qoO+k + alpha.(Z(uX)g1g2g3-Z(X)f1f2f3) + alpha**2L1(Z-1) = HZ
-var zeta, gamma, alpha fr.Element
-
-func init() {
-	zeta.SetString("2938092839238274283")
-	gamma.SetString("82782638268278263826")
-	alpha.SetString("2567832343425678323434")
-}
 
 // ProofRaw PLONK proofs, consisting of opening proofs
 type ProofRaw struct {
@@ -114,7 +104,7 @@ func ComputeLRO(spr *cs.SparseR1CS, publicData *PublicRaw, solution []fr.Element
 //								     (l_i+s1+gamma)*(r_i+s2+gamma)*(o_i+s3+gamma)
 //
 //	* l, r, o are the solution in Lagrange basis
-func ComputeZ(l, r, o bn254.Polynomial, publicData *PublicRaw) bn254.Polynomial {
+func ComputeZ(l, r, o bn254.Polynomial, publicData *PublicRaw, gamma fr.Element) bn254.Polynomial {
 
 	z := make(bn254.Polynomial, publicData.DomainNum.Cardinality)
 	nbElmts := int(publicData.DomainNum.Cardinality)
@@ -244,7 +234,7 @@ func evalIDCosets(publicData *PublicRaw) (id, uid, uuid bn254.Polynomial) {
 //
 // z: permutation accumulator polynomial in canonical form
 // l, r, o: solution, in canonical form
-func evalConstraintOrdering(publicData *PublicRaw, evalZ, evalZu, evalL, evalR, evalO bn254.Polynomial) bn254.Polynomial {
+func evalConstraintOrdering(publicData *PublicRaw, evalZ, evalZu, evalL, evalR, evalO bn254.Polynomial, gamma fr.Element) bn254.Polynomial {
 
 	// evaluation of z, zu, s1, s2, s3, on the odd cosets of (Z/8mZ)/(Z/mZ)
 	evalS1 := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
@@ -375,7 +365,7 @@ func shiftZ(z bn254.Polynomial) bn254.Polynomial {
 //    constraintsInd			    constraintOrdering					startsAtOne
 //
 // constraintInd, constraintOrdering are evaluated on the odd cosets of (Z/8mZ)/(Z/mZ)
-func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsAtOne bn254.Polynomial) (bn254.Polynomial, bn254.Polynomial, bn254.Polynomial) {
+func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsAtOne bn254.Polynomial, alpha fr.Element) (bn254.Polynomial, bn254.Polynomial, bn254.Polynomial) {
 
 	h := make(bn254.Polynomial, publicData.DomainH.Cardinality)
 
@@ -433,35 +423,59 @@ func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsA
 // TODO add a parameter to force the resolution of the system even if a constraint does not hold
 func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness bn254witness.Witness) *ProofRaw {
 
+	// create a transcript manager to apply Fiat Shamir
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma", "alpha", "zeta")
+
+	// result
+	proof := &ProofRaw{}
+
 	// compute the solution
 	solution, _ := spr.Solve(fullWitness)
 
 	// query l, r, o in Lagrange basis
-	l, r, o, partialL := ComputeLRO(spr, publicData, solution)
+	ll, lr, lo, partialL := ComputeLRO(spr, publicData, solution)
+
+	// save ll, lr, lo, and make a copy of them in canonical basis.
+	// We commit them and derive gamma from them.
+	cl := make(bn254.Polynomial, len(ll))
+	cr := make(bn254.Polynomial, len(lr))
+	co := make(bn254.Polynomial, len(lo))
+	copy(cl, ll)
+	copy(cr, lr)
+	copy(co, lo)
+	publicData.DomainNum.FFTInverse(cl, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(cr, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(co, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(partialL, fft.DIF, 0)
+	fft.BitReverse(cl)
+	fft.BitReverse(cr)
+	fft.BitReverse(co)
+	fft.BitReverse(partialL)
+
+	// derive gamma from the Comm(l), Comm(r), Comm(o)
+	proof.CommitmentsLROZH[0] = publicData.CommitmentScheme.Commit(cl)
+	proof.CommitmentsLROZH[1] = publicData.CommitmentScheme.Commit(cr)
+	proof.CommitmentsLROZH[2] = publicData.CommitmentScheme.Commit(co)
+	fs.Bind("gamma", proof.CommitmentsLROZH[0].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[1].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[2].Bytes())
+	bgamma, _ := fs.ComputeChallenge("gamma")
+	var gamma fr.Element
+	gamma.SetBytes(bgamma)
 
 	// compute Z, the permutation accumulator polynomial, in Lagrange basis
-	z := ComputeZ(l, r, o, publicData)
+	z := ComputeZ(ll, lr, lo, publicData, gamma)
 
 	// compute Z(uX), in Lagrange basis
 	zu := shiftZ(z)
-
-	// put l, r, o, partialL  in canonical basis
-	publicData.DomainNum.FFTInverse(l, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(r, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(o, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(partialL, fft.DIF, 0)
-	fft.BitReverse(l)
-	fft.BitReverse(r)
-	fft.BitReverse(o)
-	fft.BitReverse(partialL)
 
 	// compute the evaluations of l, r, o on odd cosets of (Z/8mZ)/(Z/mZ)
 	evalL := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
 	evalR := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
 	evalO := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
-	evaluateCosets(l, evalL, publicData.DomainNum)
-	evaluateCosets(r, evalR, publicData.DomainNum)
-	evaluateCosets(o, evalO, publicData.DomainNum)
+	evaluateCosets(cl, evalL, publicData.DomainNum)
+	evaluateCosets(cr, evalR, publicData.DomainNum)
+	evaluateCosets(co, evalO, publicData.DomainNum)
 
 	// compute the evaluation of qlL+qrR+qmL.R+qoO+k on the odd cosets of (Z/8mZ)/(Z/mZ)
 	constraintsInd := evalConstraints(publicData, evalL, evalR, evalO)
@@ -479,21 +493,42 @@ func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness bn254witnes
 	evaluateCosets(zu, evalZu, publicData.DomainNum)
 
 	// compute zu*g1*g2*g3-z*f1*f2*f3 on the odd cosets of (Z/8mZ)/(Z/mZ)
-	constraintsOrdering := evalConstraintOrdering(publicData, evalZ, evalZu, evalL, evalR, evalO)
+	constraintsOrdering := evalConstraintOrdering(publicData, evalZ, evalZu, evalL, evalR, evalO, gamma)
 
 	// compute L1*(z-1) on the odd cosets of (Z/8mZ)/(Z/mZ)
 	startsAtOne := evalStartsAtOne(publicData, evalZ)
 
+	// commit to Z
+	proof.CommitmentsLROZH[3] = publicData.CommitmentScheme.Commit(z)
+
+	// derive alpha from the Comm(l), Comm(r), Comm(o), Com(Z)
+	fs.Bind("alpha", proof.CommitmentsLROZH[3].Bytes())
+	balpha, _ := fs.ComputeChallenge("alpha")
+	var alpha fr.Element
+	alpha.SetBytes(balpha)
+
 	// compute h in canonical form
-	h1, h2, h3 := computeH(publicData, constraintsInd, constraintsOrdering, startsAtOne)
+	h1, h2, h3 := computeH(publicData, constraintsInd, constraintsOrdering, startsAtOne, alpha)
+
+	// commit to h (3 commitments h1 + x*h2 + x**2*h3)
+	proof.CommitmentsLROZH[4] = publicData.CommitmentScheme.Commit(h1)
+	proof.CommitmentsLROZH[5] = publicData.CommitmentScheme.Commit(h2)
+	proof.CommitmentsLROZH[6] = publicData.CommitmentScheme.Commit(h3)
+
+	// derive zeta, the point of evaluation
+	fs.Bind("zeta", proof.CommitmentsLROZH[4].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[5].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[6].Bytes())
+	bzeta, _ := fs.ComputeChallenge("zeta")
+	var zeta fr.Element
+	zeta.SetBytes(bzeta)
 
 	// compute evaluations of l, r, o, z at zeta
-	proof := &ProofRaw{}
 	tmp := partialL.Eval(&zeta)
 	proof.LROZH[0].Set(tmp.(*fr.Element))
-	tmp = r.Eval(&zeta)
+	tmp = cr.Eval(&zeta)
 	proof.LROZH[1].Set(tmp.(*fr.Element))
-	tmp = o.Eval(&zeta)
+	tmp = co.Eval(&zeta)
 	proof.LROZH[2].Set(tmp.(*fr.Element))
 	tmp = z.Eval(&zeta)
 	proof.LROZH[3].Set(tmp.(*fr.Element))
@@ -512,18 +547,8 @@ func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness bn254witnes
 	tmp = z.Eval(&zzeta)
 	proof.ZShift.Set(tmp.(*fr.Element))
 
-	// compute commitments of l,r,o,z,h
-	// TODO when using Fiat Shamir, commitments need to be re ordered
-	proof.CommitmentsLROZH[0] = publicData.CommitmentScheme.Commit(l)
-	proof.CommitmentsLROZH[1] = publicData.CommitmentScheme.Commit(r)
-	proof.CommitmentsLROZH[2] = publicData.CommitmentScheme.Commit(o)
-	proof.CommitmentsLROZH[3] = publicData.CommitmentScheme.Commit(z)
-	proof.CommitmentsLROZH[4] = publicData.CommitmentScheme.Commit(h1)
-	proof.CommitmentsLROZH[5] = publicData.CommitmentScheme.Commit(h2)
-	proof.CommitmentsLROZH[6] = publicData.CommitmentScheme.Commit(h3)
-
 	// compute batch opening proof for l, r, o, h, z at zeta
-	polynomialsToOpenAtZeta := []bn254.Polynomial{l, r, o, z, h1, h2, h3}
+	polynomialsToOpenAtZeta := []bn254.Polynomial{cl, cr, co, z, h1, h2, h3}
 	proof.BatchOpenings = publicData.CommitmentScheme.BatchOpenSinglePoint(&zeta, polynomialsToOpenAtZeta)
 
 	// compute opening proof for z at z*zeta

--- a/internal/backend/bn254/plonk/verify.go
+++ b/internal/backend/bn254/plonk/verify.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
+
 	bn254witness "github.com/consensys/gnark/internal/backend/bn254/witness"
 )
 
@@ -30,11 +32,40 @@ var (
 )
 
 // VerifyRaw verifies a PLONK proof
-// TODO use Fiat Shamir to derive the challenges
 func VerifyRaw(proof *ProofRaw, publicData *PublicRaw, publicWitness bn254witness.Witness) error {
 
+	// create a transcript manager to apply Fiat Shamir and get the challenges
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma", "alpha", "zeta")
+	fs.Bind("gamma", proof.CommitmentsLROZH[0].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[1].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[2].Bytes())
+	bgamma, err := fs.ComputeChallenge("gamma")
+	if err != nil {
+		return err
+	}
+	var gamma fr.Element
+	gamma.SetBytes(bgamma)
+
+	fs.Bind("alpha", proof.CommitmentsLROZH[3].Bytes())
+	balpha, err := fs.ComputeChallenge("alpha")
+	if err != nil {
+		return err
+	}
+	var alpha fr.Element
+	alpha.SetBytes(balpha)
+
+	fs.Bind("zeta", proof.CommitmentsLROZH[4].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[5].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[6].Bytes())
+	bzeta, err := fs.ComputeChallenge("zeta")
+	if err != nil {
+		return err
+	}
+	var zeta fr.Element
+	zeta.SetBytes(bzeta)
+
 	// checks the opening proofs
-	err := publicData.CommitmentScheme.BatchVerifySinglePoint(&zeta, proof.LROZH, proof.CommitmentsLROZH, proof.BatchOpenings)
+	err = publicData.CommitmentScheme.BatchVerifySinglePoint(&zeta, proof.LROZH, proof.CommitmentsLROZH, proof.BatchOpenings)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bw6-761/plonk/prove.go
+++ b/internal/backend/bw6-761/plonk/prove.go
@@ -29,19 +29,9 @@ import (
 	bw6_761witness "github.com/consensys/gnark/internal/backend/bw6-761/witness"
 
 	"github.com/consensys/gnark/internal/backend/bw6-761/cs"
+
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
-
-// TODO derive those random values using Fiat Shamir
-// zeta: value at which l, r, o, h are evaluated
-// gamma: used in (l+X+gamma)*(r+u.X+gamma).(o+u**2X+gamma)
-// alpha: used in qlL+qrR+qmL.R+qoO+k + alpha.(Z(uX)g1g2g3-Z(X)f1f2f3) + alpha**2L1(Z-1) = HZ
-var zeta, gamma, alpha fr.Element
-
-func init() {
-	zeta.SetString("2938092839238274283")
-	gamma.SetString("82782638268278263826")
-	alpha.SetString("2567832343425678323434")
-}
 
 // ProofRaw PLONK proofs, consisting of opening proofs
 type ProofRaw struct {
@@ -114,7 +104,7 @@ func ComputeLRO(spr *cs.SparseR1CS, publicData *PublicRaw, solution []fr.Element
 //								     (l_i+s1+gamma)*(r_i+s2+gamma)*(o_i+s3+gamma)
 //
 //	* l, r, o are the solution in Lagrange basis
-func ComputeZ(l, r, o bw6761.Polynomial, publicData *PublicRaw) bw6761.Polynomial {
+func ComputeZ(l, r, o bw6761.Polynomial, publicData *PublicRaw, gamma fr.Element) bw6761.Polynomial {
 
 	z := make(bw6761.Polynomial, publicData.DomainNum.Cardinality)
 	nbElmts := int(publicData.DomainNum.Cardinality)
@@ -244,7 +234,7 @@ func evalIDCosets(publicData *PublicRaw) (id, uid, uuid bw6761.Polynomial) {
 //
 // z: permutation accumulator polynomial in canonical form
 // l, r, o: solution, in canonical form
-func evalConstraintOrdering(publicData *PublicRaw, evalZ, evalZu, evalL, evalR, evalO bw6761.Polynomial) bw6761.Polynomial {
+func evalConstraintOrdering(publicData *PublicRaw, evalZ, evalZu, evalL, evalR, evalO bw6761.Polynomial, gamma fr.Element) bw6761.Polynomial {
 
 	// evaluation of z, zu, s1, s2, s3, on the odd cosets of (Z/8mZ)/(Z/mZ)
 	evalS1 := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
@@ -375,7 +365,7 @@ func shiftZ(z bw6761.Polynomial) bw6761.Polynomial {
 //    constraintsInd			    constraintOrdering					startsAtOne
 //
 // constraintInd, constraintOrdering are evaluated on the odd cosets of (Z/8mZ)/(Z/mZ)
-func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsAtOne bw6761.Polynomial) (bw6761.Polynomial, bw6761.Polynomial, bw6761.Polynomial) {
+func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsAtOne bw6761.Polynomial, alpha fr.Element) (bw6761.Polynomial, bw6761.Polynomial, bw6761.Polynomial) {
 
 	h := make(bw6761.Polynomial, publicData.DomainH.Cardinality)
 
@@ -433,35 +423,59 @@ func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsA
 // TODO add a parameter to force the resolution of the system even if a constraint does not hold
 func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness bw6_761witness.Witness) *ProofRaw {
 
+	// create a transcript manager to apply Fiat Shamir
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma", "alpha", "zeta")
+
+	// result
+	proof := &ProofRaw{}
+
 	// compute the solution
 	solution, _ := spr.Solve(fullWitness)
 
 	// query l, r, o in Lagrange basis
-	l, r, o, partialL := ComputeLRO(spr, publicData, solution)
+	ll, lr, lo, partialL := ComputeLRO(spr, publicData, solution)
+
+	// save ll, lr, lo, and make a copy of them in canonical basis.
+	// We commit them and derive gamma from them.
+	cl := make(bw6761.Polynomial, len(ll))
+	cr := make(bw6761.Polynomial, len(lr))
+	co := make(bw6761.Polynomial, len(lo))
+	copy(cl, ll)
+	copy(cr, lr)
+	copy(co, lo)
+	publicData.DomainNum.FFTInverse(cl, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(cr, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(co, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(partialL, fft.DIF, 0)
+	fft.BitReverse(cl)
+	fft.BitReverse(cr)
+	fft.BitReverse(co)
+	fft.BitReverse(partialL)
+
+	// derive gamma from the Comm(l), Comm(r), Comm(o)
+	proof.CommitmentsLROZH[0] = publicData.CommitmentScheme.Commit(cl)
+	proof.CommitmentsLROZH[1] = publicData.CommitmentScheme.Commit(cr)
+	proof.CommitmentsLROZH[2] = publicData.CommitmentScheme.Commit(co)
+	fs.Bind("gamma", proof.CommitmentsLROZH[0].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[1].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[2].Bytes())
+	bgamma, _ := fs.ComputeChallenge("gamma")
+	var gamma fr.Element
+	gamma.SetBytes(bgamma)
 
 	// compute Z, the permutation accumulator polynomial, in Lagrange basis
-	z := ComputeZ(l, r, o, publicData)
+	z := ComputeZ(ll, lr, lo, publicData, gamma)
 
 	// compute Z(uX), in Lagrange basis
 	zu := shiftZ(z)
-
-	// put l, r, o, partialL  in canonical basis
-	publicData.DomainNum.FFTInverse(l, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(r, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(o, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(partialL, fft.DIF, 0)
-	fft.BitReverse(l)
-	fft.BitReverse(r)
-	fft.BitReverse(o)
-	fft.BitReverse(partialL)
 
 	// compute the evaluations of l, r, o on odd cosets of (Z/8mZ)/(Z/mZ)
 	evalL := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
 	evalR := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
 	evalO := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
-	evaluateCosets(l, evalL, publicData.DomainNum)
-	evaluateCosets(r, evalR, publicData.DomainNum)
-	evaluateCosets(o, evalO, publicData.DomainNum)
+	evaluateCosets(cl, evalL, publicData.DomainNum)
+	evaluateCosets(cr, evalR, publicData.DomainNum)
+	evaluateCosets(co, evalO, publicData.DomainNum)
 
 	// compute the evaluation of qlL+qrR+qmL.R+qoO+k on the odd cosets of (Z/8mZ)/(Z/mZ)
 	constraintsInd := evalConstraints(publicData, evalL, evalR, evalO)
@@ -479,21 +493,42 @@ func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness bw6_761witn
 	evaluateCosets(zu, evalZu, publicData.DomainNum)
 
 	// compute zu*g1*g2*g3-z*f1*f2*f3 on the odd cosets of (Z/8mZ)/(Z/mZ)
-	constraintsOrdering := evalConstraintOrdering(publicData, evalZ, evalZu, evalL, evalR, evalO)
+	constraintsOrdering := evalConstraintOrdering(publicData, evalZ, evalZu, evalL, evalR, evalO, gamma)
 
 	// compute L1*(z-1) on the odd cosets of (Z/8mZ)/(Z/mZ)
 	startsAtOne := evalStartsAtOne(publicData, evalZ)
 
+	// commit to Z
+	proof.CommitmentsLROZH[3] = publicData.CommitmentScheme.Commit(z)
+
+	// derive alpha from the Comm(l), Comm(r), Comm(o), Com(Z)
+	fs.Bind("alpha", proof.CommitmentsLROZH[3].Bytes())
+	balpha, _ := fs.ComputeChallenge("alpha")
+	var alpha fr.Element
+	alpha.SetBytes(balpha)
+
 	// compute h in canonical form
-	h1, h2, h3 := computeH(publicData, constraintsInd, constraintsOrdering, startsAtOne)
+	h1, h2, h3 := computeH(publicData, constraintsInd, constraintsOrdering, startsAtOne, alpha)
+
+	// commit to h (3 commitments h1 + x*h2 + x**2*h3)
+	proof.CommitmentsLROZH[4] = publicData.CommitmentScheme.Commit(h1)
+	proof.CommitmentsLROZH[5] = publicData.CommitmentScheme.Commit(h2)
+	proof.CommitmentsLROZH[6] = publicData.CommitmentScheme.Commit(h3)
+
+	// derive zeta, the point of evaluation
+	fs.Bind("zeta", proof.CommitmentsLROZH[4].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[5].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[6].Bytes())
+	bzeta, _ := fs.ComputeChallenge("zeta")
+	var zeta fr.Element
+	zeta.SetBytes(bzeta)
 
 	// compute evaluations of l, r, o, z at zeta
-	proof := &ProofRaw{}
 	tmp := partialL.Eval(&zeta)
 	proof.LROZH[0].Set(tmp.(*fr.Element))
-	tmp = r.Eval(&zeta)
+	tmp = cr.Eval(&zeta)
 	proof.LROZH[1].Set(tmp.(*fr.Element))
-	tmp = o.Eval(&zeta)
+	tmp = co.Eval(&zeta)
 	proof.LROZH[2].Set(tmp.(*fr.Element))
 	tmp = z.Eval(&zeta)
 	proof.LROZH[3].Set(tmp.(*fr.Element))
@@ -512,18 +547,8 @@ func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness bw6_761witn
 	tmp = z.Eval(&zzeta)
 	proof.ZShift.Set(tmp.(*fr.Element))
 
-	// compute commitments of l,r,o,z,h
-	// TODO when using Fiat Shamir, commitments need to be re ordered
-	proof.CommitmentsLROZH[0] = publicData.CommitmentScheme.Commit(l)
-	proof.CommitmentsLROZH[1] = publicData.CommitmentScheme.Commit(r)
-	proof.CommitmentsLROZH[2] = publicData.CommitmentScheme.Commit(o)
-	proof.CommitmentsLROZH[3] = publicData.CommitmentScheme.Commit(z)
-	proof.CommitmentsLROZH[4] = publicData.CommitmentScheme.Commit(h1)
-	proof.CommitmentsLROZH[5] = publicData.CommitmentScheme.Commit(h2)
-	proof.CommitmentsLROZH[6] = publicData.CommitmentScheme.Commit(h3)
-
 	// compute batch opening proof for l, r, o, h, z at zeta
-	polynomialsToOpenAtZeta := []bw6761.Polynomial{l, r, o, z, h1, h2, h3}
+	polynomialsToOpenAtZeta := []bw6761.Polynomial{cl, cr, co, z, h1, h2, h3}
 	proof.BatchOpenings = publicData.CommitmentScheme.BatchOpenSinglePoint(&zeta, polynomialsToOpenAtZeta)
 
 	// compute opening proof for z at z*zeta

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
@@ -9,19 +9,8 @@ import (
 	{{ template "import_witness" . }}
 	{{ template "import_backend_cs" . }}
 
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 )
-
-// TODO derive those random values using Fiat Shamir
-// zeta: value at which l, r, o, h are evaluated
-// gamma: used in (l+X+gamma)*(r+u.X+gamma).(o+u**2X+gamma)
-// alpha: used in qlL+qrR+qmL.R+qoO+k + alpha.(Z(uX)g1g2g3-Z(X)f1f2f3) + alpha**2L1(Z-1) = HZ
-var zeta, gamma, alpha fr.Element
-
-func init() {
-	zeta.SetString("2938092839238274283")
-	gamma.SetString("82782638268278263826")
-	alpha.SetString("2567832343425678323434")
-}
 
 // ProofRaw PLONK proofs, consisting of opening proofs
 type ProofRaw struct {
@@ -94,7 +83,7 @@ func ComputeLRO(spr *cs.SparseR1CS, publicData *PublicRaw, solution []fr.Element
 //								     (l_i+s1+gamma)*(r_i+s2+gamma)*(o_i+s3+gamma)
 //
 //	* l, r, o are the solution in Lagrange basis
-func ComputeZ(l, r, o {{ .Package }}.Polynomial, publicData *PublicRaw) {{ .Package }}.Polynomial {
+func ComputeZ(l, r, o {{ .Package }}.Polynomial, publicData *PublicRaw, gamma fr.Element) {{ .Package }}.Polynomial {
 
 	z := make({{ .Package }}.Polynomial, publicData.DomainNum.Cardinality)
 	nbElmts := int(publicData.DomainNum.Cardinality)
@@ -224,7 +213,7 @@ func evalIDCosets(publicData *PublicRaw) (id, uid, uuid {{ .Package }}.Polynomia
 //
 // z: permutation accumulator polynomial in canonical form
 // l, r, o: solution, in canonical form
-func evalConstraintOrdering(publicData *PublicRaw, evalZ, evalZu, evalL, evalR, evalO {{ .Package }}.Polynomial) {{ .Package }}.Polynomial {
+func evalConstraintOrdering(publicData *PublicRaw, evalZ, evalZu, evalL, evalR, evalO {{ .Package }}.Polynomial, gamma fr.Element) {{ .Package }}.Polynomial {
 
 	// evaluation of z, zu, s1, s2, s3, on the odd cosets of (Z/8mZ)/(Z/mZ)
 	evalS1 := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
@@ -355,7 +344,7 @@ func shiftZ(z {{ .Package }}.Polynomial) {{ .Package }}.Polynomial {
 //    constraintsInd			    constraintOrdering					startsAtOne
 //
 // constraintInd, constraintOrdering are evaluated on the odd cosets of (Z/8mZ)/(Z/mZ)
-func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsAtOne {{ .Package }}.Polynomial) ({{ .Package }}.Polynomial, {{ .Package }}.Polynomial, {{ .Package }}.Polynomial) {
+func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsAtOne {{ .Package }}.Polynomial, alpha fr.Element) ({{ .Package }}.Polynomial, {{ .Package }}.Polynomial, {{ .Package }}.Polynomial) {
 
 	h := make({{ .Package }}.Polynomial, publicData.DomainH.Cardinality)
 
@@ -413,35 +402,59 @@ func computeH(publicData *PublicRaw, constraintsInd, constraintOrdering, startsA
 // TODO add a parameter to force the resolution of the system even if a constraint does not hold
 func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness {{toLower .CurveID}}witness.Witness) *ProofRaw {
 
+	// create a transcript manager to apply Fiat Shamir
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma", "alpha", "zeta")
+
+	// result
+	proof := &ProofRaw{}
+
 	// compute the solution
 	solution, _ := spr.Solve(fullWitness)
 
 	// query l, r, o in Lagrange basis
-	l, r, o, partialL := ComputeLRO(spr, publicData, solution)
+	ll, lr, lo, partialL := ComputeLRO(spr, publicData, solution)
+
+	// save ll, lr, lo, and make a copy of them in canonical basis.
+	// We commit them and derive gamma from them.
+	cl := make({{ .Package }}.Polynomial, len(ll))
+	cr := make({{ .Package }}.Polynomial, len(lr))
+	co := make({{ .Package }}.Polynomial, len(lo))
+	copy(cl, ll)
+	copy(cr, lr)
+	copy(co, lo)
+	publicData.DomainNum.FFTInverse(cl, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(cr, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(co, fft.DIF, 0)
+	publicData.DomainNum.FFTInverse(partialL, fft.DIF, 0)
+	fft.BitReverse(cl)
+	fft.BitReverse(cr)
+	fft.BitReverse(co)
+	fft.BitReverse(partialL)
+
+	// derive gamma from the Comm(l), Comm(r), Comm(o)
+	proof.CommitmentsLROZH[0] = publicData.CommitmentScheme.Commit(cl)
+	proof.CommitmentsLROZH[1] = publicData.CommitmentScheme.Commit(cr)
+	proof.CommitmentsLROZH[2] = publicData.CommitmentScheme.Commit(co)
+	fs.Bind("gamma", proof.CommitmentsLROZH[0].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[1].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[2].Bytes())
+	bgamma, _ := fs.ComputeChallenge("gamma")
+	var gamma fr.Element
+	gamma.SetBytes(bgamma)
 
 	// compute Z, the permutation accumulator polynomial, in Lagrange basis
-	z := ComputeZ(l, r, o, publicData)
+	z := ComputeZ(ll, lr, lo, publicData, gamma)
 
 	// compute Z(uX), in Lagrange basis
 	zu := shiftZ(z)
-
-	// put l, r, o, partialL  in canonical basis
-	publicData.DomainNum.FFTInverse(l, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(r, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(o, fft.DIF, 0)
-	publicData.DomainNum.FFTInverse(partialL, fft.DIF, 0)
-	fft.BitReverse(l)
-	fft.BitReverse(r)
-	fft.BitReverse(o)
-	fft.BitReverse(partialL)
 
 	// compute the evaluations of l, r, o on odd cosets of (Z/8mZ)/(Z/mZ)
 	evalL := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
 	evalR := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
 	evalO := make([]fr.Element, 4*publicData.DomainNum.Cardinality)
-	evaluateCosets(l, evalL, publicData.DomainNum)
-	evaluateCosets(r, evalR, publicData.DomainNum)
-	evaluateCosets(o, evalO, publicData.DomainNum)
+	evaluateCosets(cl, evalL, publicData.DomainNum)
+	evaluateCosets(cr, evalR, publicData.DomainNum)
+	evaluateCosets(co, evalO, publicData.DomainNum)
 
 	// compute the evaluation of qlL+qrR+qmL.R+qoO+k on the odd cosets of (Z/8mZ)/(Z/mZ)
 	constraintsInd := evalConstraints(publicData, evalL, evalR, evalO)
@@ -459,21 +472,42 @@ func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness {{toLower .
 	evaluateCosets(zu, evalZu, publicData.DomainNum)
 
 	// compute zu*g1*g2*g3-z*f1*f2*f3 on the odd cosets of (Z/8mZ)/(Z/mZ)
-	constraintsOrdering := evalConstraintOrdering(publicData, evalZ, evalZu, evalL, evalR, evalO)
+	constraintsOrdering := evalConstraintOrdering(publicData, evalZ, evalZu, evalL, evalR, evalO, gamma)
 
 	// compute L1*(z-1) on the odd cosets of (Z/8mZ)/(Z/mZ)
 	startsAtOne := evalStartsAtOne(publicData, evalZ)
 
+	// commit to Z
+	proof.CommitmentsLROZH[3] = publicData.CommitmentScheme.Commit(z)
+
+	// derive alpha from the Comm(l), Comm(r), Comm(o), Com(Z)
+	fs.Bind("alpha", proof.CommitmentsLROZH[3].Bytes())
+	balpha, _ := fs.ComputeChallenge("alpha")
+	var alpha fr.Element
+	alpha.SetBytes(balpha)
+
 	// compute h in canonical form
-	h1, h2, h3 := computeH(publicData, constraintsInd, constraintsOrdering, startsAtOne)
+	h1, h2, h3 := computeH(publicData, constraintsInd, constraintsOrdering, startsAtOne, alpha)
+
+	// commit to h (3 commitments h1 + x*h2 + x**2*h3)
+	proof.CommitmentsLROZH[4] = publicData.CommitmentScheme.Commit(h1)
+	proof.CommitmentsLROZH[5] = publicData.CommitmentScheme.Commit(h2)
+	proof.CommitmentsLROZH[6] = publicData.CommitmentScheme.Commit(h3)
+
+	// derive zeta, the point of evaluation
+	fs.Bind("zeta", proof.CommitmentsLROZH[4].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[5].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[6].Bytes())
+	bzeta, _ := fs.ComputeChallenge("zeta")
+	var zeta fr.Element
+	zeta.SetBytes(bzeta)
 
 	// compute evaluations of l, r, o, z at zeta
-	proof := &ProofRaw{}
 	tmp := partialL.Eval(&zeta)
 	proof.LROZH[0].Set(tmp.(*fr.Element))
-	tmp = r.Eval(&zeta)
+	tmp = cr.Eval(&zeta)
 	proof.LROZH[1].Set(tmp.(*fr.Element))
-	tmp = o.Eval(&zeta)
+	tmp = co.Eval(&zeta)
 	proof.LROZH[2].Set(tmp.(*fr.Element))
 	tmp = z.Eval(&zeta)
 	proof.LROZH[3].Set(tmp.(*fr.Element))
@@ -492,18 +526,8 @@ func ProveRaw(spr *cs.SparseR1CS, publicData *PublicRaw, fullWitness {{toLower .
 	tmp = z.Eval(&zzeta)
 	proof.ZShift.Set(tmp.(*fr.Element))
 
-	// compute commitments of l,r,o,z,h
-	// TODO when using Fiat Shamir, commitments need to be re ordered
-	proof.CommitmentsLROZH[0] = publicData.CommitmentScheme.Commit(l)
-	proof.CommitmentsLROZH[1] = publicData.CommitmentScheme.Commit(r)
-	proof.CommitmentsLROZH[2] = publicData.CommitmentScheme.Commit(o)
-	proof.CommitmentsLROZH[3] = publicData.CommitmentScheme.Commit(z)
-	proof.CommitmentsLROZH[4] = publicData.CommitmentScheme.Commit(h1)
-	proof.CommitmentsLROZH[5] = publicData.CommitmentScheme.Commit(h2)
-	proof.CommitmentsLROZH[6] = publicData.CommitmentScheme.Commit(h3)
-
 	// compute batch opening proof for l, r, o, h, z at zeta
-	polynomialsToOpenAtZeta := []{{ .Package }}.Polynomial{l, r, o, z, h1, h2, h3}
+	polynomialsToOpenAtZeta := []{{ .Package }}.Polynomial{cl, cr, co, z, h1, h2, h3}
 	proof.BatchOpenings = publicData.CommitmentScheme.BatchOpenSinglePoint(&zeta, polynomialsToOpenAtZeta)
 
 	// compute opening proof for z at z*zeta

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.verify.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.verify.go.tmpl
@@ -3,6 +3,7 @@ import (
 	"math/big"
 
 	{{ template "import_fr" . }}
+	fiatshamir "github.com/consensys/gnark-crypto/fiat-shamir"
 	{{ template "import_witness" . }}
 )
 
@@ -11,16 +12,45 @@ var (
 )
 
 // VerifyRaw verifies a PLONK proof
-// TODO use Fiat Shamir to derive the challenges
-func VerifyRaw(proof *ProofRaw, publicData *PublicRaw, publicWitness {{ toLower .CurveID }}witness.Witness) error {
+func VerifyRaw(proof *ProofRaw, publicData *PublicRaw, publicWitness {{toLower .CurveID}}witness.Witness) error {
+
+	// create a transcript manager to apply Fiat Shamir and get the challenges
+	fs := fiatshamir.NewTranscript(fiatshamir.SHA256, "gamma", "alpha", "zeta")
+	fs.Bind("gamma", proof.CommitmentsLROZH[0].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[1].Bytes())
+	fs.Bind("gamma", proof.CommitmentsLROZH[2].Bytes())
+	bgamma, err := fs.ComputeChallenge("gamma")
+	if err != nil {
+		return err
+	}
+	var gamma fr.Element
+	gamma.SetBytes(bgamma)
+
+	fs.Bind("alpha", proof.CommitmentsLROZH[3].Bytes())
+	balpha, err := fs.ComputeChallenge("alpha")
+	if err != nil {
+		return err
+	}
+	var alpha fr.Element
+	alpha.SetBytes(balpha)
+
+	fs.Bind("zeta", proof.CommitmentsLROZH[4].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[5].Bytes())
+	fs.Bind("zeta", proof.CommitmentsLROZH[6].Bytes())
+	bzeta, err := fs.ComputeChallenge("zeta")
+	if err != nil {
+		return err
+	}
+	var zeta fr.Element
+	zeta.SetBytes(bzeta)
 
 	// checks the opening proofs
-	err := publicData.CommitmentScheme.BatchVerifySinglePoint(&zeta, proof.LROZH, proof.CommitmentsLROZH, proof.BatchOpenings)
+	err = publicData.CommitmentScheme.BatchVerifySinglePoint(&zeta, proof.LROZH, proof.CommitmentsLROZH, proof.BatchOpenings)
 	if err != nil {
 		return err
 	}
 	err = publicData.CommitmentScheme.Verify(&zeta, proof.CommitmentsLROZH[3], proof.OpeningZShift)
-	if err!=nil {
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds a transcript object to apply Fiat Shamir transform.

## API breaking change

Addition of method `Bytes() []byte` on Digest struct:
```
type Digest interface {
	io.WriterTo
	io.ReaderFrom
	Bytes() []byte
}
```

## Transcript

To apply Fiat Shamir one needs to create a transcript while providing the hash function used for challenges derivation as well as a list of names for the challenges. No challenges can be added afterwards:

`func NewTranscript(h HashFS, challenges ...string) Transcript `

Transcript object offers the following API:
* `(m *Transcript) Bind(challenge string, value []byte) error`: binds a challenge (referred to by its name) to a value. An error is returned when the challenge has already been computed or if the name is not recorded
* `(m *Transcript) ComputeChallenge(challenge string) ([]byte, error)`: computes the challenge linked to the name. It returns an error if the previous challenge (in the order defined during the Transcript creation) is not computed.