### PR TITLE
Add Bandersnatch curve

### DIFF
--- a/std/algebra/twistededwards/bandersnatch/curve.go
+++ b/std/algebra/twistededwards/bandersnatch/curve.go
@@ -1,0 +1,68 @@
+/*
+Copyright © 2020 ConsenSys
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bandersnatch
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bandersnatch "github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards/bandersnatch"
+	"github.com/consensys/gnark/frontend"
+)
+
+// EdCurve stores the info on the chosen edwards curve
+type EdCurve struct {
+	A, D, Cofactor, Order, BaseX, BaseY big.Int
+	ID                                  ecc.ID
+}
+
+var constructors map[ecc.ID]func() EdCurve
+
+func init() {
+	constructors = map[ecc.ID]func() EdCurve{
+		ecc.BLS12_381: newBandersnatch,
+	}
+}
+
+// NewEdCurve returns an Edwards curve parameters
+func NewEdCurve(id ecc.ID) (EdCurve, error) {
+	if constructor, ok := constructors[id]; ok {
+		return constructor(), nil
+	}
+	return EdCurve{}, errors.New("unknown curve id")
+}
+
+// -------------------------------------------------------------------------------------------------
+// constructors
+
+func newBandersnatch() EdCurve {
+
+	edcurve := bandersnatch.GetEdwardsCurve()
+	edcurve.Cofactor.FromMont()
+
+	return EdCurve{
+		A:        frontend.FromInterface(edcurve.A),
+		D:        frontend.FromInterface(edcurve.D),
+		Cofactor: frontend.FromInterface(edcurve.Cofactor),
+		Order:    frontend.FromInterface(edcurve.Order),
+		BaseX:    frontend.FromInterface(edcurve.Base.X),
+		BaseY:    frontend.FromInterface(edcurve.Base.Y),
+		ID:       ecc.BLS12_381,
+	}
+
+}

--- a/std/algebra/twistededwards/bandersnatch/point.go
+++ b/std/algebra/twistededwards/bandersnatch/point.go
@@ -1,0 +1,183 @@
+/*
+Copyright © 2020 ConsenSys
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bandersnatch
+
+import (
+	"math/big"
+
+	"github.com/consensys/gnark/frontend"
+)
+
+// Point point on a twisted Edwards curve in a Snark cs
+type Point struct {
+	X, Y frontend.Variable
+}
+
+// MustBeOnCurve checks if a point is on the reduced twisted Edwards curve
+// a*x^2 + y^2 = 1 + d*x^2*y^2.
+func (p *Point) MustBeOnCurve(api frontend.API, curve EdCurve) {
+
+	one := big.NewInt(1)
+
+	xx := api.Mul(p.X, p.X)
+	yy := api.Mul(p.Y, p.Y)
+	axx := api.Mul(xx, &curve.A)
+	lhs := api.Add(axx, yy)
+
+	dxx := api.Mul(xx, &curve.D)
+	dxxyy := api.Mul(dxx, yy)
+	rhs := api.Add(dxxyy, one)
+
+	api.AssertIsEqual(lhs, rhs)
+
+}
+
+// AddFixedPoint Adds two points, among which is one fixed point (the base), on a twisted edwards curve (eg jubjub)
+// p1, base, ecurve are respectively: the point to add, a known base point, and the parameters of the twisted edwards curve
+func (p *Point) AddFixedPoint(api frontend.API, p1 *Point /*basex*/, x /*basey*/, y interface{}, curve EdCurve) *Point {
+
+	// https://eprint.iacr.org/2008/013.pdf
+
+	n11 := api.Mul(p1.X, y)
+	n12 := api.Mul(p1.Y, x)
+	n1 := api.Add(n11, n12)
+
+	n21 := api.Mul(p1.Y, y)
+	n22 := api.Mul(p1.X, x)
+	an22 := api.Mul(n22, &curve.A)
+	n2 := api.Sub(n21, an22)
+
+	d11 := api.Mul(curve.D, n11, n12)
+	d1 := api.Add(1, d11)
+	d2 := api.Sub(1, d11)
+
+	p.X = api.DivUnchecked(n1, d1)
+	p.Y = api.DivUnchecked(n2, d2)
+
+	return p
+}
+
+// AddGeneric Adds two points on a twisted edwards curve (eg jubjub)
+// p1, p2, c are respectively: the point to add, a known base point, and the parameters of the twisted edwards curve
+func (p *Point) AddGeneric(api frontend.API, p1, p2 *Point, curve EdCurve) *Point {
+
+	// https://eprint.iacr.org/2008/013.pdf
+
+	n11 := api.Mul(p1.X, p2.Y)
+	n12 := api.Mul(p1.Y, p2.X)
+	n1 := api.Add(n11, n12)
+
+	n21 := api.Mul(p1.Y, p2.Y)
+	n22 := api.Mul(p1.X, p2.X)
+	an22 := api.Mul(n22, &curve.A)
+	n2 := api.Sub(n21, an22)
+
+	d11 := api.Mul(curve.D, n11, n12)
+	d1 := api.Add(1, d11)
+
+	d2 := api.Sub(1, d11)
+
+	p.X = api.DivUnchecked(n1, d1)
+	p.Y = api.DivUnchecked(n2, d2)
+
+	return p
+}
+
+// Double doubles a points in SNARK coordinates
+func (p *Point) Double(api frontend.API, p1 *Point, curve EdCurve) *Point {
+
+	u := api.Mul(p1.X, p1.Y)
+	v := api.Mul(p1.X, p1.X)
+	w := api.Mul(p1.Y, p1.Y)
+	z := api.Mul(v, w)
+
+	n1 := api.Mul(2, u)
+	av := api.Mul(v, &curve.A)
+	n2 := api.Sub(w, av)
+	d := api.Mul(z, curve.D)
+	d1 := api.Add(1, d)
+	d2 := api.Sub(1, d)
+
+	p.X = api.DivUnchecked(n1, d1)
+	p.Y = api.DivUnchecked(n2, d2)
+
+	return p
+}
+
+// ScalarMulNonFixedBase computes the scalar multiplication of a point on a twisted Edwards curve
+// p1: base point (as snark point)
+// curve: parameters of the Edwards curve
+// scal: scalar as a SNARK constraint
+// Standard left to right double and add
+func (p *Point) ScalarMulNonFixedBase(api frontend.API, p1 *Point, scalar frontend.Variable, curve EdCurve) *Point {
+
+	// first unpack the scalar
+	b := api.ToBinary(scalar)
+
+	res := Point{
+		api.Constant(0),
+		api.Constant(1),
+	}
+
+	for i := len(b) - 1; i >= 0; i-- {
+		res.Double(api, &res, curve)
+		tmp := Point{}
+		tmp.AddGeneric(api, &res, p1, curve)
+		res.X = api.Select(b[i], tmp.X, res.X)
+		res.Y = api.Select(b[i], tmp.Y, res.Y)
+	}
+
+	p.X = res.X
+	p.Y = res.Y
+	return p
+}
+
+// ScalarMulFixedBase computes the scalar multiplication of a point on a twisted Edwards curve
+// x, y: coordinates of the base point
+// curve: parameters of the Edwards curve
+// scal: scalar as a SNARK constraint
+// Standard left to right double and add
+func (p *Point) ScalarMulFixedBase(api frontend.API, x, y interface{}, scalar frontend.Variable, curve EdCurve) *Point {
+
+	// first unpack the scalar
+	b := api.ToBinary(scalar)
+
+	res := Point{
+		api.Constant(0),
+		api.Constant(1),
+	}
+
+	for i := len(b) - 1; i >= 0; i-- {
+		res.Double(api, &res, curve)
+		tmp := Point{}
+		tmp.AddFixedPoint(api, &res, x, y, curve)
+		res.X = api.Select(b[i], tmp.X, res.X)
+		res.Y = api.Select(b[i], tmp.Y, res.Y)
+	}
+
+	p.X = res.X
+	p.Y = res.Y
+
+	return p
+}
+
+// Neg computes the negative of a point in SNARK coordinates
+func (p *Point) Neg(api frontend.API, p1 *Point) *Point {
+	p.X = api.Neg(p1.X)
+	p.Y = p1.Y
+	return p
+}

--- a/std/algebra/twistededwards/bandersnatch/point_test.go
+++ b/std/algebra/twistededwards/bandersnatch/point_test.go
@@ -1,0 +1,375 @@
+/*
+Copyright © 2020 ConsenSys
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bandersnatch
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards/bandersnatch"
+	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+)
+
+type mustBeOnCurve struct {
+	P Point
+}
+
+func (circuit *mustBeOnCurve) Define(curveID ecc.ID, api frontend.API) error {
+
+	// get edwards curve params
+	params, err := NewEdCurve(curveID)
+	if err != nil {
+		return err
+	}
+
+	circuit.P.MustBeOnCurve(api, params)
+
+	return nil
+}
+
+func TestIsOnCurve(t *testing.T) {
+
+	assert := test.NewAssert(t)
+
+	var circuit, witness mustBeOnCurve
+
+	params, err := NewEdCurve(ecc.BLS12_381)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witness.P.X.Assign(params.BaseX)
+	witness.P.Y.Assign(params.BaseY)
+
+	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
+
+}
+
+type add struct {
+	P, E Point
+}
+
+func (circuit *add) Define(curveID ecc.ID, api frontend.API) error {
+
+	// get edwards curve params
+	params, err := NewEdCurve(curveID)
+	if err != nil {
+		return err
+	}
+
+	res := circuit.P.AddFixedPoint(api, &circuit.P, params.BaseX, params.BaseY, params)
+
+	api.AssertIsEqual(res.X, circuit.E.X)
+	api.AssertIsEqual(res.Y, circuit.E.Y)
+
+	return nil
+}
+
+func TestAddFixedPoint(t *testing.T) {
+
+	assert := test.NewAssert(t)
+
+	var circuit, witness add
+
+	// generate a random point, and compute expected_point = base + random_point
+	params, err := NewEdCurve(ecc.BLS12_381)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var base, point, expected bandersnatch.PointAffine
+	base.X.SetBigInt(&params.BaseX)
+	base.Y.SetBigInt(&params.BaseY)
+	point.Set(&base)
+	r := big.NewInt(5)
+	point.ScalarMul(&point, r)
+	expected.Add(&base, &point)
+
+	// populate witness
+	witness.P.X.Assign(point.X.String())
+	witness.P.Y.Assign(point.Y.String())
+	witness.E.X.Assign(expected.X.String())
+	witness.E.Y.Assign(expected.Y.String())
+
+	// creates r1cs
+	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
+
+}
+
+type addGeneric struct {
+	P1, P2, E Point
+}
+
+func (circuit *addGeneric) Define(curveID ecc.ID, api frontend.API) error {
+
+	// get edwards curve params
+	params, err := NewEdCurve(curveID)
+	if err != nil {
+		return err
+	}
+
+	res := circuit.P1.AddGeneric(api, &circuit.P1, &circuit.P2, params)
+
+	api.AssertIsEqual(res.X, circuit.E.X)
+	api.AssertIsEqual(res.Y, circuit.E.Y)
+
+	return nil
+}
+
+func TestAddGeneric(t *testing.T) {
+
+	assert := test.NewAssert(t)
+	var circuit, witness addGeneric
+
+	// generate random points, and compute expected_point = point1 + point2s
+	params, err := NewEdCurve(ecc.BLS12_381)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var point1, point2, expected bandersnatch.PointAffine
+	point1.X.SetBigInt(&params.BaseX)
+	point1.Y.SetBigInt(&params.BaseY)
+	point2.Set(&point1)
+	r1 := big.NewInt(5)
+	r2 := big.NewInt(12)
+	point1.ScalarMul(&point1, r1)
+	point2.ScalarMul(&point2, r2)
+	expected.Add(&point1, &point2)
+
+	// populate witness
+	witness.P1.X.Assign(point1.X.String())
+	witness.P1.Y.Assign(point1.Y.String())
+	witness.P2.X.Assign(point2.X.String())
+	witness.P2.Y.Assign(point2.Y.String())
+	witness.E.X.Assign(expected.X.String())
+	witness.E.Y.Assign(expected.Y.String())
+
+	// creates r1cs
+	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
+
+}
+
+type double struct {
+	P, E Point
+}
+
+func (circuit *double) Define(curveID ecc.ID, api frontend.API) error {
+
+	// get edwards curve params
+	params, err := NewEdCurve(curveID)
+	if err != nil {
+		return err
+	}
+
+	res := circuit.P.Double(api, &circuit.P, params)
+
+	api.AssertIsEqual(res.X, circuit.E.X)
+	api.AssertIsEqual(res.Y, circuit.E.Y)
+
+	return nil
+}
+
+func TestDouble(t *testing.T) {
+
+	assert := test.NewAssert(t)
+
+	var circuit, witness double
+
+	// generate witness data
+	params, err := NewEdCurve(ecc.BLS12_381)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var base, expected bandersnatch.PointAffine
+	base.X.SetBigInt(&params.BaseX)
+	base.Y.SetBigInt(&params.BaseY)
+	expected.Double(&base)
+
+	// populate witness
+	witness.P.X.Assign(base.X.String())
+	witness.P.Y.Assign(base.Y.String())
+	witness.E.X.Assign(expected.X.String())
+	witness.E.Y.Assign(expected.Y.String())
+
+	// creates r1cs
+	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
+
+}
+
+type scalarMulFixed struct {
+	E Point
+	S frontend.Variable
+}
+
+func (circuit *scalarMulFixed) Define(curveID ecc.ID, api frontend.API) error {
+
+	// get edwards curve params
+	params, err := NewEdCurve(curveID)
+	if err != nil {
+		return err
+	}
+
+	var resFixed Point
+	resFixed.ScalarMulFixedBase(api, params.BaseX, params.BaseY, circuit.S, params)
+
+	api.AssertIsEqual(resFixed.X, circuit.E.X)
+	api.AssertIsEqual(resFixed.Y, circuit.E.Y)
+
+	return nil
+}
+
+func TestScalarMulFixed(t *testing.T) {
+
+	assert := test.NewAssert(t)
+
+	var circuit, witness scalarMulFixed
+
+	// generate witness data
+	params, err := NewEdCurve(ecc.BLS12_381)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var base, expected bandersnatch.PointAffine
+	base.X.SetBigInt(&params.BaseX)
+	base.Y.SetBigInt(&params.BaseY)
+	r := big.NewInt(928323002)
+	expected.ScalarMul(&base, r)
+
+	// populate witness
+	witness.E.X.Assign(expected.X.String())
+	witness.E.Y.Assign(expected.Y.String())
+	witness.S.Assign(r)
+
+	// creates r1cs
+	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
+
+}
+
+type scalarMulGeneric struct {
+	P, E Point
+	S    frontend.Variable
+}
+
+func (circuit *scalarMulGeneric) Define(curveID ecc.ID, api frontend.API) error {
+
+	// get edwards curve params
+	params, err := NewEdCurve(curveID)
+	if err != nil {
+		return err
+	}
+
+	resGeneric := circuit.P.ScalarMulNonFixedBase(api, &circuit.P, circuit.S, params)
+
+	api.AssertIsEqual(resGeneric.X, circuit.E.X)
+	api.AssertIsEqual(resGeneric.Y, circuit.E.Y)
+
+	return nil
+}
+
+func TestScalarMulGeneric(t *testing.T) {
+
+	assert := test.NewAssert(t)
+
+	var circuit, witness scalarMulGeneric
+
+	// generate witness data
+	params, err := NewEdCurve(ecc.BLS12_381)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var base, point, expected bandersnatch.PointAffine
+	base.X.SetBigInt(&params.BaseX)
+	base.Y.SetBigInt(&params.BaseY)
+	s := big.NewInt(902)
+	point.ScalarMul(&base, s) // random point
+	r := big.NewInt(230928302)
+	expected.ScalarMul(&point, r)
+
+	// populate witness
+	witness.P.X.Assign(point.X.String())
+	witness.P.Y.Assign(point.Y.String())
+	witness.E.X.Assign(expected.X.String())
+	witness.E.Y.Assign(expected.Y.String())
+	witness.S.Assign(r)
+
+	// creates r1cs
+	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
+
+}
+
+type neg struct {
+	P, E Point
+}
+
+func (circuit *neg) Define(curveID ecc.ID, api frontend.API) error {
+
+	circuit.P.Neg(api, &circuit.P)
+	api.AssertIsEqual(circuit.P.X, circuit.E.X)
+	api.AssertIsEqual(circuit.P.Y, circuit.E.Y)
+
+	return nil
+}
+
+func TestNeg(t *testing.T) {
+
+	assert := test.NewAssert(t)
+
+	// generate witness data
+	params, err := NewEdCurve(ecc.BLS12_381)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var base, expected bandersnatch.PointAffine
+	base.X.SetBigInt(&params.BaseX)
+	base.Y.SetBigInt(&params.BaseY)
+	expected.Neg(&base)
+
+	// generate witness
+	var circuit, witness neg
+	witness.P.X.Assign(base.X)
+	witness.P.Y.Assign(base.Y)
+	witness.E.X.Assign(expected.X)
+	witness.E.Y.Assign(expected.Y)
+
+	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
+
+}
+
+// benches
+
+var ccsBench frontend.CompiledConstraintSystem
+
+func BenchmarkScalarMulG1(b *testing.B) {
+	var c scalarMulGeneric
+	b.Run("groth16", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			ccsBench, _ = frontend.Compile(ecc.BLS12_381, backend.GROTH16, &c)
+		}
+
+	})
+	b.Log("groth16", ccsBench.GetNbConstraints())
+	b.Run("plonk", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			ccsBench, _ = frontend.Compile(ecc.BLS12_381, backend.PLONK, &c)
+		}
+
+	})
+	b.Log("plonk", ccsBench.GetNbConstraints())
+
+}


### PR DESCRIPTION
A proposition to add bandersnatch curve (in twisted Edwards form) to gnark. This PR implements Bandersnatch as a separate package from `twistededwards` mainly because each companion curve is identified by the base curve ID (e.g. BLS12-381 for both Bandersnatch and Jubjub). This has the advantage to keep backward compatibility but duplicates the exact same code. The other option is to create in gnark-crypto an ID for companion curves but gnark users should update their code.