### PR TITLE
feat: lighter stack trace by default for circuits, more verbose when -tags=debug provided

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -1,0 +1,70 @@
+package debug
+
+import (
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+var light = true
+
+func Stack() string {
+	var sbb strings.Builder
+	WriteStack(&sbb)
+	return sbb.String()
+}
+
+func WriteStack(sbb *strings.Builder) {
+	// derived from: https://golang.org/pkg/runtime/#example_Frames
+	// we stop when func name == Define as it is where the gnark circuit code should start
+
+	// Ask runtime.Callers for up to 10 pcs
+	pc := make([]uintptr, 10)
+	n := runtime.Callers(3, pc)
+	if n == 0 {
+		// No pcs available. Stop now.
+		// This can happen if the first argument to runtime.Callers is large.
+		return
+	}
+	pc = pc[:n] // pass only valid pcs to runtime.CallersFrames
+	frames := runtime.CallersFrames(pc)
+	// Loop to get frames.
+	// A fixed number of pcs can expand to an indefinite number of Frames.
+	for {
+		frame, more := frames.Next()
+		fe := strings.Split(frame.Function, "/")
+		function := fe[len(fe)-1]
+		file := frame.File
+
+		if light {
+			if strings.Contains(function, "runtime.gopanic") {
+				continue
+			}
+			if strings.Contains(function, "frontend.(*constraintSystem)") {
+				continue
+			}
+			if strings.Contains(frame.File, "test/engine.go") {
+				continue
+			}
+			if strings.Contains(frame.File, "gnark/frontend") {
+				continue
+			}
+			file = filepath.Base(file)
+		}
+
+		sbb.WriteString(function)
+		sbb.WriteByte('\n')
+		sbb.WriteByte('\t')
+		sbb.WriteString(file)
+		sbb.WriteByte(':')
+		sbb.WriteString(strconv.Itoa(frame.Line))
+		sbb.WriteByte('\n')
+		if !more {
+			break
+		}
+		if strings.HasSuffix(function, "Define") {
+			break
+		}
+	}
+}

--- a/debug/debug_full.go
+++ b/debug/debug_full.go
@@ -1,0 +1,8 @@
+//go:build debug
+// +build debug
+
+package debug
+
+func init() {
+	light = false
+}

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -17,9 +17,7 @@ limitations under the License.
 package frontend
 
 import (
-	"fmt"
 	"math/big"
-	"runtime/debug"
 
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/internal/backend/compiled"
@@ -152,8 +150,7 @@ func (cs *constraintSystem) Inverse(i1 interface{}) Variable {
 	if vars[0].isConstant() {
 		c := vars[0].constantValue(cs)
 		if c.IsUint64() && c.Uint64() == 0 {
-			stack := string(debug.Stack())
-			panic(fmt.Sprintf("inverse by constant(0):\n%s", stack))
+			panic("inverse by constant(0)")
 		}
 
 		c.ModInverse(c, cs.curveID.Info().Fr.Modulus())
@@ -189,8 +186,7 @@ func (cs *constraintSystem) Div(i1, i2 interface{}) Variable {
 	// v2 is constant
 	b2 := v2.constantValue(cs)
 	if b2.IsUint64() && b2.Uint64() == 0 {
-		stack := string(debug.Stack())
-		panic(fmt.Sprintf("div by constant(0):\n%s", stack))
+		panic("div by constant(0)")
 	}
 	q := cs.curveID.Info().Fr.Modulus()
 	b2.ModInverse(b2, q)
@@ -221,8 +217,7 @@ func (cs *constraintSystem) DivUnchecked(i1, i2 interface{}) Variable {
 	// v2 is constant
 	b2 := v2.constantValue(cs)
 	if b2.IsUint64() && b2.Uint64() == 0 {
-		stack := string(debug.Stack())
-		panic(fmt.Sprintf("div by constant(0):\n%s", stack))
+		panic("div by constant(0)")
 	}
 	q := cs.curveID.Info().Fr.Modulus()
 	b2.ModInverse(b2, q)

--- a/frontend/cs_assertions.go
+++ b/frontend/cs_assertions.go
@@ -19,7 +19,6 @@ package frontend
 import (
 	"fmt"
 	"math/big"
-	"runtime/debug"
 
 	"github.com/consensys/gnark/internal/backend/compiled"
 )
@@ -52,7 +51,7 @@ func (cs *constraintSystem) AssertIsBoolean(i1 interface{}) {
 	if v.isConstant() {
 		c := v.constantValue(cs)
 		if !(c.IsUint64() && (c.Uint64() == 0 || c.Uint64() == 1)) {
-			panic(fmt.Sprintf("assertIsBoolean failed: constant(%s)\n%s", c.String(), string(debug.Stack())))
+			panic(fmt.Sprintf("assertIsBoolean failed: constant(%s)", c.String()))
 		}
 	}
 

--- a/frontend/cs_debug.go
+++ b/frontend/cs_debug.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/internal/parser"
 )
@@ -111,7 +112,7 @@ func printArg(log *compiled.LogEntry, sbb *strings.Builder, a interface{}) {
 }
 
 func (cs *constraintSystem) addDebugInfo(errName string, i ...interface{}) int {
-	var debug compiled.LogEntry
+	var l compiled.LogEntry
 
 	const minLogSize = 500
 	var sbb strings.Builder
@@ -126,7 +127,7 @@ func (cs *constraintSystem) addDebugInfo(errName string, i ...interface{}) int {
 			if len(v.linExp) > 1 {
 				sbb.WriteString("(")
 			}
-			debug.WriteLinearExpression(v.linExp, &sbb)
+			l.WriteLinearExpression(v.linExp, &sbb)
 			if len(v.linExp) > 1 {
 				sbb.WriteString(")")
 			}
@@ -136,15 +137,15 @@ func (cs *constraintSystem) addDebugInfo(errName string, i ...interface{}) int {
 		case int:
 			sbb.WriteString(strconv.Itoa(v))
 		case compiled.Term:
-			debug.WriteTerm(v, &sbb)
+			l.WriteTerm(v, &sbb)
 		default:
 			panic("unsupported log type")
 		}
 	}
 	sbb.WriteByte('\n')
 	debug.WriteStack(&sbb)
-	debug.Format = sbb.String()
+	l.Format = sbb.String()
 
-	cs.debugInfo = append(cs.debugInfo, debug)
+	cs.debugInfo = append(cs.debugInfo, l)
 	return len(cs.debugInfo) - 1
 }

--- a/test/engine.go
+++ b/test/engine.go
@@ -21,9 +21,10 @@ import (
 	"math/big"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"strconv"
 	"strings"
+
+	"github.com/consensys/gnark/debug"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
@@ -51,7 +52,6 @@ type engine struct {
 //
 // This is an experimental feature.
 func IsSolved(circuit, witness frontend.Circuit, curveID ecc.ID, opts ...func(opt *backend.ProverOption) error) (err error) {
-
 	// apply options
 	opt, err := backend.NewProverOption(opts...)
 	if err != nil {


### PR DESCRIPTION
Example, when testing / building with no tags (default):

```
 Error:          groth16(bn254): [assertIsEqual] 35 == 62
                                cubic.(*Circuit).Define
                                        cubic.go:35
                            
                                witness:{
                                    "Public": {
                                        "Y": "35"
                                    },
                                    "Secret": {
                                        "x": "3"
                                    }
                                }
                Test:           TestCubicEquation
 ```
 
 With `-tags=debug`
 
 ```
  Error:          groth16(bn254): [assertIsEqual] 35 == 62
                                test.IsSolved.func1
                                        /Users/gbotrel/dev/go/src/github.com/consensys/gnark/test/engine.go:80
                                runtime.gopanic
                                        /usr/local/go/src/runtime/panic.go:1038
                                test.(*engine).AssertIsEqual
                                        /Users/gbotrel/dev/go/src/github.com/consensys/gnark/test/engine.go:263
                                cubic.(*Circuit).Define
                                        /Users/gbotrel/dev/go/src/github.com/consensys/gnark/examples/cubic/cubic.go:35
                            
                                witness:{
                                    "Public": {
                                        "Y": "35"
                                    },
                                    "Secret": {
                                        "x": "3"
                                    }
                                }
                Test:           TestCubicEquation
   ```
 