### PR TITLE
perf: `cs.IsZero` uses 3 constraints

### DIFF
--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 
 	"github.com/consensys/gnark/internal/backend/compiled"
-
-	"github.com/consensys/gnark-crypto/ecc"
 )
 
 // Add returns res = i1+i2+...in
@@ -325,7 +323,7 @@ func (cs *ConstraintSystem) And(a, b Variable) Variable {
 }
 
 // IsZero returns 1 if a is zero, 0 otherwise
-func (cs *ConstraintSystem) IsZero(a Variable, id ecc.ID) Variable {
+func (cs *ConstraintSystem) IsZero(a Variable) Variable {
 	a.assertIsSet()
 
 	//m * (1 - m) = 0       // constrain m to be 0 or 1
@@ -341,34 +339,6 @@ func (cs *ConstraintSystem) IsZero(a Variable, id ecc.ID) Variable {
 	_ = cs.Inverse(ma)
 	return m
 
-	// var expo big.Int
-	// switch id {
-	// case ecc.BN254:
-	// 	expo.Set(frbn254.Modulus())
-	// case ecc.BLS12_381:
-	// 	expo.Set(frbls12381.Modulus())
-	// case ecc.BLS12_377:
-	// 	expo.Set(frbls12377.Modulus())
-	// case ecc.BW6_761:
-	// 	expo.Set(frbw6761.Modulus())
-	// case ecc.BLS24_315:
-	// 	expo.Set(frbls24315.Modulus())
-	// default:
-	// 	panic("not implemented")
-	// }
-
-	// res := cs.Constant(1)
-	// expoBytes := expo.Bytes()
-	// nbBits := len(expoBytes) * 8
-	// for i := nbBits - 1; i >= 1; i-- { // up to i-1 because we go up to q-1
-	// 	res = cs.Mul(res, res)
-	// 	if expo.Bit(i) == 1 {
-	// 		res = cs.Mul(res, a)
-	// 	}
-	// }
-	// res = cs.Mul(res, res) // final squaring
-	// res = cs.Sub(1, res)
-	// return res
 }
 
 // ToBinary unpacks a variable in binary, n is the number of bits of the variable

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -137,6 +137,38 @@ func (cs *SparseR1CS) computeTerm(t compiled.Term, solution []fr.Element) fr.Ele
 func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, wireInstantiated []bool, solution, coefficientsNegInv []fr.Element) {
 
 	switch c.Solver {
+	case compiled.IsZero:
+		// inital constraint is in the form a * m == 0
+		// it was transform in a plonk constraint like so:
+		// L = constantTerm(a) * m
+		// M[0] = m
+		// M[1] = a - constantTerm(a)
+
+		// we want to reconstruct a, and compute m = 1 - a^(q-1)
+		vID := c.L.VariableID()
+
+		// sanity checks
+		lro := findUnsolvedVariable(c, wireInstantiated)
+		if lro != 0 || !wireInstantiated[c.M[1].VariableID()] || c.M[0].VariableID() != vID {
+			panic("sanity check for plonk.IsZero failed")
+		}
+
+		// reconstruct a
+		a := cs.Coefficients[c.L.CoeffID()]
+		a.Add(&a, &solution[c.M[1].VariableID()])
+
+		// compute a ^ (q-1)
+		// q - 1
+		var eOne big.Int
+		eOne.SetUint64(1)
+		eOne.Sub(fr.Modulus(), &eOne)
+
+		one := fr.One()
+		solution[vID].Exp(a, &eOne)
+		// m = 1 - a ^ (q-1)
+		solution[vID].Sub(&one, &solution[vID])
+		wireInstantiated[vID] = true
+
 	case compiled.SingleOutput:
 
 		lro := findUnsolvedVariable(c, wireInstantiated)

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -137,6 +137,38 @@ func (cs *SparseR1CS) computeTerm(t compiled.Term, solution []fr.Element) fr.Ele
 func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, wireInstantiated []bool, solution, coefficientsNegInv []fr.Element) {
 
 	switch c.Solver {
+	case compiled.IsZero:
+		// inital constraint is in the form a * m == 0
+		// it was transform in a plonk constraint like so:
+		// L = constantTerm(a) * m
+		// M[0] = m
+		// M[1] = a - constantTerm(a)
+
+		// we want to reconstruct a, and compute m = 1 - a^(q-1)
+		vID := c.L.VariableID()
+
+		// sanity checks
+		lro := findUnsolvedVariable(c, wireInstantiated)
+		if lro != 0 || !wireInstantiated[c.M[1].VariableID()] || c.M[0].VariableID() != vID {
+			panic("sanity check for plonk.IsZero failed")
+		}
+
+		// reconstruct a
+		a := cs.Coefficients[c.L.CoeffID()]
+		a.Add(&a, &solution[c.M[1].VariableID()])
+
+		// compute a ^ (q-1)
+		// q - 1
+		var eOne big.Int
+		eOne.SetUint64(1)
+		eOne.Sub(fr.Modulus(), &eOne)
+
+		one := fr.One()
+		solution[vID].Exp(a, &eOne)
+		// m = 1 - a ^ (q-1)
+		solution[vID].Sub(&one, &solution[vID])
+		wireInstantiated[vID] = true
+
 	case compiled.SingleOutput:
 
 		lro := findUnsolvedVariable(c, wireInstantiated)

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -137,6 +137,38 @@ func (cs *SparseR1CS) computeTerm(t compiled.Term, solution []fr.Element) fr.Ele
 func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, wireInstantiated []bool, solution, coefficientsNegInv []fr.Element) {
 
 	switch c.Solver {
+	case compiled.IsZero:
+		// inital constraint is in the form a * m == 0
+		// it was transform in a plonk constraint like so:
+		// L = constantTerm(a) * m
+		// M[0] = m
+		// M[1] = a - constantTerm(a)
+
+		// we want to reconstruct a, and compute m = 1 - a^(q-1)
+		vID := c.L.VariableID()
+
+		// sanity checks
+		lro := findUnsolvedVariable(c, wireInstantiated)
+		if lro != 0 || !wireInstantiated[c.M[1].VariableID()] || c.M[0].VariableID() != vID {
+			panic("sanity check for plonk.IsZero failed")
+		}
+
+		// reconstruct a
+		a := cs.Coefficients[c.L.CoeffID()]
+		a.Add(&a, &solution[c.M[1].VariableID()])
+
+		// compute a ^ (q-1)
+		// q - 1
+		var eOne big.Int
+		eOne.SetUint64(1)
+		eOne.Sub(fr.Modulus(), &eOne)
+
+		one := fr.One()
+		solution[vID].Exp(a, &eOne)
+		// m = 1 - a ^ (q-1)
+		solution[vID].Sub(&one, &solution[vID])
+		wireInstantiated[vID] = true
+
 	case compiled.SingleOutput:
 
 		lro := findUnsolvedVariable(c, wireInstantiated)

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -137,6 +137,38 @@ func (cs *SparseR1CS) computeTerm(t compiled.Term, solution []fr.Element) fr.Ele
 func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, wireInstantiated []bool, solution, coefficientsNegInv []fr.Element) {
 
 	switch c.Solver {
+	case compiled.IsZero:
+		// inital constraint is in the form a * m == 0
+		// it was transform in a plonk constraint like so:
+		// L = constantTerm(a) * m
+		// M[0] = m
+		// M[1] = a - constantTerm(a)
+
+		// we want to reconstruct a, and compute m = 1 - a^(q-1)
+		vID := c.L.VariableID()
+
+		// sanity checks
+		lro := findUnsolvedVariable(c, wireInstantiated)
+		if lro != 0 || !wireInstantiated[c.M[1].VariableID()] || c.M[0].VariableID() != vID {
+			panic("sanity check for plonk.IsZero failed")
+		}
+
+		// reconstruct a
+		a := cs.Coefficients[c.L.CoeffID()]
+		a.Add(&a, &solution[c.M[1].VariableID()])
+
+		// compute a ^ (q-1)
+		// q - 1
+		var eOne big.Int
+		eOne.SetUint64(1)
+		eOne.Sub(fr.Modulus(), &eOne)
+
+		one := fr.One()
+		solution[vID].Exp(a, &eOne)
+		// m = 1 - a ^ (q-1)
+		solution[vID].Sub(&one, &solution[vID])
+		wireInstantiated[vID] = true
+
 	case compiled.SingleOutput:
 
 		lro := findUnsolvedVariable(c, wireInstantiated)

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -137,6 +137,38 @@ func (cs *SparseR1CS) computeTerm(t compiled.Term, solution []fr.Element) fr.Ele
 func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, wireInstantiated []bool, solution, coefficientsNegInv []fr.Element) {
 
 	switch c.Solver {
+	case compiled.IsZero:
+		// inital constraint is in the form a * m == 0
+		// it was transform in a plonk constraint like so:
+		// L = constantTerm(a) * m
+		// M[0] = m
+		// M[1] = a - constantTerm(a)
+
+		// we want to reconstruct a, and compute m = 1 - a^(q-1)
+		vID := c.L.VariableID()
+
+		// sanity checks
+		lro := findUnsolvedVariable(c, wireInstantiated)
+		if lro != 0 || !wireInstantiated[c.M[1].VariableID()] || c.M[0].VariableID() != vID {
+			panic("sanity check for plonk.IsZero failed")
+		}
+
+		// reconstruct a
+		a := cs.Coefficients[c.L.CoeffID()]
+		a.Add(&a, &solution[c.M[1].VariableID()])
+
+		// compute a ^ (q-1)
+		// q - 1
+		var eOne big.Int
+		eOne.SetUint64(1)
+		eOne.Sub(fr.Modulus(), &eOne)
+
+		one := fr.One()
+		solution[vID].Exp(a, &eOne)
+		// m = 1 - a ^ (q-1)
+		solution[vID].Sub(&one, &solution[vID])
+		wireInstantiated[vID] = true
+
 	case compiled.SingleOutput:
 
 		lro := findUnsolvedVariable(c, wireInstantiated)

--- a/internal/backend/circuits/iszero.go
+++ b/internal/backend/circuits/iszero.go
@@ -11,8 +11,8 @@ type isZero struct {
 
 func (circuit *isZero) Define(curveID ecc.ID, cs *frontend.ConstraintSystem) error {
 
-	a := cs.IsZero(circuit.X, curveID)
-	b := cs.IsZero(circuit.Y, curveID)
+	a := cs.IsZero(circuit.X)
+	b := cs.IsZero(circuit.Y)
 	cs.AssertIsEqual(a, 1)
 	cs.AssertIsEqual(b, 0)
 

--- a/internal/backend/compiled/r1c.go
+++ b/internal/backend/compiled/r1c.go
@@ -79,4 +79,5 @@ type SolvingMethod uint8
 const (
 	SingleOutput SolvingMethod = iota
 	BinaryDec
+	IsZero // TODO this is temporary, solver will be improved to be extensible at runtime, or with lambdas.
 )

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -396,6 +396,45 @@ func (r1cs *R1CS) solveR1C(r *compiled.R1C, wireInstantiated []bool, wireValues 
 			wireValues[cID].SetUint64(uint64(bitSlice[ithBit]))
 			wireInstantiated[cID] = true
 		}
+	
+	case compiled.IsZero:
+		// TODO this is temporary need to be able to extend the solver in a cleaner way
+		// IsZero is in the form a * m = 0 
+		// m is computed as m = 1 - a^(q-1)
+
+		var a fr.Element
+
+		processTerm := func(t compiled.Term, val *fr.Element) {
+			cID := t.VariableID()
+			if wireInstantiated[cID] {
+				r1cs.AddTerm(val, t, wireValues[cID])
+			} else {
+				panic("L should be instantiated at this stage (IsZero constraint)")
+			}
+		}
+
+		for _, t := range r.L {
+			processTerm(t, &a)
+		}
+
+		if len(r.R) != 1 {
+			panic("expecting 1 term to solve only")
+		}
+		
+		m := r.R[0]
+		vID := m.VariableID()
+
+		// q - 1
+		var eOne big.Int 
+		eOne.SetUint64(1)
+		eOne.Sub(fr.Modulus(), &eOne)
+
+		one := fr.One()
+		wireValues[vID].Exp(a, &eOne)
+
+		wireValues[vID].Sub(&one, &wireValues[vID])
+		wireInstantiated[vID] = true
+		
 
 	default:
 		panic("unimplemented solving method")

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -119,6 +119,38 @@ func (cs *SparseR1CS) computeTerm(t compiled.Term, solution []fr.Element) fr.Ele
 func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, wireInstantiated []bool, solution, coefficientsNegInv []fr.Element) {
 
 	switch c.Solver {
+	case compiled.IsZero:
+		// inital constraint is in the form a * m == 0
+		// it was transform in a plonk constraint like so:
+		// L = constantTerm(a) * m
+		// M[0] = m
+		// M[1] = a - constantTerm(a)
+
+		// we want to reconstruct a, and compute m = 1 - a^(q-1)
+		vID := c.L.VariableID()
+
+		// sanity checks 
+		lro := findUnsolvedVariable(c, wireInstantiated)
+		if lro != 0 || !wireInstantiated[c.M[1].VariableID()] || c.M[0].VariableID() != vID {
+			panic("sanity check for plonk.IsZero failed")
+		}
+
+		// reconstruct a
+		a := cs.Coefficients[c.L.CoeffID()]
+		a.Add(&a, &solution[c.M[1].VariableID()])
+
+		// compute a ^ (q-1)
+		// q - 1
+		var eOne big.Int 
+		eOne.SetUint64(1)
+		eOne.Sub(fr.Modulus(), &eOne)
+
+		one := fr.One()
+		solution[vID].Exp(a, &eOne)
+		// m = 1 - a ^ (q-1)
+		solution[vID].Sub(&one, &solution[vID])
+		wireInstantiated[vID] = true
+
 	case compiled.SingleOutput:
 
 		lro := findUnsolvedVariable(c, wireInstantiated)


### PR DESCRIPTION
Fixes #132 . 

Note that the way the solver was extended is likely to be superseded by #133 . 