### PR TITLE
Fix/reduce constraints eddsa

### DIFF
--- a/examples/rollup/operator.go
+++ b/examples/rollup/operator.go
@@ -175,8 +175,7 @@ func (o *Operator) updateState(t Transfer, numTransfer int) error {
 	o.witnesses.Transfers[numTransfer].Amount.Assign(t.amount)
 	o.witnesses.Transfers[numTransfer].Signature.R.X.Assign(t.signature.R.X)
 	o.witnesses.Transfers[numTransfer].Signature.R.Y.Assign(t.signature.R.Y)
-	o.witnesses.Transfers[numTransfer].Signature.S1.Assign(t.signature.S[:16])
-	o.witnesses.Transfers[numTransfer].Signature.S2.Assign(t.signature.S[16:])
+	o.witnesses.Transfers[numTransfer].Signature.S.Assign(t.signature.S[:])
 
 	// verifying the signature. The msg is the hash (o.h) of the transfer
 	// nonce || amount || senderpubKey(x&y) || receiverPubkey(x&y)

--- a/std/signature/eddsa/eddsa.go
+++ b/std/signature/eddsa/eddsa.go
@@ -61,17 +61,17 @@ func Verify(cs *frontend.ConstraintSystem, sig Signature, msg frontend.Variable,
 	//hramConstant := hash.Sum(data...)
 	hramConstant := hash.Sum()
 
-	// lhs = cofactor*SB
+	// lhs = [S]G
 	cofactor := pubKey.Curve.Cofactor.Uint64()
 	lhs := twistededwards.Point{}
-
-	// rhs = [S]G
 	lhs.ScalarMulFixedBase(cs, pubKey.Curve.BaseX, pubKey.Curve.BaseY, sig.S, pubKey.Curve)
+	lhs.MustBeOnCurve(cs, pubKey.Curve)
 
-	// lhs = R+[H(R,A,M)]*A
+	// rhs = R+[H(R,A,M)]*A
 	rhs := twistededwards.Point{}
 	rhs.ScalarMulNonFixedBase(cs, &pubKey.A, hramConstant, pubKey.Curve).
 		AddGeneric(cs, &rhs, &sig.R, pubKey.Curve)
+	rhs.MustBeOnCurve(cs, pubKey.Curve)
 
 	// lhs-rhs
 	rhs.Neg(cs, &rhs).AddGeneric(cs, &lhs, &rhs, pubKey.Curve)

--- a/std/signature/eddsa/eddsa.go
+++ b/std/signature/eddsa/eddsa.go
@@ -31,12 +31,11 @@ type PublicKey struct {
 
 // Signature stores a signature  (to be used in gnark circuit)
 // An EdDSA signature is a tuple (R,S) where R is a point on the twisted Edwards curve
-// and S a scalar. S can be greater than r, the size of the zk snark field, and must
-// not be reduced modulo r. Therefore it is split in S1 and S2, such that if r is n-bits long,
-// S = 2^(n/2)*S1 + S2. In other words, S is written S1S2 in basis 2^(n/2).
+// and S a scalar. Since the base field of the twisted Edwards is Fr, the number of points
+// N on the Edwards is < r+1+2sqrt(r). The subgroup l used in eddsa is <1/2N, so the reduction
+// mod l ensures S < r, therefore there is no risk of overflow.
 type Signature struct {
 	R twistededwards.Point
-	//S1, S2 frontend.Variable
 	S frontend.Variable
 }
 

--- a/std/signature/eddsa/eddsa_test.go
+++ b/std/signature/eddsa/eddsa_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package eddsa
 
 import (
-	"fmt"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -198,8 +197,6 @@ func TestEddsa(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		fmt.Printf("ID: %s, c = %d\n", id.String(), r1cs.GetNbConstraints())
 
 		// verification with the correct Message
 		{

--- a/std/signature/eddsa/eddsa_test.go
+++ b/std/signature/eddsa/eddsa_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package eddsa
 
 import (
+	"fmt"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -46,7 +47,8 @@ type eddsaCircuit struct {
 	Message   frontend.Variable `gnark:",public"`
 }
 
-func parseSignature(id ecc.ID, buf []byte) ([]byte, []byte, []byte, []byte) {
+//func parseSignature(id ecc.ID, buf []byte) ([]byte, []byte, []byte) {
+func parseSignature(id ecc.ID, buf []byte) ([]byte, []byte, []byte) {
 
 	var pointbn254 edwardsbn254.PointAffine
 	var pointbls12381 edwardsbls12381.PointAffine
@@ -58,35 +60,30 @@ func parseSignature(id ecc.ID, buf []byte) ([]byte, []byte, []byte, []byte) {
 	case ecc.BN254:
 		pointbn254.SetBytes(buf[:32])
 		a, b := parsePoint(id, buf)
-		s1 := buf[32:48] // r is 256 bits, so s = 2^128*s1 + s2
-		s2 := buf[48:]
-		return a[:], b[:], s1, s2
+		s := buf[32:]
+		return a[:], b[:], s
 	case ecc.BLS12_381:
 		pointbls12381.SetBytes(buf[:32])
 		a, b := parsePoint(id, buf)
-		s1 := buf[32:48]
-		s2 := buf[48:]
-		return a[:], b[:], s1, s2
+		s := buf[32:]
+		return a[:], b[:], s
 	case ecc.BLS12_377:
 		pointbls12377.SetBytes(buf[:32])
 		a, b := parsePoint(id, buf)
-		s1 := buf[32:48]
-		s2 := buf[48:]
-		return a[:], b[:], s1, s2
+		s := buf[32:]
+		return a[:], b[:], s
 	case ecc.BW6_761:
-		pointbw6761.SetBytes(buf[:48]) // r is 384 bits, so s = 2^192*s1 + s2
+		pointbw6761.SetBytes(buf[:48])
 		a, b := parsePoint(id, buf)
-		s1 := buf[48:72]
-		s2 := buf[72:]
-		return a[:], b[:], s1, s2
+		s := buf[48:]
+		return a[:], b[:], s
 	case ecc.BLS24_315:
 		pointbls24315.SetBytes(buf[:32])
 		a, b := parsePoint(id, buf)
-		s1 := buf[32:48]
-		s2 := buf[48:]
-		return a[:], b[:], s1, s2
+		s := buf[32:]
+		return a[:], b[:], s
 	default:
-		return buf, buf, buf, buf
+		return buf, buf, buf
 	}
 }
 
@@ -202,6 +199,8 @@ func TestEddsa(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		fmt.Printf("ID: %s, c = %d\n", id.String(), r1cs.GetNbConstraints())
+
 		// verification with the correct Message
 		{
 			var witness eddsaCircuit
@@ -214,11 +213,13 @@ func TestEddsa(t *testing.T) {
 			witness.PublicKey.A.X.Assign(pubkeyAx)
 			witness.PublicKey.A.Y.Assign(pubkeyAy)
 
-			sigRx, sigRy, sigS1, sigS2 := parseSignature(id, signature)
+			// sigRx, sigRy, sigS1, sigS2 := parseSignature(id, signature)
+			sigRx, sigRy, sigS := parseSignature(id, signature)
 			witness.Signature.R.X.Assign(sigRx)
 			witness.Signature.R.Y.Assign(sigRy)
-			witness.Signature.S1.Assign(sigS1)
-			witness.Signature.S2.Assign(sigS2)
+			// witness.Signature.S1.Assign(sigS1)
+			// witness.Signature.S2.Assign(sigS2)
+			witness.Signature.S.Assign(sigS)
 
 			assert.SolvingSucceeded(r1cs, &witness)
 		}
@@ -232,11 +233,11 @@ func TestEddsa(t *testing.T) {
 			witness.PublicKey.A.X.Assign(pubkeyAx)
 			witness.PublicKey.A.Y.Assign(pubkeyAy)
 
-			sigRx, sigRy, sigS1, sigS2 := parseSignature(id, signature)
+			// sigRx, sigRy, sigS1, sigS2 := parseSignature(id, signature)
+			sigRx, sigRy, sigS := parseSignature(id, signature)
 			witness.Signature.R.X.Assign(sigRx)
 			witness.Signature.R.Y.Assign(sigRy)
-			witness.Signature.S1.Assign(sigS1)
-			witness.Signature.S2.Assign(sigS2)
+			witness.Signature.S.Assign(sigS)
 
 			assert.SolvingFailed(r1cs, &witness)
 		}


### PR DESCRIPTION
This PR removes the splitting of S in S1+2^bS2 in the EDDSA snark circuit.

- Breaking changes:
```
type Signature struct {
	R twistededwards.Point
	S1, S2 frontend.Variable // S1+2^b S2 = S
}
```
-->
```
type Signature struct {
	R twistededwards.Point
	S frontend.Variable
}
```

The splitting was due to an earlier version of gnark-crypto where S was reduced modulo the number of points of the twisted Edwards instead of the group order of the base point.

A twisted Edwards on Z/rZ has at most N=r+2*sqrt(r)+3 points  because there are 2 points of multiplicity 2. The group that is used for eddsa contains at most N/2 points because there is a point of order 2 on the twisted Edwards. Therefore l<r.