### PR TITLE
Fix/i 128

### DIFF
--- a/frontend/cs.go
+++ b/frontend/cs.go
@@ -60,9 +60,10 @@ type ConstraintSystem struct {
 	coeffsIDs map[string]int // map to fast check existence of a coefficient (key = coeff.Text(16))
 
 	// debug info
-	logs           []logEntry // list of logs to be printed when solving a circuit. The logs are called with the method Println
-	debugInfo      []logEntry // list of logs storing information about assertions. If an assertion fails, it prints it in a friendly format
-	unsetVariables []logEntry // unset variables. If a variable is unset, the error is caught when compiling the circuit
+	logs                 []logEntry // list of logs to be printed when solving a circuit. The logs are called with the method Println
+	debugInfoComputation []logEntry // list of logs storing information about computations (e.g. division by 0).If an computation fails, it prints it in a friendly format
+	debugInfoAssertion   []logEntry // list of logs storing information about assertions. If an assertion fails, it prints it in a friendly format
+	unsetVariables       []logEntry // unset variables. If a variable is unset, the error is caught when compiling the circuit
 
 }
 
@@ -200,7 +201,7 @@ func (cs *ConstraintSystem) reduce(l compiled.LinearExpression) compiled.LinearE
 
 func (cs *ConstraintSystem) addAssertion(constraint compiled.R1C, debugInfo logEntry) {
 	cs.assertions = append(cs.assertions, constraint)
-	cs.debugInfo = append(cs.debugInfo, debugInfo)
+	cs.debugInfoAssertion = append(cs.debugInfoAssertion, debugInfo)
 }
 
 // coeffID tries to fetch the entry where b is if it exits, otherwise appends b to

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -195,7 +195,6 @@ func (cs *ConstraintSystem) Mul(i1, i2 interface{}, in ...interface{}) Variable 
 }
 
 // Inverse returns res = inverse(v)
-// TODO the function should take an interface
 func (cs *ConstraintSystem) Inverse(v Variable) Variable {
 
 	v.assertIsSet()
@@ -206,6 +205,26 @@ func (cs *ConstraintSystem) Inverse(v Variable) Variable {
 	cs.constraints = append(cs.constraints, newR1C(v, res, cs.one()))
 
 	return res
+}
+
+// AssertIsDifferent constrain i1 and i2 to be different
+func (cs *ConstraintSystem) AssertIsDifferent(i1, i2 interface{}) {
+
+	cs.Inverse(cs.Sub(i1, i2))
+
+	// // prepare debug info to be displayed in case the constraint is not solved
+	// debugInfo := logEntry{
+	// 	toResolve: nil,
+	// }
+	// var sbb strings.Builder
+	// sbb.WriteString("error AssertIsDifferent")
+	// stack := getCallStack()
+	// for i := 0; i < len(stack); i++ {
+	// 	sbb.WriteByte('\n')
+	// 	sbb.WriteString(stack[i])
+	// }
+	// debugInfo.format = sbb.String()
+
 }
 
 // Div returns res = i1 / i2

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -204,27 +204,28 @@ func (cs *ConstraintSystem) Inverse(v Variable) Variable {
 
 	cs.constraints = append(cs.constraints, newR1C(v, res, cs.one()))
 
+	// prepare debug info to be displayed in case the constraint is not solved
+	debugInfo := logEntry{
+		toResolve: nil,
+	}
+	var sbb strings.Builder
+	sbb.WriteString("error Inverse (inversion by zero ?)")
+	stack := getCallStack()
+	for i := 0; i < len(stack); i++ {
+		sbb.WriteByte('\n')
+		sbb.WriteString(stack[i])
+	}
+	debugInfo.format = sbb.String()
+
+	// add it to the logs record
+	cs.debugInfoComputation = append(cs.debugInfoComputation, debugInfo)
+
 	return res
 }
 
 // AssertIsDifferent constrain i1 and i2 to be different
 func (cs *ConstraintSystem) AssertIsDifferent(i1, i2 interface{}) {
-
 	cs.Inverse(cs.Sub(i1, i2))
-
-	// // prepare debug info to be displayed in case the constraint is not solved
-	// debugInfo := logEntry{
-	// 	toResolve: nil,
-	// }
-	// var sbb strings.Builder
-	// sbb.WriteString("error AssertIsDifferent")
-	// stack := getCallStack()
-	// for i := 0; i < len(stack); i++ {
-	// 	sbb.WriteByte('\n')
-	// 	sbb.WriteString(stack[i])
-	// }
-	// debugInfo.format = sbb.String()
-
 }
 
 // Div returns res = i1 / i2
@@ -257,6 +258,22 @@ func (cs *ConstraintSystem) Div(i1, i2 interface{}) Variable {
 			cs.constraints = append(cs.constraints, newR1C(tmp2, res, tmp1))
 		}
 	}
+
+	// prepare debug info to be displayed in case the constraint is not solved
+	debugInfo := logEntry{
+		toResolve: nil,
+	}
+	var sbb strings.Builder
+	sbb.WriteString("error Inverse (inversion by zero ?)")
+	stack := getCallStack()
+	for i := 0; i < len(stack); i++ {
+		sbb.WriteByte('\n')
+		sbb.WriteString(stack[i])
+	}
+	debugInfo.format = sbb.String()
+
+	// add it to the logs record
+	cs.debugInfoComputation = append(cs.debugInfoComputation, debugInfo)
 
 	return res
 }

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -209,7 +209,7 @@ func (cs *ConstraintSystem) Inverse(v Variable) Variable {
 		toResolve: nil,
 	}
 	var sbb strings.Builder
-	sbb.WriteString("error Inverse (inversion by zero ?)")
+	sbb.WriteString("couldn't solve computational constraint (inversion by zero ?)")
 	stack := getCallStack()
 	for i := 0; i < len(stack); i++ {
 		sbb.WriteByte('\n')
@@ -264,7 +264,7 @@ func (cs *ConstraintSystem) Div(i1, i2 interface{}) Variable {
 		toResolve: nil,
 	}
 	var sbb strings.Builder
-	sbb.WriteString("error Inverse (inversion by zero ?)")
+	sbb.WriteString("couldn't solve computational constraint (inversion by zero ?)")
 	stack := getCallStack()
 	for i := 0; i < len(stack); i++ {
 		sbb.WriteByte('\n')

--- a/frontend/cs_to_r1cs.go
+++ b/frontend/cs_to_r1cs.go
@@ -27,7 +27,7 @@ func (cs *ConstraintSystem) toR1CS(curveID ecc.ID) (CompiledConstraintSystem, er
 		NbCOConstraints:     len(cs.constraints),
 		Constraints:         make([]compiled.R1C, len(cs.constraints)+len(cs.assertions)),
 		Logs:                make([]compiled.LogEntry, len(cs.logs)),
-		DebugInfo:           make([]compiled.LogEntry, len(cs.debugInfo)),
+		DebugInfoAssertion:  make([]compiled.LogEntry, len(cs.debugInfoAssertion)),
 	}
 
 	// computational constraints (= gates)
@@ -91,13 +91,13 @@ func (cs *ConstraintSystem) toR1CS(curveID ecc.ID) (CompiledConstraintSystem, er
 		res.Logs[i] = entry
 	}
 
-	// offset ids in the debugInfo
-	for i := 0; i < len(cs.debugInfo); i++ {
+	// offset ids in the debugInfoAssertion
+	for i := 0; i < len(cs.debugInfoAssertion); i++ {
 		entry := compiled.LogEntry{
-			Format: cs.debugInfo[i].format,
+			Format: cs.debugInfoAssertion[i].format,
 		}
-		for j := 0; j < len(cs.debugInfo[i].toResolve); j++ {
-			_, cID, cVisibility := cs.debugInfo[i].toResolve[j].Unpack()
+		for j := 0; j < len(cs.debugInfoAssertion[i].toResolve); j++ {
+			_, cID, cVisibility := cs.debugInfoAssertion[i].toResolve[j].Unpack()
 			switch cVisibility {
 			case compiled.Internal:
 				cID += len(cs.public.variables) + len(cs.secret.variables)
@@ -111,7 +111,7 @@ func (cs *ConstraintSystem) toR1CS(curveID ecc.ID) (CompiledConstraintSystem, er
 			entry.ToResolve = append(entry.ToResolve, cID)
 		}
 
-		res.DebugInfo[i] = entry
+		res.DebugInfoAssertion[i] = entry
 	}
 
 	switch curveID {

--- a/frontend/cs_to_r1cs_sparse.go
+++ b/frontend/cs_to_r1cs_sparse.go
@@ -269,13 +269,15 @@ func popInternalVariable(l compiled.LinearExpression, id int) (compiled.LinearEx
 
 // pops the constant associated to the one_wire in the cs, which will become
 // a constant in a PLONK constraint.
-// returns the reduced linear expression and the ID of the coeff corresponding to the constant term (in cs.coeffs).
+//
+// Returns the reduced linear expression and the ID of the coeff corresponding to the constant term (in cs.coeffs).
 // If there is no constant term, the id is 0 (the 0-th entry is reserved for this purpose).
+//
+// ex: if l = <expr> + k1*ONE_WIRE the function returns <expr>, k1.
 func (scs *sparseR1CS) popConstantTerm(l compiled.LinearExpression) (compiled.LinearExpression, big.Int) {
 
 	const idOneWire = 0
 
-	// TODO @thomas can "1 public" appear only once?
 	for i := 0; i < len(l); i++ {
 		if l[i].VariableID() == idOneWire && l[i].VariableVisibility() == compiled.Public {
 			lCopy := make(compiled.LinearExpression, len(l)-1)

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -167,7 +167,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 		// check that the constraint is satisfied
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			debugInfo := r1cs.DebugInfo[i-int(r1cs.NbCOConstraints)]
+			debugInfo := r1cs.DebugInfoAssertion[i-int(r1cs.NbCOConstraints)]
 			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
 			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -116,14 +116,18 @@ func (r1cs *R1CS) IsSolved(witness []fr.Element) error {
 // wireValues =  [publicWires | secretWires | internalWires ]
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) error {
+
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables-1, r1cs.NbSecretVariables)
 	}
+
 	nbWires := r1cs.NbPublicVariables + r1cs.NbSecretVariables + r1cs.NbInternalVariables
+
 	// compute the wires and the a, b, c polynomials
 	if len(a) != int(r1cs.NbConstraints) || len(b) != int(r1cs.NbConstraints) || len(c) != int(r1cs.NbConstraints) || len(wireValues) != nbWires {
 		return errors.New("invalid input size: len(a, b, c) == r1cs.NbConstraints and len(wireValues) == r1cs.NbWires")
 	}
+
 	// keep track of wire that have a value
 	wireInstantiated := make([]bool, nbWires)
 	wireInstantiated[0] = true // ONE_WIRE
@@ -140,11 +144,15 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 	// check if there is an inconsistant constraint
 	var check fr.Element
 
+	// this variable is used to navigate in the debugInfoComputation slice.
+	// It is incremented by one each time a division happens for solving a constraint.
+	var debugInfoComputationOffset uint
+
 	// Loop through computational constraints (the one wwe need to solve and compute a wire in)
 	for i := 0; i < int(r1cs.NbCOConstraints); i++ {
 
 		// solve the constraint, this will compute the missing wire of the gate
-		r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
+		debugInfoComputationOffset += r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
 
 		// at this stage we are guaranteed that a[i]*b[i]=c[i]
 		// if not, it means there is a bug in the solver
@@ -152,7 +160,10 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			//return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			debugInfo := r1cs.DebugInfoComputation[debugInfoComputationOffset]
+			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}
 	}
 
@@ -265,7 +276,14 @@ func instantiateR1C(r *compiled.R1C, r1cs *R1CS, wireValues []fr.Element) (a, b,
 // alone, or it can be computed without ambiguity using the other computed wires
 // , eg when doing a binary decomposition: either way the missing wire can
 // be computed without ambiguity because the r1cs is correctly ordered)
-func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) {
+//
+// It returns the 1 if the the position to solve is in the quadratic part (it
+// means that there is a division and serves to navigate in the log info for the
+// computational constraints), and 0 otherwise.
+func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) uint {
+
+	// value to return: 1 if the wire to solve is in the quadratic term, 0 otherwise
+	var offset uint
 
 	switch r.Solver {
 
@@ -307,7 +325,7 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 		// ensure we found the unset wire
 		if loc == 0 {
 			// this wire may have been instantiated as part of moExpression already
-			return
+			return 0
 		}
 
 		// we compute the wire value and instantiate it
@@ -319,12 +337,14 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 				wireValues[cID].Div(&c, &b).
 					Sub(&wireValues[cID], &a)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 2:
 			if !a.IsZero() {
 				wireValues[cID].Div(&c, &a).
 					Sub(&wireValues[cID], &b)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 3:
 			wireValues[cID].Mul(&a, &b).
@@ -393,4 +413,6 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 	default:
 		panic("unimplemented solving method")
 	}
+
+	return offset
 }

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -167,7 +167,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 		// check that the constraint is satisfied
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			debugInfo := r1cs.DebugInfo[i-int(r1cs.NbCOConstraints)]
+			debugInfo := r1cs.DebugInfoAssertion[i-int(r1cs.NbCOConstraints)]
 			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
 			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -116,14 +116,18 @@ func (r1cs *R1CS) IsSolved(witness []fr.Element) error {
 // wireValues =  [publicWires | secretWires | internalWires ]
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) error {
+
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables-1, r1cs.NbSecretVariables)
 	}
+
 	nbWires := r1cs.NbPublicVariables + r1cs.NbSecretVariables + r1cs.NbInternalVariables
+
 	// compute the wires and the a, b, c polynomials
 	if len(a) != int(r1cs.NbConstraints) || len(b) != int(r1cs.NbConstraints) || len(c) != int(r1cs.NbConstraints) || len(wireValues) != nbWires {
 		return errors.New("invalid input size: len(a, b, c) == r1cs.NbConstraints and len(wireValues) == r1cs.NbWires")
 	}
+
 	// keep track of wire that have a value
 	wireInstantiated := make([]bool, nbWires)
 	wireInstantiated[0] = true // ONE_WIRE
@@ -140,11 +144,15 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 	// check if there is an inconsistant constraint
 	var check fr.Element
 
+	// this variable is used to navigate in the debugInfoComputation slice.
+	// It is incremented by one each time a division happens for solving a constraint.
+	var debugInfoComputationOffset uint
+
 	// Loop through computational constraints (the one wwe need to solve and compute a wire in)
 	for i := 0; i < int(r1cs.NbCOConstraints); i++ {
 
 		// solve the constraint, this will compute the missing wire of the gate
-		r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
+		debugInfoComputationOffset += r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
 
 		// at this stage we are guaranteed that a[i]*b[i]=c[i]
 		// if not, it means there is a bug in the solver
@@ -152,7 +160,10 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			//return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			debugInfo := r1cs.DebugInfoComputation[debugInfoComputationOffset]
+			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}
 	}
 
@@ -265,7 +276,14 @@ func instantiateR1C(r *compiled.R1C, r1cs *R1CS, wireValues []fr.Element) (a, b,
 // alone, or it can be computed without ambiguity using the other computed wires
 // , eg when doing a binary decomposition: either way the missing wire can
 // be computed without ambiguity because the r1cs is correctly ordered)
-func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) {
+//
+// It returns the 1 if the the position to solve is in the quadratic part (it
+// means that there is a division and serves to navigate in the log info for the
+// computational constraints), and 0 otherwise.
+func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) uint {
+
+	// value to return: 1 if the wire to solve is in the quadratic term, 0 otherwise
+	var offset uint
 
 	switch r.Solver {
 
@@ -307,7 +325,7 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 		// ensure we found the unset wire
 		if loc == 0 {
 			// this wire may have been instantiated as part of moExpression already
-			return
+			return 0
 		}
 
 		// we compute the wire value and instantiate it
@@ -319,12 +337,14 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 				wireValues[cID].Div(&c, &b).
 					Sub(&wireValues[cID], &a)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 2:
 			if !a.IsZero() {
 				wireValues[cID].Div(&c, &a).
 					Sub(&wireValues[cID], &b)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 3:
 			wireValues[cID].Mul(&a, &b).
@@ -393,4 +413,6 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 	default:
 		panic("unimplemented solving method")
 	}
+
+	return offset
 }

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -167,7 +167,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 		// check that the constraint is satisfied
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			debugInfo := r1cs.DebugInfo[i-int(r1cs.NbCOConstraints)]
+			debugInfo := r1cs.DebugInfoAssertion[i-int(r1cs.NbCOConstraints)]
 			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
 			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -116,14 +116,18 @@ func (r1cs *R1CS) IsSolved(witness []fr.Element) error {
 // wireValues =  [publicWires | secretWires | internalWires ]
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) error {
+
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables-1, r1cs.NbSecretVariables)
 	}
+
 	nbWires := r1cs.NbPublicVariables + r1cs.NbSecretVariables + r1cs.NbInternalVariables
+
 	// compute the wires and the a, b, c polynomials
 	if len(a) != int(r1cs.NbConstraints) || len(b) != int(r1cs.NbConstraints) || len(c) != int(r1cs.NbConstraints) || len(wireValues) != nbWires {
 		return errors.New("invalid input size: len(a, b, c) == r1cs.NbConstraints and len(wireValues) == r1cs.NbWires")
 	}
+
 	// keep track of wire that have a value
 	wireInstantiated := make([]bool, nbWires)
 	wireInstantiated[0] = true // ONE_WIRE
@@ -140,11 +144,15 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 	// check if there is an inconsistant constraint
 	var check fr.Element
 
+	// this variable is used to navigate in the debugInfoComputation slice.
+	// It is incremented by one each time a division happens for solving a constraint.
+	var debugInfoComputationOffset uint
+
 	// Loop through computational constraints (the one wwe need to solve and compute a wire in)
 	for i := 0; i < int(r1cs.NbCOConstraints); i++ {
 
 		// solve the constraint, this will compute the missing wire of the gate
-		r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
+		debugInfoComputationOffset += r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
 
 		// at this stage we are guaranteed that a[i]*b[i]=c[i]
 		// if not, it means there is a bug in the solver
@@ -152,7 +160,10 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			//return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			debugInfo := r1cs.DebugInfoComputation[debugInfoComputationOffset]
+			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}
 	}
 
@@ -265,7 +276,14 @@ func instantiateR1C(r *compiled.R1C, r1cs *R1CS, wireValues []fr.Element) (a, b,
 // alone, or it can be computed without ambiguity using the other computed wires
 // , eg when doing a binary decomposition: either way the missing wire can
 // be computed without ambiguity because the r1cs is correctly ordered)
-func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) {
+//
+// It returns the 1 if the the position to solve is in the quadratic part (it
+// means that there is a division and serves to navigate in the log info for the
+// computational constraints), and 0 otherwise.
+func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) uint {
+
+	// value to return: 1 if the wire to solve is in the quadratic term, 0 otherwise
+	var offset uint
 
 	switch r.Solver {
 
@@ -307,7 +325,7 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 		// ensure we found the unset wire
 		if loc == 0 {
 			// this wire may have been instantiated as part of moExpression already
-			return
+			return 0
 		}
 
 		// we compute the wire value and instantiate it
@@ -319,12 +337,14 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 				wireValues[cID].Div(&c, &b).
 					Sub(&wireValues[cID], &a)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 2:
 			if !a.IsZero() {
 				wireValues[cID].Div(&c, &a).
 					Sub(&wireValues[cID], &b)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 3:
 			wireValues[cID].Mul(&a, &b).
@@ -393,4 +413,6 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 	default:
 		panic("unimplemented solving method")
 	}
+
+	return offset
 }

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -167,7 +167,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 		// check that the constraint is satisfied
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			debugInfo := r1cs.DebugInfo[i-int(r1cs.NbCOConstraints)]
+			debugInfo := r1cs.DebugInfoAssertion[i-int(r1cs.NbCOConstraints)]
 			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
 			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -116,14 +116,18 @@ func (r1cs *R1CS) IsSolved(witness []fr.Element) error {
 // wireValues =  [publicWires | secretWires | internalWires ]
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) error {
+
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables-1, r1cs.NbSecretVariables)
 	}
+
 	nbWires := r1cs.NbPublicVariables + r1cs.NbSecretVariables + r1cs.NbInternalVariables
+
 	// compute the wires and the a, b, c polynomials
 	if len(a) != int(r1cs.NbConstraints) || len(b) != int(r1cs.NbConstraints) || len(c) != int(r1cs.NbConstraints) || len(wireValues) != nbWires {
 		return errors.New("invalid input size: len(a, b, c) == r1cs.NbConstraints and len(wireValues) == r1cs.NbWires")
 	}
+
 	// keep track of wire that have a value
 	wireInstantiated := make([]bool, nbWires)
 	wireInstantiated[0] = true // ONE_WIRE
@@ -140,11 +144,15 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 	// check if there is an inconsistant constraint
 	var check fr.Element
 
+	// this variable is used to navigate in the debugInfoComputation slice.
+	// It is incremented by one each time a division happens for solving a constraint.
+	var debugInfoComputationOffset uint
+
 	// Loop through computational constraints (the one wwe need to solve and compute a wire in)
 	for i := 0; i < int(r1cs.NbCOConstraints); i++ {
 
 		// solve the constraint, this will compute the missing wire of the gate
-		r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
+		debugInfoComputationOffset += r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
 
 		// at this stage we are guaranteed that a[i]*b[i]=c[i]
 		// if not, it means there is a bug in the solver
@@ -152,7 +160,10 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			//return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			debugInfo := r1cs.DebugInfoComputation[debugInfoComputationOffset]
+			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}
 	}
 
@@ -265,7 +276,14 @@ func instantiateR1C(r *compiled.R1C, r1cs *R1CS, wireValues []fr.Element) (a, b,
 // alone, or it can be computed without ambiguity using the other computed wires
 // , eg when doing a binary decomposition: either way the missing wire can
 // be computed without ambiguity because the r1cs is correctly ordered)
-func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) {
+//
+// It returns the 1 if the the position to solve is in the quadratic part (it
+// means that there is a division and serves to navigate in the log info for the
+// computational constraints), and 0 otherwise.
+func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) uint {
+
+	// value to return: 1 if the wire to solve is in the quadratic term, 0 otherwise
+	var offset uint
 
 	switch r.Solver {
 
@@ -307,7 +325,7 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 		// ensure we found the unset wire
 		if loc == 0 {
 			// this wire may have been instantiated as part of moExpression already
-			return
+			return 0
 		}
 
 		// we compute the wire value and instantiate it
@@ -319,12 +337,14 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 				wireValues[cID].Div(&c, &b).
 					Sub(&wireValues[cID], &a)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 2:
 			if !a.IsZero() {
 				wireValues[cID].Div(&c, &a).
 					Sub(&wireValues[cID], &b)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 3:
 			wireValues[cID].Mul(&a, &b).
@@ -393,4 +413,6 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 	default:
 		panic("unimplemented solving method")
 	}
+
+	return offset
 }

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -167,7 +167,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 		// check that the constraint is satisfied
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			debugInfo := r1cs.DebugInfo[i-int(r1cs.NbCOConstraints)]
+			debugInfo := r1cs.DebugInfoAssertion[i-int(r1cs.NbCOConstraints)]
 			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
 			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -116,14 +116,18 @@ func (r1cs *R1CS) IsSolved(witness []fr.Element) error {
 // wireValues =  [publicWires | secretWires | internalWires ]
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) error {
+
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables-1, r1cs.NbSecretVariables)
 	}
+
 	nbWires := r1cs.NbPublicVariables + r1cs.NbSecretVariables + r1cs.NbInternalVariables
+
 	// compute the wires and the a, b, c polynomials
 	if len(a) != int(r1cs.NbConstraints) || len(b) != int(r1cs.NbConstraints) || len(c) != int(r1cs.NbConstraints) || len(wireValues) != nbWires {
 		return errors.New("invalid input size: len(a, b, c) == r1cs.NbConstraints and len(wireValues) == r1cs.NbWires")
 	}
+
 	// keep track of wire that have a value
 	wireInstantiated := make([]bool, nbWires)
 	wireInstantiated[0] = true // ONE_WIRE
@@ -140,11 +144,15 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 	// check if there is an inconsistant constraint
 	var check fr.Element
 
+	// this variable is used to navigate in the debugInfoComputation slice.
+	// It is incremented by one each time a division happens for solving a constraint.
+	var debugInfoComputationOffset uint
+
 	// Loop through computational constraints (the one wwe need to solve and compute a wire in)
 	for i := 0; i < int(r1cs.NbCOConstraints); i++ {
 
 		// solve the constraint, this will compute the missing wire of the gate
-		r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
+		debugInfoComputationOffset += r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
 
 		// at this stage we are guaranteed that a[i]*b[i]=c[i]
 		// if not, it means there is a bug in the solver
@@ -152,7 +160,10 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			//return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			debugInfo := r1cs.DebugInfoComputation[debugInfoComputationOffset]
+			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}
 	}
 
@@ -265,7 +276,14 @@ func instantiateR1C(r *compiled.R1C, r1cs *R1CS, wireValues []fr.Element) (a, b,
 // alone, or it can be computed without ambiguity using the other computed wires
 // , eg when doing a binary decomposition: either way the missing wire can
 // be computed without ambiguity because the r1cs is correctly ordered)
-func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) {
+//
+// It returns the 1 if the the position to solve is in the quadratic part (it
+// means that there is a division and serves to navigate in the log info for the
+// computational constraints), and 0 otherwise.
+func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) uint {
+
+	// value to return: 1 if the wire to solve is in the quadratic term, 0 otherwise
+	var offset uint
 
 	switch r.Solver {
 
@@ -307,7 +325,7 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 		// ensure we found the unset wire
 		if loc == 0 {
 			// this wire may have been instantiated as part of moExpression already
-			return
+			return 0
 		}
 
 		// we compute the wire value and instantiate it
@@ -319,12 +337,14 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 				wireValues[cID].Div(&c, &b).
 					Sub(&wireValues[cID], &a)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 2:
 			if !a.IsZero() {
 				wireValues[cID].Div(&c, &a).
 					Sub(&wireValues[cID], &b)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 3:
 			wireValues[cID].Mul(&a, &b).
@@ -393,4 +413,6 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 	default:
 		panic("unimplemented solving method")
 	}
+
+	return offset
 }

--- a/internal/backend/circuits/assertisdifferent.go
+++ b/internal/backend/circuits/assertisdifferent.go
@@ -1,0 +1,35 @@
+package circuits
+
+import (
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+)
+
+type assertIsDifferentCircuit struct {
+	X frontend.Variable
+	Y frontend.Variable `gnark:",public"`
+}
+
+func (circuit *assertIsDifferentCircuit) Define(curveID ecc.ID, cs *frontend.ConstraintSystem) error {
+	m := cs.Mul(circuit.X, circuit.X)
+	cs.AssertIsDifferent(m, circuit.Y)
+	return nil
+}
+
+func init() {
+	var circuit, good, bad, public assertIsDifferentCircuit
+
+	// expected Z
+	var expectedZ big.Int
+	expectedZ.SetUint64(3)
+
+	good.X.Assign(6)
+	good.Y.Assign(37)
+
+	bad.X.Assign(6)
+	bad.Y.Assign(36)
+
+	addEntry("assert_different", &circuit, &good, &bad, &public)
+}

--- a/internal/backend/compiled/r1cs.go
+++ b/internal/backend/compiled/r1cs.go
@@ -24,12 +24,14 @@ import (
 // The coefficients from the rank-1 constraint it contains
 // are big.Int and not tied to a curve base field
 type R1CS struct {
+
 	// Wires
-	NbInternalVariables int
-	NbPublicVariables   int // includes ONE wire
-	NbSecretVariables   int
-	Logs                []LogEntry
-	DebugInfoAssertion  []LogEntry
+	NbInternalVariables  int
+	NbPublicVariables    int // includes ONE wire
+	NbSecretVariables    int
+	Logs                 []LogEntry
+	DebugInfoComputation []LogEntry
+	DebugInfoAssertion   []LogEntry
 
 	// Constraints
 	NbConstraints   int // total number of constraints

--- a/internal/backend/compiled/r1cs.go
+++ b/internal/backend/compiled/r1cs.go
@@ -29,7 +29,7 @@ type R1CS struct {
 	NbPublicVariables   int // includes ONE wire
 	NbSecretVariables   int
 	Logs                []LogEntry
-	DebugInfo           []LogEntry
+	DebugInfoAssertion  []LogEntry
 
 	// Constraints
 	NbConstraints   int // total number of constraints

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -103,23 +103,27 @@ func (r1cs *R1CS) IsSolved(witness []fr.Element) error {
 // wireValues =  [publicWires | secretWires | internalWires ]
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) error {
-	if len(witness) != int(r1cs.NbPublicVariables - 1 + r1cs.NbSecretVariables) { // - 1 for ONE_WIRE
-		return fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables -1 + r1cs.NbSecretVariables), r1cs.NbPublicVariables - 1, r1cs.NbSecretVariables)
+
+	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) { // - 1 for ONE_WIRE
+		return fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables-1, r1cs.NbSecretVariables)
 	}
+
 	nbWires := r1cs.NbPublicVariables + r1cs.NbSecretVariables + r1cs.NbInternalVariables
+
 	// compute the wires and the a, b, c polynomials
 	if len(a) != int(r1cs.NbConstraints) || len(b) != int(r1cs.NbConstraints) || len(c) != int(r1cs.NbConstraints) || len(wireValues) != nbWires {
 		return errors.New("invalid input size: len(a, b, c) == r1cs.NbConstraints and len(wireValues) == r1cs.NbWires")
 	}
+
 	// keep track of wire that have a value
 	wireInstantiated := make([]bool, nbWires)
 	wireInstantiated[0] = true // ONE_WIRE
 	wireValues[0].SetOne()
 	copy(wireValues[1:], witness) // TODO factorize
-	for i:=0; i < len(witness); i++ {
+	for i := 0; i < len(witness); i++ {
 		wireInstantiated[i+1] = true
 	}
-	
+
 	// now that we know all inputs are set, defer log printing once all wireValues are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer r1cs.printLogs(wireValues, wireInstantiated)
@@ -127,11 +131,15 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 	// check if there is an inconsistant constraint
 	var check fr.Element
 
+	// this variable is used to navigate in the debugInfoComputation slice.
+	// It is incremented by one each time a division happens for solving a constraint.
+	var debugInfoComputationOffset uint
+
 	// Loop through computational constraints (the one wwe need to solve and compute a wire in)
 	for i := 0; i < int(r1cs.NbCOConstraints); i++ {
 
 		// solve the constraint, this will compute the missing wire of the gate
-		r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
+		debugInfoComputationOffset += r1cs.solveR1C(&r1cs.Constraints[i], wireInstantiated, wireValues)
 
 		// at this stage we are guaranteed that a[i]*b[i]=c[i]
 		// if not, it means there is a bug in the solver
@@ -139,7 +147,10 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			//return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, "couldn't solve computational constraint. May happen: div by 0 or no inverse found")
+			debugInfo := r1cs.DebugInfoComputation[debugInfoComputationOffset]
+			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
+			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}
 	}
 
@@ -252,7 +263,14 @@ func instantiateR1C(r *compiled.R1C, r1cs *R1CS, wireValues []fr.Element) (a, b,
 // alone, or it can be computed without ambiguity using the other computed wires
 // , eg when doing a binary decomposition: either way the missing wire can
 // be computed without ambiguity because the r1cs is correctly ordered)
-func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) {
+//
+// It returns the 1 if the the position to solve is in the quadratic part (it
+// means that there is a division and serves to navigate in the log info for the
+// computational constraints), and 0 otherwise.
+func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues []fr.Element) uint {
+
+	// value to return: 1 if the wire to solve is in the quadratic term, 0 otherwise
+	var offset uint
 
 	switch r.Solver {
 
@@ -294,7 +312,7 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 		// ensure we found the unset wire
 		if loc == 0 {
 			// this wire may have been instantiated as part of moExpression already
-			return
+			return 0
 		}
 
 		// we compute the wire value and instantiate it
@@ -306,12 +324,14 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 				wireValues[cID].Div(&c, &b).
 					Sub(&wireValues[cID], &a)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 2:
 			if !a.IsZero() {
 				wireValues[cID].Div(&c, &a).
 					Sub(&wireValues[cID], &b)
 				r1cs.mulWireByCoeff(&wireValues[cID], termToCompute)
+				offset = 1
 			}
 		case 3:
 			wireValues[cID].Mul(&a, &b).
@@ -380,4 +400,6 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 	default:
 		panic("unimplemented solving method")
 	}
+
+	return offset
 }

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -154,7 +154,7 @@ func (r1cs *R1CS) Solve(witness []fr.Element, a, b, c, wireValues []fr.Element) 
 		// check that the constraint is satisfied
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
-			debugInfo := r1cs.DebugInfo[i-int(r1cs.NbCOConstraints)]
+			debugInfo := r1cs.DebugInfoAssertion[i-int(r1cs.NbCOConstraints)]
 			debugInfoStr := r1cs.logValue(debugInfo, wireValues, wireInstantiated)
 			return fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 		}


### PR DESCRIPTION
This PR fixes #128 , that is a constraint to assert that 2 variables are different has been added.

@gbotrel internal changes --> the `ConstraintSystem` struct now contains `debugInfoComputation []logEntry` and `debugInfoAssertion   []logEntry`, one for the computational constraints and the other for the assertions (formerly named `debugInfo`). 

A computational constraint fails only when a division by 0 occurs, so the `debugInfoComputation` is populated each time an api call to a function using division is made. When solving the constraint system, a counter is incremented each time a division is done, so that when a division by zero happens the corresponding entry ins debugInfoComputation (of index counter) is displayed (using the callstack).