### PR TITLE
feat: added UnsafeReadFrom for groth16 Proving and Verifying keys

### DIFF
--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -68,6 +68,7 @@ type Proof interface {
 // it's underlying implementation is strongly typed with the curve (see gnark/internal/backend)
 type ProvingKey interface {
 	groth16Object
+	gnarkio.UnsafeReaderFrom
 
 	// NbG1 returns the number of G1 elements in the ProvingKey
 	NbG1() int
@@ -85,6 +86,7 @@ type ProvingKey interface {
 // ExportSolidity is implemented for BN254 and will return an error with other curves
 type VerifyingKey interface {
 	groth16Object
+	gnarkio.UnsafeReaderFrom
 
 	// NbPublicWitness returns number of elements expected in the public witness
 	NbPublicWitness() int

--- a/internal/backend/bls12-377/groth16/marshal.go
+++ b/internal/backend/bls12-377/groth16/marshal.go
@@ -22,14 +22,14 @@ import (
 )
 
 // WriteTo writes binary encoding of the Proof elements to writer
-// points are stored in compressed form Ar | Krs | Bs
+// points are stored in compressed form Ar | Krs | Bs
 // use WriteRawTo(...) to encode the proof without point compression
 func (proof *Proof) WriteTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, false)
 }
 
 // WriteRawTo writes binary encoding of the Proof elements to writer
-// points are stored in uncompressed form Ar | Krs | Bs
+// points are stored in uncompressed form Ar | Krs | Bs
 // use WriteTo(...) to encode the proof with point compression
 func (proof *Proof) WriteRawTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, true)
@@ -133,8 +133,17 @@ func (vk *VerifyingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // https://github.com/zkcrypto/bellman/blob/fa9be45588227a8c6ec34957de3f68705f07bd92/src/groth16/mod.rs#L143
 // [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2,uint32(len(Kvk)),[Kvk]1
 func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r)
+}
 
-	dec := curve.NewDecoder(r)
+// UnsafeReadFrom has the same behavior as ReadFrom, except that it will not check that decode points
+// are on the curve and in the correct subgroup.
+func (vk *VerifyingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
+	dec := curve.NewDecoder(r, decOptions...)
 
 	// [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2
 	if err := dec.Decode(&vk.G1.Alpha); err != nil {
@@ -233,13 +242,22 @@ func (pk *ProvingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // ProvingKey must be encoded through WriteTo (compressed) or WriteRawTo (uncompressed)
 // note that we don't check that the points are on the curve or in the correct subgroup at this point
 func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r)
+}
 
+// UnsafeReadFrom behaves like ReadFrom excepts it doesn't check if the decoded points are on the curve
+// or in the correct subgroup
+func (pk *ProvingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
 	n, err := pk.Domain.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}
 
-	dec := curve.NewDecoder(r)
+	dec := curve.NewDecoder(r, decOptions...)
 
 	var nbWires uint64
 

--- a/internal/backend/bls12-381/groth16/groth16_test.go
+++ b/internal/backend/bls12-381/groth16/groth16_test.go
@@ -27,7 +27,6 @@ import (
 
 	"bytes"
 	bls12_381groth16 "github.com/consensys/gnark/internal/backend/bls12-381/groth16"
-	"github.com/fxamacker/cbor/v2"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -141,7 +140,7 @@ func BenchmarkVerifier(b *testing.B) {
 	})
 }
 
-func BenchmarkSerialization(b *testing.B) {
+func BenchmarkProofSerialization(b *testing.B) {
 	r1cs, _solution := referenceCircuit()
 	fullWitness := bls12_381witness.Witness{}
 	err := fullWitness.FromFullAssignment(_solution)
@@ -158,82 +157,6 @@ func BenchmarkSerialization(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-
-	// ---------------------------------------------------------------------------------------------
-	// bls12_381groth16.ProvingKey binary serialization
-	b.Run("pk: binary serialization (bls12_381groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			_, _ = pk.WriteTo(&buf)
-		}
-	})
-	b.Run("pk: binary deserialization (bls12_381groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		_, _ = pk.WriteTo(&buf)
-		var pkReconstructed bls12_381groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			_, _ = pkReconstructed.ReadFrom(buf)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		_, _ = pk.WriteTo(&buf)
-	}
-
-	// ---------------------------------------------------------------------------------------------
-	// bls12_381groth16.ProvingKey binary serialization (uncompressed)
-	b.Run("pk: binary raw serialization (bls12_381groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			_, _ = pk.WriteRawTo(&buf)
-		}
-	})
-	b.Run("pk: binary raw deserialization (bls12_381groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		_, _ = pk.WriteRawTo(&buf)
-		var pkReconstructed bls12_381groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			_, _ = pkReconstructed.ReadFrom(buf)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		_, _ = pk.WriteRawTo(&buf)
-	}
-
-	// ---------------------------------------------------------------------------------------------
-	// bls12_381groth16.ProvingKey binary serialization (cbor)
-	b.Run("pk: binary cbor serialization (bls12_381groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			enc := cbor.NewEncoder(&buf)
-			enc.Encode(&pk)
-		}
-	})
-	b.Run("pk: binary cbor deserialization (bls12_381groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&pk)
-		var pkReconstructed bls12_381groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			dec := cbor.NewDecoder(buf)
-			dec.Decode(&pkReconstructed)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&pk)
-	}
 
 	// ---------------------------------------------------------------------------------------------
 	// bls12_381groth16.Proof binary serialization
@@ -283,32 +206,61 @@ func BenchmarkSerialization(b *testing.B) {
 		_, _ = proof.WriteRawTo(&buf)
 	}
 
-	// ---------------------------------------------------------------------------------------------
-	// bls12_381groth16.Proof binary serialization (cbor)
-	b.Run("proof: binary cbor serialization (bls12_381groth16.Proof)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			enc := cbor.NewEncoder(&buf)
-			enc.Encode(&proof)
-		}
-	})
-	b.Run("proof: binary cbor deserialization (bls12_381groth16.Proof)", func(b *testing.B) {
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&proof)
-		var proofReconstructed bls12_381groth16.Proof
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			dec := cbor.NewDecoder(buf)
-			dec.Decode(&proofReconstructed)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&proof)
-	}
+}
 
+func BenchmarkProvingKeySerialization(b *testing.B) {
+	r1cs, _ := referenceCircuit()
+
+	var pk bls12_381groth16.ProvingKey
+	bls12_381groth16.DummySetup(r1cs.(*cs.R1CS), &pk)
+
+	var buf bytes.Buffer
+	// grow the buffer once
+	pk.WriteTo(&buf)
+
+	b.ResetTimer()
+	b.Run("pk_serialize_compressed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			pk.WriteTo(&buf)
+		}
+	})
+
+	compressedBytes := buf.Bytes()
+	b.ResetTimer()
+	b.Run("pk_deserialize_compressed_safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.ReadFrom(bytes.NewReader(compressedBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_deserialize_compressed_unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.UnsafeReadFrom(bytes.NewReader(compressedBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_serialize_raw", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			pk.WriteRawTo(&buf)
+		}
+	})
+
+	rawBytes := buf.Bytes()
+	b.ResetTimer()
+	b.Run("pk_deserialize_raw_safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.ReadFrom(bytes.NewReader(rawBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_deserialize_raw_unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.UnsafeReadFrom(bytes.NewReader(rawBytes))
+		}
+	})
 }

--- a/internal/backend/bls12-381/groth16/marshal.go
+++ b/internal/backend/bls12-381/groth16/marshal.go
@@ -22,14 +22,14 @@ import (
 )
 
 // WriteTo writes binary encoding of the Proof elements to writer
-// points are stored in compressed form Ar | Krs | Bs
+// points are stored in compressed form Ar | Krs | Bs
 // use WriteRawTo(...) to encode the proof without point compression
 func (proof *Proof) WriteTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, false)
 }
 
 // WriteRawTo writes binary encoding of the Proof elements to writer
-// points are stored in uncompressed form Ar | Krs | Bs
+// points are stored in uncompressed form Ar | Krs | Bs
 // use WriteTo(...) to encode the proof with point compression
 func (proof *Proof) WriteRawTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, true)
@@ -133,8 +133,17 @@ func (vk *VerifyingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // https://github.com/zkcrypto/bellman/blob/fa9be45588227a8c6ec34957de3f68705f07bd92/src/groth16/mod.rs#L143
 // [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2,uint32(len(Kvk)),[Kvk]1
 func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r)
+}
 
-	dec := curve.NewDecoder(r)
+// UnsafeReadFrom has the same behavior as ReadFrom, except that it will not check that decode points
+// are on the curve and in the correct subgroup.
+func (vk *VerifyingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
+	dec := curve.NewDecoder(r, decOptions...)
 
 	// [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2
 	if err := dec.Decode(&vk.G1.Alpha); err != nil {
@@ -233,13 +242,22 @@ func (pk *ProvingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // ProvingKey must be encoded through WriteTo (compressed) or WriteRawTo (uncompressed)
 // note that we don't check that the points are on the curve or in the correct subgroup at this point
 func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r)
+}
 
+// UnsafeReadFrom behaves like ReadFrom excepts it doesn't check if the decoded points are on the curve
+// or in the correct subgroup
+func (pk *ProvingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
 	n, err := pk.Domain.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}
 
-	dec := curve.NewDecoder(r)
+	dec := curve.NewDecoder(r, decOptions...)
 
 	var nbWires uint64
 

--- a/internal/backend/bls24-315/groth16/groth16_test.go
+++ b/internal/backend/bls24-315/groth16/groth16_test.go
@@ -27,7 +27,6 @@ import (
 
 	"bytes"
 	bls24_315groth16 "github.com/consensys/gnark/internal/backend/bls24-315/groth16"
-	"github.com/fxamacker/cbor/v2"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -141,7 +140,7 @@ func BenchmarkVerifier(b *testing.B) {
 	})
 }
 
-func BenchmarkSerialization(b *testing.B) {
+func BenchmarkProofSerialization(b *testing.B) {
 	r1cs, _solution := referenceCircuit()
 	fullWitness := bls24_315witness.Witness{}
 	err := fullWitness.FromFullAssignment(_solution)
@@ -158,82 +157,6 @@ func BenchmarkSerialization(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-
-	// ---------------------------------------------------------------------------------------------
-	// bls24_315groth16.ProvingKey binary serialization
-	b.Run("pk: binary serialization (bls24_315groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			_, _ = pk.WriteTo(&buf)
-		}
-	})
-	b.Run("pk: binary deserialization (bls24_315groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		_, _ = pk.WriteTo(&buf)
-		var pkReconstructed bls24_315groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			_, _ = pkReconstructed.ReadFrom(buf)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		_, _ = pk.WriteTo(&buf)
-	}
-
-	// ---------------------------------------------------------------------------------------------
-	// bls24_315groth16.ProvingKey binary serialization (uncompressed)
-	b.Run("pk: binary raw serialization (bls24_315groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			_, _ = pk.WriteRawTo(&buf)
-		}
-	})
-	b.Run("pk: binary raw deserialization (bls24_315groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		_, _ = pk.WriteRawTo(&buf)
-		var pkReconstructed bls24_315groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			_, _ = pkReconstructed.ReadFrom(buf)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		_, _ = pk.WriteRawTo(&buf)
-	}
-
-	// ---------------------------------------------------------------------------------------------
-	// bls24_315groth16.ProvingKey binary serialization (cbor)
-	b.Run("pk: binary cbor serialization (bls24_315groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			enc := cbor.NewEncoder(&buf)
-			enc.Encode(&pk)
-		}
-	})
-	b.Run("pk: binary cbor deserialization (bls24_315groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&pk)
-		var pkReconstructed bls24_315groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			dec := cbor.NewDecoder(buf)
-			dec.Decode(&pkReconstructed)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&pk)
-	}
 
 	// ---------------------------------------------------------------------------------------------
 	// bls24_315groth16.Proof binary serialization
@@ -283,32 +206,61 @@ func BenchmarkSerialization(b *testing.B) {
 		_, _ = proof.WriteRawTo(&buf)
 	}
 
-	// ---------------------------------------------------------------------------------------------
-	// bls24_315groth16.Proof binary serialization (cbor)
-	b.Run("proof: binary cbor serialization (bls24_315groth16.Proof)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			enc := cbor.NewEncoder(&buf)
-			enc.Encode(&proof)
-		}
-	})
-	b.Run("proof: binary cbor deserialization (bls24_315groth16.Proof)", func(b *testing.B) {
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&proof)
-		var proofReconstructed bls24_315groth16.Proof
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			dec := cbor.NewDecoder(buf)
-			dec.Decode(&proofReconstructed)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&proof)
-	}
+}
 
+func BenchmarkProvingKeySerialization(b *testing.B) {
+	r1cs, _ := referenceCircuit()
+
+	var pk bls24_315groth16.ProvingKey
+	bls24_315groth16.DummySetup(r1cs.(*cs.R1CS), &pk)
+
+	var buf bytes.Buffer
+	// grow the buffer once
+	pk.WriteTo(&buf)
+
+	b.ResetTimer()
+	b.Run("pk_serialize_compressed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			pk.WriteTo(&buf)
+		}
+	})
+
+	compressedBytes := buf.Bytes()
+	b.ResetTimer()
+	b.Run("pk_deserialize_compressed_safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.ReadFrom(bytes.NewReader(compressedBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_deserialize_compressed_unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.UnsafeReadFrom(bytes.NewReader(compressedBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_serialize_raw", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			pk.WriteRawTo(&buf)
+		}
+	})
+
+	rawBytes := buf.Bytes()
+	b.ResetTimer()
+	b.Run("pk_deserialize_raw_safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.ReadFrom(bytes.NewReader(rawBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_deserialize_raw_unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.UnsafeReadFrom(bytes.NewReader(rawBytes))
+		}
+	})
 }

--- a/internal/backend/bls24-315/groth16/marshal.go
+++ b/internal/backend/bls24-315/groth16/marshal.go
@@ -22,14 +22,14 @@ import (
 )
 
 // WriteTo writes binary encoding of the Proof elements to writer
-// points are stored in compressed form Ar | Krs | Bs
+// points are stored in compressed form Ar | Krs | Bs
 // use WriteRawTo(...) to encode the proof without point compression
 func (proof *Proof) WriteTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, false)
 }
 
 // WriteRawTo writes binary encoding of the Proof elements to writer
-// points are stored in uncompressed form Ar | Krs | Bs
+// points are stored in uncompressed form Ar | Krs | Bs
 // use WriteTo(...) to encode the proof with point compression
 func (proof *Proof) WriteRawTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, true)
@@ -133,8 +133,17 @@ func (vk *VerifyingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // https://github.com/zkcrypto/bellman/blob/fa9be45588227a8c6ec34957de3f68705f07bd92/src/groth16/mod.rs#L143
 // [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2,uint32(len(Kvk)),[Kvk]1
 func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r)
+}
 
-	dec := curve.NewDecoder(r)
+// UnsafeReadFrom has the same behavior as ReadFrom, except that it will not check that decode points
+// are on the curve and in the correct subgroup.
+func (vk *VerifyingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
+	dec := curve.NewDecoder(r, decOptions...)
 
 	// [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2
 	if err := dec.Decode(&vk.G1.Alpha); err != nil {
@@ -233,13 +242,22 @@ func (pk *ProvingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // ProvingKey must be encoded through WriteTo (compressed) or WriteRawTo (uncompressed)
 // note that we don't check that the points are on the curve or in the correct subgroup at this point
 func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r)
+}
 
+// UnsafeReadFrom behaves like ReadFrom excepts it doesn't check if the decoded points are on the curve
+// or in the correct subgroup
+func (pk *ProvingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
 	n, err := pk.Domain.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}
 
-	dec := curve.NewDecoder(r)
+	dec := curve.NewDecoder(r, decOptions...)
 
 	var nbWires uint64
 

--- a/internal/backend/bn254/groth16/groth16_test.go
+++ b/internal/backend/bn254/groth16/groth16_test.go
@@ -27,7 +27,6 @@ import (
 
 	"bytes"
 	bn254groth16 "github.com/consensys/gnark/internal/backend/bn254/groth16"
-	"github.com/fxamacker/cbor/v2"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -141,7 +140,7 @@ func BenchmarkVerifier(b *testing.B) {
 	})
 }
 
-func BenchmarkSerialization(b *testing.B) {
+func BenchmarkProofSerialization(b *testing.B) {
 	r1cs, _solution := referenceCircuit()
 	fullWitness := bn254witness.Witness{}
 	err := fullWitness.FromFullAssignment(_solution)
@@ -158,82 +157,6 @@ func BenchmarkSerialization(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-
-	// ---------------------------------------------------------------------------------------------
-	// bn254groth16.ProvingKey binary serialization
-	b.Run("pk: binary serialization (bn254groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			_, _ = pk.WriteTo(&buf)
-		}
-	})
-	b.Run("pk: binary deserialization (bn254groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		_, _ = pk.WriteTo(&buf)
-		var pkReconstructed bn254groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			_, _ = pkReconstructed.ReadFrom(buf)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		_, _ = pk.WriteTo(&buf)
-	}
-
-	// ---------------------------------------------------------------------------------------------
-	// bn254groth16.ProvingKey binary serialization (uncompressed)
-	b.Run("pk: binary raw serialization (bn254groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			_, _ = pk.WriteRawTo(&buf)
-		}
-	})
-	b.Run("pk: binary raw deserialization (bn254groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		_, _ = pk.WriteRawTo(&buf)
-		var pkReconstructed bn254groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			_, _ = pkReconstructed.ReadFrom(buf)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		_, _ = pk.WriteRawTo(&buf)
-	}
-
-	// ---------------------------------------------------------------------------------------------
-	// bn254groth16.ProvingKey binary serialization (cbor)
-	b.Run("pk: binary cbor serialization (bn254groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			enc := cbor.NewEncoder(&buf)
-			enc.Encode(&pk)
-		}
-	})
-	b.Run("pk: binary cbor deserialization (bn254groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&pk)
-		var pkReconstructed bn254groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			dec := cbor.NewDecoder(buf)
-			dec.Decode(&pkReconstructed)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&pk)
-	}
 
 	// ---------------------------------------------------------------------------------------------
 	// bn254groth16.Proof binary serialization
@@ -283,32 +206,61 @@ func BenchmarkSerialization(b *testing.B) {
 		_, _ = proof.WriteRawTo(&buf)
 	}
 
-	// ---------------------------------------------------------------------------------------------
-	// bn254groth16.Proof binary serialization (cbor)
-	b.Run("proof: binary cbor serialization (bn254groth16.Proof)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			enc := cbor.NewEncoder(&buf)
-			enc.Encode(&proof)
-		}
-	})
-	b.Run("proof: binary cbor deserialization (bn254groth16.Proof)", func(b *testing.B) {
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&proof)
-		var proofReconstructed bn254groth16.Proof
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			dec := cbor.NewDecoder(buf)
-			dec.Decode(&proofReconstructed)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&proof)
-	}
+}
 
+func BenchmarkProvingKeySerialization(b *testing.B) {
+	r1cs, _ := referenceCircuit()
+
+	var pk bn254groth16.ProvingKey
+	bn254groth16.DummySetup(r1cs.(*cs.R1CS), &pk)
+
+	var buf bytes.Buffer
+	// grow the buffer once
+	pk.WriteTo(&buf)
+
+	b.ResetTimer()
+	b.Run("pk_serialize_compressed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			pk.WriteTo(&buf)
+		}
+	})
+
+	compressedBytes := buf.Bytes()
+	b.ResetTimer()
+	b.Run("pk_deserialize_compressed_safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.ReadFrom(bytes.NewReader(compressedBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_deserialize_compressed_unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.UnsafeReadFrom(bytes.NewReader(compressedBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_serialize_raw", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			pk.WriteRawTo(&buf)
+		}
+	})
+
+	rawBytes := buf.Bytes()
+	b.ResetTimer()
+	b.Run("pk_deserialize_raw_safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.ReadFrom(bytes.NewReader(rawBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_deserialize_raw_unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.UnsafeReadFrom(bytes.NewReader(rawBytes))
+		}
+	})
 }

--- a/internal/backend/bn254/groth16/marshal.go
+++ b/internal/backend/bn254/groth16/marshal.go
@@ -22,14 +22,14 @@ import (
 )
 
 // WriteTo writes binary encoding of the Proof elements to writer
-// points are stored in compressed form Ar | Krs | Bs
+// points are stored in compressed form Ar | Krs | Bs
 // use WriteRawTo(...) to encode the proof without point compression
 func (proof *Proof) WriteTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, false)
 }
 
 // WriteRawTo writes binary encoding of the Proof elements to writer
-// points are stored in uncompressed form Ar | Krs | Bs
+// points are stored in uncompressed form Ar | Krs | Bs
 // use WriteTo(...) to encode the proof with point compression
 func (proof *Proof) WriteRawTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, true)
@@ -133,8 +133,17 @@ func (vk *VerifyingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // https://github.com/zkcrypto/bellman/blob/fa9be45588227a8c6ec34957de3f68705f07bd92/src/groth16/mod.rs#L143
 // [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2,uint32(len(Kvk)),[Kvk]1
 func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r)
+}
 
-	dec := curve.NewDecoder(r)
+// UnsafeReadFrom has the same behavior as ReadFrom, except that it will not check that decode points
+// are on the curve and in the correct subgroup.
+func (vk *VerifyingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
+	dec := curve.NewDecoder(r, decOptions...)
 
 	// [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2
 	if err := dec.Decode(&vk.G1.Alpha); err != nil {
@@ -233,13 +242,22 @@ func (pk *ProvingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // ProvingKey must be encoded through WriteTo (compressed) or WriteRawTo (uncompressed)
 // note that we don't check that the points are on the curve or in the correct subgroup at this point
 func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r)
+}
 
+// UnsafeReadFrom behaves like ReadFrom excepts it doesn't check if the decoded points are on the curve
+// or in the correct subgroup
+func (pk *ProvingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
 	n, err := pk.Domain.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}
 
-	dec := curve.NewDecoder(r)
+	dec := curve.NewDecoder(r, decOptions...)
 
 	var nbWires uint64
 

--- a/internal/backend/bw6-761/groth16/groth16_test.go
+++ b/internal/backend/bw6-761/groth16/groth16_test.go
@@ -27,7 +27,6 @@ import (
 
 	"bytes"
 	bw6_761groth16 "github.com/consensys/gnark/internal/backend/bw6-761/groth16"
-	"github.com/fxamacker/cbor/v2"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -141,7 +140,7 @@ func BenchmarkVerifier(b *testing.B) {
 	})
 }
 
-func BenchmarkSerialization(b *testing.B) {
+func BenchmarkProofSerialization(b *testing.B) {
 	r1cs, _solution := referenceCircuit()
 	fullWitness := bw6_761witness.Witness{}
 	err := fullWitness.FromFullAssignment(_solution)
@@ -158,82 +157,6 @@ func BenchmarkSerialization(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-
-	// ---------------------------------------------------------------------------------------------
-	// bw6_761groth16.ProvingKey binary serialization
-	b.Run("pk: binary serialization (bw6_761groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			_, _ = pk.WriteTo(&buf)
-		}
-	})
-	b.Run("pk: binary deserialization (bw6_761groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		_, _ = pk.WriteTo(&buf)
-		var pkReconstructed bw6_761groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			_, _ = pkReconstructed.ReadFrom(buf)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		_, _ = pk.WriteTo(&buf)
-	}
-
-	// ---------------------------------------------------------------------------------------------
-	// bw6_761groth16.ProvingKey binary serialization (uncompressed)
-	b.Run("pk: binary raw serialization (bw6_761groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			_, _ = pk.WriteRawTo(&buf)
-		}
-	})
-	b.Run("pk: binary raw deserialization (bw6_761groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		_, _ = pk.WriteRawTo(&buf)
-		var pkReconstructed bw6_761groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			_, _ = pkReconstructed.ReadFrom(buf)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		_, _ = pk.WriteRawTo(&buf)
-	}
-
-	// ---------------------------------------------------------------------------------------------
-	// bw6_761groth16.ProvingKey binary serialization (cbor)
-	b.Run("pk: binary cbor serialization (bw6_761groth16.ProvingKey)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			enc := cbor.NewEncoder(&buf)
-			enc.Encode(&pk)
-		}
-	})
-	b.Run("pk: binary cbor deserialization (bw6_761groth16.ProvingKey)", func(b *testing.B) {
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&pk)
-		var pkReconstructed bw6_761groth16.ProvingKey
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			dec := cbor.NewDecoder(buf)
-			dec.Decode(&pkReconstructed)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&pk)
-	}
 
 	// ---------------------------------------------------------------------------------------------
 	// bw6_761groth16.Proof binary serialization
@@ -283,32 +206,61 @@ func BenchmarkSerialization(b *testing.B) {
 		_, _ = proof.WriteRawTo(&buf)
 	}
 
-	// ---------------------------------------------------------------------------------------------
-	// bw6_761groth16.Proof binary serialization (cbor)
-	b.Run("proof: binary cbor serialization (bw6_761groth16.Proof)", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			enc := cbor.NewEncoder(&buf)
-			enc.Encode(&proof)
-		}
-	})
-	b.Run("proof: binary cbor deserialization (bw6_761groth16.Proof)", func(b *testing.B) {
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&proof)
-		var proofReconstructed bw6_761groth16.Proof
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			dec := cbor.NewDecoder(buf)
-			dec.Decode(&proofReconstructed)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&proof)
-	}
+}
 
+func BenchmarkProvingKeySerialization(b *testing.B) {
+	r1cs, _ := referenceCircuit()
+
+	var pk bw6_761groth16.ProvingKey
+	bw6_761groth16.DummySetup(r1cs.(*cs.R1CS), &pk)
+
+	var buf bytes.Buffer
+	// grow the buffer once
+	pk.WriteTo(&buf)
+
+	b.ResetTimer()
+	b.Run("pk_serialize_compressed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			pk.WriteTo(&buf)
+		}
+	})
+
+	compressedBytes := buf.Bytes()
+	b.ResetTimer()
+	b.Run("pk_deserialize_compressed_safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.ReadFrom(bytes.NewReader(compressedBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_deserialize_compressed_unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.UnsafeReadFrom(bytes.NewReader(compressedBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_serialize_raw", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			pk.WriteRawTo(&buf)
+		}
+	})
+
+	rawBytes := buf.Bytes()
+	b.ResetTimer()
+	b.Run("pk_deserialize_raw_safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.ReadFrom(bytes.NewReader(rawBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_deserialize_raw_unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.UnsafeReadFrom(bytes.NewReader(rawBytes))
+		}
+	})
 }

--- a/internal/backend/bw6-761/groth16/marshal.go
+++ b/internal/backend/bw6-761/groth16/marshal.go
@@ -22,14 +22,14 @@ import (
 )
 
 // WriteTo writes binary encoding of the Proof elements to writer
-// points are stored in compressed form Ar | Krs | Bs
+// points are stored in compressed form Ar | Krs | Bs
 // use WriteRawTo(...) to encode the proof without point compression
 func (proof *Proof) WriteTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, false)
 }
 
 // WriteRawTo writes binary encoding of the Proof elements to writer
-// points are stored in uncompressed form Ar | Krs | Bs
+// points are stored in uncompressed form Ar | Krs | Bs
 // use WriteTo(...) to encode the proof with point compression
 func (proof *Proof) WriteRawTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, true)
@@ -133,8 +133,17 @@ func (vk *VerifyingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // https://github.com/zkcrypto/bellman/blob/fa9be45588227a8c6ec34957de3f68705f07bd92/src/groth16/mod.rs#L143
 // [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2,uint32(len(Kvk)),[Kvk]1
 func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r)
+}
 
-	dec := curve.NewDecoder(r)
+// UnsafeReadFrom has the same behavior as ReadFrom, except that it will not check that decode points
+// are on the curve and in the correct subgroup.
+func (vk *VerifyingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
+	dec := curve.NewDecoder(r, decOptions...)
 
 	// [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2
 	if err := dec.Decode(&vk.G1.Alpha); err != nil {
@@ -233,13 +242,22 @@ func (pk *ProvingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // ProvingKey must be encoded through WriteTo (compressed) or WriteRawTo (uncompressed)
 // note that we don't check that the points are on the curve or in the correct subgroup at this point
 func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r)
+}
 
+// UnsafeReadFrom behaves like ReadFrom excepts it doesn't check if the decoded points are on the curve
+// or in the correct subgroup
+func (pk *ProvingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
 	n, err := pk.Domain.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}
 
-	dec := curve.NewDecoder(r)
+	dec := curve.NewDecoder(r, decOptions...)
 
 	var nbWires uint64
 

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.marshal.go.tmpl
@@ -4,14 +4,14 @@ import (
 )
 
 // WriteTo writes binary encoding of the Proof elements to writer
-// points are stored in compressed form Ar | Krs | Bs
+// points are stored in compressed form Ar | Krs | Bs
 // use WriteRawTo(...) to encode the proof without point compression 
 func (proof *Proof) WriteTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, false)
 }
 
 // WriteRawTo writes binary encoding of the Proof elements to writer
-// points are stored in uncompressed form Ar | Krs | Bs
+// points are stored in uncompressed form Ar | Krs | Bs
 // use WriteTo(...) to encode the proof with point compression 
 func (proof *Proof) WriteRawTo(w io.Writer) (n int64, err error) {
 	return proof.writeTo(w, true)
@@ -117,8 +117,17 @@ func (vk *VerifyingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // https://github.com/zkcrypto/bellman/blob/fa9be45588227a8c6ec34957de3f68705f07bd92/src/groth16/mod.rs#L143
 // [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2,uint32(len(Kvk)),[Kvk]1
 func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r)
+}
 
-	dec := curve.NewDecoder(r)
+// UnsafeReadFrom has the same behavior as ReadFrom, except that it will not check that decode points
+// are on the curve and in the correct subgroup. 
+func (vk *VerifyingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return vk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (vk *VerifyingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
+	dec := curve.NewDecoder(r, decOptions...)
 
 	// [α]1,[β]1,[β]2,[γ]2,[δ]1,[δ]2
 	if err := dec.Decode(&vk.G1.Alpha); err != nil {
@@ -220,13 +229,23 @@ func (pk *ProvingKey) writeTo(w io.Writer, raw bool) (int64, error) {
 // ProvingKey must be encoded through WriteTo (compressed) or WriteRawTo (uncompressed) 
 // note that we don't check that the points are on the curve or in the correct subgroup at this point
 func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r)
+}
 
+
+// UnsafeReadFrom behaves like ReadFrom excepts it doesn't check if the decoded points are on the curve
+// or in the correct subgroup
+func (pk *ProvingKey) UnsafeReadFrom(r io.Reader) (int64, error) {
+	return pk.readFrom(r, curve.NoSubgroupChecks())
+}
+
+func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) (int64, error) {
 	n, err := pk.Domain.ReadFrom(r)
 	if err != nil {
 		return n, err
 	}
 
-	dec := curve.NewDecoder(r)
+	dec := curve.NewDecoder(r, decOptions...)
 
 	var nbWires uint64 
 

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
@@ -6,7 +6,6 @@ import (
 	{{ template "import_groth16" . }}
 	"bytes"
 	"testing"
-	"github.com/fxamacker/cbor/v2"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
@@ -124,7 +123,7 @@ func BenchmarkVerifier(b *testing.B) {
 
 
 
-func BenchmarkSerialization(b *testing.B) {
+func BenchmarkProofSerialization(b *testing.B) {
 	r1cs, _solution := referenceCircuit()
 	fullWitness := {{toLower .CurveID}}witness.Witness{}
 	err := fullWitness.FromFullAssignment(_solution)
@@ -144,7 +143,6 @@ func BenchmarkSerialization(b *testing.B) {
 
 	{{ $base := toLower .CurveID }}
 	
-	{{ template "benchBinarySerialization" dict "Type" (print $base "groth16.ProvingKey") "Name" "pk" }}
 	{{ template "benchBinarySerialization" dict "Type" (print $base "groth16.Proof") "Name" "proof" }}
 
 
@@ -199,33 +197,65 @@ func BenchmarkSerialization(b *testing.B) {
 		_, _ = {{$.Name}}.WriteRawTo(&buf)
 	}
 
-	// ---------------------------------------------------------------------------------------------
-	// {{$.Type}} binary serialization (cbor)
-	b.Run("{{$.Name}}: binary cbor serialization ({{$.Type}})", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			var buf bytes.Buffer
-			enc := cbor.NewEncoder(&buf)
-			enc.Encode(&{{- $.Name}})
-		}
-	})
-	b.Run("{{$.Name}}: binary cbor deserialization ({{$.Type}})", func(b *testing.B) {
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&{{- $.Name}})
-		var {{ $.Name}}Reconstructed {{$.Type}}
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			buf := bytes.NewBuffer(buf.Bytes())
-			dec := cbor.NewDecoder(buf)
-			dec.Decode(&{{- $.Name}}Reconstructed)
-		}
-	})
-	{
-		var buf bytes.Buffer
-		enc := cbor.NewEncoder(&buf)
-		enc.Encode(&{{- $.Name}})
-	}
-
 {{ end }}
 
+
+
+
+
+func BenchmarkProvingKeySerialization(b *testing.B) {
+	r1cs, _ := referenceCircuit()
+	
+	var pk {{toLower .CurveID}}groth16.ProvingKey
+	{{toLower .CurveID}}groth16.DummySetup(r1cs.(*cs.R1CS), &pk)
+
+	var buf bytes.Buffer 
+	// grow the buffer once
+	pk.WriteTo(&buf)
+
+	b.ResetTimer()
+	b.Run("pk_serialize_compressed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			pk.WriteTo(&buf)
+		}
+	})
+
+	compressedBytes := buf.Bytes()
+	b.ResetTimer()
+	b.Run("pk_deserialize_compressed_safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.ReadFrom(bytes.NewReader(compressedBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_deserialize_compressed_unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.UnsafeReadFrom(bytes.NewReader(compressedBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_serialize_raw", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			pk.WriteRawTo(&buf)
+		}
+	})
+
+	rawBytes := buf.Bytes()
+	b.ResetTimer()
+	b.Run("pk_deserialize_raw_safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.ReadFrom(bytes.NewReader(rawBytes))
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("pk_deserialize_raw_unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			pk.UnsafeReadFrom(bytes.NewReader(rawBytes))
+		}
+	})
+}

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.marshal.go.tmpl
@@ -2,6 +2,7 @@
 import (
 	{{ template "import_curve" . }}
 	{{ template "import_fft" . }}
+	
 
 	"bytes"
 	"math/big"
@@ -265,3 +266,5 @@ func GenG2() gopter.Gen {
 		return genResult
 	}
 }
+
+

--- a/io/io.go
+++ b/io/io.go
@@ -31,3 +31,11 @@ import (
 type WriterRawTo interface {
 	WriteRawTo(w io.Writer) (n int64, err error)
 }
+
+// UnsafeReaderFrom is the interface that wraps the UnsafeReadFrom method.
+//
+// UnsafeReadFrom reads data from reader but doesn't perform any checks, such as
+// subgroup checks for elliptic curves points for example.
+type UnsafeReaderFrom interface {
+	UnsafeReadFrom(r io.Reader) (int64, error)
+}


### PR DESCRIPTION
Can now decode `groth16.ProvingKey` and `groth16.VerifyingKey` without doing subgroup checks on the points. 

Usage:

```
pk.UnsafeReadFrom(reader)
```

In some cases, subgroup check can be done at the application level once, and `gnark` user can ensure through other means (checksum, signatures, ...) that the `ProvingKey` /  `VerifyingKey` are legit. 