### PR TITLE
refactor: frontend.Variable is now an interface, simplifies witness assignment and constant usage

### DIFF
--- a/backend/witness/witness.go
+++ b/backend/witness/witness.go
@@ -151,7 +151,7 @@ func WriteSequence(w io.Writer, circuit frontend.Circuit) error {
 		}
 		return nil
 	}
-	if err := parser.Visit(circuit, "", compiled.Unset, collectHandler, reflect.TypeOf(frontend.Variable{})); err != nil {
+	if err := parser.Visit(circuit, "", compiled.Unset, collectHandler, tVariable); err != nil {
 		return err
 	}
 
@@ -196,7 +196,7 @@ func ReadPublicFrom(r io.Reader, curveID ecc.ID, witness frontend.Circuit) (int6
 		}
 		return nil
 	}
-	_ = parser.Visit(witness, "", compiled.Unset, collectHandler, reflect.TypeOf(frontend.Variable{}))
+	_ = parser.Visit(witness, "", compiled.Unset, collectHandler, tVariable)
 
 	if nbPublic == 0 {
 		return 0, nil
@@ -227,14 +227,12 @@ func ReadPublicFrom(r io.Reader, curveID ecc.ID, witness frontend.Circuit) (int6
 			if err != nil {
 				return err
 			}
-			v := tInput.Interface().(frontend.Variable)
-			v.Assign(new(big.Int).SetBytes(bufElement))
-			tInput.Set(reflect.ValueOf(v))
+			tInput.Set(reflect.ValueOf(new(big.Int).SetBytes(bufElement)))
 		}
 		return nil
 	}
 
-	if err := parser.Visit(witness, "", compiled.Unset, reader, reflect.TypeOf(frontend.Variable{})); err != nil {
+	if err := parser.Visit(witness, "", compiled.Unset, reader, tVariable); err != nil {
 		return int64(read), err
 	}
 
@@ -258,7 +256,7 @@ func ReadFullFrom(r io.Reader, curveID ecc.ID, witness frontend.Circuit) (int64,
 		}
 		return nil
 	}
-	_ = parser.Visit(witness, "", compiled.Unset, collectHandler, reflect.TypeOf(frontend.Variable{}))
+	_ = parser.Visit(witness, "", compiled.Unset, collectHandler, tVariable)
 
 	if nbPublic == 0 && nbSecrets == 0 {
 		return 0, nil
@@ -289,9 +287,7 @@ func ReadFullFrom(r io.Reader, curveID ecc.ID, witness frontend.Circuit) (int64,
 			if err != nil {
 				return err
 			}
-			v := tInput.Interface().(frontend.Variable)
-			v.Assign(new(big.Int).SetBytes(bufElement))
-			tInput.Set(reflect.ValueOf(v))
+			tInput.Set(reflect.ValueOf(new(big.Int).SetBytes(bufElement)))
 		}
 		return nil
 	}
@@ -305,12 +301,12 @@ func ReadFullFrom(r io.Reader, curveID ecc.ID, witness frontend.Circuit) (int64,
 	}
 
 	// public
-	if err := parser.Visit(witness, "", compiled.Unset, publicReader, reflect.TypeOf(frontend.Variable{})); err != nil {
+	if err := parser.Visit(witness, "", compiled.Unset, publicReader, tVariable); err != nil {
 		return int64(read), err
 	}
 
 	// secret
-	if err := parser.Visit(witness, "", compiled.Unset, secretReader, reflect.TypeOf(frontend.Variable{})); err != nil {
+	if err := parser.Visit(witness, "", compiled.Unset, secretReader, tVariable); err != nil {
 		return int64(read), err
 	}
 
@@ -354,4 +350,10 @@ func ToJSON(witness frontend.Circuit, curveID ecc.ID) (string, error) {
 	default:
 		panic("not implemented")
 	}
+}
+
+var tVariable reflect.Type
+
+func init() {
+	tVariable = reflect.ValueOf(struct{ A frontend.Variable }{}).FieldByName("A").Type()
 }

--- a/backend/witness/witness.go
+++ b/backend/witness/witness.go
@@ -48,11 +48,6 @@ import (
 	"reflect"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	fr_bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
-	fr_bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
-	fr_bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
-	fr_bn254 "github.com/consensys/gnark-crypto/ecc/bn254/fr"
-	fr_bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark/frontend"
 	witness_bls12377 "github.com/consensys/gnark/internal/backend/bls12-377/witness"
 	witness_bls12381 "github.com/consensys/gnark/internal/backend/bls12-381/witness"
@@ -212,7 +207,7 @@ func ReadPublicFrom(r io.Reader, curveID ecc.ID, witness frontend.Circuit) (int6
 		return 4, errors.New("invalid witness size")
 	}
 
-	elementSize := getElementSize(curveID)
+	elementSize := curveID.Info().Fr.Bytes
 
 	expectedSize := elementSize * nbPublic
 
@@ -272,7 +267,7 @@ func ReadFullFrom(r io.Reader, curveID ecc.ID, witness frontend.Circuit) (int64,
 		return 4, errors.New("invalid witness size")
 	}
 
-	elementSize := getElementSize(curveID)
+	elementSize := curveID.Info().Fr.Bytes
 	expectedSize := elementSize * (nbPublic + nbSecrets)
 
 	lr := io.LimitReader(r, int64(expectedSize*elementSize))
@@ -311,26 +306,6 @@ func ReadFullFrom(r io.Reader, curveID ecc.ID, witness frontend.Circuit) (int64,
 	}
 
 	return int64(read), nil
-}
-
-func getElementSize(curve ecc.ID) int {
-	// now compute expected size from field element size.
-	var elementSize int
-	switch curve {
-	case ecc.BLS12_377:
-		elementSize = fr_bls12377.Bytes
-	case ecc.BLS12_381:
-		elementSize = fr_bls12381.Bytes
-	case ecc.BLS24_315:
-		elementSize = fr_bls24315.Bytes
-	case ecc.BN254:
-		elementSize = fr_bn254.Bytes
-	case ecc.BW6_761:
-		elementSize = fr_bw6761.Bytes
-	default:
-		panic("not implemented")
-	}
-	return elementSize
 }
 
 // ToJSON outputs a JSON string with variableName: value

--- a/backend/witness/witness_test.go
+++ b/backend/witness/witness_test.go
@@ -28,8 +28,8 @@ func TestReconstructionPublic(t *testing.T) {
 	assert := require.New(t)
 
 	var wPublic, wPublicReconstructed circuit
-	wPublic.X.Assign(new(big.Int).SetInt64(42))
-	wPublic.Y.Assign(new(big.Int).SetInt64(8000))
+	wPublic.X = new(big.Int).SetInt64(42)
+	wPublic.Y = new(big.Int).SetInt64(8000)
 
 	var buf bytes.Buffer
 	written, err := WritePublicTo(&buf, ecc.BN254, &wPublic)
@@ -48,9 +48,9 @@ func TestReconstructionFull(t *testing.T) {
 	assert := require.New(t)
 
 	var wFull, wFullReconstructed circuit
-	wFull.X.Assign(new(big.Int).SetInt64(42))
-	wFull.Y.Assign(new(big.Int).SetInt64(8000))
-	wFull.E.Assign(new(big.Int).SetInt64(1))
+	wFull.X = new(big.Int).SetInt64(42)
+	wFull.Y = new(big.Int).SetInt64(8000)
+	wFull.E = new(big.Int).SetInt64(1)
 
 	var buf bytes.Buffer
 	written, err := WriteFullTo(&buf, ecc.BN254, &wFull)

--- a/backend/witness/witness_test.go
+++ b/backend/witness/witness_test.go
@@ -20,7 +20,7 @@ type circuit struct {
 	E frontend.Variable
 }
 
-func (circuit *circuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *circuit) Define(api frontend.API) error {
 	return nil
 }
 

--- a/debug_test.go
+++ b/debug_test.go
@@ -20,7 +20,7 @@ type printlnCircuit struct {
 	A, B frontend.Variable
 }
 
-func (circuit *printlnCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *printlnCircuit) Define(api frontend.API) error {
 	c := api.Add(circuit.A, circuit.B)
 	api.Println(c, "is the addition")
 	d := api.Mul(circuit.A, c)
@@ -66,7 +66,7 @@ type divBy0Trace struct {
 	A, B, C frontend.Variable
 }
 
-func (circuit *divBy0Trace) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *divBy0Trace) Define(api frontend.API) error {
 	d := api.Add(circuit.B, circuit.C)
 	api.Div(circuit.A, d)
 	return nil
@@ -103,7 +103,7 @@ type notEqualTrace struct {
 	A, B, C frontend.Variable
 }
 
-func (circuit *notEqualTrace) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *notEqualTrace) Define(api frontend.API) error {
 	d := api.Add(circuit.B, circuit.C)
 	api.AssertIsEqual(circuit.A, d)
 	return nil
@@ -140,7 +140,7 @@ type notBooleanTrace struct {
 	B, C frontend.Variable
 }
 
-func (circuit *notBooleanTrace) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *notBooleanTrace) Define(api frontend.API) error {
 	d := api.Add(circuit.B, circuit.C)
 	api.AssertIsBoolean(d)
 	return nil

--- a/debug_test.go
+++ b/debug_test.go
@@ -39,8 +39,8 @@ func TestPrintln(t *testing.T) {
 	assert := require.New(t)
 
 	var circuit, witness printlnCircuit
-	witness.A.Assign(2)
-	witness.B.Assign(11)
+	witness.A = (2)
+	witness.B = (11)
 
 	var expected bytes.Buffer
 	expected.WriteString("debug_test.go:25 13 is the addition\n")
@@ -76,9 +76,9 @@ func TestTraceDivBy0(t *testing.T) {
 	assert := require.New(t)
 
 	var circuit, witness divBy0Trace
-	witness.A.Assign(2)
-	witness.B.Assign(-2)
-	witness.C.Assign(2)
+	witness.A = (2)
+	witness.B = (-2)
+	witness.C = (2)
 
 	{
 		_, err := getGroth16Trace(&circuit, &witness)
@@ -113,9 +113,9 @@ func TestTraceNotEqual(t *testing.T) {
 	assert := require.New(t)
 
 	var circuit, witness notEqualTrace
-	witness.A.Assign(1)
-	witness.B.Assign(24)
-	witness.C.Assign(42)
+	witness.A = (1)
+	witness.B = (24)
+	witness.C = (42)
 
 	{
 		_, err := getGroth16Trace(&circuit, &witness)
@@ -150,9 +150,9 @@ func TestTraceNotBoolean(t *testing.T) {
 	assert := require.New(t)
 
 	var circuit, witness notBooleanTrace
-	// witness.A.Assign(1)
-	witness.B.Assign(24)
-	witness.C.Assign(42)
+	// witness.A = (1)
+	witness.B = (24)
+	witness.C = (42)
 
 	{
 		_, err := getGroth16Trace(&circuit, &witness)

--- a/debug_test.go
+++ b/debug_test.go
@@ -39,8 +39,8 @@ func TestPrintln(t *testing.T) {
 	assert := require.New(t)
 
 	var circuit, witness printlnCircuit
-	witness.A = (2)
-	witness.B = (11)
+	witness.A = 2
+	witness.B = 11
 
 	var expected bytes.Buffer
 	expected.WriteString("debug_test.go:25 13 is the addition\n")
@@ -76,9 +76,9 @@ func TestTraceDivBy0(t *testing.T) {
 	assert := require.New(t)
 
 	var circuit, witness divBy0Trace
-	witness.A = (2)
-	witness.B = (-2)
-	witness.C = (2)
+	witness.A = 2
+	witness.B = -2
+	witness.C = 2
 
 	{
 		_, err := getGroth16Trace(&circuit, &witness)
@@ -113,9 +113,9 @@ func TestTraceNotEqual(t *testing.T) {
 	assert := require.New(t)
 
 	var circuit, witness notEqualTrace
-	witness.A = (1)
-	witness.B = (24)
-	witness.C = (42)
+	witness.A = 1
+	witness.B = 24
+	witness.C = 42
 
 	{
 		_, err := getGroth16Trace(&circuit, &witness)
@@ -150,9 +150,9 @@ func TestTraceNotBoolean(t *testing.T) {
 	assert := require.New(t)
 
 	var circuit, witness notBooleanTrace
-	// witness.A = (1)
-	witness.B = (24)
-	witness.C = (42)
+	// witness.A = 1
+	witness.B = 24
+	witness.C = 42
 
 	{
 		_, err := getGroth16Trace(&circuit, &witness)

--- a/examples/cubic/cubic.go
+++ b/examples/cubic/cubic.go
@@ -15,7 +15,6 @@
 package cubic
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -30,7 +29,7 @@ type Circuit struct {
 
 // Define declares the circuit constraints
 // x**3 + x + 5 == y
-func (circuit *Circuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *Circuit) Define(api frontend.API) error {
 	x3 := api.Mul(circuit.X, circuit.X, circuit.X)
 	api.AssertIsEqual(circuit.Y, api.Add(x3, circuit.X, 5))
 	return nil

--- a/examples/cubic/cubic_test.go
+++ b/examples/cubic/cubic_test.go
@@ -17,7 +17,6 @@ package cubic
 import (
 	"testing"
 
-	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/test"
 )
 
@@ -27,13 +26,13 @@ func TestCubicEquation(t *testing.T) {
 	var cubicCircuit Circuit
 
 	assert.ProverFailed(&cubicCircuit, &Circuit{
-		X: frontend.Value(42),
-		Y: frontend.Value(42),
+		X: (42),
+		Y: (42),
 	})
 
 	assert.ProverSucceeded(&cubicCircuit, &Circuit{
-		X: frontend.Value(3),
-		Y: frontend.Value(35),
+		X: (3),
+		Y: (35),
 	})
 
 }

--- a/examples/cubic/cubic_test.go
+++ b/examples/cubic/cubic_test.go
@@ -26,13 +26,13 @@ func TestCubicEquation(t *testing.T) {
 	var cubicCircuit Circuit
 
 	assert.ProverFailed(&cubicCircuit, &Circuit{
-		X: (42),
-		Y: (42),
+		X: 42,
+		Y: 42,
 	})
 
 	assert.ProverSucceeded(&cubicCircuit, &Circuit{
-		X: (3),
-		Y: (35),
+		X: 3,
+		Y: 35,
 	})
 
 }

--- a/examples/exponentiate/exponentiate.go
+++ b/examples/exponentiate/exponentiate.go
@@ -38,7 +38,7 @@ func (circuit *Circuit) Define(curveID ecc.ID, api frontend.API) error {
 	const bitSize = 8
 
 	// specify constraints
-	output := api.Constant(1)
+	output := frontend.Variable(1)
 	bits := api.ToBinary(circuit.E, bitSize)
 	api.ToBinary(circuit.E, bitSize)
 

--- a/examples/exponentiate/exponentiate.go
+++ b/examples/exponentiate/exponentiate.go
@@ -15,7 +15,6 @@
 package exponentiate
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -32,7 +31,7 @@ type Circuit struct {
 
 // Define declares the circuit's constraints
 // y == x**e
-func (circuit *Circuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *Circuit) Define(api frontend.API) error {
 
 	// number of bits of exponent
 	const bitSize = 8

--- a/examples/exponentiate/exponentiate_test.go
+++ b/examples/exponentiate/exponentiate_test.go
@@ -17,7 +17,6 @@ package exponentiate
 import (
 	"testing"
 
-	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/test"
 )
 
@@ -28,15 +27,15 @@ func TestExponentiateGroth16(t *testing.T) {
 	var expCircuit Circuit
 
 	assert.ProverFailed(&expCircuit, &Circuit{
-		X: frontend.Value(2),
-		E: frontend.Value(12),
-		Y: frontend.Value(4095),
+		X: (2),
+		E: (12),
+		Y: (4095),
 	})
 
 	assert.ProverSucceeded(&expCircuit, &Circuit{
-		X: frontend.Value(2),
-		E: frontend.Value(12),
-		Y: frontend.Value(4096),
+		X: (2),
+		E: (12),
+		Y: (4096),
 	})
 
 }

--- a/examples/exponentiate/exponentiate_test.go
+++ b/examples/exponentiate/exponentiate_test.go
@@ -27,15 +27,15 @@ func TestExponentiateGroth16(t *testing.T) {
 	var expCircuit Circuit
 
 	assert.ProverFailed(&expCircuit, &Circuit{
-		X: (2),
-		E: (12),
-		Y: (4095),
+		X: 2,
+		E: 12,
+		Y: 4095,
 	})
 
 	assert.ProverSucceeded(&expCircuit, &Circuit{
-		X: (2),
-		E: (12),
-		Y: (4096),
+		X: 2,
+		E: 12,
+		Y: 4096,
 	})
 
 }

--- a/examples/mimc/mimc.go
+++ b/examples/mimc/mimc.go
@@ -15,7 +15,6 @@
 package mimc
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/hash/mimc"
 )
@@ -31,9 +30,9 @@ type Circuit struct {
 
 // Define declares the circuit's constraints
 // Hash = mimc(PreImage)
-func (circuit *Circuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *Circuit) Define(api frontend.API) error {
 	// hash function
-	mimc, _ := mimc.NewMiMC("seed", curveID, api)
+	mimc, _ := mimc.NewMiMC("seed", api)
 
 	// specify constraints
 	// mimc(preImage) == hash

--- a/examples/mimc/mimc_test.go
+++ b/examples/mimc/mimc_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/test"
 )
 
@@ -28,13 +27,13 @@ func TestPreimage(t *testing.T) {
 	var mimcCircuit Circuit
 
 	assert.ProverFailed(&mimcCircuit, &Circuit{
-		Hash:     frontend.Value(42),
-		PreImage: frontend.Value(42),
+		Hash:     (42),
+		PreImage: (42),
 	})
 
 	assert.ProverSucceeded(&mimcCircuit, &Circuit{
-		PreImage: frontend.Value(35),
-		Hash:     frontend.Value("16130099170765464552823636852555369511329944820189892919423002775646948828469"),
+		PreImage: (35),
+		Hash:     ("16130099170765464552823636852555369511329944820189892919423002775646948828469"),
 	}, test.WithCurves(ecc.BN254))
 
 }

--- a/examples/mimc/mimc_test.go
+++ b/examples/mimc/mimc_test.go
@@ -27,13 +27,13 @@ func TestPreimage(t *testing.T) {
 	var mimcCircuit Circuit
 
 	assert.ProverFailed(&mimcCircuit, &Circuit{
-		Hash:     (42),
-		PreImage: (42),
+		Hash:     42,
+		PreImage: 42,
 	})
 
 	assert.ProverSucceeded(&mimcCircuit, &Circuit{
-		PreImage: (35),
-		Hash:     ("16130099170765464552823636852555369511329944820189892919423002775646948828469"),
+		PreImage: 35,
+		Hash:     "16130099170765464552823636852555369511329944820189892919423002775646948828469",
 	}, test.WithCurves(ecc.BN254))
 
 }

--- a/examples/plonk/main.go
+++ b/examples/plonk/main.go
@@ -43,7 +43,7 @@ type Circuit struct {
 
 // Define declares the circuit's constraints
 // y == x**e
-func (circuit *Circuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *Circuit) Define(api frontend.API) error {
 
 	// number of bits of exponent
 	const bitSize = 2

--- a/examples/plonk/main.go
+++ b/examples/plonk/main.go
@@ -107,12 +107,12 @@ func main() {
 		// Witnesses instantiation. Witness is known only by the prover,
 		// while public witness is a public data known by the verifier.
 		var witness, publicWitness Circuit
-		witness.X = (2)
-		witness.E = (2)
-		witness.Y = (4)
+		witness.X = 2
+		witness.E = 2
+		witness.Y = 4
 
-		publicWitness.X = (2)
-		publicWitness.Y = (4)
+		publicWitness.X = 2
+		publicWitness.Y = 4
 
 		// public data consists the polynomials describing the constants involved
 		// in the constraints, the polynomial describing the permutation ("grand
@@ -141,12 +141,12 @@ func main() {
 		// Witnesses instantiation. Witness is known only by the prover,
 		// while public witness is a public data known by the verifier.
 		var witness, publicWitness Circuit
-		witness.X = (3)
-		witness.E = (12)
-		witness.Y = (4096)
+		witness.X = 3
+		witness.E = 12
+		witness.Y = 4096
 
-		publicWitness.X = (2)
-		publicWitness.Y = (4096)
+		publicWitness.X = 2
+		publicWitness.Y = 4096
 
 		// public data consists the polynomials describing the constants involved
 		// in the constraints, the polynomial describing the permutation ("grand

--- a/examples/plonk/main.go
+++ b/examples/plonk/main.go
@@ -107,12 +107,12 @@ func main() {
 		// Witnesses instantiation. Witness is known only by the prover,
 		// while public witness is a public data known by the verifier.
 		var witness, publicWitness Circuit
-		witness.X.Assign(2)
-		witness.E.Assign(2)
-		witness.Y.Assign(4)
+		witness.X = (2)
+		witness.E = (2)
+		witness.Y = (4)
 
-		publicWitness.X.Assign(2)
-		publicWitness.Y.Assign(4)
+		publicWitness.X = (2)
+		publicWitness.Y = (4)
 
 		// public data consists the polynomials describing the constants involved
 		// in the constraints, the polynomial describing the permutation ("grand
@@ -141,12 +141,12 @@ func main() {
 		// Witnesses instantiation. Witness is known only by the prover,
 		// while public witness is a public data known by the verifier.
 		var witness, publicWitness Circuit
-		witness.X.Assign(3)
-		witness.E.Assign(12)
-		witness.Y.Assign(4096)
+		witness.X = (3)
+		witness.E = (12)
+		witness.Y = (4096)
 
-		publicWitness.X.Assign(2)
-		publicWitness.Y.Assign(4096)
+		publicWitness.X = (2)
+		publicWitness.Y = (4096)
 
 		// public data consists the polynomials describing the constants involved
 		// in the constraints, the polynomial describing the permutation ("grand

--- a/examples/plonk/main.go
+++ b/examples/plonk/main.go
@@ -49,7 +49,7 @@ func (circuit *Circuit) Define(curveID ecc.ID, api frontend.API) error {
 	const bitSize = 2
 
 	// specify constraints
-	output := api.Constant(1)
+	output := frontend.Variable(1)
 	bits := api.ToBinary(circuit.E, bitSize)
 
 	for i := 0; i < len(bits); i++ {

--- a/examples/rollup/circuit.go
+++ b/examples/rollup/circuit.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rollup
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/accumulator/merkle"
 	"github.com/consensys/gnark/std/algebra/twistededwards"
@@ -87,9 +86,9 @@ type TransferConstraints struct {
 	Signature      eddsa.Signature
 }
 
-func (circuit *Circuit) postInit(curveID ecc.ID, api frontend.API) error {
+func (circuit *Circuit) postInit(api frontend.API) error {
 	// edward curve params
-	params, err := twistededwards.NewEdCurve(curveID)
+	params, err := twistededwards.NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -123,12 +122,12 @@ func (circuit *Circuit) postInit(curveID ecc.ID, api frontend.API) error {
 }
 
 // Define declares the circuit's constraints
-func (circuit *Circuit) Define(curveID ecc.ID, api frontend.API) error {
-	if err := circuit.postInit(curveID, api); err != nil {
+func (circuit *Circuit) Define(api frontend.API) error {
+	if err := circuit.postInit(api); err != nil {
 		return err
 	}
 	// hash function for the merkle proof and the eddsa signature
-	hFunc, err := mimc.NewMiMC("seed", curveID, api)
+	hFunc, err := mimc.NewMiMC("seed", api)
 	if err != nil {
 		return err
 	}

--- a/examples/rollup/circuit.go
+++ b/examples/rollup/circuit.go
@@ -174,8 +174,7 @@ func verifyTransferSignature(api frontend.API, t TransferConstraints, hFunc mimc
 func verifyAccountUpdated(api frontend.API, from, to, fromUpdated, toUpdated AccountConstraints, amount frontend.Variable) {
 
 	// ensure that nonce is correctly updated
-	one := api.Constant(1)
-	nonceUpdated := api.Add(from.Nonce, one)
+	nonceUpdated := api.Add(from.Nonce, 1)
 	api.AssertIsEqual(nonceUpdated, fromUpdated.Nonce)
 
 	// ensures that the amount is less than the balance

--- a/examples/rollup/circuit_test.go
+++ b/examples/rollup/circuit_test.go
@@ -31,11 +31,11 @@ type circuitSignature struct {
 }
 
 // Circuit implements part of the rollup circuit only by delcaring a subset of the constraints
-func (t *circuitSignature) Define(curveID ecc.ID, api frontend.API) error {
-	if err := t.postInit(curveID, api); err != nil {
+func (t *circuitSignature) Define(api frontend.API) error {
+	if err := t.postInit(api); err != nil {
 		return err
 	}
-	hFunc, err := mimc.NewMiMC("seed", curveID, api)
+	hFunc, err := mimc.NewMiMC("seed", api)
 	if err != nil {
 		return err
 	}
@@ -88,11 +88,11 @@ type circuitInclusionProof struct {
 }
 
 // Circuit implements part of the rollup circuit only by delcaring a subset of the constraints
-func (t *circuitInclusionProof) Define(curveID ecc.ID, api frontend.API) error {
-	if err := t.postInit(curveID, api); err != nil {
+func (t *circuitInclusionProof) Define(api frontend.API) error {
+	if err := t.postInit(api); err != nil {
 		return err
 	}
-	hashFunc, err := mimc.NewMiMC("seed", curveID, api)
+	hashFunc, err := mimc.NewMiMC("seed", api)
 	if err != nil {
 		return err
 	}
@@ -154,8 +154,8 @@ type circuitUpdateAccount struct {
 }
 
 // Circuit implements part of the rollup circuit only by delcaring a subset of the constraints
-func (t *circuitUpdateAccount) Define(curveID ecc.ID, api frontend.API) error {
-	if err := t.postInit(curveID, api); err != nil {
+func (t *circuitUpdateAccount) Define(api frontend.API) error {
+	if err := t.postInit(api); err != nil {
 		return err
 	}
 	verifyAccountUpdated(api, t.SenderAccountsBefore[0], t.ReceiverAccountsBefore[0],

--- a/examples/rollup/operator.go
+++ b/examples/rollup/operator.go
@@ -123,19 +123,19 @@ func (o *Operator) updateState(t Transfer, numTransfer int) error {
 	}
 
 	// set witnesses for the public keys
-	o.witnesses.PublicKeysSender[numTransfer].A.X = (senderAccount.pubKey.A.X)
-	o.witnesses.PublicKeysSender[numTransfer].A.Y = (senderAccount.pubKey.A.Y)
-	o.witnesses.PublicKeysReceiver[numTransfer].A.X = (receiverAccount.pubKey.A.X)
-	o.witnesses.PublicKeysReceiver[numTransfer].A.Y = (receiverAccount.pubKey.A.Y)
+	o.witnesses.PublicKeysSender[numTransfer].A.X = senderAccount.pubKey.A.X
+	o.witnesses.PublicKeysSender[numTransfer].A.Y = senderAccount.pubKey.A.Y
+	o.witnesses.PublicKeysReceiver[numTransfer].A.X = receiverAccount.pubKey.A.X
+	o.witnesses.PublicKeysReceiver[numTransfer].A.Y = receiverAccount.pubKey.A.Y
 
 	// set witnesses for the accounts before update
-	o.witnesses.SenderAccountsBefore[numTransfer].Index = (senderAccount.index)
-	o.witnesses.SenderAccountsBefore[numTransfer].Nonce = (senderAccount.nonce)
-	o.witnesses.SenderAccountsBefore[numTransfer].Balance = (senderAccount.balance)
+	o.witnesses.SenderAccountsBefore[numTransfer].Index = senderAccount.index
+	o.witnesses.SenderAccountsBefore[numTransfer].Nonce = senderAccount.nonce
+	o.witnesses.SenderAccountsBefore[numTransfer].Balance = senderAccount.balance
 
-	o.witnesses.ReceiverAccountsBefore[numTransfer].Index = (receiverAccount.index)
-	o.witnesses.ReceiverAccountsBefore[numTransfer].Nonce = (receiverAccount.nonce)
-	o.witnesses.ReceiverAccountsBefore[numTransfer].Balance = (receiverAccount.balance)
+	o.witnesses.ReceiverAccountsBefore[numTransfer].Index = receiverAccount.index
+	o.witnesses.ReceiverAccountsBefore[numTransfer].Nonce = receiverAccount.nonce
+	o.witnesses.ReceiverAccountsBefore[numTransfer].Balance = receiverAccount.balance
 
 	//  Set witnesses for the proof of inclusion of sender and receivers account before update
 	var buf bytes.Buffer
@@ -160,7 +160,7 @@ func (o *Operator) updateState(t Transfer, numTransfer int) error {
 		return err
 	}
 	merkleProofHelperReceiverBefore := merkle.GenerateProofHelper(proofInclusionReceiverBefore, posReceiver, numLeaves)
-	o.witnesses.RootHashesBefore[numTransfer] = (merkleRootBefore)
+	o.witnesses.RootHashesBefore[numTransfer] = merkleRootBefore
 	for i := 0; i < len(proofInclusionSenderBefore); i++ {
 		o.witnesses.MerkleProofsSenderBefore[numTransfer][i] = (proofInclusionSenderBefore[i])
 		o.witnesses.MerkleProofsReceiverBefore[numTransfer][i] = (proofInclusionReceiverBefore[i])

--- a/examples/rollup/operator.go
+++ b/examples/rollup/operator.go
@@ -162,20 +162,20 @@ func (o *Operator) updateState(t Transfer, numTransfer int) error {
 	merkleProofHelperReceiverBefore := merkle.GenerateProofHelper(proofInclusionReceiverBefore, posReceiver, numLeaves)
 	o.witnesses.RootHashesBefore[numTransfer] = merkleRootBefore
 	for i := 0; i < len(proofInclusionSenderBefore); i++ {
-		o.witnesses.MerkleProofsSenderBefore[numTransfer][i] = (proofInclusionSenderBefore[i])
-		o.witnesses.MerkleProofsReceiverBefore[numTransfer][i] = (proofInclusionReceiverBefore[i])
+		o.witnesses.MerkleProofsSenderBefore[numTransfer][i] = proofInclusionSenderBefore[i]
+		o.witnesses.MerkleProofsReceiverBefore[numTransfer][i] = proofInclusionReceiverBefore[i]
 
 		if i < len(proofInclusionReceiverBefore)-1 {
-			o.witnesses.MerkleProofHelperSenderBefore[numTransfer][i] = (merkleProofHelperSenderBefore[i])
-			o.witnesses.MerkleProofHelperReceiverBefore[numTransfer][i] = (merkleProofHelperReceiverBefore[i])
+			o.witnesses.MerkleProofHelperSenderBefore[numTransfer][i] = merkleProofHelperSenderBefore[i]
+			o.witnesses.MerkleProofHelperReceiverBefore[numTransfer][i] = merkleProofHelperReceiverBefore[i]
 		}
 	}
 
 	// set witnesses for the transfer
-	o.witnesses.Transfers[numTransfer].Amount = (t.amount)
-	o.witnesses.Transfers[numTransfer].Signature.R.X = (t.signature.R.X)
-	o.witnesses.Transfers[numTransfer].Signature.R.Y = (t.signature.R.Y)
-	o.witnesses.Transfers[numTransfer].Signature.S = (t.signature.S[:])
+	o.witnesses.Transfers[numTransfer].Amount = t.amount
+	o.witnesses.Transfers[numTransfer].Signature.R.X = t.signature.R.X
+	o.witnesses.Transfers[numTransfer].Signature.R.Y = t.signature.R.Y
+	o.witnesses.Transfers[numTransfer].Signature.S = t.signature.S[:]
 
 	// verifying the signature. The msg is the hash (o.h) of the transfer
 	// nonce || amount || senderpubKey(x&y) || receiverPubkey(x&y)
@@ -210,13 +210,13 @@ func (o *Operator) updateState(t Transfer, numTransfer int) error {
 	senderAccount.nonce++
 
 	// set the witnesses for the account after update
-	o.witnesses.SenderAccountsAfter[numTransfer].Index = (senderAccount.index)
-	o.witnesses.SenderAccountsAfter[numTransfer].Nonce = (senderAccount.nonce)
-	o.witnesses.SenderAccountsAfter[numTransfer].Balance = (senderAccount.balance)
+	o.witnesses.SenderAccountsAfter[numTransfer].Index = senderAccount.index
+	o.witnesses.SenderAccountsAfter[numTransfer].Nonce = senderAccount.nonce
+	o.witnesses.SenderAccountsAfter[numTransfer].Balance = senderAccount.balance
 
-	o.witnesses.ReceiverAccountsAfter[numTransfer].Index = (receiverAccount.index)
-	o.witnesses.ReceiverAccountsAfter[numTransfer].Nonce = (receiverAccount.nonce)
-	o.witnesses.ReceiverAccountsAfter[numTransfer].Balance = (receiverAccount.balance)
+	o.witnesses.ReceiverAccountsAfter[numTransfer].Index = receiverAccount.index
+	o.witnesses.ReceiverAccountsAfter[numTransfer].Nonce = receiverAccount.nonce
+	o.witnesses.ReceiverAccountsAfter[numTransfer].Balance = receiverAccount.balance
 
 	// update the state of the operator
 	copy(o.State[int(posSender)*SizeAccount:], senderAccount.Serialize())
@@ -254,14 +254,14 @@ func (o *Operator) updateState(t Transfer, numTransfer int) error {
 	}
 	merkleProofHelperReceiverAfter := merkle.GenerateProofHelper(proofInclusionReceiverAfter, posReceiver, numLeaves)
 
-	o.witnesses.RootHashesAfter[numTransfer] = (merkleRootAfer)
+	o.witnesses.RootHashesAfter[numTransfer] = merkleRootAfer
 	for i := 0; i < len(proofInclusionSenderAfter); i++ {
-		o.witnesses.MerkleProofsSenderAfter[numTransfer][i] = (proofInclusionSenderAfter[i])
-		o.witnesses.MerkleProofsReceiverAfter[numTransfer][i] = (proofInclusionReceiverAfter[i])
+		o.witnesses.MerkleProofsSenderAfter[numTransfer][i] = proofInclusionSenderAfter[i]
+		o.witnesses.MerkleProofsReceiverAfter[numTransfer][i] = proofInclusionReceiverAfter[i]
 
 		if i < len(proofInclusionReceiverAfter)-1 {
-			o.witnesses.MerkleProofHelperSenderAfter[numTransfer][i] = (merkleProofHelperSenderAfter[i])
-			o.witnesses.MerkleProofHelperReceiverAfter[numTransfer][i] = (merkleProofHelperReceiverAfter[i])
+			o.witnesses.MerkleProofHelperSenderAfter[numTransfer][i] = merkleProofHelperSenderAfter[i]
+			o.witnesses.MerkleProofHelperReceiverAfter[numTransfer][i] = merkleProofHelperReceiverAfter[i]
 		}
 	}
 

--- a/examples/rollup/operator.go
+++ b/examples/rollup/operator.go
@@ -123,19 +123,19 @@ func (o *Operator) updateState(t Transfer, numTransfer int) error {
 	}
 
 	// set witnesses for the public keys
-	o.witnesses.PublicKeysSender[numTransfer].A.X.Assign(senderAccount.pubKey.A.X)
-	o.witnesses.PublicKeysSender[numTransfer].A.Y.Assign(senderAccount.pubKey.A.Y)
-	o.witnesses.PublicKeysReceiver[numTransfer].A.X.Assign(receiverAccount.pubKey.A.X)
-	o.witnesses.PublicKeysReceiver[numTransfer].A.Y.Assign(receiverAccount.pubKey.A.Y)
+	o.witnesses.PublicKeysSender[numTransfer].A.X = (senderAccount.pubKey.A.X)
+	o.witnesses.PublicKeysSender[numTransfer].A.Y = (senderAccount.pubKey.A.Y)
+	o.witnesses.PublicKeysReceiver[numTransfer].A.X = (receiverAccount.pubKey.A.X)
+	o.witnesses.PublicKeysReceiver[numTransfer].A.Y = (receiverAccount.pubKey.A.Y)
 
 	// set witnesses for the accounts before update
-	o.witnesses.SenderAccountsBefore[numTransfer].Index.Assign(senderAccount.index)
-	o.witnesses.SenderAccountsBefore[numTransfer].Nonce.Assign(senderAccount.nonce)
-	o.witnesses.SenderAccountsBefore[numTransfer].Balance.Assign(senderAccount.balance)
+	o.witnesses.SenderAccountsBefore[numTransfer].Index = (senderAccount.index)
+	o.witnesses.SenderAccountsBefore[numTransfer].Nonce = (senderAccount.nonce)
+	o.witnesses.SenderAccountsBefore[numTransfer].Balance = (senderAccount.balance)
 
-	o.witnesses.ReceiverAccountsBefore[numTransfer].Index.Assign(receiverAccount.index)
-	o.witnesses.ReceiverAccountsBefore[numTransfer].Nonce.Assign(receiverAccount.nonce)
-	o.witnesses.ReceiverAccountsBefore[numTransfer].Balance.Assign(receiverAccount.balance)
+	o.witnesses.ReceiverAccountsBefore[numTransfer].Index = (receiverAccount.index)
+	o.witnesses.ReceiverAccountsBefore[numTransfer].Nonce = (receiverAccount.nonce)
+	o.witnesses.ReceiverAccountsBefore[numTransfer].Balance = (receiverAccount.balance)
 
 	//  Set witnesses for the proof of inclusion of sender and receivers account before update
 	var buf bytes.Buffer
@@ -160,22 +160,22 @@ func (o *Operator) updateState(t Transfer, numTransfer int) error {
 		return err
 	}
 	merkleProofHelperReceiverBefore := merkle.GenerateProofHelper(proofInclusionReceiverBefore, posReceiver, numLeaves)
-	o.witnesses.RootHashesBefore[numTransfer].Assign(merkleRootBefore)
+	o.witnesses.RootHashesBefore[numTransfer] = (merkleRootBefore)
 	for i := 0; i < len(proofInclusionSenderBefore); i++ {
-		o.witnesses.MerkleProofsSenderBefore[numTransfer][i].Assign(proofInclusionSenderBefore[i])
-		o.witnesses.MerkleProofsReceiverBefore[numTransfer][i].Assign(proofInclusionReceiverBefore[i])
+		o.witnesses.MerkleProofsSenderBefore[numTransfer][i] = (proofInclusionSenderBefore[i])
+		o.witnesses.MerkleProofsReceiverBefore[numTransfer][i] = (proofInclusionReceiverBefore[i])
 
 		if i < len(proofInclusionReceiverBefore)-1 {
-			o.witnesses.MerkleProofHelperSenderBefore[numTransfer][i].Assign(merkleProofHelperSenderBefore[i])
-			o.witnesses.MerkleProofHelperReceiverBefore[numTransfer][i].Assign(merkleProofHelperReceiverBefore[i])
+			o.witnesses.MerkleProofHelperSenderBefore[numTransfer][i] = (merkleProofHelperSenderBefore[i])
+			o.witnesses.MerkleProofHelperReceiverBefore[numTransfer][i] = (merkleProofHelperReceiverBefore[i])
 		}
 	}
 
 	// set witnesses for the transfer
-	o.witnesses.Transfers[numTransfer].Amount.Assign(t.amount)
-	o.witnesses.Transfers[numTransfer].Signature.R.X.Assign(t.signature.R.X)
-	o.witnesses.Transfers[numTransfer].Signature.R.Y.Assign(t.signature.R.Y)
-	o.witnesses.Transfers[numTransfer].Signature.S.Assign(t.signature.S[:])
+	o.witnesses.Transfers[numTransfer].Amount = (t.amount)
+	o.witnesses.Transfers[numTransfer].Signature.R.X = (t.signature.R.X)
+	o.witnesses.Transfers[numTransfer].Signature.R.Y = (t.signature.R.Y)
+	o.witnesses.Transfers[numTransfer].Signature.S = (t.signature.S[:])
 
 	// verifying the signature. The msg is the hash (o.h) of the transfer
 	// nonce || amount || senderpubKey(x&y) || receiverPubkey(x&y)
@@ -210,13 +210,13 @@ func (o *Operator) updateState(t Transfer, numTransfer int) error {
 	senderAccount.nonce++
 
 	// set the witnesses for the account after update
-	o.witnesses.SenderAccountsAfter[numTransfer].Index.Assign(senderAccount.index)
-	o.witnesses.SenderAccountsAfter[numTransfer].Nonce.Assign(senderAccount.nonce)
-	o.witnesses.SenderAccountsAfter[numTransfer].Balance.Assign(senderAccount.balance)
+	o.witnesses.SenderAccountsAfter[numTransfer].Index = (senderAccount.index)
+	o.witnesses.SenderAccountsAfter[numTransfer].Nonce = (senderAccount.nonce)
+	o.witnesses.SenderAccountsAfter[numTransfer].Balance = (senderAccount.balance)
 
-	o.witnesses.ReceiverAccountsAfter[numTransfer].Index.Assign(receiverAccount.index)
-	o.witnesses.ReceiverAccountsAfter[numTransfer].Nonce.Assign(receiverAccount.nonce)
-	o.witnesses.ReceiverAccountsAfter[numTransfer].Balance.Assign(receiverAccount.balance)
+	o.witnesses.ReceiverAccountsAfter[numTransfer].Index = (receiverAccount.index)
+	o.witnesses.ReceiverAccountsAfter[numTransfer].Nonce = (receiverAccount.nonce)
+	o.witnesses.ReceiverAccountsAfter[numTransfer].Balance = (receiverAccount.balance)
 
 	// update the state of the operator
 	copy(o.State[int(posSender)*SizeAccount:], senderAccount.Serialize())
@@ -254,14 +254,14 @@ func (o *Operator) updateState(t Transfer, numTransfer int) error {
 	}
 	merkleProofHelperReceiverAfter := merkle.GenerateProofHelper(proofInclusionReceiverAfter, posReceiver, numLeaves)
 
-	o.witnesses.RootHashesAfter[numTransfer].Assign(merkleRootAfer)
+	o.witnesses.RootHashesAfter[numTransfer] = (merkleRootAfer)
 	for i := 0; i < len(proofInclusionSenderAfter); i++ {
-		o.witnesses.MerkleProofsSenderAfter[numTransfer][i].Assign(proofInclusionSenderAfter[i])
-		o.witnesses.MerkleProofsReceiverAfter[numTransfer][i].Assign(proofInclusionReceiverAfter[i])
+		o.witnesses.MerkleProofsSenderAfter[numTransfer][i] = (proofInclusionSenderAfter[i])
+		o.witnesses.MerkleProofsReceiverAfter[numTransfer][i] = (proofInclusionReceiverAfter[i])
 
 		if i < len(proofInclusionReceiverAfter)-1 {
-			o.witnesses.MerkleProofHelperSenderAfter[numTransfer][i].Assign(merkleProofHelperSenderAfter[i])
-			o.witnesses.MerkleProofHelperReceiverAfter[numTransfer][i].Assign(merkleProofHelperReceiverAfter[i])
+			o.witnesses.MerkleProofHelperSenderAfter[numTransfer][i] = (merkleProofHelperSenderAfter[i])
+			o.witnesses.MerkleProofHelperReceiverAfter[numTransfer][i] = (merkleProofHelperReceiverAfter[i])
 		}
 	}
 

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -97,9 +97,6 @@ type API interface {
 	// whose value will be resolved at runtime when computed by the solver
 	Println(a ...interface{})
 
-	// Constant returns a frontend.Variable representing a known value at compile time
-	Constant(input interface{}) Variable
-
 	// NewHint initialize a Variable whose value will be evaluated using the provided hint function at run time
 	//
 	// hint function is provided at proof creation time and must match the hintID

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -19,6 +19,7 @@ package frontend
 import (
 	"math/big"
 
+	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/hint"
 )
 
@@ -117,4 +118,7 @@ type API interface {
 	// ConstantValue returns the big.Int value of v
 	// will panic if v.IsConstant() == false
 	ConstantValue(v Variable) *big.Int
+
+	// CurveID returns the ecc.ID injected by the compiler
+	CurveID() ecc.ID
 }

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -47,7 +47,7 @@ type API interface {
 	// ---------------------------------------------------------------------------------------------
 	// Bit operations
 
-	// ToBinary unpacks a variable in binary,
+	// ToBinary unpacks a Variable in binary,
 	// n is the number of bits to select (starting from lsb)
 	// n default value is fr.Bits the number of bits needed to represent a field element
 	//
@@ -55,7 +55,7 @@ type API interface {
 	ToBinary(i1 interface{}, n ...int) []Variable
 
 	// FromBinary packs b, seen as a fr.Element in little endian
-	FromBinary(b ...Variable) Variable
+	FromBinary(b ...interface{}) Variable
 
 	// Xor returns a ^ b
 	// a and b must be 0 or 1
@@ -100,7 +100,7 @@ type API interface {
 	// Constant returns a frontend.Variable representing a known value at compile time
 	Constant(input interface{}) Variable
 
-	// NewHint initialize a variable whose value will be evaluated using the provided hint function at run time
+	// NewHint initialize a Variable whose value will be evaluated using the provided hint function at run time
 	//
 	// hint function is provided at proof creation time and must match the hintID
 	// inputs must be either variables or convertible to big int

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -115,8 +115,8 @@ type API interface {
 	// IsConstant returns true if v is a constant known at compile time
 	IsConstant(v Variable) bool
 
-	// ConstantValue returns the big.Int value of v
-	// will panic if v.IsConstant() == false
+	// ConstantValue returns the big.Int value of v. It
+	// panics if v.IsConstant() == false
 	ConstantValue(v Variable) *big.Int
 
 	// CurveID returns the ecc.ID injected by the compiler

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package frontend
 
-import "github.com/consensys/gnark/backend/hint"
+import (
+	"math/big"
+
+	"github.com/consensys/gnark/backend/hint"
+)
 
 // API represents the available functions to circuit developers
 type API interface {
@@ -106,4 +110,11 @@ type API interface {
 	// from the backend point of view, it's equivalent to a user-supplied witness
 	// except, the solver is going to assign it a value, not the caller
 	NewHint(f hint.Function, inputs ...interface{}) Variable
+
+	// IsConstant returns true if v is a constant known at compile time
+	IsConstant(v Variable) bool
+
+	// ConstantValue returns the big.Int value of v
+	// will panic if v.IsConstant() == false
+	ConstantValue(v Variable) *big.Int
 }

--- a/frontend/circuit.go
+++ b/frontend/circuit.go
@@ -22,7 +22,7 @@ import "github.com/consensys/gnark-crypto/ecc"
 //
 // the tag format is as follow:
 // 		type MyCircuit struct {
-// 			Y frontend.Variable `gnark:"name,option"`
+// 			Y frontend.variable `gnark:"name,option"`
 // 		}
 // if empty, default resolves to variable name (here "Y") and secret visibility
 // similarly to json or xml struct tags, these are valid:
@@ -30,8 +30,8 @@ import "github.com/consensys/gnark-crypto/ecc"
 // using "-" marks the variable as ignored by the Compile method. This can be useful when you need to
 // declare variables as aliases that are already allocated. For example
 // 		type MyCircuit struct {
-// 			Y frontend.Variable `gnark:",public"`
-//			Z frontend.Variable `gnark:"-"`
+// 			Y frontend.variable `gnark:",public"`
+//			Z frontend.variable `gnark:"-"`
 // 		}
 // it is then the developer responsability to do circuit.Z = circuit.Y in the Define() method
 type Circuit interface {

--- a/frontend/circuit.go
+++ b/frontend/circuit.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package frontend
 
-import "github.com/consensys/gnark-crypto/ecc"
-
 // Circuit must be implemented by user-defined circuits
 //
 // the tag format is as follow:
@@ -36,5 +34,5 @@ import "github.com/consensys/gnark-crypto/ecc"
 // it is then the developer responsability to do circuit.Z = circuit.Y in the Define() method
 type Circuit interface {
 	// Define declares the circuit's Constraints
-	Define(curveID ecc.ID, api API) error
+	Define(api API) error
 }

--- a/frontend/circuit.go
+++ b/frontend/circuit.go
@@ -20,7 +20,7 @@ package frontend
 //
 // the tag format is as follow:
 // 		type MyCircuit struct {
-// 			Y frontend.variable `gnark:"name,option"`
+// 			Y frontend.Variable `gnark:"name,option"`
 // 		}
 // if empty, default resolves to variable name (here "Y") and secret visibility
 // similarly to json or xml struct tags, these are valid:
@@ -28,8 +28,8 @@ package frontend
 // using "-" marks the variable as ignored by the Compile method. This can be useful when you need to
 // declare variables as aliases that are already allocated. For example
 // 		type MyCircuit struct {
-// 			Y frontend.variable `gnark:",public"`
-//			Z frontend.variable `gnark:"-"`
+// 			Y frontend.Variable `gnark:",public"`
+//			Z frontend.Variable `gnark:"-"`
 // 		}
 // it is then the developer responsability to do circuit.Z = circuit.Y in the Define() method
 type Circuit interface {

--- a/frontend/cs.go
+++ b/frontend/cs.go
@@ -454,3 +454,7 @@ func (cs *constraintSystem) checkVariables() error {
 	return errors.New(sbb.String())
 
 }
+
+func (cs *constraintSystem) CurveID() ecc.ID {
+	return cs.curveID
+}

--- a/frontend/cs.go
+++ b/frontend/cs.go
@@ -171,7 +171,7 @@ func (cs *constraintSystem) NewHint(f hint.Function, inputs ...interface{}) Vari
 
 	// ensure inputs are set and pack them in a []uint64
 	for i, in := range inputs {
-		t := cs.Constant(in).(variable)
+		t := cs.constant(in).(variable)
 		hintInputs[i] = t.linExp.Clone() // TODO @gbotrel check that we need to clone here ?
 	}
 

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -29,8 +29,8 @@ func (cs *constraintSystem) Add(i1, i2 interface{}, in ...interface{}) Variable 
 	// extract variables from input
 	vars, s := cs.toVariables(append([]interface{}{i1, i2}, in...)...)
 
-	// allocate resulting variable
-	res := Variable{linExp: make(compiled.LinearExpression, 0, s)}
+	// allocate resulting Variable
+	res := variable{linExp: make(compiled.LinearExpression, 0, s)}
 
 	for _, v := range vars {
 		res.linExp = append(res.linExp, v.linExp.Clone()...)
@@ -51,7 +51,7 @@ func (cs *constraintSystem) Neg(i interface{}) Variable {
 		return cs.Constant(n)
 	}
 
-	return Variable{linExp: cs.negateLinExp(vars[0].linExp)}
+	return variable{linExp: cs.negateLinExp(vars[0].linExp)}
 }
 
 // Sub returns res = i1 - i2
@@ -60,8 +60,8 @@ func (cs *constraintSystem) Sub(i1, i2 interface{}, in ...interface{}) Variable 
 	// extract variables from input
 	vars, s := cs.toVariables(append([]interface{}{i1, i2}, in...)...)
 
-	// allocate resulting variable
-	res := Variable{
+	// allocate resulting Variable
+	res := variable{
 		linExp: make(compiled.LinearExpression, 0, s),
 	}
 
@@ -81,7 +81,7 @@ func (cs *constraintSystem) Sub(i1, i2 interface{}, in ...interface{}) Variable 
 func (cs *constraintSystem) Mul(i1, i2 interface{}, in ...interface{}) Variable {
 	vars, _ := cs.toVariables(append([]interface{}{i1, i2}, in...)...)
 
-	mul := func(v1, v2 Variable) Variable {
+	mul := func(v1, v2 variable) variable {
 
 		// v1 and v2 are both unknown, this is the only case we add a constraint
 		if !v1.isConstant() && !v2.isConstant() {
@@ -96,7 +96,7 @@ func (cs *constraintSystem) Mul(i1, i2 interface{}, in ...interface{}) Variable 
 			b2 := v2.constantValue(cs)
 
 			b1.Mul(b1, b2).Mod(b1, cs.curveID.Info().Fr.Modulus())
-			return cs.Constant(b1)
+			return cs.Constant(b1).(variable)
 		}
 
 		// ensure v2 is the constant
@@ -116,9 +116,9 @@ func (cs *constraintSystem) Mul(i1, i2 interface{}, in ...interface{}) Variable 
 	return res
 }
 
-func (cs *constraintSystem) mulConstant(v1, constant Variable) Variable {
-	// multiplying a variable by a constant -> we updated the coefficients in the linear expression
-	// leading to that variable
+func (cs *constraintSystem) mulConstant(v1, constant variable) variable {
+	// multiplying a Variable by a constant -> we updated the coefficients in the linear expression
+	// leading to that Variable
 	linExp := v1.linExp.Clone()
 	lambda := constant.constantValue(cs)
 
@@ -138,9 +138,9 @@ func (cs *constraintSystem) mulConstant(v1, constant Variable) Variable {
 			coeff := cs.coeffs[cID]
 			newCoeff.Mul(&coeff, lambda)
 		}
-		linExp[i] = cs.makeTerm(Variable{visibility: visibility, id: vID}, &newCoeff)
+		linExp[i] = cs.makeTerm(variable{visibility: visibility, id: vID}, &newCoeff)
 	}
-	return Variable{linExp: linExp}
+	return variable{linExp: linExp}
 }
 
 // Inverse returns res = inverse(v)
@@ -157,7 +157,7 @@ func (cs *constraintSystem) Inverse(i1 interface{}) Variable {
 		return cs.Constant(c)
 	}
 
-	// allocate resulting variable
+	// allocate resulting Variable
 	res := cs.newInternalVariable()
 
 	debug := cs.addDebugInfo("inverse", vars[0], "*", res, " == 1")
@@ -197,7 +197,7 @@ func (cs *constraintSystem) Div(i1, i2 interface{}) Variable {
 	}
 
 	// v1 is not constant
-	return cs.mulConstant(v1, cs.Constant(b2))
+	return cs.mulConstant(v1, cs.Constant(b2).(variable))
 }
 
 func (cs *constraintSystem) DivUnchecked(i1, i2 interface{}) Variable {
@@ -228,14 +228,16 @@ func (cs *constraintSystem) DivUnchecked(i1, i2 interface{}) Variable {
 	}
 
 	// v1 is not constant
-	return cs.mulConstant(v1, cs.Constant(b2))
+	return cs.mulConstant(v1, cs.Constant(b2).(variable))
 }
 
 // Xor compute the XOR between two variables
-func (cs *constraintSystem) Xor(a, b Variable) Variable {
+func (cs *constraintSystem) Xor(_a, _b Variable) Variable {
 
-	a.assertIsSet(cs)
-	b.assertIsSet(cs)
+	vars, _ := cs.toVariables(_a, _b)
+
+	a := vars[0]
+	b := vars[1]
 
 	cs.AssertIsBoolean(a)
 	cs.AssertIsBoolean(b)
@@ -251,10 +253,11 @@ func (cs *constraintSystem) Xor(a, b Variable) Variable {
 }
 
 // Or compute the OR between two variables
-func (cs *constraintSystem) Or(a, b Variable) Variable {
+func (cs *constraintSystem) Or(_a, _b Variable) Variable {
+	vars, _ := cs.toVariables(_a, _b)
 
-	a.assertIsSet(cs)
-	b.assertIsSet(cs)
+	a := vars[0]
+	b := vars[1]
 
 	cs.AssertIsBoolean(a)
 	cs.AssertIsBoolean(b)
@@ -269,10 +272,11 @@ func (cs *constraintSystem) Or(a, b Variable) Variable {
 }
 
 // And compute the AND between two variables
-func (cs *constraintSystem) And(a, b Variable) Variable {
+func (cs *constraintSystem) And(_a, _b Variable) Variable {
+	vars, _ := cs.toVariables(_a, _b)
 
-	a.assertIsSet(cs)
-	b.assertIsSet(cs)
+	a := vars[0]
+	b := vars[1]
 
 	cs.AssertIsBoolean(a)
 	cs.AssertIsBoolean(b)
@@ -311,7 +315,7 @@ func (cs *constraintSystem) IsZero(i1 interface{}) Variable {
 
 }
 
-// ToBinary unpacks a variable in binary,
+// ToBinary unpacks a Variable in binary,
 // n is the number of bits to select (starting from lsb)
 // n default value is fr.Bits the number of bits needed to represent a field element
 //
@@ -332,17 +336,17 @@ func (cs *constraintSystem) ToBinary(i1 interface{}, n ...int) []Variable {
 	// if a is a constant, work with the big int value.
 	if a.isConstant() {
 		c := a.constantValue(cs)
-		b := make([]Variable, nbBits)
+		b := make([]variable, nbBits)
 		for i := 0; i < len(b); i++ {
-			b[i] = cs.Constant(c.Bit(i))
+			b[i] = cs.Constant(c.Bit(i)).(variable)
 		}
-		return b
+		return toSliceOfVariables(b)
 	}
 
 	// allocate the resulting variables and bit-constraint them
-	b := make([]Variable, nbBits)
+	b := make([]variable, nbBits)
 	for i := 0; i < nbBits; i++ {
-		b[i] = cs.NewHint(hint.IthBit, a, i)
+		b[i] = cs.NewHint(hint.IthBit, a, i).(variable)
 		cs.AssertIsBoolean(b[i])
 	}
 
@@ -351,11 +355,11 @@ func (cs *constraintSystem) ToBinary(i1 interface{}, n ...int) []Variable {
 	var c big.Int
 	c.SetUint64(1)
 
-	var Σbi Variable
+	var Σbi variable
 	Σbi.linExp = make(compiled.LinearExpression, nbBits)
 
 	for i := 0; i < nbBits; i++ {
-		Σbi.linExp[i] = cs.makeTerm(Variable{visibility: compiled.Internal, id: b[i].id}, &c)
+		Σbi.linExp[i] = cs.makeTerm(variable{visibility: compiled.Internal, id: b[i].id}, &c)
 		c.Lsh(&c, 1)
 	}
 
@@ -363,12 +367,12 @@ func (cs *constraintSystem) ToBinary(i1 interface{}, n ...int) []Variable {
 
 	// record the constraint Σ (2**i * b[i]) == a
 	cs.addConstraint(newR1C(Σbi, cs.one(), a), debug)
-	return b
+	return toSliceOfVariables(b)
 
 }
 
 // toBinaryUnsafe is equivalent to ToBinary, exept the returned bits are NOT boolean constrained.
-func (cs *constraintSystem) toBinaryUnsafe(a Variable, nbBits int) []Variable {
+func (cs *constraintSystem) toBinaryUnsafe(a variable, nbBits int) []Variable {
 	if a.isConstant() {
 		return cs.ToBinary(a, nbBits)
 	}
@@ -376,9 +380,9 @@ func (cs *constraintSystem) toBinaryUnsafe(a Variable, nbBits int) []Variable {
 	a.assertIsSet(cs)
 
 	// allocate the resulting variables and bit-constraint them
-	b := make([]Variable, nbBits)
+	b := make([]variable, nbBits)
 	for i := 0; i < nbBits; i++ {
-		b[i] = cs.NewHint(hint.IthBit, a, i)
+		b[i] = cs.NewHint(hint.IthBit, a, i).(variable)
 	}
 
 	// here what we do is we add a single constraint where
@@ -386,11 +390,11 @@ func (cs *constraintSystem) toBinaryUnsafe(a Variable, nbBits int) []Variable {
 	var c big.Int
 	c.SetUint64(1)
 
-	var Σbi Variable
+	var Σbi variable
 	Σbi.linExp = make(compiled.LinearExpression, nbBits)
 
 	for i := 0; i < nbBits; i++ {
-		Σbi.linExp[i] = cs.makeTerm(Variable{visibility: compiled.Internal, id: b[i].id}, &c)
+		Σbi.linExp[i] = cs.makeTerm(variable{visibility: compiled.Internal, id: b[i].id}, &c)
 		c.Lsh(&c, 1)
 	}
 
@@ -398,12 +402,23 @@ func (cs *constraintSystem) toBinaryUnsafe(a Variable, nbBits int) []Variable {
 
 	// record the constraint Σ (2**i * b[i]) == a
 	cs.addConstraint(newR1C(Σbi, cs.one(), a), debug)
-	return b
+	return toSliceOfVariables(b)
 
 }
 
+func toSliceOfVariables(v []variable) []Variable {
+	// TODO this is ugly.
+	r := make([]Variable, len(v))
+	for i := 0; i < len(v); i++ {
+		r[i] = v[i]
+	}
+	return r
+}
+
 // FromBinary packs b, seen as a fr.Element in little endian
-func (cs *constraintSystem) FromBinary(b ...Variable) Variable {
+func (cs *constraintSystem) FromBinary(_b ...interface{}) Variable {
+	b, _ := cs.toVariables(_b...)
+
 	// ensure inputs are set
 	for i := 0; i < len(b); i++ {
 		b[i].assertIsSet(cs)
@@ -467,12 +482,12 @@ func (cs *constraintSystem) Select(i0, i1, i2 interface{}) Variable {
 // if input is already a Variable, does nothing
 // else, attempts to convert input to a big.Int (see FromInterface) and returns a Constant Variable
 //
-// a Constant variable does NOT necessary allocate a Variable in the ConstraintSystem
+// a Constant Variable does NOT necessary allocate a Variable in the ConstraintSystem
 // it is in the form ONE_WIRE * coeff
 func (cs *constraintSystem) Constant(input interface{}) Variable {
 
 	switch t := input.(type) {
-	case Variable:
+	case variable:
 		t.assertIsSet(cs)
 		return t
 	default:
@@ -480,18 +495,18 @@ func (cs *constraintSystem) Constant(input interface{}) Variable {
 		if n.IsUint64() && n.Uint64() == 1 {
 			return cs.one()
 		}
-		return Variable{linExp: compiled.LinearExpression{
-			cs.makeTerm(Variable{visibility: compiled.Public, id: 0}, &n),
+		return variable{linExp: compiled.LinearExpression{
+			cs.makeTerm(variable{visibility: compiled.Public, id: 0}, &n),
 		}}
 	}
 }
 
 // toVariables return Variable corresponding to inputs and the total size of the linear expressions
-func (cs *constraintSystem) toVariables(in ...interface{}) ([]Variable, int) {
-	r := make([]Variable, 0, len(in))
+func (cs *constraintSystem) toVariables(in ...interface{}) ([]variable, int) {
+	r := make([]variable, 0, len(in))
 	s := 0
 	e := func(i interface{}) {
-		v := cs.Constant(i)
+		v := cs.Constant(i).(variable)
 		r = append(r, v)
 		s += len(v.linExp)
 	}
@@ -510,7 +525,7 @@ func (cs *constraintSystem) negateLinExp(l compiled.LinearExpression) compiled.L
 	for i, t := range l {
 		cID, vID, visibility := t.Unpack()
 		lambda.Neg(&cs.coeffs[cID])
-		res[i] = cs.makeTerm(Variable{visibility: visibility, id: vID}, &lambda)
+		res[i] = cs.makeTerm(variable{visibility: visibility, id: vID}, &lambda)
 	}
 	return res
 }

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -488,8 +488,8 @@ func (cs *constraintSystem) IsConstant(v Variable) bool {
 	return true
 }
 
-// ConstantValue returns the big.Int value of v
-// will panic if v.IsConstant() == false
+// ConstantValue returns the big.Int value of v.
+// Will panic if v.IsConstant() == false
 func (cs *constraintSystem) ConstantValue(v Variable) *big.Int {
 	if _v, ok := v.(variable); ok {
 		return _v.constantValue(cs)

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -477,6 +477,27 @@ func (cs *constraintSystem) Select(i0, i1, i2 interface{}) Variable {
 
 }
 
+// IsConstant returns true if v is a constant known at compile time
+func (cs *constraintSystem) IsConstant(v Variable) bool {
+	if _v, ok := v.(variable); ok {
+		return _v.isConstant()
+	}
+	// it's not a wire, it's another golang type, we consider it constant.
+	// TODO we may want to use the struct parser to ensure this Variable interface doesn't contain fields which are
+	// variable
+	return true
+}
+
+// ConstantValue returns the big.Int value of v
+// will panic if v.IsConstant() == false
+func (cs *constraintSystem) ConstantValue(v Variable) *big.Int {
+	if _v, ok := v.(variable); ok {
+		return _v.constantValue(cs)
+	}
+	r := FromInterface(v)
+	return &r
+}
+
 // constant will return (and allocate if neccesary) a Variable from given value
 //
 // if input is already a Variable, does nothing

--- a/frontend/cs_api_test.go
+++ b/frontend/cs_api_test.go
@@ -73,21 +73,21 @@ func TestIsBool3(t *testing.T) {
 	}
 }
 
-func (c *IsBool1) Define(curve ecc.ID, cs API) error {
+func (c *IsBool1) Define(cs API) error {
 
 	cs.AssertIsBoolean(0)
 	cs.AssertIsBoolean(1)
 	return nil
 }
 
-func (c *IsBool2) Define(curve ecc.ID, cs API) error {
+func (c *IsBool2) Define(cs API) error {
 
 	sum := cs.Add(0, 1)
 	cs.AssertIsBoolean(sum)
 	return nil
 }
 
-func (c *IsBool3) Define(curve ecc.ID, cs API) error {
+func (c *IsBool3) Define(cs API) error {
 
 	prod := cs.Mul(0, 1)
 	cs.AssertIsBoolean(prod)

--- a/frontend/cs_api_test.go
+++ b/frontend/cs_api_test.go
@@ -75,27 +75,21 @@ func TestIsBool3(t *testing.T) {
 
 func (c *IsBool1) Define(curve ecc.ID, cs API) error {
 
-	zero := cs.Constant(0)
-	one := cs.Constant(1)
-	cs.AssertIsBoolean(zero)
-	cs.AssertIsBoolean(one)
+	cs.AssertIsBoolean(0)
+	cs.AssertIsBoolean(1)
 	return nil
 }
 
 func (c *IsBool2) Define(curve ecc.ID, cs API) error {
 
-	zero := cs.Constant(0)
-	one := cs.Constant(1)
-	sum := cs.Add(zero, one)
+	sum := cs.Add(0, 1)
 	cs.AssertIsBoolean(sum)
 	return nil
 }
 
 func (c *IsBool3) Define(curve ecc.ID, cs API) error {
 
-	zero := cs.Constant(0)
-	one := cs.Constant(1)
-	prod := cs.Mul(zero, one)
+	prod := cs.Mul(0, 1)
 	cs.AssertIsBoolean(prod)
 
 	return nil

--- a/frontend/cs_assertions.go
+++ b/frontend/cs_assertions.go
@@ -27,8 +27,8 @@ import (
 func (cs *constraintSystem) AssertIsEqual(i1, i2 interface{}) {
 	// encoded i1 * 1 == i2
 
-	l := cs.Constant(i1).(variable)
-	o := cs.Constant(i2).(variable)
+	l := cs.constant(i1).(variable)
+	o := cs.constant(i2).(variable)
 
 	if len(l.linExp) > len(o.linExp) {
 		l, o = o, l // maximize number of zeroes in r1cs.A
@@ -69,7 +69,7 @@ func (cs *constraintSystem) AssertIsBoolean(i1 interface{}) {
 
 	// ensure v * (1 - v) == 0
 	_v := cs.Sub(1, v)
-	o := cs.Constant(0)
+	o := cs.constant(0)
 	cs.addConstraint(newR1C(v, _v, o), debug)
 }
 
@@ -101,9 +101,9 @@ func (cs *constraintSystem) mustBeLessOrEqVar(a, bound variable) {
 	boundBits := cs.ToBinary(bound, nbBits)
 
 	p := make([]Variable, nbBits+1)
-	p[nbBits] = cs.Constant(1)
+	p[nbBits] = cs.constant(1)
 
-	zero := cs.Constant(0)
+	zero := cs.constant(0)
 
 	for i := nbBits - 1; i >= 0; i-- {
 
@@ -146,7 +146,7 @@ func (cs *constraintSystem) mustBeLessOrEqCst(a variable, bound big.Int) {
 	}
 
 	// debug info
-	debug := cs.addDebugInfo("mustBeLessOrEq", a, " <= ", cs.Constant(bound))
+	debug := cs.addDebugInfo("mustBeLessOrEq", a, " <= ", cs.constant(bound))
 
 	// note that at this stage, we didn't boolean-constraint these new variables yet
 	// (as opposed to ToBinary)
@@ -163,7 +163,7 @@ func (cs *constraintSystem) mustBeLessOrEqCst(a variable, bound big.Int) {
 
 	p := make([]Variable, nbBits+1)
 	// p[i] == 1 --> a[j] == c[j] for all j >= i
-	p[nbBits] = cs.Constant(1)
+	p[nbBits] = cs.constant(1)
 
 	for i := nbBits - 1; i >= t; i-- {
 		if bound.Bit(i) == 0 {
@@ -181,7 +181,7 @@ func (cs *constraintSystem) mustBeLessOrEqCst(a variable, bound big.Int) {
 			l = cs.Sub(l, p[i+1])
 			l = cs.Sub(l, aBits[i])
 
-			cs.addConstraint(newR1C(l, aBits[i], cs.Constant(0)), debug)
+			cs.addConstraint(newR1C(l, aBits[i], cs.constant(0)), debug)
 			cs.markBoolean(aBits[i].(variable))
 		} else {
 			cs.AssertIsBoolean(aBits[i])

--- a/frontend/cs_debug.go
+++ b/frontend/cs_debug.go
@@ -33,7 +33,7 @@ import (
 //
 // the print will be done once the R1CS.Solve() method is executed
 //
-// if one of the input is a Variable, its value will be resolved avec R1CS.Solve() method is called
+// if one of the input is a variable, its value will be resolved avec R1CS.Solve() method is called
 func (cs *constraintSystem) Println(a ...interface{}) {
 	var sbb strings.Builder
 
@@ -51,7 +51,7 @@ func (cs *constraintSystem) Println(a ...interface{}) {
 		if i > 0 {
 			sbb.WriteByte(' ')
 		}
-		if v, ok := arg.(Variable); ok {
+		if v, ok := arg.(variable); ok {
 			v.assertIsSet(cs)
 
 			sbb.WriteString("%s")
@@ -80,7 +80,7 @@ func printArg(log *compiled.LogEntry, sbb *strings.Builder, a interface{}) {
 		return nil
 	}
 	// ignoring error, counter() always return nil
-	_ = parser.Visit(a, "", compiled.Unset, counter, reflect.TypeOf(Variable{}))
+	_ = parser.Visit(a, "", compiled.Unset, counter, tVariable)
 
 	// no variables in nested struct, we use fmt std print function
 	if count == 0 {
@@ -98,7 +98,7 @@ func printArg(log *compiled.LogEntry, sbb *strings.Builder, a interface{}) {
 			sbb.WriteString(", ")
 		}
 
-		v := tValue.Interface().(Variable)
+		v := tValue.Interface().(variable)
 		// we set limits to the linear expression, so that the log printer
 		// can evaluate it before printing it
 		log.ToResolve = append(log.ToResolve, compiled.TermDelimitor)
@@ -107,7 +107,7 @@ func printArg(log *compiled.LogEntry, sbb *strings.Builder, a interface{}) {
 		return nil
 	}
 	// ignoring error, printer() doesn't return errors
-	_ = parser.Visit(a, "", compiled.Unset, printer, reflect.TypeOf(Variable{}))
+	_ = parser.Visit(a, "", compiled.Unset, printer, tVariable)
 	sbb.WriteByte('}')
 }
 
@@ -123,7 +123,7 @@ func (cs *constraintSystem) addDebugInfo(errName string, i ...interface{}) int {
 
 	for _, _i := range i {
 		switch v := _i.(type) {
-		case Variable:
+		case variable:
 			if len(v.linExp) > 1 {
 				sbb.WriteString("(")
 			}

--- a/frontend/cs_test.go
+++ b/frontend/cs_test.go
@@ -61,7 +61,7 @@ func TestReduce(t *testing.T) {
 	e := cs.Mul(z, 2)
 	f := cs.Mul(z, 2)
 
-	toTest := cs.Add(a, b, c, d, e, f)
+	toTest := (cs.Add(a, b, c, d, e, f)).(variable)
 
 	// check sizes
 	if len(toTest.linExp) != 3 {

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -20,7 +20,6 @@ package frontend
 import (
 	"errors"
 	"fmt"
-	"math/big"
 	"reflect"
 
 	"github.com/consensys/gnark/debug"
@@ -85,25 +84,6 @@ func Compile(curveID ecc.ID, zkpID backend.ID, circuit Circuit, opts ...func(opt
 	}
 
 	return
-}
-
-// IsConstant returns true if v is a constant known at compile time
-func IsConstant(v Variable) bool {
-	if _v, ok := v.(variable); ok {
-		return _v.isConstant()
-	}
-	// if v is not of of type variable, then we consider it constant (it's not a wire)
-	return true
-}
-
-// ConstantValue returns the big.Int value of v
-// will panic if v.IsConstant() == false
-func ConstantValue(v Variable, api API) *big.Int {
-	if _v, ok := v.(variable); ok {
-		return _v.constantValue(api.(*constraintSystem))
-	}
-	r := FromInterface(v)
-	return &r
 }
 
 // buildCS builds the constraint system. It bootstraps the inputs

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -125,7 +125,7 @@ func buildCS(curveID ecc.ID, circuit Circuit, initialCapacity ...int) (cs constr
 	}()
 
 	// call Define() to fill in the Constraints
-	if err := circuit.Define(curveID, &cs); err != nil {
+	if err := circuit.Define(&cs); err != nil {
 		return cs, err
 	}
 

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -35,7 +35,7 @@ import (
 // 1. it will first allocate the user inputs (see type Tag for more info)
 // example:
 // 		type MyCircuit struct {
-// 			Y frontend.variable `gnark:"exponent,public"`
+// 			Y frontend.Variable `gnark:"exponent,public"`
 // 		}
 // in that case, Compile() will allocate one public variable with id "exponent"
 //

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -20,6 +20,7 @@ package frontend
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"reflect"
 
 	"github.com/consensys/gnark/debug"
@@ -84,6 +85,25 @@ func Compile(curveID ecc.ID, zkpID backend.ID, circuit Circuit, opts ...func(opt
 	}
 
 	return
+}
+
+// IsConstant returns true if v is a constant known at compile time
+func IsConstant(v Variable) bool {
+	if _v, ok := v.(variable); ok {
+		return _v.isConstant()
+	}
+	// if v is not of of type variable, then we consider it constant (it's not a wire)
+	return true
+}
+
+// ConstantValue returns the big.Int value of v
+// will panic if v.IsConstant() == false
+func ConstantValue(v Variable, api API) *big.Int {
+	if _v, ok := v.(variable); ok {
+		return _v.constantValue(api.(*constraintSystem))
+	}
+	r := FromInterface(v)
+	return &r
 }
 
 // buildCS builds the constraint system. It bootstraps the inputs

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -48,7 +48,7 @@ type benchCircuit struct {
 	Y Variable `gnark:",public"`
 }
 
-func (circuit *benchCircuit) Define(curveID ecc.ID, cs API) error {
+func (circuit *benchCircuit) Define(cs API) error {
 	for i := 0; i < benchSize; i++ {
 		circuit.X = cs.Mul(circuit.X, circuit.X)
 	}

--- a/frontend/fuzz.go
+++ b/frontend/fuzz.go
@@ -88,19 +88,19 @@ func CsFuzzed(data []byte, curveID ecc.ID) (ccs CompiledConstraintSystem) {
 			// inv
 			vv := cs.shuffleVariables(int64(b), false)
 			if len(vv) >= 1 {
-				cs.Inverse(vv[0].(Variable))
+				cs.Inverse(vv[0].(variable))
 			}
 		}
 		if b&0b01000000 == 0b01000000 {
 			v := cs.shuffleVariables(int64(b), false)
 			if len(v) >= 1 {
 				vc := cs.shuffleVariables(int64(b), true)
-				cs.AssertIsLessOrEqual(v[0].(Variable), vc[0])
+				cs.AssertIsLessOrEqual(v[0].(variable), vc[0])
 				if len(vc) >= 2 {
 					cs.AssertIsEqual(vc[0], vc[1])
 				}
 				if len(v) >= 2 {
-					cs.AssertIsBoolean(v[1].(Variable))
+					cs.AssertIsBoolean(v[1].(variable))
 				}
 			}
 		}
@@ -108,9 +108,9 @@ func CsFuzzed(data []byte, curveID ecc.ID) (ccs CompiledConstraintSystem) {
 		if b&0b10000000 == 0b10000000 {
 			v := cs.shuffleVariables(int64(b), false)
 			if len(v) >= 2 {
-				x1 := cs.Xor(v[0].(Variable), v[1].(Variable))
-				x2 := cs.And(x1, v[0].(Variable))
-				cs.Or(v[0].(Variable), v[1].(Variable))
+				x1 := cs.Xor(v[0].(variable), v[1].(variable))
+				x2 := cs.And(x1, v[0].(variable))
+				cs.Or(v[0].(variable), v[1].(variable))
 				cs.Or(x1, x2)
 			}
 		}

--- a/frontend/variable.go
+++ b/frontend/variable.go
@@ -23,6 +23,8 @@ import (
 // errNoValue triggered when trying to access a variable that was not allocated
 var errNoValue = errors.New("can't determine API input value")
 
+// Variable represents a variable in the circuit. Any integer type (e.g. int, *big.Int, fr.Element)
+// can be assigned to it. It is also allowed to set a base-10 encoded string representing an integer value.
 type Variable interface{}
 
 // variable of a circuit

--- a/frontend/variable.go
+++ b/frontend/variable.go
@@ -61,7 +61,7 @@ func (v *variable) constantValue(cs *constraintSystem) *big.Int {
 	// TODO this might be a good place to start hunting useless allocations.
 	// maybe through a big.Int pool.
 	if !v.isConstant() {
-		panic("can't get constantCoeffID on a non-constant variable")
+		panic("can't get big.Int value on a non-constant variable")
 	}
 	return new(big.Int).Set(&cs.coeffs[v.linExp[0].CoeffID()])
 }

--- a/frontend/variable.go
+++ b/frontend/variable.go
@@ -15,20 +15,9 @@ package frontend
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
-	"strings"
 
-	"github.com/consensys/gnark/debug"
-
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/internal/backend/compiled"
-
-	fr_bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
-	fr_bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
-	fr_bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
-	fr_bn254 "github.com/consensys/gnark-crypto/ecc/bn254/fr"
-	fr_bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 )
 
 // errNoValue triggered when trying to access a variable that was not allocated
@@ -75,43 +64,4 @@ func (v *variable) constantValue(cs *constraintSystem) *big.Int {
 		panic("can't get constantCoeffID on a non-constant variable")
 	}
 	return new(big.Int).Set(&cs.coeffs[v.linExp[0].CoeffID()])
-}
-
-// GetWitnessValue returns the assigned value to the variable
-// the value is converted to a field element (mod curveID base field modulus)
-// then converted to a big.Int
-// if it is not set this panics
-func GetWitnessValue(v Variable, curveID ecc.ID) big.Int {
-	if v == nil {
-		var sbb strings.Builder
-		debug.WriteStack(&sbb)
-		panic(fmt.Errorf("%w\n%s", errNoValue, sbb.String()))
-	}
-
-	b := FromInterface(v)
-	switch curveID {
-	case ecc.BLS12_377:
-		var e fr_bls12377.Element
-		e.SetBigInt(&b)
-		e.ToBigIntRegular(&b)
-	case ecc.BLS12_381:
-		var e fr_bls12381.Element
-		e.SetBigInt(&b)
-		e.ToBigIntRegular(&b)
-	case ecc.BN254:
-		var e fr_bn254.Element
-		e.SetBigInt(&b)
-		e.ToBigIntRegular(&b)
-	case ecc.BLS24_315:
-		var e fr_bls24315.Element
-		e.SetBigInt(&b)
-		e.ToBigIntRegular(&b)
-	case ecc.BW6_761:
-		var e fr_bw6761.Element
-		e.SetBigInt(&b)
-		e.ToBigIntRegular(&b)
-	default:
-		panic("curve not implemented")
-	}
-	return b
 }

--- a/frontend/variable_test.go
+++ b/frontend/variable_test.go
@@ -22,7 +22,7 @@ func TestStructTags(t *testing.T) {
 			collected[name] = visibility
 			return nil
 		}
-		if err := parser.Visit(input, "", compiled.Unset, collectHandler, reflect.TypeOf(Variable{})); err != nil {
+		if err := parser.Visit(input, "", compiled.Unset, collectHandler, tVariable); err != nil {
 			t.Log(string(debug.Stack()))
 			t.Fatal(err)
 		}
@@ -44,7 +44,7 @@ func TestStructTags(t *testing.T) {
 
 	{
 		s := struct {
-			A, B Variable
+			A, B variable
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["A"] = compiled.Secret
@@ -54,8 +54,8 @@ func TestStructTags(t *testing.T) {
 
 	{
 		s := struct {
-			A Variable `gnark:"a, public"`
-			B Variable
+			A variable `gnark:"a, public"`
+			B variable
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["a"] = compiled.Public
@@ -65,8 +65,8 @@ func TestStructTags(t *testing.T) {
 
 	{
 		s := struct {
-			A Variable `gnark:",public"`
-			B Variable
+			A variable `gnark:",public"`
+			B variable
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["A"] = compiled.Public
@@ -76,8 +76,8 @@ func TestStructTags(t *testing.T) {
 
 	{
 		s := struct {
-			A Variable `gnark:"-"`
-			B Variable
+			A variable `gnark:"-"`
+			B variable
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["B"] = compiled.Secret
@@ -86,10 +86,10 @@ func TestStructTags(t *testing.T) {
 
 	{
 		s := struct {
-			A Variable `gnark:",public"`
-			B Variable
+			A variable `gnark:",public"`
+			B variable
 			C struct {
-				D Variable
+				D variable
 			}
 		}{}
 		expected := make(map[string]compiled.Visibility)
@@ -102,15 +102,15 @@ func TestStructTags(t *testing.T) {
 	// hierarchy of structs
 	{
 		type grandchild struct {
-			D Variable `gnark:"grandchild"`
+			D variable `gnark:"grandchild"`
 		}
 		type child struct {
-			D Variable `gnark:",public"` // parent visibility is secret so public here is ignored
+			D variable `gnark:",public"` // parent visibility is secret so public here is ignored
 			G grandchild
 		}
 		s := struct {
-			A Variable `gnark:",public"`
-			B Variable
+			A variable `gnark:",public"`
+			B variable
 			C child
 		}{}
 		expected := make(map[string]compiled.Visibility)
@@ -124,7 +124,7 @@ func TestStructTags(t *testing.T) {
 	// ignore embedded structs (not exported)
 	{
 		type embedded struct {
-			D Variable
+			D variable
 		}
 		type child struct {
 			embedded // this is not exported and ignored
@@ -132,8 +132,8 @@ func TestStructTags(t *testing.T) {
 
 		s := struct {
 			C child
-			A Variable `gnark:",public"`
-			B Variable
+			A variable `gnark:",public"`
+			B variable
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["A"] = compiled.Public
@@ -144,7 +144,7 @@ func TestStructTags(t *testing.T) {
 	// array
 	{
 		s := struct {
-			A [2]Variable `gnark:",public"`
+			A [2]variable `gnark:",public"`
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["A_0"] = compiled.Public
@@ -155,8 +155,8 @@ func TestStructTags(t *testing.T) {
 	// slice
 	{
 		s := struct {
-			A []Variable `gnark:",public"`
-		}{A: make([]Variable, 2)}
+			A []variable `gnark:",public"`
+		}{A: make([]variable, 2)}
 		expected := make(map[string]compiled.Visibility)
 		expected["A_0"] = compiled.Public
 		expected["A_1"] = compiled.Public

--- a/frontend/variable_test.go
+++ b/frontend/variable_test.go
@@ -37,14 +37,14 @@ func TestStructTags(t *testing.T) {
 			delete(collected, k)
 		}
 		if len(collected) != 0 {
-			t.Fatal("collected more variable than expected")
+			t.Fatal("collected more Variable than expected")
 		}
 
 	}
 
 	{
 		s := struct {
-			A, B variable
+			A, B Variable
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["A"] = compiled.Secret
@@ -54,8 +54,8 @@ func TestStructTags(t *testing.T) {
 
 	{
 		s := struct {
-			A variable `gnark:"a, public"`
-			B variable
+			A Variable `gnark:"a, public"`
+			B Variable
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["a"] = compiled.Public
@@ -65,8 +65,8 @@ func TestStructTags(t *testing.T) {
 
 	{
 		s := struct {
-			A variable `gnark:",public"`
-			B variable
+			A Variable `gnark:",public"`
+			B Variable
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["A"] = compiled.Public
@@ -76,8 +76,8 @@ func TestStructTags(t *testing.T) {
 
 	{
 		s := struct {
-			A variable `gnark:"-"`
-			B variable
+			A Variable `gnark:"-"`
+			B Variable
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["B"] = compiled.Secret
@@ -86,10 +86,10 @@ func TestStructTags(t *testing.T) {
 
 	{
 		s := struct {
-			A variable `gnark:",public"`
-			B variable
+			A Variable `gnark:",public"`
+			B Variable
 			C struct {
-				D variable
+				D Variable
 			}
 		}{}
 		expected := make(map[string]compiled.Visibility)
@@ -102,15 +102,15 @@ func TestStructTags(t *testing.T) {
 	// hierarchy of structs
 	{
 		type grandchild struct {
-			D variable `gnark:"grandchild"`
+			D Variable `gnark:"grandchild"`
 		}
 		type child struct {
-			D variable `gnark:",public"` // parent visibility is secret so public here is ignored
+			D Variable `gnark:",public"` // parent visibility is secret so public here is ignored
 			G grandchild
 		}
 		s := struct {
-			A variable `gnark:",public"`
-			B variable
+			A Variable `gnark:",public"`
+			B Variable
 			C child
 		}{}
 		expected := make(map[string]compiled.Visibility)
@@ -124,7 +124,7 @@ func TestStructTags(t *testing.T) {
 	// ignore embedded structs (not exported)
 	{
 		type embedded struct {
-			D variable
+			D Variable
 		}
 		type child struct {
 			embedded // this is not exported and ignored
@@ -132,8 +132,8 @@ func TestStructTags(t *testing.T) {
 
 		s := struct {
 			C child
-			A variable `gnark:",public"`
-			B variable
+			A Variable `gnark:",public"`
+			B Variable
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["A"] = compiled.Public
@@ -144,7 +144,7 @@ func TestStructTags(t *testing.T) {
 	// array
 	{
 		s := struct {
-			A [2]variable `gnark:",public"`
+			A [2]Variable `gnark:",public"`
 		}{}
 		expected := make(map[string]compiled.Visibility)
 		expected["A_0"] = compiled.Public
@@ -155,8 +155,8 @@ func TestStructTags(t *testing.T) {
 	// slice
 	{
 		s := struct {
-			A []variable `gnark:",public"`
-		}{A: make([]variable, 2)}
+			A []Variable `gnark:",public"`
+		}{A: make([]Variable, 2)}
 		expected := make(map[string]compiled.Visibility)
 		expected["A_0"] = compiled.Public
 		expected["A_1"] = compiled.Public

--- a/internal/backend/bls12-377/groth16/groth16_test.go
+++ b/internal/backend/bls12-377/groth16/groth16_test.go
@@ -63,7 +63,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	}
 
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = 2
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -73,7 +73,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 
 	return r1cs, &good
 }

--- a/internal/backend/bls12-377/groth16/groth16_test.go
+++ b/internal/backend/bls12-377/groth16/groth16_test.go
@@ -29,7 +29,6 @@ import (
 	bls12_377groth16 "github.com/consensys/gnark/internal/backend/bls12-377/groth16"
 	"testing"
 
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 )
@@ -44,7 +43,7 @@ type refCircuit struct {
 	Y             frontend.Variable `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define(api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/bls12-377/plonk/plonk_test.go
+++ b/internal/backend/bls12-377/plonk/plonk_test.go
@@ -47,7 +47,7 @@ type refCircuit struct {
 	Y             frontend.Variable `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define(api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/bls12-377/plonk/plonk_test.go
+++ b/internal/backend/bls12-377/plonk/plonk_test.go
@@ -66,7 +66,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	}
 
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = (2)
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -76,7 +76,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 	srs, err := kzg.NewSRS(ecc.NextPowerOfTwo(nbConstraints)+3, new(big.Int).SetUint64(42))
 	if err != nil {
 		panic(err)

--- a/internal/backend/bls12-381/groth16/groth16_test.go
+++ b/internal/backend/bls12-381/groth16/groth16_test.go
@@ -63,7 +63,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	}
 
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = 2
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -73,7 +73,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 
 	return r1cs, &good
 }

--- a/internal/backend/bls12-381/groth16/groth16_test.go
+++ b/internal/backend/bls12-381/groth16/groth16_test.go
@@ -29,7 +29,6 @@ import (
 	bls12_381groth16 "github.com/consensys/gnark/internal/backend/bls12-381/groth16"
 	"testing"
 
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 )
@@ -44,7 +43,7 @@ type refCircuit struct {
 	Y             frontend.Variable `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define(api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/bls12-381/plonk/plonk_test.go
+++ b/internal/backend/bls12-381/plonk/plonk_test.go
@@ -47,7 +47,7 @@ type refCircuit struct {
 	Y             frontend.Variable `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define(api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/bls12-381/plonk/plonk_test.go
+++ b/internal/backend/bls12-381/plonk/plonk_test.go
@@ -66,7 +66,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	}
 
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = (2)
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -76,7 +76,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 	srs, err := kzg.NewSRS(ecc.NextPowerOfTwo(nbConstraints)+3, new(big.Int).SetUint64(42))
 	if err != nil {
 		panic(err)

--- a/internal/backend/bls24-315/groth16/groth16_test.go
+++ b/internal/backend/bls24-315/groth16/groth16_test.go
@@ -63,7 +63,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	}
 
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = 2
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -73,7 +73,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 
 	return r1cs, &good
 }

--- a/internal/backend/bls24-315/groth16/groth16_test.go
+++ b/internal/backend/bls24-315/groth16/groth16_test.go
@@ -29,7 +29,6 @@ import (
 	bls24_315groth16 "github.com/consensys/gnark/internal/backend/bls24-315/groth16"
 	"testing"
 
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 )
@@ -44,7 +43,7 @@ type refCircuit struct {
 	Y             frontend.Variable `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define(api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/bls24-315/plonk/plonk_test.go
+++ b/internal/backend/bls24-315/plonk/plonk_test.go
@@ -47,7 +47,7 @@ type refCircuit struct {
 	Y             frontend.Variable `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define(api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/bls24-315/plonk/plonk_test.go
+++ b/internal/backend/bls24-315/plonk/plonk_test.go
@@ -66,7 +66,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	}
 
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = (2)
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -76,7 +76,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 	srs, err := kzg.NewSRS(ecc.NextPowerOfTwo(nbConstraints)+3, new(big.Int).SetUint64(42))
 	if err != nil {
 		panic(err)

--- a/internal/backend/bn254/groth16/groth16_test.go
+++ b/internal/backend/bn254/groth16/groth16_test.go
@@ -29,7 +29,6 @@ import (
 	bn254groth16 "github.com/consensys/gnark/internal/backend/bn254/groth16"
 	"testing"
 
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 )
@@ -44,7 +43,7 @@ type refCircuit struct {
 	Y             frontend.Variable `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define(api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/bn254/groth16/groth16_test.go
+++ b/internal/backend/bn254/groth16/groth16_test.go
@@ -63,7 +63,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	}
 
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = 2
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -73,7 +73,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 
 	return r1cs, &good
 }

--- a/internal/backend/bn254/plonk/plonk_test.go
+++ b/internal/backend/bn254/plonk/plonk_test.go
@@ -47,7 +47,7 @@ type refCircuit struct {
 	Y             frontend.Variable `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define(api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/bn254/plonk/plonk_test.go
+++ b/internal/backend/bn254/plonk/plonk_test.go
@@ -66,7 +66,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	}
 
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = (2)
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -76,7 +76,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 	srs, err := kzg.NewSRS(ecc.NextPowerOfTwo(nbConstraints)+3, new(big.Int).SetUint64(42))
 	if err != nil {
 		panic(err)

--- a/internal/backend/bw6-761/groth16/groth16_test.go
+++ b/internal/backend/bw6-761/groth16/groth16_test.go
@@ -63,7 +63,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	}
 
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = 2
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -73,7 +73,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 
 	return r1cs, &good
 }

--- a/internal/backend/bw6-761/groth16/groth16_test.go
+++ b/internal/backend/bw6-761/groth16/groth16_test.go
@@ -29,7 +29,6 @@ import (
 	bw6_761groth16 "github.com/consensys/gnark/internal/backend/bw6-761/groth16"
 	"testing"
 
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 )
@@ -44,7 +43,7 @@ type refCircuit struct {
 	Y             frontend.Variable `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define(api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/bw6-761/plonk/plonk_test.go
+++ b/internal/backend/bw6-761/plonk/plonk_test.go
@@ -47,7 +47,7 @@ type refCircuit struct {
 	Y             frontend.Variable `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define(api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/bw6-761/plonk/plonk_test.go
+++ b/internal/backend/bw6-761/plonk/plonk_test.go
@@ -66,7 +66,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	}
 
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = (2)
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -76,7 +76,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 	srs, err := kzg.NewSRS(ecc.NextPowerOfTwo(nbConstraints)+3, new(big.Int).SetUint64(42))
 	if err != nil {
 		panic(err)

--- a/internal/backend/circuits/add.go
+++ b/internal/backend/circuits/add.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -9,7 +8,7 @@ type addCircuit struct {
 	Op1, Op2, Res frontend.Variable
 }
 
-func (circuit *addCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *addCircuit) Define(cs frontend.API) error {
 	d := cs.Add(circuit.Op1, circuit.Op2, circuit.Op1)
 
 	cs.AssertIsEqual(d, circuit.Res)

--- a/internal/backend/circuits/add.go
+++ b/internal/backend/circuits/add.go
@@ -20,17 +20,17 @@ func init() {
 
 	good := []frontend.Circuit{
 		&addCircuit{
-			Op1: frontend.Value(2),
-			Op2: frontend.Value(3),
-			Res: frontend.Value(7),
+			Op1: (2),
+			Op2: (3),
+			Res: (7),
 		},
 	}
 
 	bad := []frontend.Circuit{
 		&addCircuit{
-			Op1: frontend.Value(2),
-			Op2: frontend.Value(3),
-			Res: frontend.Value(5),
+			Op1: (2),
+			Op2: (3),
+			Res: (5),
 		},
 	}
 

--- a/internal/backend/circuits/and.go
+++ b/internal/backend/circuits/and.go
@@ -20,57 +20,57 @@ func init() {
 
 	good := []frontend.Circuit{
 		&andCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(1),
+			Op1: (1),
+			Op2: (1),
+			Res: (1),
 		},
 		&andCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(0),
+			Op1: (1),
+			Op2: (0),
+			Res: (0),
 		},
 		&andCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(0),
+			Op1: (0),
+			Op2: (1),
+			Res: (0),
 		},
 		&andCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(0),
+			Op1: (0),
+			Op2: (0),
+			Res: (0),
 		},
 	}
 
 	bad := []frontend.Circuit{
 		&andCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(0),
+			Op1: (1),
+			Op2: (1),
+			Res: (0),
 		},
 		&andCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(1),
+			Op1: (1),
+			Op2: (0),
+			Res: (1),
 		},
 		&andCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(1),
+			Op1: (0),
+			Op2: (1),
+			Res: (1),
 		},
 		&andCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(1),
+			Op1: (0),
+			Op2: (0),
+			Res: (1),
 		},
 		&andCircuit{
-			Op1: frontend.Value(42),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(1),
+			Op1: (42),
+			Op2: (1),
+			Res: (1),
 		},
 		&andCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(42),
+			Op1: (1),
+			Op2: (1),
+			Res: (42),
 		},
 	}
 

--- a/internal/backend/circuits/and.go
+++ b/internal/backend/circuits/and.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -9,7 +8,7 @@ type andCircuit struct {
 	Op1, Op2, Res frontend.Variable
 }
 
-func (circuit *andCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *andCircuit) Define(cs frontend.API) error {
 	d := cs.And(circuit.Op1, circuit.Op2)
 
 	cs.AssertIsEqual(d, circuit.Res)

--- a/internal/backend/circuits/assertequal.go
+++ b/internal/backend/circuits/assertequal.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -10,7 +9,7 @@ type checkAssertEqualCircuit struct {
 	Y frontend.Variable `gnark:",public"`
 }
 
-func (circuit *checkAssertEqualCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *checkAssertEqualCircuit) Define(cs frontend.API) error {
 	cs.AssertIsEqual(circuit.X, circuit.Y)
 	return nil
 }

--- a/internal/backend/circuits/assertequal.go
+++ b/internal/backend/circuits/assertequal.go
@@ -19,11 +19,11 @@ func init() {
 
 	var circuit, good, bad checkAssertEqualCircuit
 
-	good.X.Assign(3)
-	good.Y.Assign(3)
+	good.X = (3)
+	good.Y = (3)
 
-	bad.X.Assign(5)
-	bad.Y.Assign(2)
+	bad.X = (5)
+	bad.Y = (2)
 
 	addEntry("assert_equal", &circuit, &good, &bad)
 }

--- a/internal/backend/circuits/assertisdifferent.go
+++ b/internal/backend/circuits/assertisdifferent.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -10,7 +9,7 @@ type assertIsDifferentCircuit struct {
 	Y frontend.Variable `gnark:",public"`
 }
 
-func (circuit *assertIsDifferentCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *assertIsDifferentCircuit) Define(cs frontend.API) error {
 	cs.AssertIsDifferent(circuit.X, circuit.Y)
 	return nil
 }

--- a/internal/backend/circuits/assertisdifferent.go
+++ b/internal/backend/circuits/assertisdifferent.go
@@ -19,15 +19,15 @@ func init() {
 
 	good := []frontend.Circuit{
 		&assertIsDifferentCircuit{
-			X: frontend.Value(6),
-			Y: frontend.Value(37),
+			X: (6),
+			Y: (37),
 		},
 	}
 
 	bad := []frontend.Circuit{
 		&assertIsDifferentCircuit{
-			X: frontend.Value(6),
-			Y: frontend.Value(6),
+			X: (6),
+			Y: (6),
 		},
 	}
 

--- a/internal/backend/circuits/determinism.go
+++ b/internal/backend/circuits/determinism.go
@@ -30,19 +30,19 @@ func (circuit *determinism) Define(curveID ecc.ID, cs frontend.API) error {
 func init() {
 	var circuit, good, bad determinism
 
-	good.X[0].Assign(1)
-	good.X[1].Assign(2)
-	good.X[2].Assign(3)
-	good.X[3].Assign(4)
-	good.X[4].Assign(5)
-	good.Z.Assign(900)
+	good.X[0] = (1)
+	good.X[1] = (2)
+	good.X[2] = (3)
+	good.X[3] = (4)
+	good.X[4] = (5)
+	good.Z = (900)
 
-	bad.X[0].Assign(1)
-	bad.X[1].Assign(1)
-	bad.X[2].Assign(1)
-	bad.X[3].Assign(1)
-	bad.X[4].Assign(1)
-	bad.Z.Assign(900)
+	bad.X[0] = (1)
+	bad.X[1] = (1)
+	bad.X[2] = (1)
+	bad.X[3] = (1)
+	bad.X[4] = (1)
+	bad.Z = (900)
 
 	addEntry("determinism", &circuit, &good, &bad)
 }

--- a/internal/backend/circuits/determinism.go
+++ b/internal/backend/circuits/determinism.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -10,7 +9,7 @@ type determinism struct {
 	Z frontend.Variable `gnark:",public"`
 }
 
-func (circuit *determinism) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *determinism) Define(cs frontend.API) error {
 	a := cs.Add(circuit.X[0],
 		circuit.X[0],
 		circuit.X[1],

--- a/internal/backend/circuits/div.go
+++ b/internal/backend/circuits/div.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -10,7 +9,7 @@ type divCircuit struct {
 	Z    frontend.Variable `gnark:",public"`
 }
 
-func (circuit *divCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *divCircuit) Define(cs frontend.API) error {
 	cs.AssertIsEqual(cs.DivUnchecked(circuit.X, circuit.Y), circuit.Z)
 	return nil
 }

--- a/internal/backend/circuits/div.go
+++ b/internal/backend/circuits/div.go
@@ -18,13 +18,13 @@ func (circuit *divCircuit) Define(curveID ecc.ID, cs frontend.API) error {
 func init() {
 	var good, bad divCircuit
 
-	good.X.Assign(12)
-	good.Y.Assign(6)
-	good.Z.Assign(2)
+	good.X = (12)
+	good.Y = (6)
+	good.Z = (2)
 
-	bad.X.Assign(12)
-	bad.Y.Assign(6)
-	bad.Z.Assign(3)
+	bad.X = (12)
+	bad.Y = (6)
+	bad.Z = (3)
 
 	addEntry("div", &divCircuit{}, &good, &bad)
 }

--- a/internal/backend/circuits/exp.go
+++ b/internal/backend/circuits/exp.go
@@ -11,7 +11,7 @@ type expCircuit struct {
 }
 
 func (circuit *expCircuit) Define(curveID ecc.ID, cs frontend.API) error {
-	o := cs.Constant(1)
+	o := frontend.Variable(1)
 	b := cs.ToBinary(circuit.E, 4)
 
 	var i int

--- a/internal/backend/circuits/exp.go
+++ b/internal/backend/circuits/exp.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -10,7 +9,7 @@ type expCircuit struct {
 	Y    frontend.Variable `gnark:",public"`
 }
 
-func (circuit *expCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *expCircuit) Define(cs frontend.API) error {
 	o := frontend.Variable(1)
 	b := cs.ToBinary(circuit.E, 4)
 

--- a/internal/backend/circuits/exp.go
+++ b/internal/backend/circuits/exp.go
@@ -28,13 +28,13 @@ func (circuit *expCircuit) Define(curveID ecc.ID, cs frontend.API) error {
 func init() {
 	var circuit, good, bad expCircuit
 
-	good.X.Assign(2)
-	good.E.Assign(12)
-	good.Y.Assign(4096)
+	good.X = (2)
+	good.E = (12)
+	good.Y = (4096)
 
-	bad.X.Assign(2)
-	bad.E.Assign(11)
-	bad.Y.Assign(4096)
+	bad.X = (2)
+	bad.E = (11)
+	bad.Y = (4096)
 
 	addEntry("expo", &circuit, &good, &bad)
 }

--- a/internal/backend/circuits/frombinary.go
+++ b/internal/backend/circuits/frombinary.go
@@ -25,17 +25,17 @@ func (circuit *fromBinaryCircuit) Define(curveID ecc.ID, cs frontend.API) error 
 func init() {
 	var circuit, good, bad fromBinaryCircuit
 
-	good.B0.Assign(1)
-	good.B1.Assign(0)
-	good.B2.Assign(1)
-	good.B3.Assign(1)
-	good.Y.Assign(13)
+	good.B0 = (1)
+	good.B1 = (0)
+	good.B2 = (1)
+	good.B3 = (1)
+	good.Y = (13)
 
-	bad.B0.Assign(1)
-	bad.B1.Assign(0)
-	bad.B2.Assign(0)
-	bad.B3.Assign(1)
-	bad.Y.Assign(13)
+	bad.B0 = (1)
+	bad.B1 = (0)
+	bad.B2 = (0)
+	bad.B3 = (1)
+	bad.Y = (13)
 
 	addEntry("frombinary", &circuit, &good, &bad)
 }

--- a/internal/backend/circuits/frombinary.go
+++ b/internal/backend/circuits/frombinary.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -10,7 +9,7 @@ type fromBinaryCircuit struct {
 	Y              frontend.Variable `gnark:",public"`
 }
 
-func (circuit *fromBinaryCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *fromBinaryCircuit) Define(cs frontend.API) error {
 	cs.AssertIsBoolean(circuit.B0)
 	cs.AssertIsBoolean(circuit.B1)
 	cs.AssertIsBoolean(circuit.B2)

--- a/internal/backend/circuits/hint.go
+++ b/internal/backend/circuits/hint.go
@@ -27,15 +27,15 @@ func init() {
 
 	good := []frontend.Circuit{
 		&hintCircuit{
-			A: frontend.Value(42),
-			B: frontend.Value(42 * 7),
+			A: (42),
+			B: (42 * 7),
 		},
 	}
 
 	bad := []frontend.Circuit{
 		&hintCircuit{
-			A: frontend.Value(42),
-			B: frontend.Value(42),
+			A: (42),
+			B: (42),
 		},
 	}
 

--- a/internal/backend/circuits/hint.go
+++ b/internal/backend/circuits/hint.go
@@ -11,7 +11,7 @@ type hintCircuit struct {
 	A, B frontend.Variable
 }
 
-func (circuit *hintCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *hintCircuit) Define(api frontend.API) error {
 	a7 := api.NewHint(mulBy7, circuit.A)
 	_a7 := api.Mul(circuit.A, 7)
 

--- a/internal/backend/circuits/inv.go
+++ b/internal/backend/circuits/inv.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -9,7 +8,7 @@ type invCircuit struct {
 	X, Y, Z frontend.Variable
 }
 
-func (circuit *invCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *invCircuit) Define(cs frontend.API) error {
 	m := cs.Mul(circuit.X, circuit.Y)
 	u := cs.Inverse(circuit.Y)
 	v := cs.Mul(m, u)

--- a/internal/backend/circuits/inv.go
+++ b/internal/backend/circuits/inv.go
@@ -21,13 +21,13 @@ func init() {
 
 	var circuit, good, bad invCircuit
 
-	good.X.Assign(6)
-	good.Y.Assign(12)
-	good.Z.Assign(6)
+	good.X = (6)
+	good.Y = (12)
+	good.Z = (6)
 
-	bad.X.Assign(4)
-	bad.Y.Assign(12)
-	bad.Z.Assign(5)
+	bad.X = (4)
+	bad.Y = (12)
+	bad.Z = (5)
 
 	addEntry("inv", &circuit, &good, &bad)
 }

--- a/internal/backend/circuits/iszero.go
+++ b/internal/backend/circuits/iszero.go
@@ -23,11 +23,11 @@ func init() {
 
 	var circuit, good, bad isZero
 
-	good.X.Assign(0)
-	good.Y.Assign(203028)
+	good.X = (0)
+	good.Y = (203028)
 
-	bad.X.Assign(23)
-	bad.Y.Assign(0)
+	bad.X = (23)
+	bad.Y = (0)
 
 	addEntry("isZero", &circuit, &good, &bad)
 }

--- a/internal/backend/circuits/iszero.go
+++ b/internal/backend/circuits/iszero.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -9,7 +8,7 @@ type isZero struct {
 	X, Y frontend.Variable
 }
 
-func (circuit *isZero) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *isZero) Define(cs frontend.API) error {
 
 	a := cs.IsZero(circuit.X)
 	b := cs.IsZero(circuit.Y)

--- a/internal/backend/circuits/neg.go
+++ b/internal/backend/circuits/neg.go
@@ -22,11 +22,11 @@ func init() {
 
 	var circuit, good, bad negCircuit
 
-	good.X.Assign(6)
-	good.Z.Assign(30)
+	good.X = (6)
+	good.Z = (30)
 
-	bad.X.Assign(7)
-	bad.Z.Assign(30)
+	bad.X = (7)
+	bad.Z = (30)
 
 	addEntry("neg", &circuit, &good, &bad)
 }

--- a/internal/backend/circuits/neg.go
+++ b/internal/backend/circuits/neg.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -10,7 +9,7 @@ type negCircuit struct {
 	Z frontend.Variable `gnark:",public"`
 }
 
-func (circuit *negCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *negCircuit) Define(cs frontend.API) error {
 	a := cs.Mul(circuit.X, circuit.X)
 	b := cs.Neg(circuit.X)
 	c := cs.Add(a, b)

--- a/internal/backend/circuits/nocomputation.go
+++ b/internal/backend/circuits/nocomputation.go
@@ -20,11 +20,11 @@ func init() {
 
 	var circuit, good, bad noComputationCircuit
 
-	good.A.Assign(42)
-	good.B.Assign(42)
+	good.A = (42)
+	good.B = (42)
 
-	bad.A.Assign(42)
-	bad.B.Assign(43)
+	bad.A = (42)
+	bad.B = (43)
 
 	addEntry("noComputationCircuit", &circuit, &good, &bad)
 }

--- a/internal/backend/circuits/nocomputation.go
+++ b/internal/backend/circuits/nocomputation.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -11,7 +10,7 @@ type noComputationCircuit struct {
 	B frontend.Variable
 }
 
-func (c *noComputationCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (c *noComputationCircuit) Define(cs frontend.API) error {
 	cs.AssertIsEqual(c.A, c.B)
 	return nil
 }

--- a/internal/backend/circuits/or.go
+++ b/internal/backend/circuits/or.go
@@ -20,57 +20,57 @@ func init() {
 
 	good := []frontend.Circuit{
 		&orCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(1),
+			Op1: (1),
+			Op2: (1),
+			Res: (1),
 		},
 		&orCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(1),
+			Op1: (1),
+			Op2: (0),
+			Res: (1),
 		},
 		&orCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(1),
+			Op1: (0),
+			Op2: (1),
+			Res: (1),
 		},
 		&orCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(0),
+			Op1: (0),
+			Op2: (0),
+			Res: (0),
 		},
 	}
 
 	bad := []frontend.Circuit{
 		&orCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(0),
+			Op1: (1),
+			Op2: (1),
+			Res: (0),
 		},
 		&orCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(0),
+			Op1: (1),
+			Op2: (0),
+			Res: (0),
 		},
 		&orCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(0),
+			Op1: (0),
+			Op2: (1),
+			Res: (0),
 		},
 		&orCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(1),
+			Op1: (0),
+			Op2: (0),
+			Res: (1),
 		},
 		&orCircuit{
-			Op1: frontend.Value(42),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(1),
+			Op1: (42),
+			Op2: (1),
+			Res: (1),
 		},
 		&orCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(42),
+			Op1: (1),
+			Op2: (1),
+			Res: (42),
 		},
 	}
 

--- a/internal/backend/circuits/or.go
+++ b/internal/backend/circuits/or.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -9,7 +8,7 @@ type orCircuit struct {
 	Op1, Op2, Res frontend.Variable
 }
 
-func (circuit *orCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *orCircuit) Define(cs frontend.API) error {
 	d := cs.Or(circuit.Op1, circuit.Op2)
 
 	cs.AssertIsEqual(d, circuit.Res)

--- a/internal/backend/circuits/range.go
+++ b/internal/backend/circuits/range.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -10,7 +9,7 @@ type rangeCheckConstantCircuit struct {
 	Y frontend.Variable `gnark:",public"`
 }
 
-func (circuit *rangeCheckConstantCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *rangeCheckConstantCircuit) Define(cs frontend.API) error {
 	c1 := cs.Mul(circuit.X, circuit.Y)
 	c2 := cs.Mul(c1, circuit.Y)
 	c3 := cs.Add(circuit.X, circuit.Y)
@@ -36,7 +35,7 @@ type rangeCheckCircuit struct {
 	Y, Bound frontend.Variable `gnark:",public"`
 }
 
-func (circuit *rangeCheckCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *rangeCheckCircuit) Define(cs frontend.API) error {
 	c1 := cs.Mul(circuit.X, circuit.Y)
 	c2 := cs.Mul(c1, circuit.Y)
 	c3 := cs.Add(circuit.X, circuit.Y)

--- a/internal/backend/circuits/range.go
+++ b/internal/backend/circuits/range.go
@@ -22,11 +22,11 @@ func (circuit *rangeCheckConstantCircuit) Define(curveID ecc.ID, cs frontend.API
 func rangeCheckConstant() {
 	var circuit, good, bad rangeCheckConstantCircuit
 
-	good.X.Assign(10)
-	good.Y.Assign(4)
+	good.X = (10)
+	good.Y = (4)
 
-	bad.X.Assign(11)
-	bad.Y.Assign(4)
+	bad.X = (11)
+	bad.Y = (4)
 
 	addEntry("range_constant", &circuit, &good, &bad)
 }
@@ -50,13 +50,13 @@ func rangeCheck() {
 
 	var circuit, good, bad rangeCheckCircuit
 
-	good.X.Assign(10)
-	good.Y.Assign(4)
-	good.Bound.Assign(161)
+	good.X = (10)
+	good.Y = (4)
+	good.Bound = (161)
 
-	bad.X.Assign(11)
-	bad.Y.Assign(4)
-	bad.Bound.Assign(161)
+	bad.X = (11)
+	bad.Y = (4)
+	bad.Bound = (161)
 
 	addEntry("range", &circuit, &good, &bad)
 }

--- a/internal/backend/circuits/reference_small.go
+++ b/internal/backend/circuits/reference_small.go
@@ -25,7 +25,7 @@ func (circuit *referenceSmallCircuit) Define(curveID ecc.ID, cs frontend.API) er
 func init() {
 	var circuit, good, bad referenceSmallCircuit
 
-	good.X.Assign(2)
+	good.X = (2)
 
 	// compute expected Y
 	var expectedY big.Int
@@ -35,10 +35,10 @@ func init() {
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 
-	bad.X.Assign(3)
-	bad.Y.Assign(expectedY)
+	bad.X = (3)
+	bad.Y = (expectedY)
 
 	addEntry("reference_small", &circuit, &good, &bad)
 }

--- a/internal/backend/circuits/reference_small.go
+++ b/internal/backend/circuits/reference_small.go
@@ -3,7 +3,6 @@ package circuits
 import (
 	"math/big"
 
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -14,7 +13,7 @@ type referenceSmallCircuit struct {
 	Y frontend.Variable `gnark:",public"`
 }
 
-func (circuit *referenceSmallCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *referenceSmallCircuit) Define(cs frontend.API) error {
 	for i := 0; i < nbConstraintsRefSmall; i++ {
 		circuit.X = cs.Mul(circuit.X, circuit.X)
 	}

--- a/internal/backend/circuits/sub.go
+++ b/internal/backend/circuits/sub.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -9,7 +8,7 @@ type subCircuit struct {
 	Op1, Op2, Res frontend.Variable
 }
 
-func (circuit *subCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *subCircuit) Define(cs frontend.API) error {
 	d := cs.Sub(circuit.Op1, circuit.Op2, circuit.Op2)
 
 	cs.AssertIsEqual(d, circuit.Res)

--- a/internal/backend/circuits/sub.go
+++ b/internal/backend/circuits/sub.go
@@ -20,22 +20,22 @@ func init() {
 
 	good := []frontend.Circuit{
 		&subCircuit{
-			Op1: frontend.Value(7),
-			Op2: frontend.Value(3),
-			Res: frontend.Value(1),
+			Op1: (7),
+			Op2: (3),
+			Res: (1),
 		},
 		&subCircuit{
-			Op1: frontend.Value(6),
-			Op2: frontend.Value(3),
-			Res: frontend.Value(0),
+			Op1: (6),
+			Op2: (3),
+			Res: (0),
 		},
 	}
 
 	bad := []frontend.Circuit{
 		&subCircuit{
-			Op1: frontend.Value(2),
-			Op2: frontend.Value(3),
-			Res: frontend.Value(5),
+			Op1: (2),
+			Op2: (3),
+			Res: (5),
 		},
 	}
 

--- a/internal/backend/circuits/xor.go
+++ b/internal/backend/circuits/xor.go
@@ -1,7 +1,6 @@
 package circuits
 
 import (
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -9,7 +8,7 @@ type xorCircuit struct {
 	Op1, Op2, Res frontend.Variable
 }
 
-func (circuit *xorCircuit) Define(curveID ecc.ID, cs frontend.API) error {
+func (circuit *xorCircuit) Define(cs frontend.API) error {
 	d := cs.Xor(circuit.Op1, circuit.Op2)
 
 	cs.AssertIsEqual(d, circuit.Res)

--- a/internal/backend/circuits/xor.go
+++ b/internal/backend/circuits/xor.go
@@ -20,57 +20,57 @@ func init() {
 
 	good := []frontend.Circuit{
 		&xorCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(0),
+			Op1: (1),
+			Op2: (1),
+			Res: (0),
 		},
 		&xorCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(1),
+			Op1: (1),
+			Op2: (0),
+			Res: (1),
 		},
 		&xorCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(1),
+			Op1: (0),
+			Op2: (1),
+			Res: (1),
 		},
 		&xorCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(0),
+			Op1: (0),
+			Op2: (0),
+			Res: (0),
 		},
 	}
 
 	bad := []frontend.Circuit{
 		&xorCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(1),
+			Op1: (1),
+			Op2: (1),
+			Res: (1),
 		},
 		&xorCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(0),
+			Op1: (1),
+			Op2: (0),
+			Res: (0),
 		},
 		&xorCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(0),
+			Op1: (0),
+			Op2: (1),
+			Res: (0),
 		},
 		&xorCircuit{
-			Op1: frontend.Value(0),
-			Op2: frontend.Value(0),
-			Res: frontend.Value(1),
+			Op1: (0),
+			Op2: (0),
+			Res: (1),
 		},
 		&xorCircuit{
-			Op1: frontend.Value(42),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(1),
+			Op1: (42),
+			Op2: (1),
+			Res: (1),
 		},
 		&xorCircuit{
-			Op1: frontend.Value(1),
-			Op2: frontend.Value(1),
-			Res: frontend.Value(42),
+			Op1: (1),
+			Op2: (1),
+			Res: (42),
 		},
 	}
 

--- a/internal/generator/backend/template/representations/witness.go.tmpl
+++ b/internal/generator/backend/template/representations/witness.go.tmpl
@@ -79,24 +79,24 @@ func (witness *Witness) FromFullAssignment(w frontend.Circuit) error  {
     var collectHandler parser.LeafHandler = func(visibility compiled.Visibility, name string, tInput reflect.Value) error {
         v := tInput.Interface().(frontend.Variable)
 
-        if v.WitnessValue == nil {
+        if v == nil {
             return fmt.Errorf("when parsing variable %s: missing assignment", name) 
         }
 
         if visibility == compiled.Secret {
-            if _, err := (*witness)[i].SetInterface(v.WitnessValue) ; err != nil {
+            if _, err := (*witness)[i].SetInterface(v) ; err != nil {
                 return fmt.Errorf("when parsing variable %s: %v", name, err) 
             }
             i++
         } else if visibility == compiled.Public {
-            if _, err := (*witness)[j].SetInterface(v.WitnessValue) ; err != nil {
+            if _, err := (*witness)[j].SetInterface(v) ; err != nil {
                 return fmt.Errorf("when parsing variable %s: %v", name, err) 
             }
             j++
         }
         return nil
     }
-    return parser.Visit(w, "", compiled.Unset, collectHandler, reflect.TypeOf(frontend.Variable{}))
+    return parser.Visit(w, "", compiled.Unset, collectHandler, tVariable)
 }
 
 // FromPublicAssignment extracts the public part of witness 
@@ -116,18 +116,18 @@ func (witness *Witness) FromPublicAssignment(w frontend.Circuit) error {
        if visibility == compiled.Public {
             v := tInput.Interface().(frontend.Variable)
 
-            if v.WitnessValue == nil {
+            if v == nil {
                 return fmt.Errorf("when parsing variable %s: missing assignment", name) 
             }
 
-            if _, err := (*witness)[j].SetInterface(v.WitnessValue) ; err != nil {
+            if _, err := (*witness)[j].SetInterface(v) ; err != nil {
                 return fmt.Errorf("when parsing variable %s: %v", name, err) 
             }
             j++
         }
         return nil
     }
-    return parser.Visit(w, "", compiled.Unset, collectHandler, reflect.TypeOf(frontend.Variable{}))
+    return parser.Visit(w, "", compiled.Unset, collectHandler, tVariable)
 }
 
 
@@ -141,7 +141,7 @@ func count(w frontend.Circuit) (nbSecret, nbPublic int) {
         return nil
     }
     
-    err := parser.Visit(w, "", compiled.Unset, collectHandler, reflect.TypeOf(frontend.Variable{}))
+    err := parser.Visit(w, "", compiled.Unset, collectHandler, tVariable)
     if err != nil {
         panic("count handler doesn't return an error -- this panic should not happen")
     }
@@ -170,19 +170,19 @@ func ToJSON(w frontend.Circuit) (string, error)  {
         v := tInput.Interface().(frontend.Variable)
 
         if visibility == compiled.Secret {
-            if v.WitnessValue == nil {
+            if v == nil {
                 toPrint.Secret[name] = "<nil>"
             } else {
-                if _, err := e.SetInterface(v.WitnessValue) ; err != nil {
+                if _, err := e.SetInterface(v) ; err != nil {
                     return fmt.Errorf("when parsing variable %s: %v", name, err) 
                 }
                 toPrint.Secret[name] = e.String()
             }
         } else if visibility == compiled.Public {
-            if v.WitnessValue == nil {
+            if v == nil {
                 toPrint.Public[name] = "<nil>"
             } else {
-                if _, err := e.SetInterface(v.WitnessValue) ; err != nil {
+                if _, err := e.SetInterface(v) ; err != nil {
                     return fmt.Errorf("when parsing variable %s: %v", name, err) 
                 }
                 toPrint.Public[name] = e.String()
@@ -190,7 +190,7 @@ func ToJSON(w frontend.Circuit) (string, error)  {
         }
         return nil
     }
-    if err := parser.Visit(w, "", compiled.Unset, collectHandler, reflect.TypeOf(frontend.Variable{})); err != nil {
+    if err := parser.Visit(w, "", compiled.Unset, collectHandler, tVariable); err != nil {
         return "", err
     }
     
@@ -200,4 +200,11 @@ func ToJSON(w frontend.Circuit) (string, error)  {
        return "", err 
     }
     return string(prettyJSON), nil 
+}
+
+
+var tVariable reflect.Type
+
+func init() {
+	tVariable = reflect.ValueOf(struct{ A frontend.Variable }{}).FieldByName("A").Type()
 }

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
@@ -9,7 +9,6 @@ import (
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark-crypto/ecc"
 )
 
 
@@ -24,7 +23,7 @@ type refCircuit struct {
 	Y frontend.Variable  `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define( api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
@@ -43,7 +43,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	}
 	
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = 2
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -53,7 +53,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 
 	return r1cs, &good
 }

--- a/internal/generator/backend/template/zkpschemes/plonk/tests/plonk.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/tests/plonk.go.tmpl
@@ -27,7 +27,7 @@ type refCircuit struct {
 	Y frontend.Variable  `gnark:",public"`
 }
 
-func (circuit *refCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *refCircuit) Define( api frontend.API) error {
 	for i := 0; i < circuit.nbConstraints; i++ {
 		circuit.X = api.Mul(circuit.X, circuit.X)
 	}

--- a/internal/generator/backend/template/zkpschemes/plonk/tests/plonk.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/tests/plonk.go.tmpl
@@ -46,7 +46,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	}
 	
 	var good refCircuit
-	good.X.Assign(2)
+	good.X = (2)
 
 	// compute expected Y
 	var expectedY fr.Element
@@ -56,7 +56,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 		expectedY.Mul(&expectedY, &expectedY)
 	}
 
-	good.Y.Assign(expectedY)
+	good.Y = (expectedY)
 	srs, err := kzg.NewSRS(ecc.NextPowerOfTwo(nbConstraints) + 3, new(big.Int).SetUint64(42))
 	if err != nil {
 		panic(err)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -146,6 +146,7 @@ func Visit(input interface{}, baseName string, parentVisibility compiled.Visibil
 		if tValue.Type() == target {
 			return handler(parentVisibility, baseName, tValue)
 		}
+		// TODO @gbotrel if it's not target, we may still want to visit it. just ensure it is NOT a frontend.API
 	}
 
 	return nil

--- a/std/accumulator/merkle/verify_test.go
+++ b/std/accumulator/merkle/verify_test.go
@@ -35,8 +35,8 @@ type merkleCircuit struct {
 	Path, Helper []frontend.Variable
 }
 
-func (circuit *merkleCircuit) Define(curveID ecc.ID, api frontend.API) error {
-	hFunc, err := mimc.NewMiMC("seed", curveID, api)
+func (circuit *merkleCircuit) Define(api frontend.API) error {
+	hFunc, err := mimc.NewMiMC("seed", api)
 	if err != nil {
 		return err
 	}

--- a/std/accumulator/merkle/verify_test.go
+++ b/std/accumulator/merkle/verify_test.go
@@ -83,7 +83,7 @@ func TestVerify(t *testing.T) {
 	witness := merkleCircuit{
 		Path:     make([]frontend.Variable, len(proof)),
 		Helper:   make([]frontend.Variable, len(proof)-1),
-		RootHash: frontend.Value(merkleRoot),
+		RootHash: (merkleRoot),
 	}
 
 	for i := 0; i < len(proof); i++ {

--- a/std/accumulator/merkle/verify_test.go
+++ b/std/accumulator/merkle/verify_test.go
@@ -87,10 +87,10 @@ func TestVerify(t *testing.T) {
 	}
 
 	for i := 0; i < len(proof); i++ {
-		witness.Path[i].Assign(proof[i])
+		witness.Path[i] = (proof[i])
 	}
 	for i := 0; i < len(proof)-1; i++ {
-		witness.Helper[i].Assign(proofHelper[i])
+		witness.Helper[i] = (proofHelper[i])
 	}
 
 	assert := test.NewAssert(t)

--- a/std/algebra/fields/e12.go
+++ b/std/algebra/fields/e12.go
@@ -64,12 +64,12 @@ func GetBLS377ExtensionFp12(api frontend.API) Extension {
 
 	res.uSquare = -5
 
-	res.vCube = E2{A0: api.Constant(0), A1: api.Constant(1)}
+	res.vCube = E2{A0: 0, A1: 1}
 
 	res.wSquare = E6{
-		B0: E2{api.Constant(0), api.Constant(0)},
-		B1: E2{api.Constant(1), api.Constant(0)},
-		B2: E2{api.Constant(0), api.Constant(0)},
+		B0: E2{0, 0},
+		B1: E2{1, 0},
+		B2: E2{0, 0},
 	}
 
 	res.frobv = "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410946"
@@ -95,18 +95,18 @@ func GetBLS377ExtensionFp12(api frontend.API) Extension {
 
 // SetOne returns a newly allocated element equal to 1
 func (e *E12) SetOne(api frontend.API) *E12 {
-	e.C0.B0.A0 = api.Constant(1)
-	e.C0.B0.A1 = api.Constant(0)
-	e.C0.B1.A0 = api.Constant(0)
-	e.C0.B1.A1 = api.Constant(0)
-	e.C0.B2.A0 = api.Constant(0)
-	e.C0.B2.A1 = api.Constant(0)
-	e.C1.B0.A0 = api.Constant(0)
-	e.C1.B0.A1 = api.Constant(0)
-	e.C1.B1.A0 = api.Constant(0)
-	e.C1.B1.A1 = api.Constant(0)
-	e.C1.B2.A0 = api.Constant(0)
-	e.C1.B2.A1 = api.Constant(0)
+	e.C0.B0.A0 = 1
+	e.C0.B0.A1 = 0
+	e.C0.B1.A0 = 0
+	e.C0.B1.A1 = 0
+	e.C0.B2.A0 = 0
+	e.C0.B2.A1 = 0
+	e.C1.B0.A0 = 0
+	e.C1.B0.A1 = 0
+	e.C1.B1.A0 = 0
+	e.C1.B1.A1 = 0
+	e.C1.B2.A0 = 0
+	e.C1.B2.A1 = 0
 	return e
 }
 

--- a/std/algebra/fields/e12_test.go
+++ b/std/algebra/fields/e12_test.go
@@ -34,7 +34,7 @@ type fp12Add struct {
 	C    E12 `gnark:",public"`
 }
 
-func (circuit *fp12Add) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12Add) Define(api frontend.API) error {
 	expected := E12{}
 	expected.Add(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
@@ -65,7 +65,7 @@ type fp12Sub struct {
 	C    E12 `gnark:",public"`
 }
 
-func (circuit *fp12Sub) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12Sub) Define(api frontend.API) error {
 	expected := E12{}
 	expected.Sub(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
@@ -96,7 +96,7 @@ type fp12Mul struct {
 	C    E12 `gnark:",public"`
 }
 
-func (circuit *fp12Mul) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12Mul) Define(api frontend.API) error {
 	expected := E12{}
 	ext := GetBLS377ExtensionFp12(api)
 	expected.Mul(api, circuit.A, circuit.B, ext)
@@ -128,7 +128,7 @@ type fp12Square struct {
 	B E12 `gnark:",public"`
 }
 
-func (circuit *fp12Square) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12Square) Define(api frontend.API) error {
 	ext := GetBLS377ExtensionFp12(api)
 	s := circuit.A.Square(api, circuit.A, ext)
 	s.MustBeEqual(api, circuit.B)
@@ -158,7 +158,7 @@ type fp12CycloSquare struct {
 	B E12 `gnark:",public"`
 }
 
-func (circuit *fp12CycloSquare) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12CycloSquare) Define(api frontend.API) error {
 	ext := GetBLS377ExtensionFp12(api)
 	var u, v E12
 	u.Square(api, circuit.A, ext)
@@ -198,7 +198,7 @@ type fp12Conjugate struct {
 	C E12 `gnark:",public"`
 }
 
-func (circuit *fp12Conjugate) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12Conjugate) Define(api frontend.API) error {
 	expected := E12{}
 	expected.Conjugate(api, circuit.A)
 	expected.MustBeEqual(api, circuit.C)
@@ -227,7 +227,7 @@ type fp12Frobenius struct {
 	C, D, E E12 `gnark:",public"`
 }
 
-func (circuit *fp12Frobenius) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12Frobenius) Define(api frontend.API) error {
 	ext := GetBLS377ExtensionFp12(api)
 	fb := E12{}
 	fb.Frobenius(api, circuit.A, ext)
@@ -269,7 +269,7 @@ type fp12Inverse struct {
 	C E12 `gnark:",public"`
 }
 
-func (circuit *fp12Inverse) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12Inverse) Define(api frontend.API) error {
 	expected := E12{}
 	ext := GetBLS377ExtensionFp12(api)
 	expected.Inverse(api, circuit.A, ext)
@@ -299,7 +299,7 @@ type fp12FixedExpo struct {
 	C E12 `gnark:",public"`
 }
 
-func (circuit *fp12FixedExpo) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12FixedExpo) Define(api frontend.API) error {
 	expected := E12{}
 	ext := GetBLS377ExtensionFp12(api)
 	expo := uint64(9586122913090633729)
@@ -337,7 +337,7 @@ type fp12FinalExpo struct {
 	C E12 `gnark:",public"`
 }
 
-func (circuit *fp12FinalExpo) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12FinalExpo) Define(api frontend.API) error {
 	expected := E12{}
 	ext := GetBLS377ExtensionFp12(api)
 	expo := uint64(9586122913090633729)
@@ -369,7 +369,7 @@ type fp12MulBy034 struct {
 	B, C, D E2
 }
 
-func (circuit *fp12MulBy034) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp12MulBy034) Define(api frontend.API) error {
 	ext := GetBLS377ExtensionFp12(api)
 	circuit.A.MulBy034(api, circuit.B, circuit.C, circuit.D, ext)
 	circuit.A.MustBeEqual(api, circuit.W)

--- a/std/algebra/fields/e2.go
+++ b/std/algebra/fields/e2.go
@@ -29,8 +29,8 @@ type E2 struct {
 
 // SetOne returns a newly allocated element equal to 1
 func (e *E2) SetOne(api frontend.API) *E2 {
-	e.A0 = api.Constant(1)
-	e.A1 = api.Constant(0)
+	e.A0 = 1
+	e.A1 = 0
 	return e
 }
 

--- a/std/algebra/fields/e2.go
+++ b/std/algebra/fields/e2.go
@@ -18,7 +18,6 @@ package fields
 
 import (
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
-	"github.com/consensys/gnark-crypto/ecc/bls12-377/fp"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark/frontend"
 )
@@ -151,19 +150,12 @@ func (e *E2) Inverse(api frontend.API, e1 E2, ext Extension) *E2 {
 
 // Assign a value to self (witness assignment)
 func (e *E2) Assign(a *bls12377.E2) {
-	e.A0 = (bls12377FpTobw6761fr(&a.A0))
-	e.A1 = (bls12377FpTobw6761fr(&a.A1))
+	e.A0 = (fr.Element)(a.A0)
+	e.A1 = (fr.Element)(a.A1)
 }
 
 // MustBeEqual constraint self to be equal to other into the given constraint system
 func (e *E2) MustBeEqual(api frontend.API, other E2) {
 	api.AssertIsEqual(e.A0, other.A0)
 	api.AssertIsEqual(e.A1, other.A1)
-}
-
-func bls12377FpTobw6761fr(a *fp.Element) (r fr.Element) {
-	for i, v := range a {
-		r[i] = v
-	}
-	return
 }

--- a/std/algebra/fields/e2.go
+++ b/std/algebra/fields/e2.go
@@ -151,8 +151,8 @@ func (e *E2) Inverse(api frontend.API, e1 E2, ext Extension) *E2 {
 
 // Assign a value to self (witness assignment)
 func (e *E2) Assign(a *bls12377.E2) {
-	e.A0.Assign(bls12377FpTobw6761fr(&a.A0))
-	e.A1.Assign(bls12377FpTobw6761fr(&a.A1))
+	e.A0 = (bls12377FpTobw6761fr(&a.A0))
+	e.A1 = (bls12377FpTobw6761fr(&a.A1))
 }
 
 // MustBeEqual constraint self to be equal to other into the given constraint system

--- a/std/algebra/fields/e2_test.go
+++ b/std/algebra/fields/e2_test.go
@@ -237,11 +237,11 @@ func TestMulByImFp2(t *testing.T) {
 	// api.Tag(fp2c.Y, "c1")
 
 	//
-	// witness.A.A0.Assign(a.A0)
-	// witness.A.A1.Assign(a.A1)
+	// witness.A.A0 = (a.A0)
+	// witness.A.A1 = (a.A1)
 
 	//
-	// witness.C.A0.Assign(c.A0)
-	// witness.C.A1.Assign(c.A1)
+	// witness.C.A0 = (c.A0)
+	// witness.C.A1 = (c.A1)
 
 }

--- a/std/algebra/fields/e2_test.go
+++ b/std/algebra/fields/e2_test.go
@@ -31,7 +31,7 @@ type e2Add struct {
 	A, B, C E2
 }
 
-func (circuit *e2Add) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *e2Add) Define(api frontend.API) error {
 	var expected E2
 	expected.Add(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
@@ -60,7 +60,7 @@ type e2Sub struct {
 	A, B, C E2
 }
 
-func (circuit *e2Sub) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *e2Sub) Define(api frontend.API) error {
 	var expected E2
 	expected.Sub(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
@@ -89,7 +89,7 @@ type e2Mul struct {
 	A, B, C E2
 }
 
-func (circuit *e2Mul) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *e2Mul) Define(api frontend.API) error {
 	var expected E2
 	ext := Extension{uSquare: -5}
 	expected.Mul(api, circuit.A, circuit.B, ext)
@@ -121,7 +121,7 @@ type fp2MulByFp struct {
 	C E2 `gnark:",public"`
 }
 
-func (circuit *fp2MulByFp) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp2MulByFp) Define(api frontend.API) error {
 	expected := E2{}
 	expected.MulByFp(api, circuit.A, circuit.B)
 
@@ -155,7 +155,7 @@ type fp2Conjugate struct {
 	C E2 `gnark:",public"`
 }
 
-func (circuit *fp2Conjugate) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp2Conjugate) Define(api frontend.API) error {
 	expected := E2{}
 	expected.Conjugate(api, circuit.A)
 
@@ -185,7 +185,7 @@ type fp2Inverse struct {
 	C E2 `gnark:",public"`
 }
 
-func (circuit *fp2Inverse) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp2Inverse) Define(api frontend.API) error {
 	ext := Extension{uSquare: -5}
 	expected := E2{}
 	expected.Inverse(api, circuit.A, ext)

--- a/std/algebra/fields/e2_test.go
+++ b/std/algebra/fields/e2_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fp"
+	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/test"
 )
@@ -140,7 +141,7 @@ func TestMulByFpFp2(t *testing.T) {
 	c.MulByElement(&a, &b)
 
 	witness.A.Assign(&a)
-	witness.B = (bls12377FpTobw6761fr(&b))
+	witness.B = (fr.Element)(b)
 
 	witness.C.Assign(&c)
 

--- a/std/algebra/fields/e2_test.go
+++ b/std/algebra/fields/e2_test.go
@@ -140,7 +140,7 @@ func TestMulByFpFp2(t *testing.T) {
 	c.MulByElement(&a, &b)
 
 	witness.A.Assign(&a)
-	witness.B.Assign(bls12377FpTobw6761fr(&b))
+	witness.B = (bls12377FpTobw6761fr(&b))
 
 	witness.C.Assign(&c)
 

--- a/std/algebra/fields/e6.go
+++ b/std/algebra/fields/e6.go
@@ -39,9 +39,9 @@ func (e *E6) Add(api frontend.API, e1, e2 E6) *E6 {
 // NewFp6Zero creates a new
 func NewFp6Zero(api frontend.API) *E6 {
 	return &E6{
-		B0: E2{api.Constant(0), api.Constant(0)},
-		B1: E2{api.Constant(0), api.Constant(0)},
-		B2: E2{api.Constant(0), api.Constant(0)},
+		B0: E2{0, 0},
+		B1: E2{0, 0},
+		B2: E2{0, 0},
 	}
 }
 

--- a/std/algebra/fields/e6_test.go
+++ b/std/algebra/fields/e6_test.go
@@ -28,7 +28,7 @@ import (
 func getBLS377ExtensionFp6(api frontend.API) Extension {
 	res := Extension{}
 	res.uSquare = -5
-	res.vCube = E2{A0: api.Constant(0), A1: api.Constant(1)}
+	res.vCube = E2{A0: 0, A1: 1}
 	return res
 }
 

--- a/std/algebra/fields/e6_test.go
+++ b/std/algebra/fields/e6_test.go
@@ -40,7 +40,7 @@ type fp6Add struct {
 	C    E6 `gnark:",public"`
 }
 
-func (circuit *fp6Add) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp6Add) Define(api frontend.API) error {
 	expected := E6{}
 	expected.Add(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
@@ -71,7 +71,7 @@ type fp6Sub struct {
 	C    E6 `gnark:",public"`
 }
 
-func (circuit *fp6Sub) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp6Sub) Define(api frontend.API) error {
 	expected := E6{}
 	expected.Sub(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
@@ -102,7 +102,7 @@ type fp6Mul struct {
 	C    E6 `gnark:",public"`
 }
 
-func (circuit *fp6Mul) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp6Mul) Define(api frontend.API) error {
 	expected := E6{}
 	ext := getBLS377ExtensionFp6(api)
 	expected.Mul(api, circuit.A, circuit.B, ext)
@@ -134,7 +134,7 @@ type fp6MulByNonResidue struct {
 	C E6 `gnark:",public"`
 }
 
-func (circuit *fp6MulByNonResidue) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp6MulByNonResidue) Define(api frontend.API) error {
 	expected := E6{}
 	ext := getBLS377ExtensionFp6(api)
 	expected.MulByNonResidue(api, circuit.A, ext)
@@ -166,7 +166,7 @@ type fp6Inverse struct {
 	C E6 `gnark:",public"`
 }
 
-func (circuit *fp6Inverse) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *fp6Inverse) Define(api frontend.API) error {
 	expected := E6{}
 	ext := getBLS377ExtensionFp6(api)
 	expected.Inverse(api, circuit.A, ext)

--- a/std/algebra/sw/g1.go
+++ b/std/algebra/sw/g1.go
@@ -198,7 +198,7 @@ func (p *G1Affine) Double(api frontend.API, p1 G1Affine) *G1Affine {
 // TODO s is an interface, but treated as a variable (ToBinary), there is no specific path for constants
 func (p *G1Affine) ScalarMul(api frontend.API, p1 G1Affine, s interface{}) *G1Affine {
 	// scalar bits
-	scalar := api.Constant(s)
+	scalar := s
 	bits := api.ToBinary(scalar)
 
 	var base G1Affine

--- a/std/algebra/sw/g1.go
+++ b/std/algebra/sw/g1.go
@@ -20,7 +20,6 @@ import (
 	"math/big"
 
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
-	"github.com/consensys/gnark-crypto/ecc/bls12-377/fp"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark/frontend"
 )
@@ -228,18 +227,11 @@ func (p *G1Affine) ScalarMul(api frontend.API, p1 G1Affine, s interface{}) *G1Af
 
 }
 
-func bls12377FpTobw6761fr(a *fp.Element) (r fr.Element) {
-	for i, v := range a {
-		r[i] = v
-	}
-	return
-}
-
 // Assign a value to self (witness assignment)
 func (p *G1Jac) Assign(p1 *bls12377.G1Jac) {
-	p.X = (bls12377FpTobw6761fr(&p1.X))
-	p.Y = (bls12377FpTobw6761fr(&p1.Y))
-	p.Z = (bls12377FpTobw6761fr(&p1.Z))
+	p.X = (fr.Element)(p1.X)
+	p.Y = (fr.Element)(p1.Y)
+	p.Z = (fr.Element)(p1.Z)
 }
 
 // MustBeEqual constraint self to be equal to other into the given constraint system
@@ -251,8 +243,8 @@ func (p *G1Jac) MustBeEqual(api frontend.API, other G1Jac) {
 
 // Assign a value to self (witness assignment)
 func (p *G1Affine) Assign(p1 *bls12377.G1Affine) {
-	p.X = (bls12377FpTobw6761fr(&p1.X))
-	p.Y = (bls12377FpTobw6761fr(&p1.Y))
+	p.X = (fr.Element)(p1.X)
+	p.Y = (fr.Element)(p1.Y)
 }
 
 // MustBeEqual constraint self to be equal to other into the given constraint system

--- a/std/algebra/sw/g1.go
+++ b/std/algebra/sw/g1.go
@@ -237,9 +237,9 @@ func bls12377FpTobw6761fr(a *fp.Element) (r fr.Element) {
 
 // Assign a value to self (witness assignment)
 func (p *G1Jac) Assign(p1 *bls12377.G1Jac) {
-	p.X.Assign(bls12377FpTobw6761fr(&p1.X))
-	p.Y.Assign(bls12377FpTobw6761fr(&p1.Y))
-	p.Z.Assign(bls12377FpTobw6761fr(&p1.Z))
+	p.X = (bls12377FpTobw6761fr(&p1.X))
+	p.Y = (bls12377FpTobw6761fr(&p1.Y))
+	p.Z = (bls12377FpTobw6761fr(&p1.Z))
 }
 
 // MustBeEqual constraint self to be equal to other into the given constraint system
@@ -251,8 +251,8 @@ func (p *G1Jac) MustBeEqual(api frontend.API, other G1Jac) {
 
 // Assign a value to self (witness assignment)
 func (p *G1Affine) Assign(p1 *bls12377.G1Affine) {
-	p.X.Assign(bls12377FpTobw6761fr(&p1.X))
-	p.Y.Assign(bls12377FpTobw6761fr(&p1.Y))
+	p.X = (bls12377FpTobw6761fr(&p1.X))
+	p.Y = (bls12377FpTobw6761fr(&p1.Y))
 }
 
 // MustBeEqual constraint self to be equal to other into the given constraint system

--- a/std/algebra/sw/g1_test.go
+++ b/std/algebra/sw/g1_test.go
@@ -37,7 +37,7 @@ type g1AddAssign struct {
 	C    G1Jac `gnark:",public"`
 }
 
-func (circuit *g1AddAssign) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g1AddAssign) Define(api frontend.API) error {
 	expected := circuit.A
 	expected.AddAssign(api, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
@@ -74,7 +74,7 @@ type g1AddAssignAffine struct {
 	C    G1Affine `gnark:",public"`
 }
 
-func (circuit *g1AddAssignAffine) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g1AddAssignAffine) Define(api frontend.API) error {
 	expected := circuit.A
 	expected.AddAssign(api, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
@@ -115,7 +115,7 @@ type g1DoubleAssign struct {
 	C G1Jac `gnark:",public"`
 }
 
-func (circuit *g1DoubleAssign) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g1DoubleAssign) Define(api frontend.API) error {
 	expected := circuit.A
 	expected.DoubleAssign(api)
 	expected.MustBeEqual(api, circuit.C)
@@ -150,7 +150,7 @@ type g1DoubleAffine struct {
 	C G1Affine `gnark:",public"`
 }
 
-func (circuit *g1DoubleAffine) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g1DoubleAffine) Define(api frontend.API) error {
 	expected := circuit.A
 	expected.Double(api, circuit.A)
 	expected.MustBeEqual(api, circuit.C)
@@ -185,7 +185,7 @@ type g1Neg struct {
 	C G1Jac `gnark:",public"`
 }
 
-func (circuit *g1Neg) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g1Neg) Define(api frontend.API) error {
 	expected := G1Jac{}
 	expected.Neg(api, circuit.A)
 	expected.MustBeEqual(api, circuit.C)
@@ -217,7 +217,7 @@ type g1ScalarMul struct {
 	r fr.Element
 }
 
-func (circuit *g1ScalarMul) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g1ScalarMul) Define(api frontend.API) error {
 	expected := G1Affine{}
 	expected.ScalarMul(api, circuit.A, circuit.r)
 	expected.MustBeEqual(api, circuit.C)

--- a/std/algebra/sw/g2_test.go
+++ b/std/algebra/sw/g2_test.go
@@ -37,7 +37,7 @@ type g2AddAssign struct {
 	C    G2Jac `gnark:",public"`
 }
 
-func (circuit *g2AddAssign) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g2AddAssign) Define(api frontend.API) error {
 	expected := circuit.A
 	expected.AddAssign(api, &circuit.B, fields.GetBLS377ExtensionFp12(api))
 	expected.MustBeEqual(api, circuit.C)
@@ -74,7 +74,7 @@ type g2AddAssignAffine struct {
 	C    G2Affine `gnark:",public"`
 }
 
-func (circuit *g2AddAssignAffine) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g2AddAssignAffine) Define(api frontend.API) error {
 	expected := circuit.A
 	expected.AddAssign(api, &circuit.B, fields.GetBLS377ExtensionFp12(api))
 	expected.MustBeEqual(api, circuit.C)
@@ -115,7 +115,7 @@ type g2DoubleAssign struct {
 	C G2Jac `gnark:",public"`
 }
 
-func (circuit *g2DoubleAssign) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g2DoubleAssign) Define(api frontend.API) error {
 	expected := circuit.A
 	expected.Double(api, &circuit.A, fields.GetBLS377ExtensionFp12(api))
 	expected.MustBeEqual(api, circuit.C)
@@ -150,7 +150,7 @@ type g2DoubleAffine struct {
 	C G2Affine `gnark:",public"`
 }
 
-func (circuit *g2DoubleAffine) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g2DoubleAffine) Define(api frontend.API) error {
 	expected := circuit.A
 	expected.Double(api, &circuit.A, fields.GetBLS377ExtensionFp12(api))
 	expected.MustBeEqual(api, circuit.C)
@@ -188,7 +188,7 @@ type g2Neg struct {
 	C G2Jac `gnark:",public"`
 }
 
-func (circuit *g2Neg) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *g2Neg) Define(api frontend.API) error {
 	expected := G2Jac{}
 	expected.Neg(api, &circuit.A)
 	expected.MustBeEqual(api, circuit.C)

--- a/std/algebra/sw/pairing_test.go
+++ b/std/algebra/sw/pairing_test.go
@@ -39,8 +39,8 @@ func (circuit *pairingBLS377) Define(curveID ecc.ID, api frontend.API) error {
 	ateLoop := uint64(9586122913090633729)
 	ext := fields.GetBLS377ExtensionFp12(api)
 	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.A0 = api.Constant(0)
-	pairingInfo.BTwistCoeff.A1 = api.Constant("155198655607781456406391640216936120121836107652948796323930557600032281009004493664981332883744016074664192874906")
+	pairingInfo.BTwistCoeff.A0 = 0
+	pairingInfo.BTwistCoeff.A1 = "155198655607781456406391640216936120121836107652948796323930557600032281009004493664981332883744016074664192874906"
 
 	milRes := fields.E12{}
 	//MillerLoop(cs, circuit.P, circuit.Q, &milRes, pairingInfo)
@@ -83,8 +83,8 @@ func (circuit *ml) Define(curveID ecc.ID, api frontend.API) error {
 	ateLoop := uint64(9586122913090633729)
 	ext := fields.GetBLS377ExtensionFp12(api)
 	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.A0 = api.Constant(0)
-	pairingInfo.BTwistCoeff.A1 = api.Constant("155198655607781456406391640216936120121836107652948796323930557600032281009004493664981332883744016074664192874906")
+	pairingInfo.BTwistCoeff.A0 = 0
+	pairingInfo.BTwistCoeff.A1 = "155198655607781456406391640216936120121836107652948796323930557600032281009004493664981332883744016074664192874906"
 
 	milRes := fields.E12{}
 	MillerLoop(api, circuit.P, circuit.Q, &milRes, pairingInfo)

--- a/std/algebra/sw/pairing_test.go
+++ b/std/algebra/sw/pairing_test.go
@@ -34,7 +34,7 @@ type pairingBLS377 struct {
 	pairingRes bls12377.GT
 }
 
-func (circuit *pairingBLS377) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *pairingBLS377) Define(api frontend.API) error {
 
 	ateLoop := uint64(9586122913090633729)
 	ext := fields.GetBLS377ExtensionFp12(api)
@@ -78,7 +78,7 @@ type ml struct {
 	Q G2Affine
 }
 
-func (circuit *ml) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *ml) Define(api frontend.API) error {
 
 	ateLoop := uint64(9586122913090633729)
 	ext := fields.GetBLS377ExtensionFp12(api)

--- a/std/algebra/twistededwards/bandersnatch/point.go
+++ b/std/algebra/twistededwards/bandersnatch/point.go
@@ -129,8 +129,8 @@ func (p *Point) ScalarMulNonFixedBase(api frontend.API, p1 *Point, scalar fronte
 	b := api.ToBinary(scalar)
 
 	res := Point{
-		api.Constant(0),
-		api.Constant(1),
+		0,
+		1,
 	}
 
 	for i := len(b) - 1; i >= 0; i-- {
@@ -157,8 +157,8 @@ func (p *Point) ScalarMulFixedBase(api frontend.API, x, y interface{}, scalar fr
 	b := api.ToBinary(scalar)
 
 	res := Point{
-		api.Constant(0),
-		api.Constant(1),
+		0,
+		1,
 	}
 
 	for i := len(b) - 1; i >= 0; i-- {

--- a/std/algebra/twistededwards/bandersnatch/point_test.go
+++ b/std/algebra/twistededwards/bandersnatch/point_test.go
@@ -31,10 +31,10 @@ type mustBeOnCurve struct {
 	P Point
 }
 
-func (circuit *mustBeOnCurve) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *mustBeOnCurve) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -66,10 +66,10 @@ type add struct {
 	P, E Point
 }
 
-func (circuit *add) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *add) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -116,10 +116,10 @@ type addGeneric struct {
 	P1, P2, E Point
 }
 
-func (circuit *addGeneric) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *addGeneric) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -169,10 +169,10 @@ type double struct {
 	P, E Point
 }
 
-func (circuit *double) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *double) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -217,10 +217,10 @@ type scalarMulFixed struct {
 	S frontend.Variable
 }
 
-func (circuit *scalarMulFixed) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *scalarMulFixed) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -266,10 +266,10 @@ type scalarMulGeneric struct {
 	S    frontend.Variable
 }
 
-func (circuit *scalarMulGeneric) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *scalarMulGeneric) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ type neg struct {
 	P, E Point
 }
 
-func (circuit *neg) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *neg) Define(api frontend.API) error {
 
 	circuit.P.Neg(api, &circuit.P)
 	api.AssertIsEqual(circuit.P.X, circuit.E.X)

--- a/std/algebra/twistededwards/bandersnatch/point_test.go
+++ b/std/algebra/twistededwards/bandersnatch/point_test.go
@@ -55,8 +55,8 @@ func TestIsOnCurve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	witness.P.X.Assign(params.BaseX)
-	witness.P.Y.Assign(params.BaseY)
+	witness.P.X = (params.BaseX)
+	witness.P.Y = (params.BaseY)
 
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
 
@@ -102,10 +102,10 @@ func TestAddFixedPoint(t *testing.T) {
 	expected.Add(&base, &point)
 
 	// populate witness
-	witness.P.X.Assign(point.X.String())
-	witness.P.Y.Assign(point.Y.String())
-	witness.E.X.Assign(expected.X.String())
-	witness.E.Y.Assign(expected.Y.String())
+	witness.P.X = (point.X.String())
+	witness.P.Y = (point.Y.String())
+	witness.E.X = (expected.X.String())
+	witness.E.Y = (expected.Y.String())
 
 	// creates r1cs
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
@@ -153,12 +153,12 @@ func TestAddGeneric(t *testing.T) {
 	expected.Add(&point1, &point2)
 
 	// populate witness
-	witness.P1.X.Assign(point1.X.String())
-	witness.P1.Y.Assign(point1.Y.String())
-	witness.P2.X.Assign(point2.X.String())
-	witness.P2.Y.Assign(point2.Y.String())
-	witness.E.X.Assign(expected.X.String())
-	witness.E.Y.Assign(expected.Y.String())
+	witness.P1.X = (point1.X.String())
+	witness.P1.Y = (point1.Y.String())
+	witness.P2.X = (point2.X.String())
+	witness.P2.Y = (point2.Y.String())
+	witness.E.X = (expected.X.String())
+	witness.E.Y = (expected.Y.String())
 
 	// creates r1cs
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
@@ -202,10 +202,10 @@ func TestDouble(t *testing.T) {
 	expected.Double(&base)
 
 	// populate witness
-	witness.P.X.Assign(base.X.String())
-	witness.P.Y.Assign(base.Y.String())
-	witness.E.X.Assign(expected.X.String())
-	witness.E.Y.Assign(expected.Y.String())
+	witness.P.X = (base.X.String())
+	witness.P.Y = (base.Y.String())
+	witness.E.X = (expected.X.String())
+	witness.E.Y = (expected.Y.String())
 
 	// creates r1cs
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
@@ -252,9 +252,9 @@ func TestScalarMulFixed(t *testing.T) {
 	expected.ScalarMul(&base, r)
 
 	// populate witness
-	witness.E.X.Assign(expected.X.String())
-	witness.E.Y.Assign(expected.Y.String())
-	witness.S.Assign(r)
+	witness.E.X = (expected.X.String())
+	witness.E.Y = (expected.Y.String())
+	witness.S = (r)
 
 	// creates r1cs
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
@@ -302,11 +302,11 @@ func TestScalarMulGeneric(t *testing.T) {
 	expected.ScalarMul(&point, r)
 
 	// populate witness
-	witness.P.X.Assign(point.X.String())
-	witness.P.Y.Assign(point.Y.String())
-	witness.E.X.Assign(expected.X.String())
-	witness.E.Y.Assign(expected.Y.String())
-	witness.S.Assign(r)
+	witness.P.X = (point.X.String())
+	witness.P.Y = (point.Y.String())
+	witness.E.X = (expected.X.String())
+	witness.E.Y = (expected.Y.String())
+	witness.S = (r)
 
 	// creates r1cs
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
@@ -342,10 +342,10 @@ func TestNeg(t *testing.T) {
 
 	// generate witness
 	var circuit, witness neg
-	witness.P.X.Assign(base.X)
-	witness.P.Y.Assign(base.Y)
-	witness.E.X.Assign(expected.X)
-	witness.E.Y.Assign(expected.Y)
+	witness.P.X = (base.X)
+	witness.P.Y = (base.Y)
+	witness.E.X = (expected.X)
+	witness.E.Y = (expected.Y)
 
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BLS12_381))
 

--- a/std/algebra/twistededwards/point.go
+++ b/std/algebra/twistededwards/point.go
@@ -129,8 +129,8 @@ func (p *Point) ScalarMulNonFixedBase(api frontend.API, p1 *Point, scalar fronte
 	b := api.ToBinary(scalar)
 
 	res := Point{
-		api.Constant(0),
-		api.Constant(1),
+		0,
+		1,
 	}
 
 	for i := len(b) - 1; i >= 0; i-- {
@@ -157,8 +157,8 @@ func (p *Point) ScalarMulFixedBase(api frontend.API, x, y interface{}, scalar fr
 	b := api.ToBinary(scalar)
 
 	res := Point{
-		api.Constant(0),
-		api.Constant(1),
+		0,
+		1,
 	}
 
 	for i := len(b) - 1; i >= 0; i-- {

--- a/std/algebra/twistededwards/point_test.go
+++ b/std/algebra/twistededwards/point_test.go
@@ -54,8 +54,8 @@ func TestIsOnCurve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	witness.P.X.Assign(params.BaseX)
-	witness.P.Y.Assign(params.BaseY)
+	witness.P.X = (params.BaseX)
+	witness.P.Y = (params.BaseY)
 
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BN254))
 
@@ -101,10 +101,10 @@ func TestAddFixedPoint(t *testing.T) {
 	expected.Add(&base, &point)
 
 	// populate witness
-	witness.P.X.Assign(point.X.String())
-	witness.P.Y.Assign(point.Y.String())
-	witness.E.X.Assign(expected.X.String())
-	witness.E.Y.Assign(expected.Y.String())
+	witness.P.X = (point.X.String())
+	witness.P.Y = (point.Y.String())
+	witness.E.X = (expected.X.String())
+	witness.E.Y = (expected.Y.String())
 
 	// creates r1cs
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BN254))
@@ -152,12 +152,12 @@ func TestAddGeneric(t *testing.T) {
 	expected.Add(&point1, &point2)
 
 	// populate witness
-	witness.P1.X.Assign(point1.X.String())
-	witness.P1.Y.Assign(point1.Y.String())
-	witness.P2.X.Assign(point2.X.String())
-	witness.P2.Y.Assign(point2.Y.String())
-	witness.E.X.Assign(expected.X.String())
-	witness.E.Y.Assign(expected.Y.String())
+	witness.P1.X = (point1.X.String())
+	witness.P1.Y = (point1.Y.String())
+	witness.P2.X = (point2.X.String())
+	witness.P2.Y = (point2.Y.String())
+	witness.E.X = (expected.X.String())
+	witness.E.Y = (expected.Y.String())
 
 	// creates r1cs
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BN254))
@@ -201,10 +201,10 @@ func TestDouble(t *testing.T) {
 	expected.Double(&base)
 
 	// populate witness
-	witness.P.X.Assign(base.X.String())
-	witness.P.Y.Assign(base.Y.String())
-	witness.E.X.Assign(expected.X.String())
-	witness.E.Y.Assign(expected.Y.String())
+	witness.P.X = (base.X.String())
+	witness.P.Y = (base.Y.String())
+	witness.E.X = (expected.X.String())
+	witness.E.Y = (expected.Y.String())
 
 	// creates r1cs
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BN254))
@@ -251,9 +251,9 @@ func TestScalarMulFixed(t *testing.T) {
 	expected.ScalarMul(&base, r)
 
 	// populate witness
-	witness.E.X.Assign(expected.X.String())
-	witness.E.Y.Assign(expected.Y.String())
-	witness.S.Assign(r)
+	witness.E.X = (expected.X.String())
+	witness.E.Y = (expected.Y.String())
+	witness.S = (r)
 
 	// creates r1cs
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BN254))
@@ -301,11 +301,11 @@ func TestScalarMulGeneric(t *testing.T) {
 	expected.ScalarMul(&point, r)
 
 	// populate witness
-	witness.P.X.Assign(point.X.String())
-	witness.P.Y.Assign(point.Y.String())
-	witness.E.X.Assign(expected.X.String())
-	witness.E.Y.Assign(expected.Y.String())
-	witness.S.Assign(r)
+	witness.P.X = (point.X.String())
+	witness.P.Y = (point.Y.String())
+	witness.E.X = (expected.X.String())
+	witness.E.Y = (expected.Y.String())
+	witness.S = (r)
 
 	// creates r1cs
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BN254))
@@ -341,10 +341,10 @@ func TestNeg(t *testing.T) {
 
 	// generate witness
 	var circuit, witness neg
-	witness.P.X.Assign(base.X)
-	witness.P.Y.Assign(base.Y)
-	witness.E.X.Assign(expected.X)
-	witness.E.Y.Assign(expected.Y)
+	witness.P.X = (base.X)
+	witness.P.Y = (base.Y)
+	witness.E.X = (expected.X)
+	witness.E.Y = (expected.Y)
 
 	assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(ecc.BN254))
 

--- a/std/algebra/twistededwards/point_test.go
+++ b/std/algebra/twistededwards/point_test.go
@@ -30,10 +30,10 @@ type mustBeOnCurve struct {
 	P Point
 }
 
-func (circuit *mustBeOnCurve) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *mustBeOnCurve) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -65,10 +65,10 @@ type add struct {
 	P, E Point
 }
 
-func (circuit *add) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *add) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -115,10 +115,10 @@ type addGeneric struct {
 	P1, P2, E Point
 }
 
-func (circuit *addGeneric) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *addGeneric) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -168,10 +168,10 @@ type double struct {
 	P, E Point
 }
 
-func (circuit *double) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *double) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -216,10 +216,10 @@ type scalarMulFixed struct {
 	S frontend.Variable
 }
 
-func (circuit *scalarMulFixed) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *scalarMulFixed) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -265,10 +265,10 @@ type scalarMulGeneric struct {
 	S    frontend.Variable
 }
 
-func (circuit *scalarMulGeneric) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *scalarMulGeneric) Define(api frontend.API) error {
 
 	// get edwards curve params
-	params, err := NewEdCurve(curveID)
+	params, err := NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}
@@ -316,7 +316,7 @@ type neg struct {
 	P, E Point
 }
 
-func (circuit *neg) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *neg) Define(api frontend.API) error {
 
 	circuit.P.Neg(api, &circuit.P)
 	api.AssertIsEqual(circuit.P.X, circuit.E.X)

--- a/std/fiat-shamir/transcript.go
+++ b/std/fiat-shamir/transcript.go
@@ -98,7 +98,7 @@ func (t *Transcript) ComputeChallenge(challengeID string) (frontend.Variable, er
 	challenge, ok := t.challenges[challengeID]
 
 	if !ok {
-		return frontend.Variable{}, errChallengeNotFound
+		return nil, errChallengeNotFound
 	}
 
 	// if the challenge was already computed we return it
@@ -115,7 +115,7 @@ func (t *Transcript) ComputeChallenge(challengeID string) (frontend.Variable, er
 	// write the previous challenge if it's not the first challenge
 	if challenge.position != 0 {
 		if t.previous == nil || (t.previous.position != challenge.position-1) {
-			return frontend.Variable{}, errPreviousChallengeNotComputed
+			return nil, errPreviousChallengeNotComputed
 		}
 		t.h.Write(t.previous.value)
 	}

--- a/std/fiat-shamir/transcript.go
+++ b/std/fiat-shamir/transcript.go
@@ -109,7 +109,7 @@ func (t *Transcript) ComputeChallenge(challengeID string) (frontend.Variable, er
 	t.h.Reset()
 
 	// write the challenge name, the purpose is to have a domain separator
-	cChallenge := t.api.Constant([]byte(challengeID))
+	cChallenge := []byte(challengeID) // if we send a string, it is assumed to be a base10 number
 	t.h.Write(cChallenge)
 
 	// write the previous challenge if it's not the first challenge

--- a/std/fiat-shamir/transcript_test.go
+++ b/std/fiat-shamir/transcript_test.go
@@ -138,9 +138,9 @@ func TestFiatShamir(t *testing.T) {
 
 		for i := 0; i < 3; i++ {
 			for j := 0; j < 4; j++ {
-				witness.Bindings[i][j].WitnessValue = bindings[i][j]
+				witness.Bindings[i][j] = bindings[i][j]
 			}
-			witness.Challenges[i].WitnessValue = expectedChallenges[i]
+			witness.Challenges[i] = expectedChallenges[i]
 		}
 
 		assert.SolvingSucceeded(&FiatShamirCircuit{}, &witness, test.WithCurves(curveID))

--- a/std/fiat-shamir/transcript_test.go
+++ b/std/fiat-shamir/transcript_test.go
@@ -34,16 +34,16 @@ type FiatShamirCircuit struct {
 	Challenges [3]frontend.Variable    `gnark:",secret"`
 }
 
-func (circuit *FiatShamirCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *FiatShamirCircuit) Define(api frontend.API) error {
 
 	// create the hash function
-	hSnark, err := mimc.NewMiMC("seed", curveID, api)
+	hSnark, err := mimc.NewMiMC("seed", api)
 	if err != nil {
 		return err
 	}
 
 	// get the challenges
-	alpha, beta, gamma := getChallenges(curveID)
+	alpha, beta, gamma := getChallenges(api.CurveID())
 
 	// New transcript with 3 challenges to be derived
 	tsSnark := NewTranscript(api, &hSnark, alpha, beta, gamma)

--- a/std/groth16/verifier_test.go
+++ b/std/groth16/verifier_test.go
@@ -111,8 +111,8 @@ func (circuit *verifierCircuit) Define(curveID ecc.ID, api frontend.API) error {
 	ateLoop := uint64(9586122913090633729)
 	ext := fields.GetBLS377ExtensionFp12(api)
 	pairingInfo := sw.PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.A0 = api.Constant(0)
-	pairingInfo.BTwistCoeff.A1 = api.Constant("155198655607781456406391640216936120121836107652948796323930557600032281009004493664981332883744016074664192874906")
+	pairingInfo.BTwistCoeff.A0 = 0
+	pairingInfo.BTwistCoeff.A1 = "155198655607781456406391640216936120121836107652948796323930557600032281009004493664981332883744016074664192874906"
 
 	// create the verifier cs
 	Verify(api, pairingInfo, circuit.InnerVk, circuit.InnerProof, []frontend.Variable{circuit.Hash})

--- a/std/groth16/verifier_test.go
+++ b/std/groth16/verifier_test.go
@@ -66,8 +66,8 @@ func generateBls377InnerProof(t *testing.T, vk *groth16_bls12377.VerifyingKey, p
 		t.Fatal(err)
 	}
 
-	w.Data.Assign(preimage)
-	w.Hash.Assign(publicHash)
+	w.Data = preimage
+	w.Hash = publicHash
 
 	correctAssignment := witness.Witness{}
 
@@ -155,7 +155,7 @@ func TestVerifier(t *testing.T) {
 	gammaNeg.Neg(&innerVk.G2.Gamma)
 	witness.InnerVk.G2.DeltaNeg.Assign(&deltaNeg)
 	witness.InnerVk.G2.GammaNeg.Assign(&gammaNeg)
-	witness.Hash.Assign(publicHash)
+	witness.Hash = publicHash
 
 	// verifies the cs
 	assert := test.NewAssert(t)

--- a/std/groth16/verifier_test.go
+++ b/std/groth16/verifier_test.go
@@ -43,8 +43,8 @@ type mimcCircuit struct {
 	Hash frontend.Variable `gnark:",public"`
 }
 
-func (circuit *mimcCircuit) Define(curveID ecc.ID, api frontend.API) error {
-	mimc, err := mimc.NewMiMC("seed", curveID, api)
+func (circuit *mimcCircuit) Define(api frontend.API) error {
+	mimc, err := mimc.NewMiMC("seed", api)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ type verifierCircuit struct {
 	Hash       frontend.Variable
 }
 
-func (circuit *verifierCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *verifierCircuit) Define(api frontend.API) error {
 
 	// pairing data
 	ateLoop := uint64(9586122913090633729)

--- a/std/hash/mimc/encrypt.go
+++ b/std/hash/mimc/encrypt.go
@@ -60,7 +60,7 @@ func newMimcBLS377(seed string, api frontend.API) MiMC {
 		res.params = append(res.params, cpy)
 	}
 	res.id = ecc.BLS12_377
-	res.h = api.Constant(0)
+	res.h = 0
 	res.api = api
 	return res
 }
@@ -74,7 +74,7 @@ func newMimcBLS381(seed string, api frontend.API) MiMC {
 		res.params = append(res.params, cpy)
 	}
 	res.id = ecc.BLS12_381
-	res.h = api.Constant(0)
+	res.h = 0
 	res.api = api
 	return res
 }
@@ -88,7 +88,7 @@ func newMimcBN254(seed string, api frontend.API) MiMC {
 		res.params = append(res.params, cpy)
 	}
 	res.id = ecc.BN254
-	res.h = api.Constant(0)
+	res.h = 0
 	res.api = api
 	return res
 }
@@ -102,7 +102,7 @@ func newMimcBW761(seed string, api frontend.API) MiMC {
 		res.params = append(res.params, cpy)
 	}
 	res.id = ecc.BW6_761
-	res.h = api.Constant(0)
+	res.h = 0
 	res.api = api
 	return res
 }
@@ -116,7 +116,7 @@ func newMimcBLS315(seed string, api frontend.API) MiMC {
 		res.params = append(res.params, cpy)
 	}
 	res.id = ecc.BLS24_315
-	res.h = api.Constant(0)
+	res.h = 0
 	res.api = api
 	return res
 }

--- a/std/hash/mimc/mimc.go
+++ b/std/hash/mimc/mimc.go
@@ -50,7 +50,7 @@ func (h *MiMC) Write(data ...frontend.Variable) {
 // Reset resets the Hash to its initial state.
 func (h *MiMC) Reset() {
 	h.data = nil
-	h.h = h.api.Constant(0)
+	h.h = 0
 }
 
 // Hash hash (in r1cs form) using Miyaguchi–Preneel:

--- a/std/hash/mimc/mimc.go
+++ b/std/hash/mimc/mimc.go
@@ -35,8 +35,8 @@ type MiMC struct {
 }
 
 // NewMiMC returns a MiMC instance, than can be used in a gnark circuit
-func NewMiMC(seed string, id ecc.ID, api frontend.API) (MiMC, error) {
-	if constructor, ok := newMimc[id]; ok {
+func NewMiMC(seed string, api frontend.API) (MiMC, error) {
+	if constructor, ok := newMimc[api.CurveID()]; ok {
 		return constructor(seed, api), nil
 	}
 	return MiMC{}, errors.New("unknown curve id")

--- a/std/hash/mimc/mimc_test.go
+++ b/std/hash/mimc/mimc_test.go
@@ -31,8 +31,8 @@ type mimcCircuit struct {
 	Data           frontend.Variable
 }
 
-func (circuit *mimcCircuit) Define(curveID ecc.ID, api frontend.API) error {
-	mimc, err := NewMiMC("seed", curveID, api)
+func (circuit *mimcCircuit) Define(api frontend.API) error {
+	mimc, err := NewMiMC("seed", api)
 	if err != nil {
 		return err
 	}

--- a/std/hash/mimc/mimc_test.go
+++ b/std/hash/mimc/mimc_test.go
@@ -70,13 +70,13 @@ func TestMimcAll(t *testing.T) {
 		b := goMimc.Sum(nil)
 
 		// assert correctness against correct witness
-		witness.Data.Assign(data)
-		witness.ExpectedResult.Assign(b)
+		witness.Data = (data)
+		witness.ExpectedResult = (b)
 		assert.ProverSucceeded(&circuit, &witness, test.WithCurves(curve))
 
 		// assert failure against wrong witness
-		wrongWitness.Data.Assign(tamperedData)
-		wrongWitness.ExpectedResult.Assign(b)
+		wrongWitness.Data = (tamperedData)
+		wrongWitness.ExpectedResult = (b)
 		assert.ProverFailed(&circuit, &wrongWitness, test.WithCurves(curve))
 	}
 

--- a/std/hash/mimc/mimc_test.go
+++ b/std/hash/mimc/mimc_test.go
@@ -70,13 +70,13 @@ func TestMimcAll(t *testing.T) {
 		b := goMimc.Sum(nil)
 
 		// assert correctness against correct witness
-		witness.Data = (data)
-		witness.ExpectedResult = (b)
+		witness.Data = data
+		witness.ExpectedResult = b
 		assert.ProverSucceeded(&circuit, &witness, test.WithCurves(curve))
 
 		// assert failure against wrong witness
-		wrongWitness.Data = (tamperedData)
-		wrongWitness.ExpectedResult = (b)
+		wrongWitness.Data = tamperedData
+		wrongWitness.ExpectedResult = b
 		assert.ProverFailed(&circuit, &wrongWitness, test.WithCurves(curve))
 	}
 

--- a/std/signature/eddsa/eddsa.go
+++ b/std/signature/eddsa/eddsa.go
@@ -53,7 +53,7 @@ func Verify(api frontend.API, sig Signature, msg frontend.Variable, pubKey Publi
 		msg,
 	}
 
-	hash, err := mimc.NewMiMC("seed", pubKey.Curve.ID, api)
+	hash, err := mimc.NewMiMC("seed", api)
 	if err != nil {
 		return err
 	}

--- a/std/signature/eddsa/eddsa_test.go
+++ b/std/signature/eddsa/eddsa_test.go
@@ -196,22 +196,22 @@ func TestEddsa(t *testing.T) {
 		// verification with the correct Message
 		{
 			var witness eddsaCircuit
-			witness.Message.Assign(frMsg)
+			witness.Message = (frMsg)
 
 			pubkeyAx, pubkeyAy := parsePoint(id, pubKey.Bytes())
 			var pbAx, pbAy big.Int
 			pbAx.SetBytes(pubkeyAx)
 			pbAy.SetBytes(pubkeyAy)
-			witness.PublicKey.A.X.Assign(pubkeyAx)
-			witness.PublicKey.A.Y.Assign(pubkeyAy)
+			witness.PublicKey.A.X = (pubkeyAx)
+			witness.PublicKey.A.Y = (pubkeyAy)
 
 			// sigRx, sigRy, sigS1, sigS2 := parseSignature(id, signature)
 			sigRx, sigRy, sigS := parseSignature(id, signature)
-			witness.Signature.R.X.Assign(sigRx)
-			witness.Signature.R.Y.Assign(sigRy)
-			// witness.Signature.S1.Assign(sigS1)
-			// witness.Signature.S2.Assign(sigS2)
-			witness.Signature.S.Assign(sigS)
+			witness.Signature.R.X = (sigRx)
+			witness.Signature.R.Y = (sigRy)
+			// witness.Signature.S1 = (sigS1)
+			// witness.Signature.S2 = (sigS2)
+			witness.Signature.S = (sigS)
 
 			assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(id))
 		}
@@ -219,17 +219,17 @@ func TestEddsa(t *testing.T) {
 		// verification with incorrect Message
 		{
 			var witness eddsaCircuit
-			witness.Message.Assign("44717650746155748460101257525078853138837311576962212923649547644148297035979")
+			witness.Message = ("44717650746155748460101257525078853138837311576962212923649547644148297035979")
 
 			pubkeyAx, pubkeyAy := parsePoint(id, pubKey.Bytes())
-			witness.PublicKey.A.X.Assign(pubkeyAx)
-			witness.PublicKey.A.Y.Assign(pubkeyAy)
+			witness.PublicKey.A.X = (pubkeyAx)
+			witness.PublicKey.A.Y = (pubkeyAy)
 
 			// sigRx, sigRy, sigS1, sigS2 := parseSignature(id, signature)
 			sigRx, sigRy, sigS := parseSignature(id, signature)
-			witness.Signature.R.X.Assign(sigRx)
-			witness.Signature.R.Y.Assign(sigRy)
-			witness.Signature.S.Assign(sigS)
+			witness.Signature.R.X = (sigRx)
+			witness.Signature.R.Y = (sigRy)
+			witness.Signature.S = (sigS)
 
 			assert.SolvingFailed(&circuit, &witness, test.WithCurves(id))
 		}

--- a/std/signature/eddsa/eddsa_test.go
+++ b/std/signature/eddsa/eddsa_test.go
@@ -196,22 +196,22 @@ func TestEddsa(t *testing.T) {
 		// verification with the correct Message
 		{
 			var witness eddsaCircuit
-			witness.Message = (frMsg)
+			witness.Message = frMsg
 
 			pubkeyAx, pubkeyAy := parsePoint(id, pubKey.Bytes())
 			var pbAx, pbAy big.Int
 			pbAx.SetBytes(pubkeyAx)
 			pbAy.SetBytes(pubkeyAy)
-			witness.PublicKey.A.X = (pubkeyAx)
-			witness.PublicKey.A.Y = (pubkeyAy)
+			witness.PublicKey.A.X = pubkeyAx
+			witness.PublicKey.A.Y = pubkeyAy
 
 			// sigRx, sigRy, sigS1, sigS2 := parseSignature(id, signature)
 			sigRx, sigRy, sigS := parseSignature(id, signature)
-			witness.Signature.R.X = (sigRx)
-			witness.Signature.R.Y = (sigRy)
-			// witness.Signature.S1 = (sigS1)
-			// witness.Signature.S2 = (sigS2)
-			witness.Signature.S = (sigS)
+			witness.Signature.R.X = sigRx
+			witness.Signature.R.Y = sigRy
+			// witness.Signature.S1 = sigS1
+			// witness.Signature.S2 = sigS2
+			witness.Signature.S = sigS
 
 			assert.SolvingSucceeded(&circuit, &witness, test.WithCurves(id))
 		}
@@ -219,11 +219,11 @@ func TestEddsa(t *testing.T) {
 		// verification with incorrect Message
 		{
 			var witness eddsaCircuit
-			witness.Message = ("44717650746155748460101257525078853138837311576962212923649547644148297035979")
+			witness.Message = "44717650746155748460101257525078853138837311576962212923649547644148297035979"
 
 			pubkeyAx, pubkeyAy := parsePoint(id, pubKey.Bytes())
-			witness.PublicKey.A.X = (pubkeyAx)
-			witness.PublicKey.A.Y = (pubkeyAy)
+			witness.PublicKey.A.X = pubkeyAx
+			witness.PublicKey.A.Y = pubkeyAy
 
 			// sigRx, sigRy, sigS1, sigS2 := parseSignature(id, signature)
 			sigRx, sigRy, sigS := parseSignature(id, signature)

--- a/std/signature/eddsa/eddsa_test.go
+++ b/std/signature/eddsa/eddsa_test.go
@@ -227,9 +227,9 @@ func TestEddsa(t *testing.T) {
 
 			// sigRx, sigRy, sigS1, sigS2 := parseSignature(id, signature)
 			sigRx, sigRy, sigS := parseSignature(id, signature)
-			witness.Signature.R.X = (sigRx)
-			witness.Signature.R.Y = (sigRy)
-			witness.Signature.S = (sigS)
+			witness.Signature.R.X = sigRx
+			witness.Signature.R.Y = sigRy
+			witness.Signature.S = sigS
 
 			assert.SolvingFailed(&circuit, &witness, test.WithCurves(id))
 		}

--- a/std/signature/eddsa/eddsa_test.go
+++ b/std/signature/eddsa/eddsa_test.go
@@ -122,9 +122,9 @@ func parsePoint(id ecc.ID, buf []byte) ([]byte, []byte) {
 	}
 }
 
-func (circuit *eddsaCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *eddsaCircuit) Define(api frontend.API) error {
 
-	params, err := twistededwards.NewEdCurve(curveID)
+	params, err := twistededwards.NewEdCurve(api.CurveID())
 	if err != nil {
 		return err
 	}

--- a/test/assert.go
+++ b/test/assert.go
@@ -320,12 +320,6 @@ func (assert *Assert) Fuzz(circuit frontend.Circuit, fuzzCount int, opts ...func
 					valid += assert.fuzzer(f, circuit, w, b, curve, &opt)
 				}
 			}
-			utils.ResetWitness(w)
-
-			// ensure we're clean for next users.
-			// if we reached that point; compiled work so the circuit was clean and this does nothing
-			// except ensuring the witness cloning / fuzzing didn't mutate circuit
-			utils.ResetWitness(circuit)
 
 			// fmt.Println(reflect.TypeOf(circuit).String(), valid)
 		}

--- a/test/engine.go
+++ b/test/engine.go
@@ -333,6 +333,21 @@ func (e *engine) NewHint(f hint.Function, inputs ...interface{}) frontend.Variab
 	return (result)
 }
 
+// IsConstant returns true if v is a constant known at compile time
+func (e *engine) IsConstant(v frontend.Variable) bool {
+	// TODO @gbotrel this is a problem. if a circuit component has 2 code path depending
+	// on constant parameter, it will never be tested in the test engine
+	// we may want to call IsSolved twice, and return false to all IsConstant on one of the runs
+	return true
+}
+
+// ConstantValue returns the big.Int value of v
+// will panic if v.IsConstant() == false
+func (e *engine) ConstantValue(v frontend.Variable) *big.Int {
+	r := e.toBigInt(v)
+	return &r
+}
+
 func (e *engine) toBigInt(i1 interface{}) big.Int {
 
 	b := frontend.FromInterface(i1)

--- a/test/engine.go
+++ b/test/engine.go
@@ -252,10 +252,6 @@ func (e *engine) IsZero(i1 interface{}) frontend.Variable {
 	return (0)
 }
 
-func (e *engine) Constant(input interface{}) frontend.Variable {
-	return (e.toBigInt(input))
-}
-
 func (e *engine) AssertIsEqual(i1, i2 interface{}) {
 	b1, b2 := e.toBigInt(i1), e.toBigInt(i2)
 	if b1.Cmp(&b2) != 0 {

--- a/test/engine.go
+++ b/test/engine.go
@@ -31,12 +31,6 @@ import (
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/internal/utils"
-
-	fr_bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
-	fr_bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
-	fr_bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
-	fr_bn254 "github.com/consensys/gnark-crypto/ecc/bn254/fr"
-	fr_bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 )
 
 // engine implements frontend.API
@@ -340,10 +334,13 @@ func (e *engine) NewHint(f hint.Function, inputs ...interface{}) frontend.Variab
 }
 
 func (e *engine) toBigInt(i1 interface{}) big.Int {
-	if v1, ok := i1.(frontend.Variable); ok {
-		return witnessValue(v1, e.curveID)
+
+	b := frontend.FromInterface(i1)
+	if _, ok := i1.(frontend.Variable); ok {
+		// we reduce mod q
+		b.Mod(&b, e.modulus())
 	}
-	return frontend.FromInterface(i1)
+	return b
 }
 
 // bitLen returns the number of bits needed to represent a fr.Element
@@ -359,38 +356,4 @@ func (e *engine) mustBeBoolean(b *big.Int) {
 
 func (e *engine) modulus() *big.Int {
 	return e.curveID.Info().Fr.Modulus()
-}
-
-// witnessValue returns the assigned value to the variable
-// the value is converted to a field element (mod curveID base field modulus)
-// then converted to a big.Int
-// if it is not set this panics
-func witnessValue(v frontend.Variable, curveID ecc.ID) big.Int {
-
-	b := frontend.FromInterface(v)
-	switch curveID {
-	case ecc.BLS12_377:
-		var e fr_bls12377.Element
-		e.SetBigInt(&b)
-		e.ToBigIntRegular(&b)
-	case ecc.BLS12_381:
-		var e fr_bls12381.Element
-		e.SetBigInt(&b)
-		e.ToBigIntRegular(&b)
-	case ecc.BN254:
-		var e fr_bn254.Element
-		e.SetBigInt(&b)
-		e.ToBigIntRegular(&b)
-	case ecc.BLS24_315:
-		var e fr_bls24315.Element
-		e.SetBigInt(&b)
-		e.ToBigIntRegular(&b)
-	case ecc.BW6_761:
-		var e fr_bw6761.Element
-		e.SetBigInt(&b)
-		e.ToBigIntRegular(&b)
-	default:
-		panic("curve not implemented")
-	}
-	return b
 }

--- a/test/engine.go
+++ b/test/engine.go
@@ -81,7 +81,7 @@ func IsSolved(circuit, witness frontend.Circuit, curveID ecc.ID, opts ...func(op
 		}
 	}()
 
-	err = c.Define(curveID, e)
+	err = c.Define(e)
 
 	return
 }

--- a/test/engine.go
+++ b/test/engine.go
@@ -373,3 +373,7 @@ func (e *engine) mustBeBoolean(b *big.Int) {
 func (e *engine) modulus() *big.Int {
 	return e.curveID.Info().Fr.Modulus()
 }
+
+func (e *engine) CurveID() ecc.ID {
+	return e.curveID
+}

--- a/test/engine.go
+++ b/test/engine.go
@@ -338,6 +338,7 @@ func (e *engine) toBigInt(i1 interface{}) big.Int {
 	b := frontend.FromInterface(i1)
 	if _, ok := i1.(frontend.Variable); ok {
 		// we reduce mod q
+		// TODO @gbotrel that seems unnecessary; should be done by FromInterface()
 		b.Mod(&b, e.modulus())
 	}
 	return b

--- a/test/engine.go
+++ b/test/engine.go
@@ -83,10 +83,6 @@ func IsSolved(circuit, witness frontend.Circuit, curveID ecc.ID, opts ...func(op
 
 	err = c.Define(curveID, e)
 
-	// we clear the frontend.Variable values, in case we accidentally mutated the circuit
-	// (our clone earlier copied somes slices or pointers)
-	utils.ResetWitness(c)
-
 	return
 }
 
@@ -98,7 +94,7 @@ func (e *engine) Add(i1, i2 interface{}, in ...interface{}) frontend.Variable {
 		b1.Add(&b1, &bn)
 	}
 	b1.Mod(&b1, e.modulus())
-	return frontend.Value(b1)
+	return (b1)
 }
 
 func (e *engine) Sub(i1, i2 interface{}, in ...interface{}) frontend.Variable {
@@ -109,14 +105,14 @@ func (e *engine) Sub(i1, i2 interface{}, in ...interface{}) frontend.Variable {
 		b1.Sub(&b1, &bn)
 	}
 	b1.Mod(&b1, e.modulus())
-	return frontend.Value(b1)
+	return (b1)
 }
 
 func (e *engine) Neg(i1 interface{}) frontend.Variable {
 	b1 := e.toBigInt(i1)
 	b1.Neg(&b1)
 	b1.Mod(&b1, e.modulus())
-	return frontend.Value(b1)
+	return (b1)
 }
 
 func (e *engine) Mul(i1, i2 interface{}, in ...interface{}) frontend.Variable {
@@ -126,7 +122,7 @@ func (e *engine) Mul(i1, i2 interface{}, in ...interface{}) frontend.Variable {
 		bn := e.toBigInt(in[i])
 		b1.Mul(&b1, &bn).Mod(&b1, e.modulus())
 	}
-	return frontend.Value(b1)
+	return (b1)
 }
 
 func (e *engine) Div(i1, i2 interface{}) frontend.Variable {
@@ -135,19 +131,19 @@ func (e *engine) Div(i1, i2 interface{}) frontend.Variable {
 		panic("no inverse")
 	}
 	b2.Mul(&b1, &b2).Mod(&b2, e.modulus())
-	return frontend.Value(b2)
+	return (b2)
 }
 
 func (e *engine) DivUnchecked(i1, i2 interface{}) frontend.Variable {
 	b1, b2 := e.toBigInt(i1), e.toBigInt(i2)
 	if b1.IsUint64() && b2.IsUint64() && b1.Uint64() == 0 && b2.Uint64() == 0 {
-		return frontend.Value(0)
+		return (0)
 	}
 	if b2.ModInverse(&b2, e.modulus()) == nil {
 		panic("no inverse")
 	}
 	b2.Mul(&b1, &b2).Mod(&b2, e.modulus())
-	return frontend.Value(b2)
+	return (b2)
 }
 
 func (e *engine) Inverse(i1 interface{}) frontend.Variable {
@@ -155,7 +151,7 @@ func (e *engine) Inverse(i1 interface{}) frontend.Variable {
 	if b1.ModInverse(&b1, e.modulus()) == nil {
 		panic("no inverse")
 	}
-	return frontend.Value(b1)
+	return (b1)
 }
 
 func (e *engine) ToBinary(i1 interface{}, n ...int) []frontend.Variable {
@@ -174,19 +170,22 @@ func (e *engine) ToBinary(i1 interface{}, n ...int) []frontend.Variable {
 	}
 
 	r := make([]frontend.Variable, nbBits)
+	ri := make([]interface{}, nbBits)
 	for i := 0; i < len(r); i++ {
-		r[i] = frontend.Value(b1.Bit(i))
+		r[i] = (b1.Bit(i))
+		ri[i] = r[i]
 	}
 
-	value := e.toBigInt(e.FromBinary(r...))
+	// this is a sanity check, it should never happen
+	value := e.toBigInt(e.FromBinary(ri...))
 	if value.Cmp(&b1) != 0 {
-		// this is a sanitfy check, it should never happen
+
 		panic(fmt.Sprintf("[ToBinary] decomposing %s (bitLen == %d) with %d bits reconstructs into %s", b1.String(), b1.BitLen(), nbBits, value.String()))
 	}
 	return r
 }
 
-func (e *engine) FromBinary(v ...frontend.Variable) frontend.Variable {
+func (e *engine) FromBinary(v ...interface{}) frontend.Variable {
 	bits := make([]big.Int, len(v))
 	for i := 0; i < len(v); i++ {
 		bits[i] = e.toBigInt(v[i])
@@ -204,7 +203,7 @@ func (e *engine) FromBinary(v ...frontend.Variable) frontend.Variable {
 	}
 	r.Mod(&r, e.modulus())
 
-	return frontend.Value(r)
+	return (r)
 }
 
 func (e *engine) Xor(i1, i2 frontend.Variable) frontend.Variable {
@@ -212,7 +211,7 @@ func (e *engine) Xor(i1, i2 frontend.Variable) frontend.Variable {
 	e.mustBeBoolean(&b1)
 	e.mustBeBoolean(&b2)
 	b1.Xor(&b1, &b2)
-	return frontend.Value(b1)
+	return (b1)
 }
 
 func (e *engine) Or(i1, i2 frontend.Variable) frontend.Variable {
@@ -220,7 +219,7 @@ func (e *engine) Or(i1, i2 frontend.Variable) frontend.Variable {
 	e.mustBeBoolean(&b1)
 	e.mustBeBoolean(&b2)
 	b1.Or(&b1, &b2)
-	return frontend.Value(b1)
+	return (b1)
 }
 
 func (e *engine) And(i1, i2 frontend.Variable) frontend.Variable {
@@ -228,7 +227,7 @@ func (e *engine) And(i1, i2 frontend.Variable) frontend.Variable {
 	e.mustBeBoolean(&b1)
 	e.mustBeBoolean(&b2)
 	b1.And(&b1, &b2)
-	return frontend.Value(b1)
+	return (b1)
 }
 
 // Select if b is true, yields i1 else yields i2
@@ -237,9 +236,9 @@ func (e *engine) Select(b interface{}, i1, i2 interface{}) frontend.Variable {
 	e.mustBeBoolean(&b1)
 
 	if b1.Uint64() == 1 {
-		return frontend.Value(e.toBigInt(i1))
+		return (e.toBigInt(i1))
 	}
-	return frontend.Value(e.toBigInt(i2))
+	return (e.toBigInt(i2))
 }
 
 // IsZero returns 1 if a is zero, 0 otherwise
@@ -247,14 +246,14 @@ func (e *engine) IsZero(i1 interface{}) frontend.Variable {
 	b1 := e.toBigInt(i1)
 
 	if b1.IsUint64() && b1.Uint64() == 0 {
-		return frontend.Value(1)
+		return (1)
 	}
 
-	return frontend.Value(0)
+	return (0)
 }
 
 func (e *engine) Constant(input interface{}) frontend.Variable {
-	return frontend.Value(e.toBigInt(input))
+	return (e.toBigInt(input))
 }
 
 func (e *engine) AssertIsEqual(i1, i2 interface{}) {
@@ -280,7 +279,7 @@ func (e *engine) AssertIsLessOrEqual(v frontend.Variable, bound interface{}) {
 
 	var bValue big.Int
 	if v, ok := bound.(frontend.Variable); ok {
-		bValue = frontend.FromInterface(v.WitnessValue)
+		bValue = frontend.FromInterface(v)
 		bValue.Mod(&bValue, e.modulus())
 	} else {
 		// note: here we don't do a mod reduce on the bound.
@@ -335,12 +334,12 @@ func (e *engine) NewHint(f hint.Function, inputs ...interface{}) frontend.Variab
 		panic("NewHint: " + err.Error())
 	}
 
-	return frontend.Value(result)
+	return (result)
 }
 
 func (e *engine) toBigInt(i1 interface{}) big.Int {
 	if v1, ok := i1.(frontend.Variable); ok {
-		return v1.GetWitnessValue(e.curveID)
+		return frontend.GetWitnessValue(v1, e.curveID)
 	}
 	return frontend.FromInterface(i1)
 }

--- a/test/engine.go
+++ b/test/engine.go
@@ -94,7 +94,7 @@ func (e *engine) Add(i1, i2 interface{}, in ...interface{}) frontend.Variable {
 		b1.Add(&b1, &bn)
 	}
 	b1.Mod(&b1, e.modulus())
-	return (b1)
+	return b1
 }
 
 func (e *engine) Sub(i1, i2 interface{}, in ...interface{}) frontend.Variable {
@@ -105,14 +105,14 @@ func (e *engine) Sub(i1, i2 interface{}, in ...interface{}) frontend.Variable {
 		b1.Sub(&b1, &bn)
 	}
 	b1.Mod(&b1, e.modulus())
-	return (b1)
+	return b1
 }
 
 func (e *engine) Neg(i1 interface{}) frontend.Variable {
 	b1 := e.toBigInt(i1)
 	b1.Neg(&b1)
 	b1.Mod(&b1, e.modulus())
-	return (b1)
+	return b1
 }
 
 func (e *engine) Mul(i1, i2 interface{}, in ...interface{}) frontend.Variable {
@@ -122,7 +122,7 @@ func (e *engine) Mul(i1, i2 interface{}, in ...interface{}) frontend.Variable {
 		bn := e.toBigInt(in[i])
 		b1.Mul(&b1, &bn).Mod(&b1, e.modulus())
 	}
-	return (b1)
+	return b1
 }
 
 func (e *engine) Div(i1, i2 interface{}) frontend.Variable {
@@ -131,19 +131,19 @@ func (e *engine) Div(i1, i2 interface{}) frontend.Variable {
 		panic("no inverse")
 	}
 	b2.Mul(&b1, &b2).Mod(&b2, e.modulus())
-	return (b2)
+	return b2
 }
 
 func (e *engine) DivUnchecked(i1, i2 interface{}) frontend.Variable {
 	b1, b2 := e.toBigInt(i1), e.toBigInt(i2)
 	if b1.IsUint64() && b2.IsUint64() && b1.Uint64() == 0 && b2.Uint64() == 0 {
-		return (0)
+		return 0
 	}
 	if b2.ModInverse(&b2, e.modulus()) == nil {
 		panic("no inverse")
 	}
 	b2.Mul(&b1, &b2).Mod(&b2, e.modulus())
-	return (b2)
+	return b2
 }
 
 func (e *engine) Inverse(i1 interface{}) frontend.Variable {
@@ -151,7 +151,7 @@ func (e *engine) Inverse(i1 interface{}) frontend.Variable {
 	if b1.ModInverse(&b1, e.modulus()) == nil {
 		panic("no inverse")
 	}
-	return (b1)
+	return b1
 }
 
 func (e *engine) ToBinary(i1 interface{}, n ...int) []frontend.Variable {
@@ -203,7 +203,7 @@ func (e *engine) FromBinary(v ...interface{}) frontend.Variable {
 	}
 	r.Mod(&r, e.modulus())
 
-	return (r)
+	return r
 }
 
 func (e *engine) Xor(i1, i2 frontend.Variable) frontend.Variable {
@@ -211,7 +211,7 @@ func (e *engine) Xor(i1, i2 frontend.Variable) frontend.Variable {
 	e.mustBeBoolean(&b1)
 	e.mustBeBoolean(&b2)
 	b1.Xor(&b1, &b2)
-	return (b1)
+	return b1
 }
 
 func (e *engine) Or(i1, i2 frontend.Variable) frontend.Variable {
@@ -219,7 +219,7 @@ func (e *engine) Or(i1, i2 frontend.Variable) frontend.Variable {
 	e.mustBeBoolean(&b1)
 	e.mustBeBoolean(&b2)
 	b1.Or(&b1, &b2)
-	return (b1)
+	return b1
 }
 
 func (e *engine) And(i1, i2 frontend.Variable) frontend.Variable {
@@ -227,7 +227,7 @@ func (e *engine) And(i1, i2 frontend.Variable) frontend.Variable {
 	e.mustBeBoolean(&b1)
 	e.mustBeBoolean(&b2)
 	b1.And(&b1, &b2)
-	return (b1)
+	return b1
 }
 
 // Select if b is true, yields i1 else yields i2
@@ -236,7 +236,7 @@ func (e *engine) Select(b interface{}, i1, i2 interface{}) frontend.Variable {
 	e.mustBeBoolean(&b1)
 
 	if b1.Uint64() == 1 {
-		return (e.toBigInt(i1))
+		return e.toBigInt(i1)
 	}
 	return (e.toBigInt(i2))
 }
@@ -246,7 +246,7 @@ func (e *engine) IsZero(i1 interface{}) frontend.Variable {
 	b1 := e.toBigInt(i1)
 
 	if b1.IsUint64() && b1.Uint64() == 0 {
-		return (1)
+		return 1
 	}
 
 	return (0)

--- a/test/engine_test.go
+++ b/test/engine_test.go
@@ -12,7 +12,7 @@ type hintCircuit struct {
 	A, B frontend.Variable
 }
 
-func (circuit *hintCircuit) Define(curveID ecc.ID, api frontend.API) error {
+func (circuit *hintCircuit) Define(api frontend.API) error {
 	a3b := api.NewHint(hint.IthBit, circuit.A, 3)
 	a25b := api.NewHint(hint.IthBit, circuit.A, 25)
 	aisZero := api.NewHint(hint.IsZero, circuit.A)

--- a/test/engine_test.go
+++ b/test/engine_test.go
@@ -29,15 +29,15 @@ func (circuit *hintCircuit) Define(curveID ecc.ID, api frontend.API) error {
 func TestBuiltinHints(t *testing.T) {
 	for _, curve := range ecc.Implemented() {
 		if err := IsSolved(&hintCircuit{}, &hintCircuit{
-			A: frontend.Value(0b1000),
-			B: frontend.Value(0),
+			A: (0b1000),
+			B: (0),
 		}, curve); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := IsSolved(&hintCircuit{}, &hintCircuit{
-			A: frontend.Value(0b10),
-			B: frontend.Value(1),
+			A: (0b10),
+			B: (1),
 		}, curve); err == nil {
 			t.Fatal("witness shouldn't solve circuit")
 		}

--- a/test/fuzz.go
+++ b/test/fuzz.go
@@ -116,10 +116,16 @@ func fill(w frontend.Circuit, nextValue func() interface{}) {
 	var setHandler parser.LeafHandler = func(visibility compiled.Visibility, name string, tInput reflect.Value) error {
 		if visibility == compiled.Secret || visibility == compiled.Public {
 			v := nextValue()
-			tInput.Set(reflect.ValueOf(frontend.Value(v)))
+			tInput.Set(reflect.ValueOf((v)))
 		}
 		return nil
 	}
 	// this can't error.
-	_ = parser.Visit(w, "", compiled.Unset, setHandler, reflect.TypeOf(frontend.Variable{}))
+	_ = parser.Visit(w, "", compiled.Unset, setHandler, tVariable)
+}
+
+var tVariable reflect.Type
+
+func init() {
+	tVariable = reflect.ValueOf(struct{ A frontend.Variable }{}).FieldByName("A").Type()
 }


### PR DESCRIPTION
This PR addresses few feedbacks.

It unfortunately  introduces some breaking changes in the API.

* `circuit.Define(curveID, api)` is now `circuit.Define(api)` 
* `frontend.Variable` is now an interface. Consequences to that is; 
* `api.Constant(x)` is removed, doing `myVariable = 2` instead of `myVariable = api.Constant(2)` will behaves as expected. 
* `Assign()` method is removed, one can now simply assign witness value like so `witness := &circuit{A: value}` 
* added `api.IsConstant(Variable) -> bool` and `api.ConstantValue(Variable) -> big.Int` which enables circuit developers to write specific version of their circuit depending on if a variable is known at compile time. Note: the big.Int test engine will return true to all values, and may not test all code path against the constraint solver. 

Unsuspected side effect to this PR; `frontend.Compile` is now ~40% faster for Groth16.