### PR TITLE
groth16: filter points at infinity in setup

### DIFF
--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -181,8 +181,10 @@ func ReadAndVerify(proof Proof, vk VerifyingKey, publicWitness io.Reader) error 
 
 // Prove runs the groth16.Prove algorithm.
 //
-// If force flag is set, executes all the prover computations, even if the witness is invalid
-// (in which case it will produce an invalid proof)
+// if the force flag is set:
+// 	will executes all the prover computations, even if the witness is invalid
+//  will produce an invalid proof
+//	internally, the solution vector to the R1CS will be filled with random values which may impact benchmarking
 func Prove(r1cs frontend.CompiledConstraintSystem, pk ProvingKey, witness frontend.Circuit, force ...bool) (Proof, error) {
 
 	_force := false

--- a/frontend/cs.go
+++ b/frontend/cs.go
@@ -151,6 +151,7 @@ func newR1C(l, r, o Variable, s ...compiled.SolvingMethod) compiled.R1C {
 	if len(s) > 0 {
 		solver = s[0]
 	}
+
 	return compiled.R1C{L: l.linExp.Clone(), R: r.linExp.Clone(), O: o.linExp.Clone(), Solver: solver}
 }
 

--- a/frontend/cs.go
+++ b/frontend/cs.go
@@ -152,6 +152,16 @@ func newR1C(l, r, o Variable, s ...compiled.SolvingMethod) compiled.R1C {
 		solver = s[0]
 	}
 
+	// interestingly, this is key to groth16 performance.
+	// l * r == r * l == o
+	// but the "l" linear expression is going to end up in the A matrix
+	// the "r" linear expression is going to end up in the B matrix
+	// the less variable we have appearing in the B matrix, the more likely groth16.Setup
+	// is going to produce infinity points in pk.G1.B and pk.G2.B, which will speed up proving time
+	if len(l.linExp) > len(r.linExp) {
+		l, r = r, l
+	}
+
 	return compiled.R1C{L: l.linExp.Clone(), R: r.linExp.Clone(), O: o.linExp.Clone(), Solver: solver}
 }
 

--- a/frontend/cs.go
+++ b/frontend/cs.go
@@ -158,7 +158,7 @@ func newR1C(l, r, o Variable, s ...compiled.SolvingMethod) compiled.R1C {
 	// the "r" linear expression is going to end up in the B matrix
 	// the less variable we have appearing in the B matrix, the more likely groth16.Setup
 	// is going to produce infinity points in pk.G1.B and pk.G2.B, which will speed up proving time
-	if len(l.linExp) > len(r.linExp) {
+	if solver == compiled.SingleOutput && len(l.linExp) > len(r.linExp) {
 		l, r = r, l
 	}
 

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -224,7 +224,7 @@ func (cs *ConstraintSystem) Div(i1, i2 interface{}) Variable {
 			cs.constraints = append(cs.constraints, newR1C(t2, res, t1))
 		default:
 			tmp := cs.Constant(t2)
-			cs.constraints = append(cs.constraints, newR1C(tmp, res, t1))
+			cs.constraints = append(cs.constraints, newR1C(res, tmp, t1))
 		}
 	default:
 		switch t2 := i2.(type) {
@@ -235,7 +235,7 @@ func (cs *ConstraintSystem) Div(i1, i2 interface{}) Variable {
 		default:
 			tmp1 := cs.Constant(t1)
 			tmp2 := cs.Constant(t2)
-			cs.constraints = append(cs.constraints, newR1C(tmp2, res, tmp1))
+			cs.constraints = append(cs.constraints, newR1C(res, tmp2, tmp1))
 		}
 	}
 
@@ -402,7 +402,7 @@ func (cs *ConstraintSystem) Select(b Variable, i1, i2 interface{}) Variable {
 		v := cs.Sub(t1, i2)  // no constraint is recorded
 		w := cs.Sub(res, i2) // no constraint is recorded
 		//cs.Println("u-v: ", v)
-		cs.constraints = append(cs.constraints, newR1C(b, v, w))
+		cs.constraints = append(cs.constraints, newR1C(v, b, w))
 		return res
 	default:
 		switch t2 := i2.(type) {
@@ -411,7 +411,7 @@ func (cs *ConstraintSystem) Select(b Variable, i1, i2 interface{}) Variable {
 			res = cs.newInternalVariable()
 			v := cs.Sub(t1, t2)  // no constraint is recorded
 			w := cs.Sub(res, t2) // no constraint is recorded
-			cs.constraints = append(cs.constraints, newR1C(b, v, w))
+			cs.constraints = append(cs.constraints, newR1C(v, b, w))
 			return res
 		default:
 			// in this case, no constraint is recorded
@@ -531,7 +531,7 @@ func (cs *ConstraintSystem) markBoolean(v Variable) bool {
 	return true
 }
 
-// AssertIsBoolean adds an assertion in the constraint system (v == 0 || v == 1)
+// AssertIsBoolean adds an assertion in the constraint system (v == 0 || v == 1)
 func (cs *ConstraintSystem) AssertIsBoolean(v Variable) {
 
 	v.assertIsSet()
@@ -539,6 +539,8 @@ func (cs *ConstraintSystem) AssertIsBoolean(v Variable) {
 	if !cs.markBoolean(v) {
 		return // variable is already constrained
 	}
+
+	// ensure v * (1 - v) == 0
 
 	_v := cs.Sub(1, v)  // no variable is recorded in the cs
 	o := cs.Constant(0) // no variable is recorded in the cs

--- a/internal/backend/bls12-377/groth16/prove.go
+++ b/internal/backend/bls12-377/groth16/prove.go
@@ -70,7 +70,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, forc
 		} else {
 			// we need to fill wireValues with random values else multi exps don't do much
 			var r fr.Element
-			r.SetRandom()
+			_, _ = r.SetRandom()
 			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
 				wireValues[i] = r
 				r.Double(&r)

--- a/internal/backend/bls12-377/groth16/prove.go
+++ b/internal/backend/bls12-377/groth16/prove.go
@@ -86,6 +86,25 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, forc
 		chHDone <- struct{}{}
 	}()
 
+	// we need to copy and filter the wireValues for each multi exp
+	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
+	wireValuesA := make([]fr.Element, len(wireValues)-pk.NbInfinityA)
+	wireValuesB := make([]fr.Element, len(wireValues)-pk.NbInfinityB)
+	for i, j := 0, 0; j < len(wireValuesA); i++ {
+		if pk.InfinityA[i] {
+			continue
+		}
+		wireValuesA[j] = wireValues[i]
+		j++
+	}
+	for i, j := 0, 0; j < len(wireValuesB); i++ {
+		if pk.InfinityB[i] {
+			continue
+		}
+		wireValuesB[j] = wireValues[i]
+		j++
+	}
+
 	// sample random r and s
 	var r, s big.Int
 	var _r, _s, _kr fr.Element
@@ -113,7 +132,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, forc
 
 	chBs1Done := make(chan error, 1)
 	computeBS1 := func() {
-		if _, err := bs1.MultiExp(pk.G1.B, wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chBs1Done <- err
 			close(chBs1Done)
 			return
@@ -125,7 +144,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, forc
 
 	chArDone := make(chan error, 1)
 	computeAR1 := func() {
-		if _, err := ar.MultiExp(pk.G1.A, wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chArDone <- err
 			close(chArDone)
 			return
@@ -192,7 +211,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, forc
 			// if we don't have a lot of CPUs, this may artificially split the MSM
 			nbTasks *= 2
 		}
-		if _, err := Bs.MultiExp(pk.G2.B, wireValues, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
+		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
 			return err
 		}
 

--- a/internal/backend/bls12-377/groth16/prove.go
+++ b/internal/backend/bls12-377/groth16/prove.go
@@ -88,22 +88,31 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, forc
 
 	// we need to copy and filter the wireValues for each multi exp
 	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
-	wireValuesA := make([]fr.Element, len(wireValues)-pk.NbInfinityA)
-	wireValuesB := make([]fr.Element, len(wireValues)-pk.NbInfinityB)
-	for i, j := 0, 0; j < len(wireValuesA); i++ {
-		if pk.InfinityA[i] {
-			continue
+	var wireValuesA, wireValuesB []fr.Element
+	chWireValuesA, chWireValuesB := make(chan struct{}, 1), make(chan struct{}, 1)
+
+	go func() {
+		wireValuesA = make([]fr.Element, len(wireValues)-pk.NbInfinityA)
+		for i, j := 0, 0; j < len(wireValuesA); i++ {
+			if pk.InfinityA[i] {
+				continue
+			}
+			wireValuesA[j] = wireValues[i]
+			j++
 		}
-		wireValuesA[j] = wireValues[i]
-		j++
-	}
-	for i, j := 0, 0; j < len(wireValuesB); i++ {
-		if pk.InfinityB[i] {
-			continue
+		close(chWireValuesA)
+	}()
+	go func() {
+		wireValuesB = make([]fr.Element, len(wireValues)-pk.NbInfinityB)
+		for i, j := 0, 0; j < len(wireValuesB); i++ {
+			if pk.InfinityB[i] {
+				continue
+			}
+			wireValuesB[j] = wireValues[i]
+			j++
 		}
-		wireValuesB[j] = wireValues[i]
-		j++
-	}
+		close(chWireValuesB)
+	}()
 
 	// sample random r and s
 	var r, s big.Int
@@ -132,6 +141,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, forc
 
 	chBs1Done := make(chan error, 1)
 	computeBS1 := func() {
+		<-chWireValuesB
 		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chBs1Done <- err
 			close(chBs1Done)
@@ -144,6 +154,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, forc
 
 	chArDone := make(chan error, 1)
 	computeAR1 := func() {
+		<-chWireValuesA
 		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chArDone <- err
 			close(chArDone)
@@ -211,6 +222,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, forc
 			// if we don't have a lot of CPUs, this may artificially split the MSM
 			nbTasks *= 2
 		}
+		<-chWireValuesB
 		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
 			return err
 		}

--- a/internal/backend/bls12-377/groth16/setup.go
+++ b/internal/backend/bls12-377/groth16/setup.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/consensys/gnark/internal/backend/bls12-377/cs"
 
-	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/fft"
 	"math/big"
@@ -198,8 +197,6 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 	B = B[:n]
 	pk.NbInfinityB = nbWires - n
-
-	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 
 	// compute our batch scalar multiplication with g1 elements
 	g1Scalars := make([]fr.Element, 0, (nbWires*3)+int(domain.Cardinality)+3)

--- a/internal/backend/bls12-377/groth16/setup.go
+++ b/internal/backend/bls12-377/groth16/setup.go
@@ -417,6 +417,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
 	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
+	// set infinity markers
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+	for i := 0; i < nbZeroesA; i++ {
+		pk.InfinityA[i] = true
+	}
+	for i := 0; i < nbZeroesB; i++ {
+		pk.InfinityB[i] = true
+	}
+
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
 	if err != nil {

--- a/internal/backend/bls12-377/groth16/setup.go
+++ b/internal/backend/bls12-377/groth16/setup.go
@@ -420,6 +420,8 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// set infinity markers
 	pk.InfinityA = make([]bool, nbWires)
 	pk.InfinityB = make([]bool, nbWires)
+	pk.NbInfinityA = nbZeroesA
+	pk.NbInfinityB = nbZeroesB
 	for i := 0; i < nbZeroesA; i++ {
 		pk.InfinityA[i] = true
 	}

--- a/internal/backend/bls12-377/groth16/setup.go
+++ b/internal/backend/bls12-377/groth16/setup.go
@@ -175,36 +175,29 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// mark points at infinity and filter them
 	pk.InfinityA = make([]bool, len(A))
 	pk.InfinityB = make([]bool, len(B))
-	for i := 0; i < len(A); i++ {
-		if A[i].IsZero() {
+
+	n := 0
+	for i, e := range A {
+		if e.IsZero() {
 			pk.InfinityA[i] = true
-			pk.NbInfinityA++
+			continue
 		}
-		if B[i].IsZero() {
+		A[n] = A[i]
+		n++
+	}
+	A = A[:n]
+	pk.NbInfinityA = nbWires - n
+	n = 0
+	for i, e := range B {
+		if e.IsZero() {
 			pk.InfinityB[i] = true
-			pk.NbInfinityB++
-		}
-	}
-	// can be done in place, not sure it will help much though.
-	_A := make([]fr.Element, len(A)-pk.NbInfinityA)
-	_B := make([]fr.Element, len(B)-pk.NbInfinityB)
-
-	for i, j := 0, 0; j < len(_A); i++ {
-		if pk.InfinityA[i] {
 			continue
 		}
-		_A[j] = A[i]
-		j++
+		B[n] = B[i]
+		n++
 	}
-
-	for i, j := 0, 0; j < len(_B); i++ {
-		if pk.InfinityB[i] {
-			continue
-		}
-		_B[j] = B[i]
-		j++
-	}
-	A, B = _A, _B
+	B = B[:n]
+	pk.NbInfinityB = nbWires - n
 
 	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 

--- a/internal/backend/bls12-377/groth16/setup.go
+++ b/internal/backend/bls12-377/groth16/setup.go
@@ -406,12 +406,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// Setting group for fft
 	domain := fft.NewDomain(uint64(nbConstraints), 1, true)
 
+	// count number of infinity points we would have had we a normal setup
+	// in pk.G1.A, pk.G1.B, and pk.G2.B
+	nbZeroesA, nbZeroesB := dummyInfinityCount(r1cs)
+
 	// initialize proving key
-	pk.G1.A = make([]curve.G1Affine, nbWires)
-	pk.G1.B = make([]curve.G1Affine, nbWires)
+	pk.G1.A = make([]curve.G1Affine, nbWires-nbZeroesA)
+	pk.G1.B = make([]curve.G1Affine, nbWires-nbZeroesB)
 	pk.G1.K = make([]curve.G1Affine, nbWires-r1cs.NbPublicVariables)
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
-	pk.G2.B = make([]curve.G2Affine, nbWires)
+	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
@@ -429,9 +433,13 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r2Aff curve.G2Affine
 	r2Jac.ScalarMultiplication(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
-	for i := 0; i < int(nbWires); i++ {
+	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff
+	}
+	for i := 0; i < len(pk.G1.B); i++ {
 		pk.G1.B[i] = r1Aff
+	}
+	for i := 0; i < len(pk.G2.B); i++ {
 		pk.G2.B[i] = r2Aff
 	}
 	for i := 0; i < len(pk.G1.Z); i++ {
@@ -449,6 +457,34 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.Domain = *domain
 
 	return nil
+}
+
+// dummyInfinityCount helps us simulate the number of infinity points we have with the given R1CS
+// in A and B as it directly impacts prover performance
+func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
+
+	nbWires := r1cs.NbInternalVariables + r1cs.NbPublicVariables + r1cs.NbSecretVariables
+
+	A := make([]bool, nbWires)
+	B := make([]bool, nbWires)
+	for _, c := range r1cs.Constraints {
+		for _, t := range c.L {
+			A[t.VariableID()] = true
+		}
+		for _, t := range c.R {
+			B[t.VariableID()] = true
+		}
+	}
+	for i := 0; i < nbWires; i++ {
+		if !A[i] {
+			nbZeroesA++
+		}
+		if !B[i] {
+			nbZeroesB++
+		}
+	}
+	return
+
 }
 
 // IsDifferent returns true if provided vk is different than self

--- a/internal/backend/bls12-381/groth16/prove.go
+++ b/internal/backend/bls12-381/groth16/prove.go
@@ -88,22 +88,31 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, forc
 
 	// we need to copy and filter the wireValues for each multi exp
 	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
-	wireValuesA := make([]fr.Element, len(wireValues)-pk.NbInfinityA)
-	wireValuesB := make([]fr.Element, len(wireValues)-pk.NbInfinityB)
-	for i, j := 0, 0; j < len(wireValuesA); i++ {
-		if pk.InfinityA[i] {
-			continue
+	var wireValuesA, wireValuesB []fr.Element
+	chWireValuesA, chWireValuesB := make(chan struct{}, 1), make(chan struct{}, 1)
+
+	go func() {
+		wireValuesA = make([]fr.Element, len(wireValues)-pk.NbInfinityA)
+		for i, j := 0, 0; j < len(wireValuesA); i++ {
+			if pk.InfinityA[i] {
+				continue
+			}
+			wireValuesA[j] = wireValues[i]
+			j++
 		}
-		wireValuesA[j] = wireValues[i]
-		j++
-	}
-	for i, j := 0, 0; j < len(wireValuesB); i++ {
-		if pk.InfinityB[i] {
-			continue
+		close(chWireValuesA)
+	}()
+	go func() {
+		wireValuesB = make([]fr.Element, len(wireValues)-pk.NbInfinityB)
+		for i, j := 0, 0; j < len(wireValuesB); i++ {
+			if pk.InfinityB[i] {
+				continue
+			}
+			wireValuesB[j] = wireValues[i]
+			j++
 		}
-		wireValuesB[j] = wireValues[i]
-		j++
-	}
+		close(chWireValuesB)
+	}()
 
 	// sample random r and s
 	var r, s big.Int
@@ -132,6 +141,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, forc
 
 	chBs1Done := make(chan error, 1)
 	computeBS1 := func() {
+		<-chWireValuesB
 		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chBs1Done <- err
 			close(chBs1Done)
@@ -144,6 +154,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, forc
 
 	chArDone := make(chan error, 1)
 	computeAR1 := func() {
+		<-chWireValuesA
 		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chArDone <- err
 			close(chArDone)
@@ -211,6 +222,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, forc
 			// if we don't have a lot of CPUs, this may artificially split the MSM
 			nbTasks *= 2
 		}
+		<-chWireValuesB
 		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
 			return err
 		}

--- a/internal/backend/bls12-381/groth16/prove.go
+++ b/internal/backend/bls12-381/groth16/prove.go
@@ -64,8 +64,18 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, forc
 	b := make([]fr.Element, r1cs.NbConstraints, pk.Domain.Cardinality)
 	c := make([]fr.Element, r1cs.NbConstraints, pk.Domain.Cardinality)
 	wireValues := make([]fr.Element, r1cs.NbInternalVariables+r1cs.NbPublicVariables+r1cs.NbSecretVariables)
-	if err := r1cs.Solve(witness, a, b, c, wireValues); err != nil && !force {
-		return nil, err
+	if err := r1cs.Solve(witness, a, b, c, wireValues); err != nil {
+		if !force {
+			return nil, err
+		} else {
+			// we need to fill wireValues with random values else multi exps don't do much
+			var r fr.Element
+			r.SetRandom()
+			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
+				wireValues[i] = r
+				r.Double(&r)
+			}
+		}
 	}
 
 	// set the wire values in regular form

--- a/internal/backend/bls12-381/groth16/prove.go
+++ b/internal/backend/bls12-381/groth16/prove.go
@@ -86,6 +86,25 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, forc
 		chHDone <- struct{}{}
 	}()
 
+	// we need to copy and filter the wireValues for each multi exp
+	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
+	wireValuesA := make([]fr.Element, len(wireValues)-pk.NbInfinityA)
+	wireValuesB := make([]fr.Element, len(wireValues)-pk.NbInfinityB)
+	for i, j := 0, 0; j < len(wireValuesA); i++ {
+		if pk.InfinityA[i] {
+			continue
+		}
+		wireValuesA[j] = wireValues[i]
+		j++
+	}
+	for i, j := 0, 0; j < len(wireValuesB); i++ {
+		if pk.InfinityB[i] {
+			continue
+		}
+		wireValuesB[j] = wireValues[i]
+		j++
+	}
+
 	// sample random r and s
 	var r, s big.Int
 	var _r, _s, _kr fr.Element
@@ -113,7 +132,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, forc
 
 	chBs1Done := make(chan error, 1)
 	computeBS1 := func() {
-		if _, err := bs1.MultiExp(pk.G1.B, wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chBs1Done <- err
 			close(chBs1Done)
 			return
@@ -125,7 +144,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, forc
 
 	chArDone := make(chan error, 1)
 	computeAR1 := func() {
-		if _, err := ar.MultiExp(pk.G1.A, wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chArDone <- err
 			close(chArDone)
 			return
@@ -192,7 +211,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, forc
 			// if we don't have a lot of CPUs, this may artificially split the MSM
 			nbTasks *= 2
 		}
-		if _, err := Bs.MultiExp(pk.G2.B, wireValues, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
+		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
 			return err
 		}
 

--- a/internal/backend/bls12-381/groth16/prove.go
+++ b/internal/backend/bls12-381/groth16/prove.go
@@ -70,7 +70,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, forc
 		} else {
 			// we need to fill wireValues with random values else multi exps don't do much
 			var r fr.Element
-			r.SetRandom()
+			_, _ = r.SetRandom()
 			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
 				wireValues[i] = r
 				r.Double(&r)

--- a/internal/backend/bls12-381/groth16/setup.go
+++ b/internal/backend/bls12-381/groth16/setup.go
@@ -417,6 +417,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
 	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
+	// set infinity markers
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+	for i := 0; i < nbZeroesA; i++ {
+		pk.InfinityA[i] = true
+	}
+	for i := 0; i < nbZeroesB; i++ {
+		pk.InfinityB[i] = true
+	}
+
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
 	if err != nil {

--- a/internal/backend/bls12-381/groth16/setup.go
+++ b/internal/backend/bls12-381/groth16/setup.go
@@ -420,6 +420,8 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// set infinity markers
 	pk.InfinityA = make([]bool, nbWires)
 	pk.InfinityB = make([]bool, nbWires)
+	pk.NbInfinityA = nbZeroesA
+	pk.NbInfinityB = nbZeroesB
 	for i := 0; i < nbZeroesA; i++ {
 		pk.InfinityA[i] = true
 	}

--- a/internal/backend/bls12-381/groth16/setup.go
+++ b/internal/backend/bls12-381/groth16/setup.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/consensys/gnark/internal/backend/bls12-381/cs"
 
-	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/fft"
 	"math/big"
@@ -198,8 +197,6 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 	B = B[:n]
 	pk.NbInfinityB = nbWires - n
-
-	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 
 	// compute our batch scalar multiplication with g1 elements
 	g1Scalars := make([]fr.Element, 0, (nbWires*3)+int(domain.Cardinality)+3)

--- a/internal/backend/bls12-381/groth16/setup.go
+++ b/internal/backend/bls12-381/groth16/setup.go
@@ -175,36 +175,29 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// mark points at infinity and filter them
 	pk.InfinityA = make([]bool, len(A))
 	pk.InfinityB = make([]bool, len(B))
-	for i := 0; i < len(A); i++ {
-		if A[i].IsZero() {
+
+	n := 0
+	for i, e := range A {
+		if e.IsZero() {
 			pk.InfinityA[i] = true
-			pk.NbInfinityA++
+			continue
 		}
-		if B[i].IsZero() {
+		A[n] = A[i]
+		n++
+	}
+	A = A[:n]
+	pk.NbInfinityA = nbWires - n
+	n = 0
+	for i, e := range B {
+		if e.IsZero() {
 			pk.InfinityB[i] = true
-			pk.NbInfinityB++
-		}
-	}
-	// can be done in place, not sure it will help much though.
-	_A := make([]fr.Element, len(A)-pk.NbInfinityA)
-	_B := make([]fr.Element, len(B)-pk.NbInfinityB)
-
-	for i, j := 0, 0; j < len(_A); i++ {
-		if pk.InfinityA[i] {
 			continue
 		}
-		_A[j] = A[i]
-		j++
+		B[n] = B[i]
+		n++
 	}
-
-	for i, j := 0, 0; j < len(_B); i++ {
-		if pk.InfinityB[i] {
-			continue
-		}
-		_B[j] = B[i]
-		j++
-	}
-	A, B = _A, _B
+	B = B[:n]
+	pk.NbInfinityB = nbWires - n
 
 	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 

--- a/internal/backend/bls12-381/groth16/setup.go
+++ b/internal/backend/bls12-381/groth16/setup.go
@@ -406,12 +406,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// Setting group for fft
 	domain := fft.NewDomain(uint64(nbConstraints), 1, true)
 
+	// count number of infinity points we would have had we a normal setup
+	// in pk.G1.A, pk.G1.B, and pk.G2.B
+	nbZeroesA, nbZeroesB := dummyInfinityCount(r1cs)
+
 	// initialize proving key
-	pk.G1.A = make([]curve.G1Affine, nbWires)
-	pk.G1.B = make([]curve.G1Affine, nbWires)
+	pk.G1.A = make([]curve.G1Affine, nbWires-nbZeroesA)
+	pk.G1.B = make([]curve.G1Affine, nbWires-nbZeroesB)
 	pk.G1.K = make([]curve.G1Affine, nbWires-r1cs.NbPublicVariables)
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
-	pk.G2.B = make([]curve.G2Affine, nbWires)
+	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
@@ -429,9 +433,13 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r2Aff curve.G2Affine
 	r2Jac.ScalarMultiplication(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
-	for i := 0; i < int(nbWires); i++ {
+	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff
+	}
+	for i := 0; i < len(pk.G1.B); i++ {
 		pk.G1.B[i] = r1Aff
+	}
+	for i := 0; i < len(pk.G2.B); i++ {
 		pk.G2.B[i] = r2Aff
 	}
 	for i := 0; i < len(pk.G1.Z); i++ {
@@ -449,6 +457,34 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.Domain = *domain
 
 	return nil
+}
+
+// dummyInfinityCount helps us simulate the number of infinity points we have with the given R1CS
+// in A and B as it directly impacts prover performance
+func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
+
+	nbWires := r1cs.NbInternalVariables + r1cs.NbPublicVariables + r1cs.NbSecretVariables
+
+	A := make([]bool, nbWires)
+	B := make([]bool, nbWires)
+	for _, c := range r1cs.Constraints {
+		for _, t := range c.L {
+			A[t.VariableID()] = true
+		}
+		for _, t := range c.R {
+			B[t.VariableID()] = true
+		}
+	}
+	for i := 0; i < nbWires; i++ {
+		if !A[i] {
+			nbZeroesA++
+		}
+		if !B[i] {
+			nbZeroesB++
+		}
+	}
+	return
+
 }
 
 // IsDifferent returns true if provided vk is different than self

--- a/internal/backend/bls12-381/groth16/setup.go
+++ b/internal/backend/bls12-381/groth16/setup.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/consensys/gnark/internal/backend/bls12-381/cs"
 
+	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/fft"
 	"math/big"
@@ -48,6 +49,10 @@ type ProvingKey struct {
 		Beta, Delta curve.G2Affine
 		B           []curve.G2Affine
 	}
+
+	// if InfinityA[i] == true, the point G1.A[i] == infinity
+	InfinityA []bool
+	InfinityB []bool
 }
 
 // VerifyingKey is used by a Groth16 verifier to verify the validity of a proof and a statement
@@ -241,6 +246,22 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// set domain
 	pk.Domain = *domain
 
+	// mark points at infinity
+	pk.InfinityA = make([]bool, len(A))
+	pk.InfinityB = make([]bool, len(B))
+	nbZeroesA, nbZeroesB := 0, 0
+	for i := 0; i < len(A); i++ {
+		if A[i].IsZero() {
+			pk.InfinityA[i] = true
+			nbZeroesA++
+		}
+		if B[i].IsZero() {
+			pk.InfinityB[i] = true
+			nbZeroesB++
+		}
+	}
+	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), nbZeroesA, nbZeroesB)
+
 	return nil
 }
 
@@ -270,13 +291,18 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 
 	// L = 1/n*(t^n-1)/(t-1), Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
 
-	// Setting L
+	// Setting L0
 	L.Exp(toxicWaste.t, new(big.Int).SetUint64(uint64(domain.Cardinality))).
 		Sub(&L, &one)
 	L.Mul(&L, &tInv[0]).
 		Mul(&L, &domain.CardinalityInv)
 
-	// Constraints
+	// each constraint is in the form
+	// L * R == O
+	// L, R and O being linear expressions
+	// for each term appearing in the linear expression,
+	// we compute term.Coefficient * L, and cumulate it in
+	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
 		for _, t := range c.L {

--- a/internal/backend/bls24-315/groth16/prove.go
+++ b/internal/backend/bls24-315/groth16/prove.go
@@ -86,6 +86,25 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, forc
 		chHDone <- struct{}{}
 	}()
 
+	// we need to copy and filter the wireValues for each multi exp
+	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
+	wireValuesA := make([]fr.Element, len(wireValues)-pk.NbInfinityA)
+	wireValuesB := make([]fr.Element, len(wireValues)-pk.NbInfinityB)
+	for i, j := 0, 0; j < len(wireValuesA); i++ {
+		if pk.InfinityA[i] {
+			continue
+		}
+		wireValuesA[j] = wireValues[i]
+		j++
+	}
+	for i, j := 0, 0; j < len(wireValuesB); i++ {
+		if pk.InfinityB[i] {
+			continue
+		}
+		wireValuesB[j] = wireValues[i]
+		j++
+	}
+
 	// sample random r and s
 	var r, s big.Int
 	var _r, _s, _kr fr.Element
@@ -113,7 +132,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, forc
 
 	chBs1Done := make(chan error, 1)
 	computeBS1 := func() {
-		if _, err := bs1.MultiExp(pk.G1.B, wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chBs1Done <- err
 			close(chBs1Done)
 			return
@@ -125,7 +144,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, forc
 
 	chArDone := make(chan error, 1)
 	computeAR1 := func() {
-		if _, err := ar.MultiExp(pk.G1.A, wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chArDone <- err
 			close(chArDone)
 			return
@@ -192,7 +211,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, forc
 			// if we don't have a lot of CPUs, this may artificially split the MSM
 			nbTasks *= 2
 		}
-		if _, err := Bs.MultiExp(pk.G2.B, wireValues, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
+		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
 			return err
 		}
 

--- a/internal/backend/bls24-315/groth16/prove.go
+++ b/internal/backend/bls24-315/groth16/prove.go
@@ -64,8 +64,18 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, forc
 	b := make([]fr.Element, r1cs.NbConstraints, pk.Domain.Cardinality)
 	c := make([]fr.Element, r1cs.NbConstraints, pk.Domain.Cardinality)
 	wireValues := make([]fr.Element, r1cs.NbInternalVariables+r1cs.NbPublicVariables+r1cs.NbSecretVariables)
-	if err := r1cs.Solve(witness, a, b, c, wireValues); err != nil && !force {
-		return nil, err
+	if err := r1cs.Solve(witness, a, b, c, wireValues); err != nil {
+		if !force {
+			return nil, err
+		} else {
+			// we need to fill wireValues with random values else multi exps don't do much
+			var r fr.Element
+			r.SetRandom()
+			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
+				wireValues[i] = r
+				r.Double(&r)
+			}
+		}
 	}
 
 	// set the wire values in regular form

--- a/internal/backend/bls24-315/groth16/prove.go
+++ b/internal/backend/bls24-315/groth16/prove.go
@@ -70,7 +70,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, forc
 		} else {
 			// we need to fill wireValues with random values else multi exps don't do much
 			var r fr.Element
-			r.SetRandom()
+			_, _ = r.SetRandom()
 			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
 				wireValues[i] = r
 				r.Double(&r)

--- a/internal/backend/bls24-315/groth16/prove.go
+++ b/internal/backend/bls24-315/groth16/prove.go
@@ -88,22 +88,31 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, forc
 
 	// we need to copy and filter the wireValues for each multi exp
 	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
-	wireValuesA := make([]fr.Element, len(wireValues)-pk.NbInfinityA)
-	wireValuesB := make([]fr.Element, len(wireValues)-pk.NbInfinityB)
-	for i, j := 0, 0; j < len(wireValuesA); i++ {
-		if pk.InfinityA[i] {
-			continue
+	var wireValuesA, wireValuesB []fr.Element
+	chWireValuesA, chWireValuesB := make(chan struct{}, 1), make(chan struct{}, 1)
+
+	go func() {
+		wireValuesA = make([]fr.Element, len(wireValues)-pk.NbInfinityA)
+		for i, j := 0, 0; j < len(wireValuesA); i++ {
+			if pk.InfinityA[i] {
+				continue
+			}
+			wireValuesA[j] = wireValues[i]
+			j++
 		}
-		wireValuesA[j] = wireValues[i]
-		j++
-	}
-	for i, j := 0, 0; j < len(wireValuesB); i++ {
-		if pk.InfinityB[i] {
-			continue
+		close(chWireValuesA)
+	}()
+	go func() {
+		wireValuesB = make([]fr.Element, len(wireValues)-pk.NbInfinityB)
+		for i, j := 0, 0; j < len(wireValuesB); i++ {
+			if pk.InfinityB[i] {
+				continue
+			}
+			wireValuesB[j] = wireValues[i]
+			j++
 		}
-		wireValuesB[j] = wireValues[i]
-		j++
-	}
+		close(chWireValuesB)
+	}()
 
 	// sample random r and s
 	var r, s big.Int
@@ -132,6 +141,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, forc
 
 	chBs1Done := make(chan error, 1)
 	computeBS1 := func() {
+		<-chWireValuesB
 		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chBs1Done <- err
 			close(chBs1Done)
@@ -144,6 +154,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, forc
 
 	chArDone := make(chan error, 1)
 	computeAR1 := func() {
+		<-chWireValuesA
 		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chArDone <- err
 			close(chArDone)
@@ -211,6 +222,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, forc
 			// if we don't have a lot of CPUs, this may artificially split the MSM
 			nbTasks *= 2
 		}
+		<-chWireValuesB
 		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
 			return err
 		}

--- a/internal/backend/bls24-315/groth16/setup.go
+++ b/internal/backend/bls24-315/groth16/setup.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/consensys/gnark/internal/backend/bls24-315/cs"
 
-	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/fft"
 	"math/big"
@@ -198,8 +197,6 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 	B = B[:n]
 	pk.NbInfinityB = nbWires - n
-
-	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 
 	// compute our batch scalar multiplication with g1 elements
 	g1Scalars := make([]fr.Element, 0, (nbWires*3)+int(domain.Cardinality)+3)

--- a/internal/backend/bls24-315/groth16/setup.go
+++ b/internal/backend/bls24-315/groth16/setup.go
@@ -417,6 +417,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
 	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
+	// set infinity markers
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+	for i := 0; i < nbZeroesA; i++ {
+		pk.InfinityA[i] = true
+	}
+	for i := 0; i < nbZeroesB; i++ {
+		pk.InfinityB[i] = true
+	}
+
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
 	if err != nil {

--- a/internal/backend/bls24-315/groth16/setup.go
+++ b/internal/backend/bls24-315/groth16/setup.go
@@ -420,6 +420,8 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// set infinity markers
 	pk.InfinityA = make([]bool, nbWires)
 	pk.InfinityB = make([]bool, nbWires)
+	pk.NbInfinityA = nbZeroesA
+	pk.NbInfinityB = nbZeroesB
 	for i := 0; i < nbZeroesA; i++ {
 		pk.InfinityA[i] = true
 	}

--- a/internal/backend/bls24-315/groth16/setup.go
+++ b/internal/backend/bls24-315/groth16/setup.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/consensys/gnark/internal/backend/bls24-315/cs"
 
+	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/fft"
 	"math/big"
@@ -48,6 +49,10 @@ type ProvingKey struct {
 		Beta, Delta curve.G2Affine
 		B           []curve.G2Affine
 	}
+
+	// if InfinityA[i] == true, the point G1.A[i] == infinity
+	InfinityA []bool
+	InfinityB []bool
 }
 
 // VerifyingKey is used by a Groth16 verifier to verify the validity of a proof and a statement
@@ -241,6 +246,22 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// set domain
 	pk.Domain = *domain
 
+	// mark points at infinity
+	pk.InfinityA = make([]bool, len(A))
+	pk.InfinityB = make([]bool, len(B))
+	nbZeroesA, nbZeroesB := 0, 0
+	for i := 0; i < len(A); i++ {
+		if A[i].IsZero() {
+			pk.InfinityA[i] = true
+			nbZeroesA++
+		}
+		if B[i].IsZero() {
+			pk.InfinityB[i] = true
+			nbZeroesB++
+		}
+	}
+	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), nbZeroesA, nbZeroesB)
+
 	return nil
 }
 
@@ -270,13 +291,18 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 
 	// L = 1/n*(t^n-1)/(t-1), Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
 
-	// Setting L
+	// Setting L0
 	L.Exp(toxicWaste.t, new(big.Int).SetUint64(uint64(domain.Cardinality))).
 		Sub(&L, &one)
 	L.Mul(&L, &tInv[0]).
 		Mul(&L, &domain.CardinalityInv)
 
-	// Constraints
+	// each constraint is in the form
+	// L * R == O
+	// L, R and O being linear expressions
+	// for each term appearing in the linear expression,
+	// we compute term.Coefficient * L, and cumulate it in
+	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
 		for _, t := range c.L {

--- a/internal/backend/bls24-315/groth16/setup.go
+++ b/internal/backend/bls24-315/groth16/setup.go
@@ -175,36 +175,29 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// mark points at infinity and filter them
 	pk.InfinityA = make([]bool, len(A))
 	pk.InfinityB = make([]bool, len(B))
-	for i := 0; i < len(A); i++ {
-		if A[i].IsZero() {
+
+	n := 0
+	for i, e := range A {
+		if e.IsZero() {
 			pk.InfinityA[i] = true
-			pk.NbInfinityA++
+			continue
 		}
-		if B[i].IsZero() {
+		A[n] = A[i]
+		n++
+	}
+	A = A[:n]
+	pk.NbInfinityA = nbWires - n
+	n = 0
+	for i, e := range B {
+		if e.IsZero() {
 			pk.InfinityB[i] = true
-			pk.NbInfinityB++
-		}
-	}
-	// can be done in place, not sure it will help much though.
-	_A := make([]fr.Element, len(A)-pk.NbInfinityA)
-	_B := make([]fr.Element, len(B)-pk.NbInfinityB)
-
-	for i, j := 0, 0; j < len(_A); i++ {
-		if pk.InfinityA[i] {
 			continue
 		}
-		_A[j] = A[i]
-		j++
+		B[n] = B[i]
+		n++
 	}
-
-	for i, j := 0, 0; j < len(_B); i++ {
-		if pk.InfinityB[i] {
-			continue
-		}
-		_B[j] = B[i]
-		j++
-	}
-	A, B = _A, _B
+	B = B[:n]
+	pk.NbInfinityB = nbWires - n
 
 	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 

--- a/internal/backend/bls24-315/groth16/setup.go
+++ b/internal/backend/bls24-315/groth16/setup.go
@@ -406,12 +406,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// Setting group for fft
 	domain := fft.NewDomain(uint64(nbConstraints), 1, true)
 
+	// count number of infinity points we would have had we a normal setup
+	// in pk.G1.A, pk.G1.B, and pk.G2.B
+	nbZeroesA, nbZeroesB := dummyInfinityCount(r1cs)
+
 	// initialize proving key
-	pk.G1.A = make([]curve.G1Affine, nbWires)
-	pk.G1.B = make([]curve.G1Affine, nbWires)
+	pk.G1.A = make([]curve.G1Affine, nbWires-nbZeroesA)
+	pk.G1.B = make([]curve.G1Affine, nbWires-nbZeroesB)
 	pk.G1.K = make([]curve.G1Affine, nbWires-r1cs.NbPublicVariables)
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
-	pk.G2.B = make([]curve.G2Affine, nbWires)
+	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
@@ -429,9 +433,13 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r2Aff curve.G2Affine
 	r2Jac.ScalarMultiplication(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
-	for i := 0; i < int(nbWires); i++ {
+	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff
+	}
+	for i := 0; i < len(pk.G1.B); i++ {
 		pk.G1.B[i] = r1Aff
+	}
+	for i := 0; i < len(pk.G2.B); i++ {
 		pk.G2.B[i] = r2Aff
 	}
 	for i := 0; i < len(pk.G1.Z); i++ {
@@ -449,6 +457,34 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.Domain = *domain
 
 	return nil
+}
+
+// dummyInfinityCount helps us simulate the number of infinity points we have with the given R1CS
+// in A and B as it directly impacts prover performance
+func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
+
+	nbWires := r1cs.NbInternalVariables + r1cs.NbPublicVariables + r1cs.NbSecretVariables
+
+	A := make([]bool, nbWires)
+	B := make([]bool, nbWires)
+	for _, c := range r1cs.Constraints {
+		for _, t := range c.L {
+			A[t.VariableID()] = true
+		}
+		for _, t := range c.R {
+			B[t.VariableID()] = true
+		}
+	}
+	for i := 0; i < nbWires; i++ {
+		if !A[i] {
+			nbZeroesA++
+		}
+		if !B[i] {
+			nbZeroesB++
+		}
+	}
+	return
+
 }
 
 // IsDifferent returns true if provided vk is different than self

--- a/internal/backend/bn254/groth16/prove.go
+++ b/internal/backend/bn254/groth16/prove.go
@@ -86,6 +86,25 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, force bo
 		chHDone <- struct{}{}
 	}()
 
+	// we need to copy and filter the wireValues for each multi exp
+	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
+	wireValuesA := make([]fr.Element, len(wireValues)-pk.NbInfinityA)
+	wireValuesB := make([]fr.Element, len(wireValues)-pk.NbInfinityB)
+	for i, j := 0, 0; j < len(wireValuesA); i++ {
+		if pk.InfinityA[i] {
+			continue
+		}
+		wireValuesA[j] = wireValues[i]
+		j++
+	}
+	for i, j := 0, 0; j < len(wireValuesB); i++ {
+		if pk.InfinityB[i] {
+			continue
+		}
+		wireValuesB[j] = wireValues[i]
+		j++
+	}
+
 	// sample random r and s
 	var r, s big.Int
 	var _r, _s, _kr fr.Element
@@ -113,7 +132,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, force bo
 
 	chBs1Done := make(chan error, 1)
 	computeBS1 := func() {
-		if _, err := bs1.MultiExp(pk.G1.B, wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chBs1Done <- err
 			close(chBs1Done)
 			return
@@ -125,7 +144,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, force bo
 
 	chArDone := make(chan error, 1)
 	computeAR1 := func() {
-		if _, err := ar.MultiExp(pk.G1.A, wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chArDone <- err
 			close(chArDone)
 			return
@@ -192,7 +211,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, force bo
 			// if we don't have a lot of CPUs, this may artificially split the MSM
 			nbTasks *= 2
 		}
-		if _, err := Bs.MultiExp(pk.G2.B, wireValues, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
+		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
 			return err
 		}
 

--- a/internal/backend/bn254/groth16/prove.go
+++ b/internal/backend/bn254/groth16/prove.go
@@ -70,7 +70,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, force bo
 		} else {
 			// we need to fill wireValues with random values else multi exps don't do much
 			var r fr.Element
-			r.SetRandom()
+			_, _ = r.SetRandom()
 			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
 				wireValues[i] = r
 				r.Double(&r)

--- a/internal/backend/bn254/groth16/prove.go
+++ b/internal/backend/bn254/groth16/prove.go
@@ -64,8 +64,18 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, force bo
 	b := make([]fr.Element, r1cs.NbConstraints, pk.Domain.Cardinality)
 	c := make([]fr.Element, r1cs.NbConstraints, pk.Domain.Cardinality)
 	wireValues := make([]fr.Element, r1cs.NbInternalVariables+r1cs.NbPublicVariables+r1cs.NbSecretVariables)
-	if err := r1cs.Solve(witness, a, b, c, wireValues); err != nil && !force {
-		return nil, err
+	if err := r1cs.Solve(witness, a, b, c, wireValues); err != nil {
+		if !force {
+			return nil, err
+		} else {
+			// we need to fill wireValues with random values else multi exps don't do much
+			var r fr.Element
+			r.SetRandom()
+			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
+				wireValues[i] = r
+				r.Double(&r)
+			}
+		}
 	}
 
 	// set the wire values in regular form

--- a/internal/backend/bn254/groth16/setup.go
+++ b/internal/backend/bn254/groth16/setup.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/consensys/gnark/internal/backend/bn254/cs"
 
+	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/fft"
 	"math/big"
@@ -48,6 +49,10 @@ type ProvingKey struct {
 		Beta, Delta curve.G2Affine
 		B           []curve.G2Affine
 	}
+
+	// if InfinityA[i] == true, the point G1.A[i] == infinity
+	InfinityA []bool
+	InfinityB []bool
 }
 
 // VerifyingKey is used by a Groth16 verifier to verify the validity of a proof and a statement
@@ -241,6 +246,22 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// set domain
 	pk.Domain = *domain
 
+	// mark points at infinity
+	pk.InfinityA = make([]bool, len(A))
+	pk.InfinityB = make([]bool, len(B))
+	nbZeroesA, nbZeroesB := 0, 0
+	for i := 0; i < len(A); i++ {
+		if A[i].IsZero() {
+			pk.InfinityA[i] = true
+			nbZeroesA++
+		}
+		if B[i].IsZero() {
+			pk.InfinityB[i] = true
+			nbZeroesB++
+		}
+	}
+	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), nbZeroesA, nbZeroesB)
+
 	return nil
 }
 
@@ -270,13 +291,18 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 
 	// L = 1/n*(t^n-1)/(t-1), Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
 
-	// Setting L
+	// Setting L0
 	L.Exp(toxicWaste.t, new(big.Int).SetUint64(uint64(domain.Cardinality))).
 		Sub(&L, &one)
 	L.Mul(&L, &tInv[0]).
 		Mul(&L, &domain.CardinalityInv)
 
-	// Constraints
+	// each constraint is in the form
+	// L * R == O
+	// L, R and O being linear expressions
+	// for each term appearing in the linear expression,
+	// we compute term.Coefficient * L, and cumulate it in
+	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
 		for _, t := range c.L {

--- a/internal/backend/bn254/groth16/setup.go
+++ b/internal/backend/bn254/groth16/setup.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/consensys/gnark/internal/backend/bn254/cs"
 
-	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/fft"
 	"math/big"
@@ -198,8 +197,6 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 	B = B[:n]
 	pk.NbInfinityB = nbWires - n
-
-	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 
 	// compute our batch scalar multiplication with g1 elements
 	g1Scalars := make([]fr.Element, 0, (nbWires*3)+int(domain.Cardinality)+3)

--- a/internal/backend/bn254/groth16/setup.go
+++ b/internal/backend/bn254/groth16/setup.go
@@ -417,6 +417,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
 	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
+	// set infinity markers
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+	for i := 0; i < nbZeroesA; i++ {
+		pk.InfinityA[i] = true
+	}
+	for i := 0; i < nbZeroesB; i++ {
+		pk.InfinityB[i] = true
+	}
+
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
 	if err != nil {

--- a/internal/backend/bn254/groth16/setup.go
+++ b/internal/backend/bn254/groth16/setup.go
@@ -420,6 +420,8 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// set infinity markers
 	pk.InfinityA = make([]bool, nbWires)
 	pk.InfinityB = make([]bool, nbWires)
+	pk.NbInfinityA = nbZeroesA
+	pk.NbInfinityB = nbZeroesB
 	for i := 0; i < nbZeroesA; i++ {
 		pk.InfinityA[i] = true
 	}

--- a/internal/backend/bn254/groth16/setup.go
+++ b/internal/backend/bn254/groth16/setup.go
@@ -175,36 +175,29 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// mark points at infinity and filter them
 	pk.InfinityA = make([]bool, len(A))
 	pk.InfinityB = make([]bool, len(B))
-	for i := 0; i < len(A); i++ {
-		if A[i].IsZero() {
+
+	n := 0
+	for i, e := range A {
+		if e.IsZero() {
 			pk.InfinityA[i] = true
-			pk.NbInfinityA++
+			continue
 		}
-		if B[i].IsZero() {
+		A[n] = A[i]
+		n++
+	}
+	A = A[:n]
+	pk.NbInfinityA = nbWires - n
+	n = 0
+	for i, e := range B {
+		if e.IsZero() {
 			pk.InfinityB[i] = true
-			pk.NbInfinityB++
-		}
-	}
-	// can be done in place, not sure it will help much though.
-	_A := make([]fr.Element, len(A)-pk.NbInfinityA)
-	_B := make([]fr.Element, len(B)-pk.NbInfinityB)
-
-	for i, j := 0, 0; j < len(_A); i++ {
-		if pk.InfinityA[i] {
 			continue
 		}
-		_A[j] = A[i]
-		j++
+		B[n] = B[i]
+		n++
 	}
-
-	for i, j := 0, 0; j < len(_B); i++ {
-		if pk.InfinityB[i] {
-			continue
-		}
-		_B[j] = B[i]
-		j++
-	}
-	A, B = _A, _B
+	B = B[:n]
+	pk.NbInfinityB = nbWires - n
 
 	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 

--- a/internal/backend/bn254/groth16/setup.go
+++ b/internal/backend/bn254/groth16/setup.go
@@ -406,12 +406,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// Setting group for fft
 	domain := fft.NewDomain(uint64(nbConstraints), 1, true)
 
+	// count number of infinity points we would have had we a normal setup
+	// in pk.G1.A, pk.G1.B, and pk.G2.B
+	nbZeroesA, nbZeroesB := dummyInfinityCount(r1cs)
+
 	// initialize proving key
-	pk.G1.A = make([]curve.G1Affine, nbWires)
-	pk.G1.B = make([]curve.G1Affine, nbWires)
+	pk.G1.A = make([]curve.G1Affine, nbWires-nbZeroesA)
+	pk.G1.B = make([]curve.G1Affine, nbWires-nbZeroesB)
 	pk.G1.K = make([]curve.G1Affine, nbWires-r1cs.NbPublicVariables)
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
-	pk.G2.B = make([]curve.G2Affine, nbWires)
+	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
@@ -429,9 +433,13 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r2Aff curve.G2Affine
 	r2Jac.ScalarMultiplication(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
-	for i := 0; i < int(nbWires); i++ {
+	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff
+	}
+	for i := 0; i < len(pk.G1.B); i++ {
 		pk.G1.B[i] = r1Aff
+	}
+	for i := 0; i < len(pk.G2.B); i++ {
 		pk.G2.B[i] = r2Aff
 	}
 	for i := 0; i < len(pk.G1.Z); i++ {
@@ -449,6 +457,34 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.Domain = *domain
 
 	return nil
+}
+
+// dummyInfinityCount helps us simulate the number of infinity points we have with the given R1CS
+// in A and B as it directly impacts prover performance
+func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
+
+	nbWires := r1cs.NbInternalVariables + r1cs.NbPublicVariables + r1cs.NbSecretVariables
+
+	A := make([]bool, nbWires)
+	B := make([]bool, nbWires)
+	for _, c := range r1cs.Constraints {
+		for _, t := range c.L {
+			A[t.VariableID()] = true
+		}
+		for _, t := range c.R {
+			B[t.VariableID()] = true
+		}
+	}
+	for i := 0; i < nbWires; i++ {
+		if !A[i] {
+			nbZeroesA++
+		}
+		if !B[i] {
+			nbZeroesB++
+		}
+	}
+	return
+
 }
 
 // IsDifferent returns true if provided vk is different than self

--- a/internal/backend/bw6-761/groth16/prove.go
+++ b/internal/backend/bw6-761/groth16/prove.go
@@ -64,8 +64,18 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, force 
 	b := make([]fr.Element, r1cs.NbConstraints, pk.Domain.Cardinality)
 	c := make([]fr.Element, r1cs.NbConstraints, pk.Domain.Cardinality)
 	wireValues := make([]fr.Element, r1cs.NbInternalVariables+r1cs.NbPublicVariables+r1cs.NbSecretVariables)
-	if err := r1cs.Solve(witness, a, b, c, wireValues); err != nil && !force {
-		return nil, err
+	if err := r1cs.Solve(witness, a, b, c, wireValues); err != nil {
+		if !force {
+			return nil, err
+		} else {
+			// we need to fill wireValues with random values else multi exps don't do much
+			var r fr.Element
+			r.SetRandom()
+			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
+				wireValues[i] = r
+				r.Double(&r)
+			}
+		}
 	}
 
 	// set the wire values in regular form

--- a/internal/backend/bw6-761/groth16/prove.go
+++ b/internal/backend/bw6-761/groth16/prove.go
@@ -88,22 +88,31 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, force 
 
 	// we need to copy and filter the wireValues for each multi exp
 	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
-	wireValuesA := make([]fr.Element, len(wireValues)-pk.NbInfinityA)
-	wireValuesB := make([]fr.Element, len(wireValues)-pk.NbInfinityB)
-	for i, j := 0, 0; j < len(wireValuesA); i++ {
-		if pk.InfinityA[i] {
-			continue
+	var wireValuesA, wireValuesB []fr.Element
+	chWireValuesA, chWireValuesB := make(chan struct{}, 1), make(chan struct{}, 1)
+
+	go func() {
+		wireValuesA = make([]fr.Element, len(wireValues)-pk.NbInfinityA)
+		for i, j := 0, 0; j < len(wireValuesA); i++ {
+			if pk.InfinityA[i] {
+				continue
+			}
+			wireValuesA[j] = wireValues[i]
+			j++
 		}
-		wireValuesA[j] = wireValues[i]
-		j++
-	}
-	for i, j := 0, 0; j < len(wireValuesB); i++ {
-		if pk.InfinityB[i] {
-			continue
+		close(chWireValuesA)
+	}()
+	go func() {
+		wireValuesB = make([]fr.Element, len(wireValues)-pk.NbInfinityB)
+		for i, j := 0, 0; j < len(wireValuesB); i++ {
+			if pk.InfinityB[i] {
+				continue
+			}
+			wireValuesB[j] = wireValues[i]
+			j++
 		}
-		wireValuesB[j] = wireValues[i]
-		j++
-	}
+		close(chWireValuesB)
+	}()
 
 	// sample random r and s
 	var r, s big.Int
@@ -132,6 +141,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, force 
 
 	chBs1Done := make(chan error, 1)
 	computeBS1 := func() {
+		<-chWireValuesB
 		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chBs1Done <- err
 			close(chBs1Done)
@@ -144,6 +154,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, force 
 
 	chArDone := make(chan error, 1)
 	computeAR1 := func() {
+		<-chWireValuesA
 		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chArDone <- err
 			close(chArDone)
@@ -211,6 +222,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, force 
 			// if we don't have a lot of CPUs, this may artificially split the MSM
 			nbTasks *= 2
 		}
+		<-chWireValuesB
 		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
 			return err
 		}

--- a/internal/backend/bw6-761/groth16/prove.go
+++ b/internal/backend/bw6-761/groth16/prove.go
@@ -70,7 +70,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, force 
 		} else {
 			// we need to fill wireValues with random values else multi exps don't do much
 			var r fr.Element
-			r.SetRandom()
+			_, _ = r.SetRandom()
 			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
 				wireValues[i] = r
 				r.Double(&r)

--- a/internal/backend/bw6-761/groth16/setup.go
+++ b/internal/backend/bw6-761/groth16/setup.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/consensys/gnark/internal/backend/bw6-761/cs"
 
-	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/fft"
 	"math/big"
@@ -198,8 +197,6 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 	B = B[:n]
 	pk.NbInfinityB = nbWires - n
-
-	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 
 	// compute our batch scalar multiplication with g1 elements
 	g1Scalars := make([]fr.Element, 0, (nbWires*3)+int(domain.Cardinality)+3)

--- a/internal/backend/bw6-761/groth16/setup.go
+++ b/internal/backend/bw6-761/groth16/setup.go
@@ -417,6 +417,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
 	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
+	// set infinity markers
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+	for i := 0; i < nbZeroesA; i++ {
+		pk.InfinityA[i] = true
+	}
+	for i := 0; i < nbZeroesB; i++ {
+		pk.InfinityB[i] = true
+	}
+
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
 	if err != nil {

--- a/internal/backend/bw6-761/groth16/setup.go
+++ b/internal/backend/bw6-761/groth16/setup.go
@@ -420,6 +420,8 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// set infinity markers
 	pk.InfinityA = make([]bool, nbWires)
 	pk.InfinityB = make([]bool, nbWires)
+	pk.NbInfinityA = nbZeroesA
+	pk.NbInfinityB = nbZeroesB
 	for i := 0; i < nbZeroesA; i++ {
 		pk.InfinityA[i] = true
 	}

--- a/internal/backend/bw6-761/groth16/setup.go
+++ b/internal/backend/bw6-761/groth16/setup.go
@@ -175,36 +175,29 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// mark points at infinity and filter them
 	pk.InfinityA = make([]bool, len(A))
 	pk.InfinityB = make([]bool, len(B))
-	for i := 0; i < len(A); i++ {
-		if A[i].IsZero() {
+
+	n := 0
+	for i, e := range A {
+		if e.IsZero() {
 			pk.InfinityA[i] = true
-			pk.NbInfinityA++
+			continue
 		}
-		if B[i].IsZero() {
+		A[n] = A[i]
+		n++
+	}
+	A = A[:n]
+	pk.NbInfinityA = nbWires - n
+	n = 0
+	for i, e := range B {
+		if e.IsZero() {
 			pk.InfinityB[i] = true
-			pk.NbInfinityB++
-		}
-	}
-	// can be done in place, not sure it will help much though.
-	_A := make([]fr.Element, len(A)-pk.NbInfinityA)
-	_B := make([]fr.Element, len(B)-pk.NbInfinityB)
-
-	for i, j := 0, 0; j < len(_A); i++ {
-		if pk.InfinityA[i] {
 			continue
 		}
-		_A[j] = A[i]
-		j++
+		B[n] = B[i]
+		n++
 	}
-
-	for i, j := 0, 0; j < len(_B); i++ {
-		if pk.InfinityB[i] {
-			continue
-		}
-		_B[j] = B[i]
-		j++
-	}
-	A, B = _A, _B
+	B = B[:n]
+	pk.NbInfinityB = nbWires - n
 
 	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 

--- a/internal/backend/bw6-761/groth16/setup.go
+++ b/internal/backend/bw6-761/groth16/setup.go
@@ -406,12 +406,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// Setting group for fft
 	domain := fft.NewDomain(uint64(nbConstraints), 1, true)
 
+	// count number of infinity points we would have had we a normal setup
+	// in pk.G1.A, pk.G1.B, and pk.G2.B
+	nbZeroesA, nbZeroesB := dummyInfinityCount(r1cs)
+
 	// initialize proving key
-	pk.G1.A = make([]curve.G1Affine, nbWires)
-	pk.G1.B = make([]curve.G1Affine, nbWires)
+	pk.G1.A = make([]curve.G1Affine, nbWires-nbZeroesA)
+	pk.G1.B = make([]curve.G1Affine, nbWires-nbZeroesB)
 	pk.G1.K = make([]curve.G1Affine, nbWires-r1cs.NbPublicVariables)
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
-	pk.G2.B = make([]curve.G2Affine, nbWires)
+	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
@@ -429,9 +433,13 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r2Aff curve.G2Affine
 	r2Jac.ScalarMultiplication(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
-	for i := 0; i < int(nbWires); i++ {
+	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff
+	}
+	for i := 0; i < len(pk.G1.B); i++ {
 		pk.G1.B[i] = r1Aff
+	}
+	for i := 0; i < len(pk.G2.B); i++ {
 		pk.G2.B[i] = r2Aff
 	}
 	for i := 0; i < len(pk.G1.Z); i++ {
@@ -449,6 +457,34 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.Domain = *domain
 
 	return nil
+}
+
+// dummyInfinityCount helps us simulate the number of infinity points we have with the given R1CS
+// in A and B as it directly impacts prover performance
+func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
+
+	nbWires := r1cs.NbInternalVariables + r1cs.NbPublicVariables + r1cs.NbSecretVariables
+
+	A := make([]bool, nbWires)
+	B := make([]bool, nbWires)
+	for _, c := range r1cs.Constraints {
+		for _, t := range c.L {
+			A[t.VariableID()] = true
+		}
+		for _, t := range c.R {
+			B[t.VariableID()] = true
+		}
+	}
+	for i := 0; i < nbWires; i++ {
+		if !A[i] {
+			nbZeroesA++
+		}
+		if !B[i] {
+			nbZeroesB++
+		}
+	}
+	return
+
 }
 
 // IsDifferent returns true if provided vk is different than self

--- a/internal/backend/bw6-761/groth16/setup.go
+++ b/internal/backend/bw6-761/groth16/setup.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/consensys/gnark/internal/backend/bw6-761/cs"
 
+	"fmt"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/fft"
 	"math/big"
@@ -48,6 +49,10 @@ type ProvingKey struct {
 		Beta, Delta curve.G2Affine
 		B           []curve.G2Affine
 	}
+
+	// if InfinityA[i] == true, the point G1.A[i] == infinity
+	InfinityA []bool
+	InfinityB []bool
 }
 
 // VerifyingKey is used by a Groth16 verifier to verify the validity of a proof and a statement
@@ -241,6 +246,22 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// set domain
 	pk.Domain = *domain
 
+	// mark points at infinity
+	pk.InfinityA = make([]bool, len(A))
+	pk.InfinityB = make([]bool, len(B))
+	nbZeroesA, nbZeroesB := 0, 0
+	for i := 0; i < len(A); i++ {
+		if A[i].IsZero() {
+			pk.InfinityA[i] = true
+			nbZeroesA++
+		}
+		if B[i].IsZero() {
+			pk.InfinityB[i] = true
+			nbZeroesB++
+		}
+	}
+	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), nbZeroesA, nbZeroesB)
+
 	return nil
 }
 
@@ -270,13 +291,18 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 
 	// L = 1/n*(t^n-1)/(t-1), Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
 
-	// Setting L
+	// Setting L0
 	L.Exp(toxicWaste.t, new(big.Int).SetUint64(uint64(domain.Cardinality))).
 		Sub(&L, &one)
 	L.Mul(&L, &tInv[0]).
 		Mul(&L, &domain.CardinalityInv)
 
-	// Constraints
+	// each constraint is in the form
+	// L * R == O
+	// L, R and O being linear expressions
+	// for each term appearing in the linear expression,
+	// we compute term.Coefficient * L, and cumulate it in
+	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
 		for _, t := range c.L {

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -48,7 +48,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 		} else {
 			// we need to fill wireValues with random values else multi exps don't do much
 			var r fr.Element
-			r.SetRandom()
+			_, _ = r.SetRandom()
 			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
 				wireValues[i] = r
 				r.Double(&r)

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -64,6 +64,25 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 		chHDone <- struct{}{}
 	}()
 
+	// we need to copy and filter the wireValues for each multi exp
+	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
+	wireValuesA := make([]fr.Element, len(wireValues) - pk.NbInfinityA)
+	wireValuesB := make([]fr.Element, len(wireValues) - pk.NbInfinityB)
+	for i,j :=0,0; j<len(wireValuesA);i++ {
+		if pk.InfinityA[i] {
+			continue
+		}
+		wireValuesA[j] = wireValues[i]
+		j++
+	}
+	for i,j :=0,0; j<len(wireValuesB);i++ {
+		if pk.InfinityB[i] {
+			continue
+		}
+		wireValuesB[j] = wireValues[i]
+		j++
+	}
+
 	// sample random r and s
 	var r, s big.Int
 	var _r, _s, _kr fr.Element
@@ -91,7 +110,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 
 	chBs1Done := make(chan error, 1)
 	computeBS1 := func() {
-		if _, err := bs1.MultiExp(pk.G1.B, wireValues, ecc.MultiExpConfig{NbTasks:n/2}); err != nil {
+		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks:n/2}); err != nil {
 			chBs1Done <- err
 			close(chBs1Done)
 			return 
@@ -103,7 +122,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 
 	chArDone := make(chan error, 1)
 	computeAR1 := func() {
-		if _, err := ar.MultiExp(pk.G1.A, wireValues, ecc.MultiExpConfig{NbTasks:n/2}); err != nil {
+		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks:n/2}); err != nil {
 			chArDone <- err 
 			close(chArDone)
 			return 
@@ -170,7 +189,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 			// if we don't have a lot of CPUs, this may artificially split the MSM
 			nbTasks *= 2
 		} 
-		if _, err := Bs.MultiExp(pk.G2.B, wireValues, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
+		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
 			return err
 		}
 

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -66,22 +66,31 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 
 	// we need to copy and filter the wireValues for each multi exp
 	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
-	wireValuesA := make([]fr.Element, len(wireValues) - pk.NbInfinityA)
-	wireValuesB := make([]fr.Element, len(wireValues) - pk.NbInfinityB)
-	for i,j :=0,0; j<len(wireValuesA);i++ {
-		if pk.InfinityA[i] {
-			continue
+	var wireValuesA, wireValuesB  []fr.Element 
+	chWireValuesA, chWireValuesB := make(chan struct{}, 1) , make(chan struct{}, 1)
+
+	go func() {
+		wireValuesA = make([]fr.Element , len(wireValues) - pk.NbInfinityA)
+		for i,j :=0,0; j<len(wireValuesA);i++ {
+			if pk.InfinityA[i] {
+				continue
+			}
+			wireValuesA[j] = wireValues[i]
+			j++
 		}
-		wireValuesA[j] = wireValues[i]
-		j++
-	}
-	for i,j :=0,0; j<len(wireValuesB);i++ {
-		if pk.InfinityB[i] {
-			continue
+		close(chWireValuesA)
+	}()
+	go func() {
+		wireValuesB = make([]fr.Element , len(wireValues) - pk.NbInfinityB)
+		for i,j :=0,0; j<len(wireValuesB);i++ {
+			if pk.InfinityB[i] {
+				continue
+			}
+			wireValuesB[j] = wireValues[i]
+			j++
 		}
-		wireValuesB[j] = wireValues[i]
-		j++
-	}
+		close(chWireValuesB)
+	}()
 
 	// sample random r and s
 	var r, s big.Int
@@ -110,6 +119,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 
 	chBs1Done := make(chan error, 1)
 	computeBS1 := func() {
+		<-chWireValuesB
 		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks:n/2}); err != nil {
 			chBs1Done <- err
 			close(chBs1Done)
@@ -122,6 +132,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 
 	chArDone := make(chan error, 1)
 	computeAR1 := func() {
+		<-chWireValuesA
 		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks:n/2}); err != nil {
 			chArDone <- err 
 			close(chArDone)
@@ -189,6 +200,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 			// if we don't have a lot of CPUs, this may artificially split the MSM
 			nbTasks *= 2
 		} 
+		<-chWireValuesB
 		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
 			return err
 		}

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -42,8 +42,18 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 	b := make([]fr.Element, r1cs.NbConstraints, pk.Domain.Cardinality)
 	c := make([]fr.Element, r1cs.NbConstraints, pk.Domain.Cardinality)
 	wireValues := make([]fr.Element, r1cs.NbInternalVariables+r1cs.NbPublicVariables+r1cs.NbSecretVariables)
-	if err := r1cs.Solve(witness, a, b, c, wireValues); err != nil && !force {
-		return nil, err
+	if err := r1cs.Solve(witness, a, b, c, wireValues); err != nil {
+		if !force {
+			return nil, err
+		} else {
+			// we need to fill wireValues with random values else multi exps don't do much
+			var r fr.Element
+			r.SetRandom()
+			for i := r1cs.NbPublicVariables + r1cs.NbSecretVariables; i < len(wireValues); i++ {
+				wireValues[i] = r
+				r.Double(&r)
+			}
+		}
 	}
 
 	// set the wire values in regular form

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -390,12 +390,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// Setting group for fft
 	domain := fft.NewDomain(uint64(nbConstraints), 1, true)
 
+	// count number of infinity points we would have had we a normal setup
+	// in pk.G1.A, pk.G1.B, and pk.G2.B
+	nbZeroesA, nbZeroesB := dummyInfinityCount(r1cs)
+
 	// initialize proving key
-	pk.G1.A = make([]curve.G1Affine, nbWires)
-	pk.G1.B = make([]curve.G1Affine, nbWires)
+	pk.G1.A = make([]curve.G1Affine, nbWires-nbZeroesA)
+	pk.G1.B = make([]curve.G1Affine, nbWires-nbZeroesB)
 	pk.G1.K = make([]curve.G1Affine, nbWires-r1cs.NbPublicVariables)
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
-	pk.G2.B = make([]curve.G2Affine, nbWires)
+	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
@@ -413,9 +417,13 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r2Aff curve.G2Affine
 	r2Jac.ScalarMultiplication(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
-	for i := 0; i < int(nbWires); i++ {
+	for i:=0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff
+	}
+	for i:=0; i < len(pk.G1.B); i++ {
 		pk.G1.B[i] = r1Aff
+	}
+	for i:=0; i < len(pk.G2.B); i++ {
 		pk.G2.B[i] = r2Aff
 	}
 	for i := 0; i < len(pk.G1.Z); i++ {
@@ -433,6 +441,34 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.Domain = *domain
 
 	return nil
+}
+
+// dummyInfinityCount helps us simulate the number of infinity points we have with the given R1CS
+// in A and B as it directly impacts prover performance
+func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
+
+	nbWires := r1cs.NbInternalVariables + r1cs.NbPublicVariables + r1cs.NbSecretVariables
+
+	A := make([]bool, nbWires)
+	B := make([]bool, nbWires)
+	for _, c := range r1cs.Constraints {
+		for _, t := range c.L {
+			A[t.VariableID()] = true 
+		}
+		for _, t := range c.R {
+			B[t.VariableID()] = true 
+		}
+	}
+	for i:=0; i < nbWires;i++ {
+		if !A[i] {
+			nbZeroesA++
+		}
+		if !B[i] {
+			nbZeroesB++
+		}
+	}
+	return
+
 }
 
 // IsDifferent returns true if provided vk is different than self

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -154,36 +154,30 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// mark points at infinity and filter them
 	pk.InfinityA = make([]bool, len(A))
 	pk.InfinityB = make([]bool, len(B))
-	for i:=0;i<len(A);i++ {
-		if A[i].IsZero() {
-			pk.InfinityA[i] = true 
-			pk.NbInfinityA++
-		}
-		if B[i].IsZero() {
-			pk.InfinityB[i] = true 
-			pk.NbInfinityB++
-		}
-	}
-	// can be done in place, not sure it will help much though.
-	_A := make([]fr.Element, len(A) - pk.NbInfinityA)
-	_B := make([]fr.Element, len(B) - pk.NbInfinityB)
 
-	for i,j :=0,0; j<len(_A);i++ {
-		if pk.InfinityA[i] {
-			continue
+	n := 0
+	for i, e := range A {
+		if e.IsZero() {
+			pk.InfinityA[i] = true
+			continue 
 		}
-		_A[j]= A[i]
-		j++
+		A[n] = A[i]
+		n++
 	}
-
-	for i,j :=0,0; j<len(_B);i++ {
-		if pk.InfinityB[i] {
-			continue
+	A = A[:n]
+	pk.NbInfinityA = nbWires - n 
+	n = 0
+	for i, e := range B {
+		if e.IsZero() {
+			pk.InfinityB[i] = true
+			continue 
 		}
-		_B[j]= B[i]
-		j++
+		B[n] = B[i]
+		n++
 	}
-	A, B = _A, _B 
+	B = B[:n]
+	pk.NbInfinityB = nbWires - n 
+	
 
 	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -6,7 +6,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"math/big"
 	"math/bits"
-	"fmt"
 )
 
 // ProvingKey is used by a Groth16 prover to encode a proof of a statement
@@ -178,8 +177,6 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	B = B[:n]
 	pk.NbInfinityB = nbWires - n 
 	
-
-	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
 
 	// compute our batch scalar multiplication with g1 elements
 	g1Scalars := make([]fr.Element, 0, (nbWires*3)+int(domain.Cardinality)+3)

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -30,8 +30,8 @@ type ProvingKey struct {
 	}
 
 	// if InfinityA[i] == true, the point G1.A[i] == infinity
-	InfinityA []bool 
-	InfinityB []bool
+	InfinityA, InfinityB []bool
+	NbInfinityA, NbInfinityB int
 }
 
 // VerifyingKey is used by a Groth16 verifier to verify the validity of a proof and a statement
@@ -151,6 +151,42 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		zdt.Mul(&zdt, &toxicWaste.t)
 	}
 
+	// mark points at infinity and filter them
+	pk.InfinityA = make([]bool, len(A))
+	pk.InfinityB = make([]bool, len(B))
+	for i:=0;i<len(A);i++ {
+		if A[i].IsZero() {
+			pk.InfinityA[i] = true 
+			pk.NbInfinityA++
+		}
+		if B[i].IsZero() {
+			pk.InfinityB[i] = true 
+			pk.NbInfinityB++
+		}
+	}
+	// can be done in place, not sure it will help much though.
+	_A := make([]fr.Element, len(A) - pk.NbInfinityA)
+	_B := make([]fr.Element, len(B) - pk.NbInfinityB)
+
+	for i,j :=0,0; j<len(_A);i++ {
+		if pk.InfinityA[i] {
+			continue
+		}
+		_A[j]= A[i]
+		j++
+	}
+
+	for i,j :=0,0; j<len(_B);i++ {
+		if pk.InfinityB[i] {
+			continue
+		}
+		_B[j]= B[i]
+		j++
+	}
+	A, B = _A, _B 
+
+	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), pk.NbInfinityA, pk.NbInfinityB)
+
 	// compute our batch scalar multiplication with g1 elements
 	g1Scalars := make([]fr.Element, 0, (nbWires*3)+int(domain.Cardinality)+3)
 	g1Scalars = append(g1Scalars, toxicWaste.alphaReg, toxicWaste.betaReg, toxicWaste.deltaReg)
@@ -168,11 +204,11 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	pk.G1.Delta = g1PointsAff[2]
 
 	offset := 3
-	pk.G1.A = g1PointsAff[offset : offset+nbWires]
-	offset += nbWires
+	pk.G1.A = g1PointsAff[offset : offset+len(A)]
+	offset += len(A)
 
-	pk.G1.B = g1PointsAff[offset : offset+nbWires]
-	offset += nbWires
+	pk.G1.B = g1PointsAff[offset : offset+len(B)]
+	offset += len(B)
 
 	pk.G1.K = g1PointsAff[offset : offset+nbPrivateWires]
 	offset += nbPrivateWires
@@ -197,15 +233,15 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	g2PointsAff := curve.BatchScalarMultiplicationG2(&g2, g2Scalars)
 
-	pk.G2.B = g2PointsAff[:nbWires]
+	pk.G2.B = g2PointsAff[:len(B)]
 
 	// sets pk: [β]2, [δ]2
-	pk.G2.Beta = g2PointsAff[nbWires+0]
-	pk.G2.Delta = g2PointsAff[nbWires+1]
+	pk.G2.Beta = g2PointsAff[len(B)+0]
+	pk.G2.Delta = g2PointsAff[len(B)+1]
 
 	// sets vk: [δ]2, [γ]2, -[δ]2, -[γ]2
-	vk.G2.Delta = g2PointsAff[nbWires+1]
-	vk.G2.Gamma = g2PointsAff[nbWires+2]
+	vk.G2.Delta = g2PointsAff[len(B)+1]
+	vk.G2.Gamma = g2PointsAff[len(B)+2]
 	vk.G2.deltaNeg.Neg(&vk.G2.Delta)
 	vk.G2.gammaNeg.Neg(&vk.G2.Gamma)
 
@@ -225,21 +261,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// set domain
 	pk.Domain = *domain
 
-	// mark points at infinity
-	pk.InfinityA = make([]bool, len(A))
-	pk.InfinityB = make([]bool, len(B))
-	nbZeroesA, nbZeroesB := 0, 0
-	for i:=0;i<len(A);i++ {
-		if A[i].IsZero() {
-			pk.InfinityA[i] = true 
-			nbZeroesA++
-		}
-		if B[i].IsZero() {
-			pk.InfinityB[i] = true 
-			nbZeroesB++
-		}
-	}
-	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), nbZeroesA, nbZeroesB)
+
 
 	return nil
 }

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -401,6 +401,16 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.G1.Z = make([]curve.G1Affine, domain.Cardinality)
 	pk.G2.B = make([]curve.G2Affine, nbWires-nbZeroesB)
 
+	// set infinity markers
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+	for i:=0; i <nbZeroesA;i++ {
+		pk.InfinityA[i] = true 
+	}
+	for i:=0; i <nbZeroesB;i++ {
+		pk.InfinityB[i] = true 
+	}
+
 	// samples toxic waste
 	toxicWaste, err := sampleToxicWaste()
 	if err != nil {

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -404,6 +404,8 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	// set infinity markers
 	pk.InfinityA = make([]bool, nbWires)
 	pk.InfinityB = make([]bool, nbWires)
+	pk.NbInfinityA = nbZeroesA
+	pk.NbInfinityB = nbZeroesB
 	for i:=0; i <nbZeroesA;i++ {
 		pk.InfinityA[i] = true 
 	}

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"math/big"
 	"math/bits"
+	"fmt"
 )
 
 // ProvingKey is used by a Groth16 prover to encode a proof of a statement
@@ -27,6 +28,10 @@ type ProvingKey struct {
 		Beta, Delta curve.G2Affine
 		B           []curve.G2Affine
 	}
+
+	// if InfinityA[i] == true, the point G1.A[i] == infinity
+	InfinityA []bool 
+	InfinityB []bool
 }
 
 // VerifyingKey is used by a Groth16 verifier to verify the validity of a proof and a statement
@@ -220,6 +225,22 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// set domain
 	pk.Domain = *domain
 
+	// mark points at infinity
+	pk.InfinityA = make([]bool, len(A))
+	pk.InfinityB = make([]bool, len(B))
+	nbZeroesA, nbZeroesB := 0, 0
+	for i:=0;i<len(A);i++ {
+		if A[i].IsZero() {
+			pk.InfinityA[i] = true 
+			nbZeroesA++
+		}
+		if B[i].IsZero() {
+			pk.InfinityB[i] = true 
+			nbZeroesB++
+		}
+	}
+	fmt.Printf("nbWires: %d, zeroes(A): %d, zeroes(B): %d\n", len(A), nbZeroesA, nbZeroesB)
+
 	return nil
 }
 
@@ -250,7 +271,7 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 
 	// L = 1/n*(t^n-1)/(t-1), Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
 
-	// Setting L
+	// Setting L0
 	L.Exp(toxicWaste.t, new(big.Int).SetUint64(uint64(domain.Cardinality))).
 		Sub(&L, &one)
 	L.Mul(&L, &tInv[0]).
@@ -258,7 +279,12 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 
 
 
-	// Constraints
+	// each constraint is in the form 
+	// L * R == O
+	// L, R and O being linear expressions
+	// for each term appearing in the linear expression, 
+	// we compute term.Coefficient * L, and cumulate it in
+	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
 		for _, t := range c.L {


### PR DESCRIPTION
fixes:
* `groth16.Prove` with `force=true` wasn't doing much since msm with zeroes don't do much. 

perf:
* `groth16.Setup` produces `pk.G1.A`, `pk.G1.B` and `pk.G2.B`, derived from the QAP. However, if a variable doesn't appear in a QAP column, the value of the corresponding interpolation vector is 0, and the resulting point in the proving key is infinity. 

Additionally, `frontend.newR1C` will put the variable with the longest linear expression in the `A` part of the QAP, maximizing the number of zeroes in the `B` part. 

In one internal circuit, using a lot of `MiMC`, this speeds up `groth16.Prove` by ~30%. 