### PR TITLE
PR to fix the non determinism of r1cs compilation

### DIFF
--- a/frontend/cs.go
+++ b/frontend/cs.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"reflect"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -179,32 +180,6 @@ func (cs *ConstraintSystem) LinearExpression(terms ...compiled.Term) compiled.Li
 	return res
 }
 
-// quickSort sorts l from lowest var ID to highest var ID.
-// There is no duplicate ID in l.
-func quickSort(l compiled.LinearExpression) compiled.LinearExpression {
-	if len(l) == 0 {
-		return nil
-	}
-	l1 := make(compiled.LinearExpression, 0, len(l))
-	l2 := make(compiled.LinearExpression, 0, len(l))
-	_, _, m, _ := l[0].Unpack()
-	for i := 1; i < len(l); i++ {
-		_, _, vID, _ := l[i].Unpack()
-		if vID < m {
-			l1 = append(l1, l[i])
-		} else {
-			l2 = append(l2, l[i])
-		}
-	}
-	l1 = quickSort(l1)
-	l2 = quickSort(l2)
-	res := make(compiled.LinearExpression, len(l))
-	copy(res, l1)
-	res[len(l1)] = l[0]
-	copy(res[len(l1)+1:], l2)
-	return res
-}
-
 // reduces redundancy in a linear expression
 func (cs *ConstraintSystem) partialReduce(linExp compiled.LinearExpression, visibility compiled.Visibility) compiled.LinearExpression {
 
@@ -244,7 +219,7 @@ func (cs *ConstraintSystem) partialReduce(linExp compiled.LinearExpression, visi
 		res = append(res, cs.makeTerm(varRecord[k], &bCoeff))
 	}
 
-	res = quickSort(res)
+	sort.Sort(res)
 
 	return res
 }

--- a/frontend/cs.go
+++ b/frontend/cs.go
@@ -206,7 +206,6 @@ func quickSort(l compiled.LinearExpression) compiled.LinearExpression {
 }
 
 // reduces redundancy in a linear expression
-// Non deterministic function
 func (cs *ConstraintSystem) partialReduce(linExp compiled.LinearExpression, visibility compiled.Visibility) compiled.LinearExpression {
 
 	if len(linExp) == 0 {

--- a/frontend/cs_test.go
+++ b/frontend/cs_test.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/consensys/gnark/internal/backend/compiled"
@@ -18,11 +19,11 @@ func TestQuickSort(t *testing.T) {
 		rand = rand % 13
 	}
 
-	sorted := quickSort(toSort)
+	sort.Sort(toSort)
 
 	for i := 0; i < 10; i++ {
-		_, _, cur, _ := sorted[i].Unpack()
-		_, _, next, _ := sorted[i+1].Unpack()
+		_, _, cur, _ := toSort[i].Unpack()
+		_, _, next, _ := toSort[i+1].Unpack()
 		if cur >= next {
 			t.Fatal("err sorting linear expression")
 		}

--- a/frontend/cs_test.go
+++ b/frontend/cs_test.go
@@ -7,6 +7,29 @@ import (
 	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
+func TestQuickSort(t *testing.T) {
+
+	toSort := make(compiled.LinearExpression, 12)
+	rand := 3
+	for i := 0; i < 12; i++ {
+		toSort[i].SetVariableVisibility(compiled.Secret)
+		toSort[i].SetVariableID(rand)
+		rand += 3
+		rand = rand % 13
+	}
+
+	sorted := quickSort(toSort)
+
+	for i := 0; i < 10; i++ {
+		_, _, cur, _ := sorted[i].Unpack()
+		_, _, next, _ := sorted[i+1].Unpack()
+		if cur >= next {
+			t.Fatal("err sorting linear expression")
+		}
+	}
+
+}
+
 func TestReduce(t *testing.T) {
 
 	cs := newConstraintSystem()

--- a/internal/backend/bls12-377/cs/r1cs_test.go
+++ b/internal/backend/bls12-377/cs/r1cs_test.go
@@ -29,9 +29,10 @@ import (
 )
 
 func TestSerialization(t *testing.T) {
-	var buffer bytes.Buffer
+
+	var buffer, buffer2 bytes.Buffer
+
 	for name, circuit := range circuits.Circuits {
-		buffer.Reset()
 
 		r1cs, err := frontend.Compile(ecc.BLS12_377, backend.GROTH16, circuit.Circuit)
 		if err != nil {
@@ -41,9 +42,17 @@ func TestSerialization(t *testing.T) {
 			continue
 		}
 
-		r1cs.SetLoggerOutput(nil) // no need to serialize.
+		// copmpile a second time to ensure determinism
+		r1cs2, err := frontend.Compile(ecc.BLS12_377, backend.GROTH16, circuit.Circuit)
+		if err != nil {
+			t.Fatal(err)
+		}
 
+		// no need to serialize.
+		r1cs.SetLoggerOutput(nil)
+		r1cs2.SetLoggerOutput(nil)
 		{
+			buffer.Reset()
 			t.Log(name)
 			var err error
 			var written, read int64
@@ -59,9 +68,48 @@ func TestSerialization(t *testing.T) {
 			if written != read {
 				t.Fatal("didn't read same number of bytes we wrote")
 			}
-			// compare both
+			// compare original and reconstructed
 			if !reflect.DeepEqual(r1cs, &reconstructed) {
 				t.Fatal("round trip serialization failed")
+			}
+		}
+
+		// ensure determinism in compilation / serialization / reconstruction
+		{
+			buffer.Reset()
+			n, err := r1cs.WriteTo(&buffer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n == 0 {
+				t.Fatal("No bytes are written")
+			}
+
+			buffer2.Reset()
+			_, err = r1cs2.WriteTo(&buffer2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
+				t.Fatal("compilation of R1CS is not deterministic")
+			}
+
+			var r, r2 cs.R1CS
+			n, err = r.ReadFrom(&buffer)
+			if err != nil {
+				t.Fatal(nil)
+			}
+			if n == 0 {
+				t.Fatal("No bytes are read")
+			}
+			_, err = r2.ReadFrom(&buffer2)
+			if err != nil {
+				t.Fatal(nil)
+			}
+
+			if !reflect.DeepEqual(r, r2) {
+				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
 			}
 		}
 	}

--- a/internal/backend/bls12-381/cs/r1cs_test.go
+++ b/internal/backend/bls12-381/cs/r1cs_test.go
@@ -29,9 +29,10 @@ import (
 )
 
 func TestSerialization(t *testing.T) {
-	var buffer bytes.Buffer
+
+	var buffer, buffer2 bytes.Buffer
+
 	for name, circuit := range circuits.Circuits {
-		buffer.Reset()
 
 		r1cs, err := frontend.Compile(ecc.BLS12_381, backend.GROTH16, circuit.Circuit)
 		if err != nil {
@@ -41,9 +42,17 @@ func TestSerialization(t *testing.T) {
 			continue
 		}
 
-		r1cs.SetLoggerOutput(nil) // no need to serialize.
+		// copmpile a second time to ensure determinism
+		r1cs2, err := frontend.Compile(ecc.BLS12_381, backend.GROTH16, circuit.Circuit)
+		if err != nil {
+			t.Fatal(err)
+		}
 
+		// no need to serialize.
+		r1cs.SetLoggerOutput(nil)
+		r1cs2.SetLoggerOutput(nil)
 		{
+			buffer.Reset()
 			t.Log(name)
 			var err error
 			var written, read int64
@@ -59,9 +68,48 @@ func TestSerialization(t *testing.T) {
 			if written != read {
 				t.Fatal("didn't read same number of bytes we wrote")
 			}
-			// compare both
+			// compare original and reconstructed
 			if !reflect.DeepEqual(r1cs, &reconstructed) {
 				t.Fatal("round trip serialization failed")
+			}
+		}
+
+		// ensure determinism in compilation / serialization / reconstruction
+		{
+			buffer.Reset()
+			n, err := r1cs.WriteTo(&buffer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n == 0 {
+				t.Fatal("No bytes are written")
+			}
+
+			buffer2.Reset()
+			_, err = r1cs2.WriteTo(&buffer2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
+				t.Fatal("compilation of R1CS is not deterministic")
+			}
+
+			var r, r2 cs.R1CS
+			n, err = r.ReadFrom(&buffer)
+			if err != nil {
+				t.Fatal(nil)
+			}
+			if n == 0 {
+				t.Fatal("No bytes are read")
+			}
+			_, err = r2.ReadFrom(&buffer2)
+			if err != nil {
+				t.Fatal(nil)
+			}
+
+			if !reflect.DeepEqual(r, r2) {
+				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
 			}
 		}
 	}

--- a/internal/backend/bw6-761/cs/r1cs_test.go
+++ b/internal/backend/bw6-761/cs/r1cs_test.go
@@ -29,9 +29,10 @@ import (
 )
 
 func TestSerialization(t *testing.T) {
-	var buffer bytes.Buffer
+
+	var buffer, buffer2 bytes.Buffer
+
 	for name, circuit := range circuits.Circuits {
-		buffer.Reset()
 
 		if testing.Short() && name != "reference_small" {
 			continue
@@ -45,9 +46,17 @@ func TestSerialization(t *testing.T) {
 			continue
 		}
 
-		r1cs.SetLoggerOutput(nil) // no need to serialize.
+		// copmpile a second time to ensure determinism
+		r1cs2, err := frontend.Compile(ecc.BW6_761, backend.GROTH16, circuit.Circuit)
+		if err != nil {
+			t.Fatal(err)
+		}
 
+		// no need to serialize.
+		r1cs.SetLoggerOutput(nil)
+		r1cs2.SetLoggerOutput(nil)
 		{
+			buffer.Reset()
 			t.Log(name)
 			var err error
 			var written, read int64
@@ -63,9 +72,48 @@ func TestSerialization(t *testing.T) {
 			if written != read {
 				t.Fatal("didn't read same number of bytes we wrote")
 			}
-			// compare both
+			// compare original and reconstructed
 			if !reflect.DeepEqual(r1cs, &reconstructed) {
 				t.Fatal("round trip serialization failed")
+			}
+		}
+
+		// ensure determinism in compilation / serialization / reconstruction
+		{
+			buffer.Reset()
+			n, err := r1cs.WriteTo(&buffer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n == 0 {
+				t.Fatal("No bytes are written")
+			}
+
+			buffer2.Reset()
+			_, err = r1cs2.WriteTo(&buffer2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
+				t.Fatal("compilation of R1CS is not deterministic")
+			}
+
+			var r, r2 cs.R1CS
+			n, err = r.ReadFrom(&buffer)
+			if err != nil {
+				t.Fatal(nil)
+			}
+			if n == 0 {
+				t.Fatal("No bytes are read")
+			}
+			_, err = r2.ReadFrom(&buffer2)
+			if err != nil {
+				t.Fatal(nil)
+			}
+
+			if !reflect.DeepEqual(r, r2) {
+				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
 			}
 		}
 	}

--- a/internal/backend/circuits/determinism.go
+++ b/internal/backend/circuits/determinism.go
@@ -1,0 +1,50 @@
+package circuits
+
+import (
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+)
+
+type determinism struct {
+	X [5]frontend.Variable
+	Z frontend.Variable `gnark:",public"`
+}
+
+func (circuit *determinism) Define(curveID ecc.ID, cs *frontend.ConstraintSystem) error {
+	a := cs.Add(circuit.X[0],
+		circuit.X[0],
+		circuit.X[1],
+		circuit.X[1],
+		circuit.X[2],
+		circuit.X[2],
+		circuit.X[3],
+		circuit.X[3],
+		circuit.X[4],
+		circuit.X[4],
+	)
+	b := cs.Mul(a, a)
+	cs.AssertIsEqual(b, circuit.Z)
+	return nil
+}
+
+func init() {
+	var circuit, good, bad, public determinism
+
+	good.X[0].Assign(1)
+	good.X[1].Assign(2)
+	good.X[2].Assign(3)
+	good.X[3].Assign(4)
+	good.X[4].Assign(5)
+	good.Z.Assign(900)
+
+	bad.X[0].Assign(1)
+	bad.X[1].Assign(1)
+	bad.X[2].Assign(1)
+	bad.X[3].Assign(1)
+	bad.X[4].Assign(1)
+	bad.Z.Assign(900)
+
+	public.Z.Assign(900)
+
+	addEntry("determinism", &circuit, &good, &bad, &public)
+}

--- a/internal/backend/compiled/r1c.go
+++ b/internal/backend/compiled/r1c.go
@@ -24,6 +24,23 @@ func (l LinearExpression) Clone() LinearExpression {
 	return res
 }
 
+// Len return the lenght of the LinearExpression (implements Sort interface)
+func (l LinearExpression) Len() int {
+	return len(l)
+}
+
+// Swap swaps terms in the LinearExpression (implements Sort interface)
+func (l LinearExpression) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+// Less returns true if variableID for term at i is less than variableID for term at j (implements Sort interface)
+func (l LinearExpression) Less(i, j int) bool {
+	_, _, iID, _ := l[i].Unpack()
+	_, _, jID, _ := l[j].Unpack()
+	return iID < jID
+}
+
 // R1C used to compute the wires
 type R1C struct {
 	L      LinearExpression

--- a/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
@@ -10,18 +10,20 @@ import (
 
 	{{ template "import_backend_cs" . }}
 )
+
 func TestSerialization(t *testing.T) {
-	var buffer bytes.Buffer
+	
+	var buffer, buffer2 bytes.Buffer
+	
 	for name, circuit := range circuits.Circuits {
-		buffer.Reset()
 
 		{{if eq .Curve "BW6-761"}}
 			if testing.Short() && name != "reference_small" {
 				continue
 			}
 		{{end}}
-	
-		r1cs, err := frontend.Compile(ecc.{{.CurveID}}, backend.GROTH16, circuit.Circuit)
+
+		r1cs, err := frontend.Compile(ecc.{{ .CurveID }}, backend.GROTH16, circuit.Circuit)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -29,9 +31,17 @@ func TestSerialization(t *testing.T) {
 			continue
 		}
 
-		r1cs.SetLoggerOutput(nil) // no need to serialize.
+		// copmpile a second time to ensure determinism
+		r1cs2, err := frontend.Compile(ecc.{{ .CurveID }}, backend.GROTH16, circuit.Circuit)
+		if err != nil {
+			t.Fatal(err)
+		}
 
+		// no need to serialize.
+		r1cs.SetLoggerOutput(nil)
+		r1cs2.SetLoggerOutput(nil)
 		{
+			buffer.Reset()
 			t.Log(name)
 			var err error
 			var written, read int64
@@ -40,16 +50,55 @@ func TestSerialization(t *testing.T) {
 				t.Fatal(err)
 			}
 			var reconstructed cs.R1CS
-			read , err = reconstructed.ReadFrom(&buffer)
+			read, err = reconstructed.ReadFrom(&buffer)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if written != read {
 				t.Fatal("didn't read same number of bytes we wrote")
 			}
-			// compare both
+			// compare original and reconstructed
 			if !reflect.DeepEqual(r1cs, &reconstructed) {
 				t.Fatal("round trip serialization failed")
+			}
+		}
+
+		// ensure determinism in compilation / serialization / reconstruction
+		{
+			buffer.Reset()
+			n, err := r1cs.WriteTo(&buffer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n == 0 {
+				t.Fatal("No bytes are written")
+			}
+
+			buffer2.Reset()
+			_, err = r1cs2.WriteTo(&buffer2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
+				t.Fatal("compilation of R1CS is not deterministic")
+			}
+
+			var r, r2 cs.R1CS
+			n, err = r.ReadFrom(&buffer)
+			if err != nil {
+				t.Fatal(nil)
+			}
+			if n == 0 {
+				t.Fatal("No bytes are read")
+			}
+			_, err = r2.ReadFrom(&buffer2)
+			if err != nil {
+				t.Fatal(nil)
+			}
+
+			if !reflect.DeepEqual(r, r2) {
+				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
 			}
 		}
 	}


### PR DESCRIPTION
This PR makes the compilation to r1cs deterministic. 

Non determinism came from the `reduce` function in frontend/cs.go. The function has been made deterministic by sorting the variables ID in the reduced linear expression.

 A specific test circuit has been added to trig non determinism when the the variables are not sorted in `reduce`.