### PR TITLE
Mark outputs of boolean operations as booleans

### DIFF
--- a/circuitstats_test.go
+++ b/circuitstats_test.go
@@ -39,6 +39,7 @@ func TestCircuitStatistics(t *testing.T) {
 			check(backend.GROTH16)
 			check(backend.PLONK)
 		}
+
 	}
 
 	// serialize newStats

--- a/debug_test.go
+++ b/debug_test.go
@@ -91,7 +91,7 @@ func TestTraceDivBy0(t *testing.T) {
 	{
 		_, err := getPlonkTrace(&circuit, &witness)
 		assert.Error(err)
-		assert.Contains(err.Error(), "constraint is not satisfied: [div] 2/(-2 + 2) == <unsolved>")
+		assert.Contains(err.Error(), "constraint is not satisfied: [div] 2/0 == <unsolved>")
 		assert.Contains(err.Error(), "(*divBy0Trace).Define")
 		assert.Contains(err.Error(), "debug_test.go:")
 	}
@@ -128,7 +128,7 @@ func TestTraceNotEqual(t *testing.T) {
 	{
 		_, err := getPlonkTrace(&circuit, &witness)
 		assert.Error(err)
-		assert.Contains(err.Error(), "constraint is not satisfied: [assertIsEqual] 1 == (24 + 42)")
+		assert.Contains(err.Error(), "constraint is not satisfied: [assertIsEqual] 1 == 66")
 		assert.Contains(err.Error(), "(*notEqualTrace).Define")
 		assert.Contains(err.Error(), "debug_test.go:")
 	}
@@ -165,7 +165,7 @@ func TestTraceNotBoolean(t *testing.T) {
 	{
 		_, err := getPlonkTrace(&circuit, &witness)
 		assert.Error(err)
-		assert.Contains(err.Error(), "constraint is not satisfied: [assertIsBoolean] (24 + 42) == (0|1)")
+		assert.Contains(err.Error(), "constraint is not satisfied: [assertIsBoolean] 66 == (0|1)")
 		assert.Contains(err.Error(), "(*notBooleanTrace).Define")
 		assert.Contains(err.Error(), "debug_test.go:")
 	}

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/hint"
 )
 
@@ -133,4 +134,7 @@ type API interface {
 
 	// CurveID returns the ecc.ID injected by the compiler
 	CurveID() ecc.ID
+
+	// Backend returns the backend.ID injected by the compiler
+	Backend() backend.ID
 }

--- a/frontend/cs.go
+++ b/frontend/cs.go
@@ -336,6 +336,9 @@ func (cs *constraintSystem) newSecretVariable(name string) compiled.Variable {
 // if a constraint was added, false if the compiled.Variable was already
 // constrained as a boolean
 func (cs *constraintSystem) markBoolean(v compiled.Variable) bool {
+	if v.IsBoolean == nil {
+		v.IsBoolean = new(bool)
+	}
 	if *v.IsBoolean {
 		return false
 	}

--- a/frontend/cs.go
+++ b/frontend/cs.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/internal/backend/compiled"
 )
@@ -36,11 +37,12 @@ import (
 //
 // these interfaces are either Variables (/LinearExpressions) or constants (big.Int, strings, uint, fr.Element)
 type constraintSystem struct {
-	// Variables (aka wires)
-	// virtual variables do not result in a new circuit wire
-	// they may only contain a linear expression
-	public, secret    inputs
-	internal, virtual variables
+
+	// input wires
+	public, secret []string
+
+	// internal wires
+	internal int
 
 	// list of constraints in the form a * b == c
 	// a,b and c being linear expressions
@@ -53,7 +55,7 @@ type constraintSystem struct {
 
 	// Hints
 	mHints            map[int]compiled.Hint // solver hints
-	mHintsConstrained map[int]bool          // marks hints variables constrained status
+	mHintsConstrained map[int]bool          // marks hints compiled.Variables constrained status
 
 	logs      []compiled.LogEntry // list of logs to be printed when solving a circuit. The logs are called with the method Println
 	debugInfo []compiled.LogEntry // list of logs storing information about R1C
@@ -62,30 +64,8 @@ type constraintSystem struct {
 
 	counters []Counter // statistic counters
 
-	curveID ecc.ID
-}
-
-type variables struct {
-	variables []variable
-	booleans  map[int]struct{} // keep track of boolean variables (we constrain them once)
-}
-
-type inputs struct {
-	variables
-	names []string
-}
-
-func (v *inputs) new(cs *constraintSystem, visibility compiled.Visibility, name string) variable {
-	v.names = append(v.names, name)
-	return v.variables.new(cs, visibility)
-}
-
-func (v *variables) new(cs *constraintSystem, visibility compiled.Visibility) variable {
-	idx := len(v.variables)
-	variable := variable{visibility: visibility, id: idx, linExp: cs.LinearExpression(compiled.Pack(idx, compiled.CoeffIdOne, visibility))}
-
-	v.variables = append(v.variables, variable)
-	return variable
+	curveID   ecc.ID
+	backendID backend.ID
 }
 
 // CompiledConstraintSystem ...
@@ -93,7 +73,7 @@ type CompiledConstraintSystem interface {
 	io.WriterTo
 	io.ReaderFrom
 
-	// GetNbVariables return number of internal, secret and public variables
+	// GetNbVariables return number of internal, secret and public compiled.Variables
 	GetNbVariables() (internal, secret, public int)
 	GetNbConstraints() int
 	GetNbCoefficients() int
@@ -110,7 +90,7 @@ type CompiledConstraintSystem interface {
 
 // initialCapacity has quite some impact on frontend performance, especially on large circuits size
 // we may want to add build tags to tune that
-func newConstraintSystem(curveID ecc.ID, initialCapacity ...int) constraintSystem {
+func newConstraintSystem(curveID ecc.ID, backendID backend.ID, initialCapacity ...int) constraintSystem {
 	capacity := 0
 	if len(initialCapacity) > 0 {
 		capacity = initialCapacity[0]
@@ -136,22 +116,18 @@ func newConstraintSystem(curveID ecc.ID, initialCapacity ...int) constraintSyste
 	cs.coeffsIDsInt64[2] = compiled.CoeffIdTwo
 	cs.coeffsIDsInt64[-1] = compiled.CoeffIdMinusOne
 
-	cs.public.variables.variables = make([]variable, 0)
-	cs.public.booleans = make(map[int]struct{})
+	// cs.public.variables = make([]compiled.Variable, 0)
+	// cs.secret.variables = make([]compiled.Variable, 0)
+	// cs.internal = make([]compiled.Variable, 0, capacity)
+	cs.public = make([]string, 1)
+	cs.secret = make([]string, 0)
 
-	cs.secret.variables.variables = make([]variable, 0)
-	cs.secret.booleans = make(map[int]struct{})
-
-	cs.internal.variables = make([]variable, 0, capacity)
-	cs.internal.booleans = make(map[int]struct{})
-
-	cs.virtual.variables = make([]variable, 0)
-	cs.virtual.booleans = make(map[int]struct{})
-
-	// by default the circuit is given on public wire equal to 1
-	cs.public.variables.variables[0] = cs.newPublicVariable("one")
+	// by default the circuit is given a public wire equal to 1
+	// cs.public.variables[0] = cs.newPublicVariable("one")
+	cs.public[0] = "one"
 
 	cs.curveID = curveID
+	cs.backendID = backendID
 
 	return cs
 }
@@ -170,22 +146,23 @@ func newConstraintSystem(curveID ecc.ID, initialCapacity ...int) constraintSyste
 func (cs *constraintSystem) NewHint(f hint.Function, inputs ...interface{}) Variable {
 	// create resulting wire
 	r := cs.newInternalVariable()
+	_, vID, _ := r.LinExp[0].Unpack()
 
 	// mark hint as unconstrained, for now
-	cs.mHintsConstrained[r.id] = false
+	cs.mHintsConstrained[vID] = false
 
 	// now we need to store the linear expressions of the expected input
 	// that will be resolved in the solver
-	hintInputs := make([]compiled.LinearExpression, len(inputs))
+	hintInputs := make([]compiled.Variable, len(inputs))
 
 	// ensure inputs are set and pack them in a []uint64
 	for i, in := range inputs {
-		t := cs.constant(in).(variable)
-		hintInputs[i] = t.linExp.Clone() // TODO @gbotrel check that we need to clone here ?
+		t := cs.constant(in).(compiled.Variable)
+		hintInputs[i] = t.Clone() // TODO @gbotrel check that we need to clone here ?
 	}
 
 	// add the hint to the constraint system
-	cs.mHints[r.id] = compiled.Hint{ID: hint.UUID(f), Inputs: hintInputs}
+	cs.mHints[vID] = compiled.Hint{ID: hint.UUID(f), Inputs: hintInputs}
 
 	return r
 }
@@ -195,33 +172,39 @@ func (cs *constraintSystem) bitLen() int {
 	return cs.curveID.Info().Fr.Bits
 }
 
-func (cs *constraintSystem) one() variable {
-	return cs.public.variables.variables[0]
+func (cs *constraintSystem) one() compiled.Variable {
+	t := false
+	return compiled.Variable{
+		LinExp:    compiled.LinearExpression{compiled.Pack(0, compiled.CoeffIdOne, compiled.Public)},
+		IsBoolean: &t,
+	}
 }
 
-// Term packs a variable and a coeff in a compiled.Term and returns it.
-func (cs *constraintSystem) makeTerm(v variable, coeff *big.Int) compiled.Term {
-	return compiled.Pack(v.id, cs.coeffID(coeff), v.visibility)
+// Term packs a compiled.Variable and a coeff in a compiled.Term and returns it.
+// func (cs *constraintSystem) setCoeff(v compiled.Variable, coeff *big.Int) compiled.Term {
+func (cs *constraintSystem) setCoeff(v compiled.Term, coeff *big.Int) compiled.Term {
+	_, vID, vVis := v.Unpack()
+	return compiled.Pack(vID, cs.coeffID(coeff), vVis)
 }
 
-// newR1C clones the linear expression associated with the variables (to avoid offseting the ID multiple time)
+// newR1C clones the linear expression associated with the compiled.Variables (to avoid offseting the ID multiple time)
 // and return a R1C
 func newR1C(_l, _r, _o Variable) compiled.R1C {
-	l := _l.(variable)
-	r := _r.(variable)
-	o := _o.(variable)
+	l := _l.(compiled.Variable)
+	r := _r.(compiled.Variable)
+	o := _o.(compiled.Variable)
 
 	// interestingly, this is key to groth16 performance.
 	// l * r == r * l == o
 	// but the "l" linear expression is going to end up in the A matrix
 	// the "r" linear expression is going to end up in the B matrix
-	// the less variable we have appearing in the B matrix, the more likely groth16.Setup
+	// the less compiled.Variable we have appearing in the B matrix, the more likely groth16.Setup
 	// is going to produce infinity points in pk.G1.B and pk.G2.B, which will speed up proving time
-	if len(l.linExp) > len(r.linExp) {
+	if len(l.LinExp) > len(r.LinExp) {
 		l, r = r, l
 	}
 
-	return compiled.R1C{L: l.linExp.Clone(), R: r.linExp.Clone(), O: o.linExp.Clone()}
+	return compiled.R1C{L: l.Clone(), R: r.Clone(), O: o.Clone()}
 }
 
 // NbConstraints enables circuit profiling and helps debugging
@@ -231,33 +214,34 @@ func (cs *constraintSystem) NbConstraints() int {
 }
 
 // LinearExpression packs a list of compiled.Term in a compiled.LinearExpression and returns it.
-func (cs *constraintSystem) LinearExpression(terms ...compiled.Term) compiled.LinearExpression {
-	res := make(compiled.LinearExpression, len(terms))
+func (cs *constraintSystem) LinearExpression(terms ...compiled.Term) compiled.Variable {
+	var res compiled.Variable
+	res.LinExp = make([]compiled.Term, len(terms))
 	for i, args := range terms {
-		res[i] = args
+		res.LinExp[i] = args
 	}
 	return res
 }
 
 // reduces redundancy in linear expression
-// It factorizes variable that appears multiple times with != coeff Ids
-// To ensure the determinism in the compile process, variables are stored as public||secret||internal||unset
-// for each visibility, the variables are sorted from lowest ID to highest ID
-func (cs *constraintSystem) reduce(l compiled.LinearExpression) compiled.LinearExpression {
-	// ensure our linear expression is sorted, by visibility and by variable ID
-	if !sort.IsSorted(l) { // may not help
-		sort.Sort(l)
+// It factorizes compiled.Variable that appears multiple times with != coeff Ids
+// To ensure the determinism in the compile process, compiled.Variables are stored as public||secret||internal||unset
+// for each visibility, the compiled.Variables are sorted from lowest ID to highest ID
+func (cs *constraintSystem) reduce(l compiled.Variable) compiled.Variable {
+	// ensure our linear expression is sorted, by visibility and by compiled.Variable ID
+	if !sort.IsSorted(l.LinExp) { // may not help
+		sort.Sort(l.LinExp)
 	}
 
 	var c big.Int
-	for i := 1; i < len(l); i++ {
-		pcID, pvID, pVis := l[i-1].Unpack()
-		ccID, cvID, cVis := l[i].Unpack()
+	for i := 1; i < len(l.LinExp); i++ {
+		pcID, pvID, pVis := l.LinExp[i-1].Unpack()
+		ccID, cvID, cVis := l.LinExp[i].Unpack()
 		if pVis == cVis && pvID == cvID {
 			// we have redundancy
 			c.Add(&cs.coeffs[pcID], &cs.coeffs[ccID])
-			l[i-1].SetCoeffID(cs.coeffID(&c))
-			l = append(l[:i], l[i+1:]...)
+			l.LinExp[i-1].SetCoeffID(cs.coeffID(&c))
+			l.LinExp = append(l.LinExp[:i], l.LinExp[i+1:]...)
 			i--
 		}
 	}
@@ -314,59 +298,52 @@ func (cs *constraintSystem) addConstraint(r1c compiled.R1C, debugID ...int) {
 
 // newInternalVariable creates a new wire, appends it on the list of wires of the circuit, sets
 // the wire's id to the number of wires, and returns it
-func (cs *constraintSystem) newInternalVariable() variable {
-	return cs.internal.new(cs, compiled.Internal)
-}
-
-// newPublicVariable creates a new public variable
-func (cs *constraintSystem) newPublicVariable(name string) variable {
-	return cs.public.new(cs, compiled.Public, name)
-}
-
-// newSecretVariable creates a new secret variable
-func (cs *constraintSystem) newSecretVariable(name string) variable {
-	return cs.secret.new(cs, compiled.Secret, name)
-}
-
-// newVirtualVariable creates a new virtual variable
-// this will not result in a new wire in the constraint system
-// and just represents a linear expression
-func (cs *constraintSystem) newVirtualVariable() variable {
-	return cs.virtual.new(cs, compiled.Virtual)
-}
-
-// markBoolean marks the variable as boolean and return true
-// if a constraint was added, false if the variable was already
-// constrained as a boolean
-func (cs *constraintSystem) markBoolean(v variable) bool {
-	switch v.visibility {
-	case compiled.Internal:
-		if _, ok := cs.internal.booleans[v.id]; ok {
-			return false
-		}
-		cs.internal.booleans[v.id] = struct{}{}
-	case compiled.Secret:
-		if _, ok := cs.secret.booleans[v.id]; ok {
-			return false
-		}
-		cs.secret.booleans[v.id] = struct{}{}
-	case compiled.Public:
-		if _, ok := cs.public.booleans[v.id]; ok {
-			return false
-		}
-		cs.public.booleans[v.id] = struct{}{}
-	case compiled.Virtual:
-		if _, ok := cs.virtual.booleans[v.id]; ok {
-			return false
-		}
-		cs.virtual.booleans[v.id] = struct{}{}
-	default:
-		panic("not implemented")
+func (cs *constraintSystem) newInternalVariable() compiled.Variable {
+	t := false
+	idx := cs.internal
+	cs.internal++
+	return compiled.Variable{
+		LinExp:    compiled.LinearExpression{compiled.Pack(idx, compiled.CoeffIdOne, compiled.Internal)},
+		IsBoolean: &t,
 	}
+}
+
+// newPublicVariable creates a new public compiled.Variable
+func (cs *constraintSystem) newPublicVariable(name string) compiled.Variable {
+	t := false
+	idx := len(cs.public)
+	cs.public = append(cs.public, name)
+	res := compiled.Variable{
+		LinExp:    compiled.LinearExpression{compiled.Pack(idx, compiled.CoeffIdOne, compiled.Public)},
+		IsBoolean: &t,
+	}
+	return res
+}
+
+// newSecretVariable creates a new secret compiled.Variable
+func (cs *constraintSystem) newSecretVariable(name string) compiled.Variable {
+	t := false
+	idx := len(cs.secret)
+	cs.secret = append(cs.secret, name)
+	res := compiled.Variable{
+		LinExp:    compiled.LinearExpression{compiled.Pack(idx, compiled.CoeffIdOne, compiled.Secret)},
+		IsBoolean: &t,
+	}
+	return res
+}
+
+// markBoolean marks the compiled.Variable as boolean and return true
+// if a constraint was added, false if the compiled.Variable was already
+// constrained as a boolean
+func (cs *constraintSystem) markBoolean(v compiled.Variable) bool {
+	if *v.IsBoolean {
+		return false
+	}
+	*v.IsBoolean = true
 	return true
 }
 
-// checkVariables perform post compilation checks on the variables
+// checkVariables perform post compilation checks on the compiled.Variables
 //
 // 1. checks that all user inputs are referenced in at least one constraint
 // 2. checks that all hints are constrained
@@ -374,8 +351,8 @@ func (cs *constraintSystem) checkVariables() error {
 
 	// TODO @gbotrel add unit test for that.
 
-	cptSecret := len(cs.secret.variables.variables)
-	cptPublic := len(cs.public.variables.variables) - 1
+	cptSecret := len(cs.secret)
+	cptPublic := len(cs.public) - 1
 	cptHints := len(cs.mHintsConstrained)
 
 	secretConstrained := make([]bool, cptSecret)
@@ -383,15 +360,15 @@ func (cs *constraintSystem) checkVariables() error {
 	publicConstrained[0] = true
 
 	// for each constraint, we check the linear expressions and mark our inputs / hints as constrained
-	processLinearExpression := func(l compiled.LinearExpression) {
-		for _, t := range l {
+	processLinearExpression := func(l compiled.Variable) {
+		for _, t := range l.LinExp {
 			if t.CoeffID() == compiled.CoeffIdZero {
-				// ignore zero coefficient, as it does not constraint the variable
-				// though, we may want to flag that IF the variable doesn't appear else where
+				// ignore zero coefficient, as it does not constraint the compiled.Variable
+				// though, we may want to flag that IF the compiled.Variable doesn't appear else where
 				continue
 			}
 			visibility := t.VariableVisibility()
-			vID := t.VariableID()
+			vID := t.WireID()
 
 			switch visibility {
 			case compiled.Public:
@@ -431,7 +408,7 @@ func (cs *constraintSystem) checkVariables() error {
 		sbb.WriteByte('\n')
 		for i := 0; i < len(secretConstrained) && cptSecret != 0; i++ {
 			if !secretConstrained[i] {
-				sbb.WriteString(cs.secret.names[i])
+				sbb.WriteString(cs.secret[i])
 				sbb.WriteByte('\n')
 				cptSecret--
 			}
@@ -445,7 +422,7 @@ func (cs *constraintSystem) checkVariables() error {
 		sbb.WriteByte('\n')
 		for i := 0; i < len(publicConstrained) && cptPublic != 0; i++ {
 			if !publicConstrained[i] {
-				sbb.WriteString(cs.public.names[i])
+				sbb.WriteString(cs.public[i])
 				sbb.WriteByte('\n')
 				cptPublic--
 			}
@@ -466,4 +443,8 @@ func (cs *constraintSystem) checkVariables() error {
 
 func (cs *constraintSystem) CurveID() ecc.ID {
 	return cs.curveID
+}
+
+func (cs *constraintSystem) Backend() backend.ID {
+	return cs.backendID
 }

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -274,11 +274,9 @@ func (cs *constraintSystem) Xor(_a, _b Variable) Variable {
 
 	// the formulation used is for easing up the conversion to sparse r1cs
 	res := cs.newInternalVariable()
-	res.IsBoolean = new(bool)
-	*res.IsBoolean = true
+	cs.markBoolean(res)
 	c := cs.Neg(res).(compiled.Variable)
-	c.IsBoolean = new(bool)
-	*c.IsBoolean = false
+	cs.markBoolean(c)
 	c.LinExp = append(c.LinExp, a.LinExp[0], b.LinExp[0])
 	aa := cs.Mul(a, 2)
 	cs.constraints = append(cs.constraints, newR1C(aa, b, c))
@@ -298,11 +296,9 @@ func (cs *constraintSystem) Or(_a, _b Variable) Variable {
 
 	// the formulation used is for easing up the conversion to sparse r1cs
 	res := cs.newInternalVariable()
-	res.IsBoolean = new(bool)
-	*res.IsBoolean = true
+	cs.markBoolean(res)
 	c := cs.Neg(res).(compiled.Variable)
-	c.IsBoolean = new(bool)
-	*c.IsBoolean = false
+	cs.markBoolean(c)
 	c.LinExp = append(c.LinExp, a.LinExp[0], b.LinExp[0])
 	cs.constraints = append(cs.constraints, newR1C(a, b, c))
 
@@ -321,7 +317,7 @@ func (cs *constraintSystem) And(_a, _b Variable) Variable {
 
 	res := cs.Mul(a, b)
 
-	cs.markBoolean(res.(variable))
+	cs.markBoolean(res.(compiled.Variable))
 
 	return res
 }

--- a/frontend/cs_api.go
+++ b/frontend/cs_api.go
@@ -247,6 +247,8 @@ func (cs *constraintSystem) Xor(_a, _b Variable) Variable {
 	v2 := cs.Add(a, b)   // no constraint recorded
 	v2 = cs.Sub(v2, res) // no constraint recorded
 
+	cs.markBoolean(res)
+
 	cs.constraints = append(cs.constraints, newR1C(v1, b, v2))
 
 	return res
@@ -266,6 +268,8 @@ func (cs *constraintSystem) Or(_a, _b Variable) Variable {
 	v1 := cs.Sub(1, a)
 	v2 := cs.Sub(res, a)
 
+	cs.markBoolean(res)
+
 	cs.constraints = append(cs.constraints, newR1C(b, v1, v2))
 
 	return res
@@ -282,6 +286,8 @@ func (cs *constraintSystem) And(_a, _b Variable) Variable {
 	cs.AssertIsBoolean(b)
 
 	res := cs.Mul(a, b)
+
+	cs.markBoolean(res.(variable))
 
 	return res
 }

--- a/frontend/cs_api_test.go
+++ b/frontend/cs_api_test.go
@@ -26,16 +26,30 @@ import (
 
 func TestPrintln(t *testing.T) {
 	// must not panic.
-	cs := newConstraintSystem(ecc.BN254)
-	one := cs.newPublicVariable("one")
+	{
+		cs := newConstraintSystem(ecc.BN254, backend.GROTH16)
+		one := cs.newPublicVariable("one")
 
-	cs.Println(nil)
-	cs.Println(1)
-	cs.Println("a")
-	cs.Println(new(big.Int).SetInt64(2))
-	cs.Println(one)
+		cs.Println(nil)
+		cs.Println(1)
+		cs.Println("a")
+		cs.Println(new(big.Int).SetInt64(2))
+		cs.Println(one)
 
-	cs.Println(nil, 1, "a", new(big.Int), one)
+		cs.Println(nil, 1, "a", new(big.Int), one)
+	}
+	{
+		cs := newConstraintSystem(ecc.BN254, backend.PLONK)
+		one := cs.newPublicVariable("one")
+
+		cs.Println(nil)
+		cs.Println(1)
+		cs.Println("a")
+		cs.Println(new(big.Int).SetInt64(2))
+		cs.Println(one)
+
+		cs.Println(nil, 1, "a", new(big.Int), one)
+	}
 }
 
 // empty circuits
@@ -47,9 +61,17 @@ func TestIsBool1(t *testing.T) {
 
 	var circuit IsBool1
 
-	_, err := Compile(ecc.BN254, backend.GROTH16, &circuit)
-	if err != nil {
-		t.Fatal("compilation failed", err)
+	{
+		_, err := Compile(ecc.BN254, backend.GROTH16, &circuit)
+		if err == nil {
+			t.Fatal("compilation should have failed", err)
+		}
+	}
+	{
+		_, err := Compile(ecc.BN254, backend.GROTH16, &circuit, IgnoreUnconstrainedInputs)
+		if err != nil {
+			t.Fatal("compilation failed", err)
+		}
 	}
 }
 
@@ -57,9 +79,17 @@ func TestIsBool2(t *testing.T) {
 
 	var circuit IsBool2
 
-	_, err := Compile(ecc.BN254, backend.GROTH16, &circuit)
-	if err != nil {
-		t.Fatal("compilation failed", err)
+	{
+		_, err := Compile(ecc.BN254, backend.GROTH16, &circuit)
+		if err == nil {
+			t.Fatal("compilation should have failed", err)
+		}
+	}
+	{
+		_, err := Compile(ecc.BN254, backend.GROTH16, &circuit, IgnoreUnconstrainedInputs)
+		if err != nil {
+			t.Fatal("compilation failed", err)
+		}
 	}
 }
 
@@ -67,9 +97,17 @@ func TestIsBool3(t *testing.T) {
 
 	var circuit IsBool3
 
-	_, err := Compile(ecc.BN254, backend.GROTH16, &circuit)
-	if err != nil {
-		t.Fatal("compilation failed", err)
+	{
+		_, err := Compile(ecc.BN254, backend.GROTH16, &circuit)
+		if err == nil {
+			t.Fatal("compilation should have failed", err)
+		}
+	}
+	{
+		_, err := Compile(ecc.BN254, backend.GROTH16, &circuit, IgnoreUnconstrainedInputs)
+		if err != nil {
+			t.Fatal("compilation failed", err)
+		}
 	}
 }
 

--- a/frontend/cs_debug.go
+++ b/frontend/cs_debug.go
@@ -51,14 +51,14 @@ func (cs *constraintSystem) Println(a ...interface{}) {
 		if i > 0 {
 			sbb.WriteByte(' ')
 		}
-		if v, ok := arg.(variable); ok {
-			v.assertIsSet(cs)
+		if v, ok := arg.(compiled.Variable); ok {
+			v.AssertIsSet()
 
 			sbb.WriteString("%s")
 			// we set limits to the linear expression, so that the log printer
 			// can evaluate it before printing it
 			log.ToResolve = append(log.ToResolve, compiled.TermDelimitor)
-			log.ToResolve = append(log.ToResolve, v.linExp...)
+			log.ToResolve = append(log.ToResolve, v.LinExp...)
 			log.ToResolve = append(log.ToResolve, compiled.TermDelimitor)
 		} else {
 			printArg(&log, &sbb, arg)
@@ -98,11 +98,11 @@ func printArg(log *compiled.LogEntry, sbb *strings.Builder, a interface{}) {
 			sbb.WriteString(", ")
 		}
 
-		v := tValue.Interface().(variable)
+		v := tValue.Interface().(compiled.Variable)
 		// we set limits to the linear expression, so that the log printer
 		// can evaluate it before printing it
 		log.ToResolve = append(log.ToResolve, compiled.TermDelimitor)
-		log.ToResolve = append(log.ToResolve, v.linExp...)
+		log.ToResolve = append(log.ToResolve, v.LinExp...)
 		log.ToResolve = append(log.ToResolve, compiled.TermDelimitor)
 		return nil
 	}
@@ -123,12 +123,12 @@ func (cs *constraintSystem) addDebugInfo(errName string, i ...interface{}) int {
 
 	for _, _i := range i {
 		switch v := _i.(type) {
-		case variable:
-			if len(v.linExp) > 1 {
+		case compiled.Variable:
+			if len(v.LinExp) > 1 {
 				sbb.WriteString("(")
 			}
-			l.WriteLinearExpression(v.linExp, &sbb)
-			if len(v.linExp) > 1 {
+			l.WriteVariable(v, &sbb)
+			if len(v.LinExp) > 1 {
 				sbb.WriteString(")")
 			}
 
@@ -157,7 +157,7 @@ func (cs *constraintSystem) Tag(name string) Tag {
 
 	return Tag{
 		Name: fmt.Sprintf("%s[%s:%d]", name, filepath.Base(file), line),
-		vID:  len(cs.internal.variables),
+		vID:  cs.internal,
 		cID:  len(cs.constraints),
 	}
 }

--- a/frontend/cs_test.go
+++ b/frontend/cs_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
@@ -30,7 +31,7 @@ func TestQuickSort(t *testing.T) {
 	rand := 3
 	for i := 0; i < 12; i++ {
 		toSort[i].SetVariableVisibility(compiled.Secret)
-		toSort[i].SetVariableID(rand)
+		toSort[i].SetWireID(rand)
 		rand += 3
 		rand = rand % 13
 	}
@@ -49,7 +50,7 @@ func TestQuickSort(t *testing.T) {
 
 func TestReduce(t *testing.T) {
 
-	cs := newConstraintSystem(ecc.BN254)
+	cs := newConstraintSystem(ecc.BN254, backend.GROTH16)
 	x := cs.newInternalVariable()
 	y := cs.newInternalVariable()
 	z := cs.newInternalVariable()
@@ -61,47 +62,14 @@ func TestReduce(t *testing.T) {
 	e := cs.Mul(z, 2)
 	f := cs.Mul(z, 2)
 
-	toTest := (cs.Add(a, b, c, d, e, f)).(variable)
+	toTest := (cs.Add(a, b, c, d, e, f)).(compiled.Variable)
 
 	// check sizes
-	if len(toTest.linExp) != 3 {
+	if len(toTest.LinExp) != 3 {
 		t.Fatal("Error reduce, duplicate variables not collapsed")
 	}
 
 }
-
-func TestPopVariable(t *testing.T) {
-
-	sizeAfterPoped := 29
-	nbInternalVars := 10
-
-	le := make([]compiled.Term, 30)
-	for i := 0; i < 10; i++ {
-		le[i] = compiled.Pack(i, 2*i, compiled.Internal)
-		le[10+i] = compiled.Pack(i, 2*(i+10), compiled.Public)
-		le[20+i] = compiled.Pack(i, 2*(i+20), compiled.Secret)
-	}
-
-	for i := 0; i < nbInternalVars; i++ {
-		l, v := popInternalVariable(le, i)
-		_v := le[i]
-		_l := make(compiled.LinearExpression, len(le)-1)
-		copy(_l, le[:i])
-		copy(_l[i:], le[i+1:])
-		if len(l) != sizeAfterPoped {
-			t.Fatal("wrong length")
-		}
-		if _v != v {
-			t.Fatal("wrong variable")
-		}
-		for j := 0; j < sizeAfterPoped; j++ {
-			if _l[j] != l[j] {
-				t.Fatal("wrong lin exp")
-			}
-		}
-	}
-}
-
 func TestFindUnsolvedVariable(t *testing.T) {
 
 	sizeLe := 10
@@ -127,7 +95,7 @@ func TestFindUnsolvedVariable(t *testing.T) {
 	for i := 0; i < totalInternalVariables; i++ {
 		solvedVariables[i] = true
 	}
-	r1c := compiled.R1C{L: l, R: r, O: o}
+	r1c := compiled.R1C{L: compiled.Variable{LinExp: l}, R: compiled.Variable{LinExp: r}, O: compiled.Variable{LinExp: o}}
 
 	for i := 0; i < totalInternalVariables; i++ {
 		solvedVariables[i] = false

--- a/frontend/cs_to_r1cs.go
+++ b/frontend/cs_to_r1cs.go
@@ -36,9 +36,9 @@ func (cs *constraintSystem) toR1CS(curveID ecc.ID) (CompiledConstraintSystem, er
 	// setting up the result
 	res := compiled.R1CS{
 		CS: compiled.CS{
-			NbInternalVariables: len(cs.internal.variables),
-			NbPublicVariables:   len(cs.public.variables.variables),
-			NbSecretVariables:   len(cs.secret.variables.variables),
+			NbInternalVariables: cs.internal,
+			NbPublicVariables:   len(cs.public),
+			NbSecretVariables:   len(cs.secret),
 			DebugInfo:           make([]compiled.LogEntry, len(cs.debugInfo)),
 			Logs:                make([]compiled.LogEntry, len(cs.logs)),
 			MHints:              make(map[int]compiled.Hint, len(cs.mHints)),
@@ -82,11 +82,11 @@ func (cs *constraintSystem) toR1CS(curveID ecc.ID) (CompiledConstraintSystem, er
 	shiftVID := func(oldID int, visibility compiled.Visibility) int {
 		switch visibility {
 		case compiled.Internal:
-			return oldID + len(cs.public.variables.variables) + len(cs.secret.variables.variables)
+			return oldID + len(cs.public) + len(cs.secret)
 		case compiled.Public:
 			return oldID
 		case compiled.Secret:
-			return oldID + len(cs.public.variables.variables)
+			return oldID + len(cs.public)
 		}
 		return oldID
 	}
@@ -95,23 +95,23 @@ func (cs *constraintSystem) toR1CS(curveID ecc.ID) (CompiledConstraintSystem, er
 	offsetIDs := func(l compiled.LinearExpression) {
 		for j := 0; j < len(l); j++ {
 			_, vID, visibility := l[j].Unpack()
-			l[j].SetVariableID(shiftVID(vID, visibility))
+			l[j].SetWireID(shiftVID(vID, visibility))
 		}
 	}
 
 	for i := 0; i < len(res.Constraints); i++ {
-		offsetIDs(res.Constraints[i].L)
-		offsetIDs(res.Constraints[i].R)
-		offsetIDs(res.Constraints[i].O)
+		offsetIDs(res.Constraints[i].L.LinExp)
+		offsetIDs(res.Constraints[i].R.LinExp)
+		offsetIDs(res.Constraints[i].O.LinExp)
 	}
 
 	// we need to offset the ids in the hints
 	for vID, hint := range cs.mHints {
 		k := shiftVID(vID, compiled.Internal)
-		inputs := make([]compiled.LinearExpression, len(hint.Inputs))
+		inputs := make([]compiled.Variable, len(hint.Inputs))
 		copy(inputs, hint.Inputs)
 		for j := 0; j < len(inputs); j++ {
-			offsetIDs(inputs[j])
+			offsetIDs(inputs[j].LinExp)
 		}
 		res.MHints[k] = compiled.Hint{ID: hint.ID, Inputs: inputs}
 	}
@@ -126,7 +126,7 @@ func (cs *constraintSystem) toR1CS(curveID ecc.ID) (CompiledConstraintSystem, er
 
 		for j := 0; j < len(res.Logs[i].ToResolve); j++ {
 			_, vID, visibility := res.Logs[i].ToResolve[j].Unpack()
-			res.Logs[i].ToResolve[j].SetVariableID(shiftVID(vID, visibility))
+			res.Logs[i].ToResolve[j].SetWireID(shiftVID(vID, visibility))
 		}
 	}
 	for i := 0; i < len(cs.debugInfo); i++ {
@@ -138,7 +138,7 @@ func (cs *constraintSystem) toR1CS(curveID ecc.ID) (CompiledConstraintSystem, er
 
 		for j := 0; j < len(res.DebugInfo[i].ToResolve); j++ {
 			_, vID, visibility := res.DebugInfo[i].ToResolve[j].Unpack()
-			res.DebugInfo[i].ToResolve[j].SetVariableID(shiftVID(vID, visibility))
+			res.DebugInfo[i].ToResolve[j].SetWireID(shiftVID(vID, visibility))
 		}
 	}
 

--- a/frontend/cs_to_r1cs_sparse.go
+++ b/frontend/cs_to_r1cs_sparse.go
@@ -53,21 +53,6 @@ type sparseR1CS struct {
 
 	currentR1CDebugID int // mark the current R1C debugID
 
-	// map LinearExpression -> Term. The goal is to not reduce
-	// the same linear expression twice.
-	// key == hashCode(linearExpression) (with collisions)
-	// value == list of tuples {LinearExpression; reduced resulting Term}
-	reducedLE map[uint64][]innerRecord
-
-	// similarly to reducedLE, excepts, the key is the hashCodeNC() which doesn't take
-	// into account the coefficient value of the terms
-	// this is used to detect if a "similar" linear expression was already recorded when splitting
-	reducedLE_ map[uint64]struct{}
-}
-
-type innerRecord struct {
-	t compiled.Term
-	l compiled.LinearExpression
 }
 
 var bOne = new(big.Int).SetInt64(1)
@@ -78,9 +63,9 @@ func (cs *constraintSystem) toSparseR1CS(curveID ecc.ID) (CompiledConstraintSyst
 		constraintSystem: cs,
 		ccs: compiled.SparseR1CS{
 			CS: compiled.CS{
-				NbInternalVariables: len(cs.internal.variables),
-				NbPublicVariables:   len(cs.public.variables.variables) - 1, // the ONE_WIRE is discarded in PlonK
-				NbSecretVariables:   len(cs.secret.variables.variables),
+				NbInternalVariables: cs.internal,
+				NbPublicVariables:   len(cs.public) - 1, // the ONE_WIRE is discarded in PlonK
+				NbSecretVariables:   len(cs.secret),
 				DebugInfo:           make([]compiled.LogEntry, len(cs.debugInfo)),
 				Logs:                make([]compiled.LogEntry, len(cs.logs)),
 				MDebug:              make(map[int]int),
@@ -89,11 +74,9 @@ func (cs *constraintSystem) toSparseR1CS(curveID ecc.ID) (CompiledConstraintSyst
 			},
 			Constraints: make([]compiled.SparseR1C, 0, len(cs.constraints)),
 		},
-		solvedVariables:      make([]bool, len(cs.internal.variables), len(cs.internal.variables)*2),
-		scsInternalVariables: len(cs.internal.variables),
+		solvedVariables:      make([]bool, cs.internal, cs.internal*2),
+		scsInternalVariables: cs.internal,
 		currentR1CDebugID:    -1,
-		reducedLE:            make(map[uint64][]innerRecord, len(cs.internal.variables)),
-		reducedLE_:           make(map[uint64]struct{}, len(cs.internal.variables)),
 	}
 
 	// logs, debugInfo and hints are copied, the only thing that will change
@@ -115,7 +98,8 @@ func (cs *constraintSystem) toSparseR1CS(curveID ecc.ID) (CompiledConstraintSyst
 	// convert the R1C to SparseR1C
 	// in particular, all linear expressions that appear in the R1C
 	// will be split in multiple constraints in the SparseR1C
-	for i := 0; i < len(cs.constraints); i++ {
+	var i int
+	for i = 0; i < len(cs.constraints); i++ {
 		// we set currentR1CDebugID to the debugInfo ID corresponding to the R1C we're processing
 		// if present. All constraints created throuh addConstraint will add a new mapping
 		if dID, ok := cs.mDebug[i]; ok {
@@ -127,6 +111,7 @@ func (cs *constraintSystem) toSparseR1CS(curveID ecc.ID) (CompiledConstraintSyst
 		Δc := len(res.ccs.Constraints)
 		Δv := res.scsInternalVariables
 
+		// res.r1cToSparseR1C(cs.constraints[i])
 		res.r1cToSparseR1C(cs.constraints[i])
 
 		Δc = len(res.ccs.Constraints) - Δc - 1 // interested in newly added constraints only
@@ -167,7 +152,7 @@ func (cs *constraintSystem) toSparseR1CS(curveID ecc.ID) (CompiledConstraintSyst
 			t.SetVariableVisibility(compiled.Virtual)
 			return
 		}
-		t.SetVariableID(shiftVID(vID, visibility))
+		t.SetWireID(shiftVID(vID, visibility))
 	}
 
 	// offset the IDs of all constraints so that the variables are
@@ -209,11 +194,11 @@ func (cs *constraintSystem) toSparseR1CS(curveID ecc.ID) (CompiledConstraintSyst
 	// we need to offset the ids in the hints
 	for vID, hint := range cs.mHints {
 		k := shiftVID(vID, compiled.Internal)
-		inputs := make([]compiled.LinearExpression, len(hint.Inputs))
+		inputs := make([]compiled.Variable, len(hint.Inputs))
 		copy(inputs, hint.Inputs)
 		for j := 0; j < len(inputs); j++ {
-			for k := 0; k < len(inputs[j]); k++ {
-				offsetTermID(&inputs[j][k])
+			for k := 0; k < len(inputs[j].LinExp); k++ {
+				offsetTermID(&inputs[j].LinExp[k])
 			}
 		}
 		res.ccs.MHints[k] = compiled.Hint{ID: hint.ID, Inputs: inputs}
@@ -257,215 +242,25 @@ func (cs *constraintSystem) toSparseR1CS(curveID ecc.ID) (CompiledConstraintSyst
 // slice hold the record of which variables have been solved.
 func findUnsolvedVariable(r1c compiled.R1C, solvedVariables []bool) (int, int) {
 	// find the variable to solve among L,R,O. pos=0,1,2 corresponds to left,right,o.
-	for i := 0; i < len(r1c.L); i++ {
-		_, vID, visibility := r1c.L[i].Unpack()
+	for i := 0; i < len(r1c.L.LinExp); i++ {
+		_, vID, visibility := r1c.L.LinExp[i].Unpack()
 		if visibility == compiled.Internal && !solvedVariables[vID] {
 			return 0, vID
 		}
 	}
-	for i := 0; i < len(r1c.R); i++ {
-		_, vID, visibility := r1c.R[i].Unpack()
+	for i := 0; i < len(r1c.R.LinExp); i++ {
+		_, vID, visibility := r1c.R.LinExp[i].Unpack()
 		if visibility == compiled.Internal && !solvedVariables[vID] {
 			return 1, vID
 		}
 	}
-	for i := 0; i < len(r1c.O); i++ {
-		_, vID, visibility := r1c.O[i].Unpack()
+	for i := 0; i < len(r1c.O.LinExp); i++ {
+		_, vID, visibility := r1c.O.LinExp[i].Unpack()
 		if visibility == compiled.Internal && !solvedVariables[vID] {
 			return 2, vID
 		}
 	}
 	return -1, -1
-}
-
-// returns l with the term (id+coef) holding the id-th variable removed
-// No side effects on l.
-func popInternalVariable(l compiled.LinearExpression, id int) (compiled.LinearExpression, compiled.Term) {
-	var t compiled.Term
-	_l := make([]compiled.Term, len(l)-1)
-	c := 0
-	for i := 0; i < len(l); i++ {
-		v := l[i]
-		if v.VariableVisibility() == compiled.Internal && v.VariableID() == id {
-			t = v
-			continue
-		}
-		_l[c] = v
-		c++
-	}
-	return _l, t
-}
-
-// as computeGCD, except, it fills the intermediate values such that gcds[i] == gcd(l[:i])
-func (scs *sparseR1CS) computeGCDs(l compiled.LinearExpression, gcds []*big.Int) {
-	mustNeg := scs.coeffs[l[0].CoeffID()].Sign() == -1
-
-	gcds[0].Set(&scs.coeffs[l[0].CoeffID()])
-	if mustNeg {
-		gcds[0].Neg(gcds[0])
-	}
-
-	for i := 1; i < len(l); i++ {
-		cID := l[i].CoeffID()
-
-		if gcds[i-1].IsUint64() {
-			// can be 0 or 1
-			prev := gcds[i-1].Uint64()
-			if prev == 0 {
-				gcds[i].Abs(&scs.coeffs[cID])
-				continue
-			} else if prev == 1 {
-				// set the rest to 1.
-				for ; i < len(l); i++ {
-					gcds[i].SetUint64(1)
-				}
-				continue
-			}
-		}
-
-		// we  check coeffID here for 1 or minus 1
-		if cID == compiled.CoeffIdMinusOne || cID == compiled.CoeffIdOne {
-			gcds[i].SetUint64(1)
-			continue
-		}
-
-		if cID == compiled.CoeffIdZero {
-			gcds[i].Set(gcds[i-1])
-			continue
-		}
-
-		// we compute the gcd.
-		gcds[i].GCD(nil, nil, gcds[i-1], &scs.coeffs[cID])
-	}
-	if mustNeg {
-		for i := 1; i < len(l); i++ {
-			gcds[i].Neg(gcds[i])
-		}
-	}
-
-}
-
-// returns ( b/computeGCD(b...), computeGCD(b...) )
-// if gcd is != 0 and gcd != 1, returns true
-func (scs *sparseR1CS) computeGCD(l compiled.LinearExpression, gcd *big.Int) {
-	mustNeg := scs.coeffs[l[0].CoeffID()].Sign() == -1
-
-	// fast path: if any of the coeffs is 1 or -1, no need to compute the GCD
-	if hasOnes(l) {
-		if mustNeg {
-			gcd.SetInt64(-1)
-			return
-		}
-		gcd.SetUint64(1)
-		return
-	}
-
-	gcd.SetUint64(0)
-	var i int
-	for i = 0; i < len(l); i++ {
-		cID := l[i].CoeffID()
-		if cID == compiled.CoeffIdZero {
-			continue
-		}
-		gcd.Set(&scs.coeffs[cID])
-		break
-	}
-
-	for ; i < len(l); i++ {
-		cID := l[i].CoeffID()
-		if cID == compiled.CoeffIdZero {
-			continue
-		}
-		other := &scs.coeffs[cID]
-
-		gcd.GCD(nil, nil, gcd, other)
-		if gcd.IsUint64() && gcd.Uint64() == 1 {
-			break
-		}
-	}
-
-	if mustNeg {
-		// ensure the gcd doesn't depend on the sign
-		gcd.Neg(gcd)
-	}
-
-}
-
-// return true if linear expression contains one or minusOne coefficients
-func hasOnes(l compiled.LinearExpression) bool {
-	for i := 0; i < len(l); i++ {
-		cID := l[i].CoeffID()
-		if cID == compiled.CoeffIdMinusOne || cID == compiled.CoeffIdOne {
-			return true
-		}
-	}
-	return false
-}
-
-// divides all coefficients in l by divisor
-// if divisor == 0 or divisor == 1, returns l
-func (scs *sparseR1CS) divideLinearExpression(l, r compiled.LinearExpression, divisor *big.Int) compiled.LinearExpression {
-	if divisor.IsUint64() && (divisor.Uint64() == 0 || divisor.Uint64() == 1) {
-		return l
-	}
-
-	// copy linear expression
-	if r == nil {
-		r = make(compiled.LinearExpression, len(l))
-	}
-	copy(r, l)
-
-	// new coeff
-	lambda := bigIntPool.Get().(*big.Int)
-
-	if divisor.IsInt64() && divisor.Int64() == -1 {
-		for i := 0; i < len(r); i++ {
-			cID := r[i].CoeffID()
-			if cID == compiled.CoeffIdZero {
-				continue
-			}
-			lambda.Neg(&scs.coeffs[cID])
-			r[i].SetCoeffID(scs.coeffID(lambda))
-		}
-		bigIntPool.Put(lambda)
-		return r
-	}
-
-	for i := 0; i < len(r); i++ {
-		cID := r[i].CoeffID()
-		if cID == compiled.CoeffIdZero {
-			continue
-		}
-		// we use Quo here instead of Div, as we know there is no remainder
-		lambda.Quo(&scs.coeffs[cID], divisor)
-		r[i].SetCoeffID(scs.coeffID(lambda))
-	}
-
-	bigIntPool.Put(lambda)
-	return r
-}
-
-// pops the constant associated to the one_wire in the cs, which will become
-// a constant in a PLONK constraint.
-//
-// Returns the reduced linear expression and the ID of the coeff corresponding to the constant term (in cs.coeffs).
-// If there is no constant term, the id is 0 (the 0-th entry is reserved for this purpose).
-//
-// ex: if l = <expr> + k1*ONE_WIRE the function returns <expr>, k1.
-func (scs *sparseR1CS) popConstantTerm(l compiled.LinearExpression) (compiled.LinearExpression, big.Int) {
-
-	const idOneWire = 0
-
-	for i := 0; i < len(l); i++ {
-		if l[i].VariableID() == idOneWire && l[i].VariableVisibility() == compiled.Public {
-			lCopy := make(compiled.LinearExpression, len(l)-1)
-			copy(lCopy, l[:i])
-			copy(lCopy[i:], l[i+1:])
-			return lCopy, scs.coeffs[l[i].CoeffID()]
-		}
-	}
-
-	return l, big.Int{}
 }
 
 // newTerm creates a new term =coeff*new_variable and records it in the scs
@@ -493,16 +288,16 @@ func (scs *sparseR1CS) newTerm(coeff *big.Int, idCS ...int) compiled.Term {
 func (scs *sparseR1CS) addConstraint(c compiled.SparseR1C) {
 	// ensure wire(L) == wire(M[0]) && wire(R) == wire(M[1])
 	if c.L == 0 {
-		c.L.SetVariableID(c.M[0].VariableID())
+		c.L.SetWireID(c.M[0].WireID())
 	}
 	if c.R == 0 {
-		c.R.SetVariableID(c.M[1].VariableID())
+		c.R.SetWireID(c.M[1].WireID())
 	}
 	if c.M[0] == 0 {
-		c.M[0].SetVariableID(c.L.VariableID())
+		c.M[0].SetWireID(c.L.WireID())
 	}
 	if c.M[1] == 0 {
-		c.M[1].SetVariableID(c.R.VariableID())
+		c.M[1].SetWireID(c.R.WireID())
 	}
 	if scs.currentR1CDebugID != -1 {
 		scs.ccs.MDebug[len(scs.ccs.Constraints)] = scs.currentR1CDebugID
@@ -570,136 +365,31 @@ func (scs *sparseR1CS) multiply(t compiled.Term, c *big.Int) compiled.Term {
 	return t
 }
 
-// l is primitive
-// that is, it has been factorized and we can't divide the coefficients further
-func (scs *sparseR1CS) wasReduced(l compiled.LinearExpression) (compiled.Term, bool) {
-	list, ok := scs.reducedLE[hashCode(l)]
-	if !ok {
-		return 0, false
-	}
-
-	for i := 0; i < len(list); i++ {
-		if list[i].l.Equal(l) {
-			return list[i].t, true
-		}
-	}
-
-	return 0, false
-}
-
-// l is primitive
-// that is, it has been factorized and we can't divide the coefficients further
-func (scs *sparseR1CS) markReduced(l compiled.LinearExpression, t compiled.Term, ncHashCode uint64) {
-	id := hashCode(l)
-	list := scs.reducedLE[id]
-	// here we know l is not already in the list, since the call to wasReduced returned false
-	list = append(list, innerRecord{t: t, l: l})
-	scs.reducedLE[id] = list
-	scs.reducedLE_[ncHashCode] = struct{}{}
-}
-
 // split decomposes the linear expression into a single term
 // for example 2a + 3b + c will be decomposed in
 // v0 := 2a + 3b
 // v1 := v0 + c
 // return v1
-//
-// for optimal output, one need to check if we can't reuse previous decompositions to avoid duplicate constraints
-func (scs *sparseR1CS) split(l compiled.LinearExpression) compiled.Term {
+func (scs *sparseR1CS) split(acc compiled.Term, l compiled.LinearExpression) compiled.Term {
+
 	// floor case
-	if len(l) == 1 {
-		return l[0]
+	if len(l) == 0 {
+		return acc
 	}
 
-	gcd := bigIntPool.Get().(*big.Int)
-
-	// lf = gcd * l
-	// compute the GCD
-	scs.computeGCD(l, gcd)
-
-	// divide if needed l by gcd
-	lf := scs.divideLinearExpression(l, nil, gcd)
-	// if we already recorded lf, the resulting term is gcd * t
-	if t, ok := scs.wasReduced(lf); ok {
-		t.SetCoeffID(scs.coeffID(gcd))
-		bigIntPool.Put(gcd)
-		return t
-	}
-
-	// we create a new resulting term for this linear expression
-	// o correspond to the factorized linear expression lf =  l / gcd
-	// r correspond to the initial linear expression l
-	// we record the factorized linear expression for potential later use
-	o := scs.newTerm(bOne)
-	r := scs.multiply(o, gcd)
-	scs.markReduced(lf, o, hashCodeNC(lf))
-	bigIntPool.Put(gcd)
-
-	var gcds []*big.Int
-	var scratch compiled.LinearExpression
-
-	// idea: find an existing reduction that partially matches l
-
-	// we compute a hash code of the sub expression that takes into account variables id and visibility
-	// but not the coeffID. Since this is computed recursively, we store the result up for each lf[:i]
-	hcs := hashCodeNC_(lf)
-
-	for i := len(lf) - 1; i > 0; i-- {
-
-		// first, we probabilistically check if it's worth it to factorize the sub expression
-		if _, ok := scs.reducedLE_[hcs[i-1]]; !ok {
-			// no need to factorize, no linear expression with same variables exist.
-			continue
-		}
-
-		// we need to factorize, so since gcd (a,b,c) == gcd ( gcd (a,b), c)
-		// we compute all gcds up to lf[:i] to use in future iterations
-		if gcds == nil {
-			gcds = make([]*big.Int, i)
-			for i := 0; i < len(gcds); i++ {
-				gcds[i] = bigIntPool.Get().(*big.Int)
-			}
-			scs.computeGCDs(lf[:i], gcds)
-			scratch = make(compiled.LinearExpression, i)
-		}
-
-		// we divide the linear expression by the gcd, same idea as above
-		// note that lff here reuses scratch space, but we never store it, we just compute
-		// a hash code on it so we're fine
-		lff := scs.divideLinearExpression(lf[:i], scratch[:i], gcds[i-1])
-
-		if t, ok := scs.wasReduced(lff); ok {
-			// the lff was already reduced
-			// so we return r such that
-			// r = (gcd * lff) + reduce(lf[i:])
-			scs.addConstraint(compiled.SparseR1C{
-				L: scs.multiply(t, gcds[i-1]),
-				R: scs.split(lf[i:]),
-				O: scs.negate(o),
-			})
-
-			for i := 0; i < len(gcds); i++ {
-				bigIntPool.Put(gcds[i])
-			}
-
-			return r
-		}
-	}
-
-	for i := 0; i < len(gcds); i++ {
-		bigIntPool.Put(gcds[i])
-	}
-
-	// else we build the reduction starting from l[0]
-	// that is we return a term r such that
-	// r = l[0] + reduced(lf[1:])
+	var a big.Int
+	o := scs.newTerm(a.Neg(bOne))
+	m1, m2 := acc, l[0]
+	m1.SetCoeffID(compiled.CoeffIdZero)
+	m2.SetCoeffID(compiled.CoeffIdZero)
 	scs.addConstraint(compiled.SparseR1C{
-		L: lf[0],
-		R: scs.split(lf[1:]),
-		O: scs.negate(o)},
-	)
-
-	return r
+		L: acc,
+		R: l[0],
+		M: [2]compiled.Term{m1, m2},
+		O: o,
+		K: compiled.CoeffIdZero,
+	})
+	return scs.split(scs.negate(o), l[1:])
 }
 
 func (scs *sparseR1CS) shiftCounters(counters []Counter, cID, Δc, Δv int) {
@@ -716,612 +406,248 @@ func (scs *sparseR1CS) shiftCounters(counters []Counter, cID, Δc, Δv int) {
 	}
 }
 
-// r1cToSparseR1C splits a r1c constraint
 func (scs *sparseR1CS) r1cToSparseR1C(r1c compiled.R1C) {
 
 	// find if the variable to solve is in the left, right, or o linear expression
 	lro, idCS := findUnsolvedVariable(r1c, scs.solvedVariables)
-	if lro == -1 {
-		// this may happen if a constraint contained hint wires, that are marked as solved.
-		// or if we r1c is an assertion (ie it does not yield any output)
-		scs.splitR1C(r1c)
-		return // no variable to solve here.
-	}
 
-	l := r1c.L
-	r := r1c.R
-	o := r1c.O
-	sort.Sort(l)
-	sort.Sort(r)
-	sort.Sort(o)
+	s := len(r1c.R.LinExp)
 
-	// if the unsolved variable in not in o,
-	// ensure that it is in r1c.L
-	if lro == 1 {
-		l, r = r, l
-		lro = 0
-	}
-
-	var (
-		cK big.Int // constant K
-		cS big.Int // constant S (associated with toSolve)
-	)
-	var toSolve compiled.Term
-
-	l, cL := scs.popConstantTerm(l)
-	r, cR := scs.popConstantTerm(r)
-	o, cO := scs.popConstantTerm(o)
-
-	// pop the unsolved wire from the linearexpression
-	if lro == 0 { // unsolved is in L
-		l, toSolve = popInternalVariable(l, idCS)
-	} else { // unsolved is in O
-		o, toSolve = popInternalVariable(o, idCS)
-	}
-
-	// set cS to toSolve coeff
-	cS.Set(&scs.coeffs[toSolve.CoeffID()])
-
-	// cL*cR = toSolve + cO
-	f1 := func() {
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
+	// special case: boolean constraint
+	if *r1c.L.IsBoolean { //} && len(r1c.L.LinExp) == 1 && scs.IsConstant(r1c.L) {
+		lz := r1c.L.LinExp[0]
+		lz.SetCoeffID(compiled.CoeffIdZero)
+		var oz compiled.Term
+		oz.SetCoeffID(compiled.CoeffIdZero)
 		scs.addConstraint(compiled.SparseR1C{
-			K: scs.coeffID(&cK),
-			O: scs.newTerm(cS.Neg(&cS), idCS),
+			L: r1c.L.LinExp[0],
+			R: lz,
+			M: [2]compiled.Term{r1c.L.LinExp[0], scs.negate(r1c.L.LinExp[0])},
+			O: oz,
+			K: compiled.CoeffIdZero,
 		})
+		*r1c.L.IsBoolean = false //-> so next time there's a constraint with the same pattern (L*(a+b)=c), we don't go there
+		return
 	}
 
-	// cL*(r + cR) = toSolve + cO
-	f2 := func() {
-		rt := scs.split(r)
+	// special cases: OR (XY=X+Y-res) and XOR (2XY = X+Y-res)
+	if len(r1c.O.LinExp) == 3 {
 
-		cRT := scs.multiply(rt, &cL)
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
+		cl, _, _ := r1c.L.LinExp[0].Unpack()
+		cr, _, _ := r1c.R.LinExp[0].Unpack()
 
-		scs.addConstraint(compiled.SparseR1C{
-			R: cRT,
-			K: scs.coeffID(&cK),
-			O: scs.newTerm(cS.Neg(&cS), idCS),
-		},
-		)
+		// OR
+		if cl == cr {
+			coeffID := compiled.CoeffIdZero
+			scs.addConstraint(compiled.SparseR1C{
+				L: scs.negate(r1c.L.LinExp[0]),
+				R: scs.negate(r1c.R.LinExp[0]),
+				M: [2]compiled.Term{r1c.L.LinExp[0], r1c.R.LinExp[0]},
+				O: scs.negate(r1c.O.LinExp[0]),
+				K: coeffID,
+			})
+		} else { //XOR (the only remaining possible case)
+			coeffID := compiled.CoeffIdZero
+			_l := r1c.L.LinExp[0]
+			_l.SetCoeffID(cr)
+			_l = scs.negate(_l)
+			scs.addConstraint(compiled.SparseR1C{
+				L: _l,
+				R: scs.negate(r1c.R.LinExp[0]),
+				M: [2]compiled.Term{r1c.L.LinExp[0], r1c.R.LinExp[0]},
+				O: scs.negate(r1c.O.LinExp[0]),
+				K: coeffID,
+			})
+		}
+		return
 	}
 
-	// (l + cL)*cR = toSolve + cO
-	f3 := func() {
-		lt := scs.split(l)
-
-		cRLT := scs.multiply(lt, &cR)
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: cRLT,
-			O: scs.newTerm(cS.Neg(&cS), idCS),
-			K: scs.coeffID(&cK),
-		})
-	}
-
-	// (l + cL)*(r + cR) = toSolve + cO
-	f4 := func() {
-		lt := scs.split(l)
-		rt := scs.split(r)
-
-		cRLT := scs.multiply(lt, &cR)
-		cRT := scs.multiply(rt, &cL)
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: cRLT,
-			R: cRT,
-			M: [2]compiled.Term{lt, rt},
-			K: scs.coeffID(&cK),
-			O: scs.newTerm(cS.Neg(&cS), idCS),
-		})
-	}
-
-	// cL*cR = toSolve + o + cO
-	f5 := func() {
-		ot := scs.split(o)
-
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-		cK.Neg(&cK)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: ot,
-			K: scs.coeffID(&cK),
-			O: scs.newTerm(cS.Neg(&cS), idCS),
-		})
-	}
-
-	// cL*(r + cR) = toSolve + o + cO
-	f6 := func() {
-		rt := scs.split(r)
-		ot := scs.split(o)
-
-		cRT := scs.multiply(rt, &cL)
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-		cK.Neg(&cK)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: scs.negate(ot),
-			R: cRT,
-			K: scs.coeffID(&cK),
-			O: scs.newTerm(cS.Neg(&cS), idCS),
-		})
-	}
-
-	// (l + cL)*cR = toSolve + o + cO
-	f7 := func() {
-		lt := scs.split(l)
-		ot := scs.split(o)
-
-		cRLT := scs.multiply(lt, &cR)
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-		cK.Neg(&cK)
-
-		scs.addConstraint(compiled.SparseR1C{
-			R: scs.negate(ot),
-			L: cRLT,
-			K: scs.coeffID(&cK),
-			O: scs.newTerm(cS.Neg(&cS), idCS),
-		})
-	}
-
-	// (l + cL)*(r + cR) = toSolve + o + cO
-	f8 := func() {
-
-		lt := scs.split(l)
-		rt := scs.split(r)
-		ot := scs.split(o)
-
-		cRLT := scs.multiply(lt, &cR)
-		cRT := scs.multiply(rt, &cL)
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-		cK.Neg(&cK)
-
-		u := scs.newTerm(bOne)
-		scs.addConstraint(compiled.SparseR1C{
-			L: cRLT,
-			R: cRT,
-			M: [2]compiled.Term{lt, rt},
-			K: scs.coeffID(&cK),
-			O: u,
-		})
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: u,
-			R: ot,
-			O: scs.newTerm(&cS, idCS),
-		})
-	}
-
-	// (toSolve + cL)*cR = cO
-	f9 := func() {
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
-		cS.Mul(&cS, &cR)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: scs.newTerm(&cS, idCS),
-			K: scs.coeffID(&cK),
-		})
-	}
-
-	// (toSolve + cL)*(r + cR) = cO
-	f10 := func() {
-		res := scs.newTerm(&cS, idCS)
-
-		rt := scs.split(r)
-		cRT := scs.multiply(rt, &cL)
-		cRes := scs.multiply(res, &cR)
-
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: cRes,
-			R: cRT,
-			M: [2]compiled.Term{res, rt},
-			K: scs.coeffID(&cK),
-		})
-	}
-
-	// (toSolve + l + cL)*cR = cO
-	f11 := func() {
-
-		lt := scs.split(l)
-		lt = scs.multiply(lt, &cR)
-
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
-		cS.Mul(&cS, &cR)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: scs.newTerm(&cS, idCS),
-			R: lt,
-			K: scs.coeffID(&cK),
-		})
-	}
-
-	// (toSolve + l + cL)*(r + cR) = cO
-	// => toSolve*r + toSolve*cR + [ l*r + l*cR +cL*r+cL*cR-cO ]=0
-	f12 := func() {
-		u := scs.newTerm(bOne)
-
-		lt := scs.split(l)
-		rt := scs.split(r)
-		cRLT := scs.multiply(lt, &cR)
-		cRT := scs.multiply(rt, &cL)
-
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: cRLT,
-			R: cRT,
-			M: [2]compiled.Term{lt, rt},
-			O: u,
-			K: scs.coeffID(&cK),
-		})
-
-		res := scs.newTerm(&cS, idCS)
-		cRes := scs.multiply(res, &cR)
-
-		scs.addConstraint(compiled.SparseR1C{
-			R: cRes,
-			M: [2]compiled.Term{res, rt},
-			O: scs.negate(u),
-		})
-	}
-
-	// (toSolve + cL)*cR = o + cO
-	f13 := func() {
-		ot := scs.split(o)
-
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
-		cS.Mul(&cS, &cR)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: scs.newTerm(&cS, idCS),
-			O: scs.negate(ot),
-			K: scs.coeffID(&cK),
-		})
-	}
-
-	// (toSolve + cL)*(r + cR) = o + cO
-	// toSolve*r + toSolve*cR+cL*r+cL*cR-cO-o=0
-	f14 := func() {
-		ot := scs.split(o)
-		res := scs.newTerm(&cS, idCS)
-
-		rt := scs.split(r)
-
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: scs.multiply(res, &cR),
-			R: scs.multiply(rt, &cL),
-			M: [2]compiled.Term{res, rt},
-			O: scs.negate(ot),
-			K: scs.coeffID(&cK),
-		})
-	}
-
-	// (toSolve + l + cL)*cR = o + cO
-	// toSolve*cR + l*cR + cL*cR-cO-o=0
-	f15 := func() {
-
-		ot := scs.split(o)
-		lt := scs.split(l)
-
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
-		cS.Mul(&cS, &cR)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: scs.newTerm(&cS, idCS),
-			R: scs.multiply(lt, &cR),
-			O: scs.negate(ot),
-			K: scs.coeffID(&cK),
-		})
-	}
-
-	// (toSolve + l + cL)*(r + cR) = o + cO
-	// => toSolve*r + toSolve*cR + [ [l*r + l*cR +cL*r+cL*cR-cO]- o ]=0
-	f16 := func() {
-		// [l*r + l*cR +cL*r+cL*cR-cO] + u = 0
-		u := scs.newTerm(bOne)
-
-		lt := scs.split(l)
-		rt := scs.split(r)
-		cRLT := scs.multiply(lt, &cR)
-		cRT := scs.multiply(rt, &cL)
-
-		cK.Mul(&cL, &cR)
-		cK.Sub(&cK, &cO)
-
-		scs.addConstraint(compiled.SparseR1C{
-			L: cRLT,
-			R: cRT,
-			M: [2]compiled.Term{lt, rt},
-			O: u,
-			K: scs.coeffID(&cK),
-		})
-
-		// u+o+v = 0 (v = -u - o = [l*r + l*cR +cL*r+cL*cR-cO] -  o)
-		v := scs.newTerm(bOne)
-		ot := scs.split(o)
-		scs.addConstraint(compiled.SparseR1C{
-			L: u,
-			R: ot,
-			O: v,
-		})
-
-		// toSolve*r + toSolve*cR + v = 0
-		res := scs.newTerm(&cS, idCS)
-		cRes := scs.multiply(res, &cR)
-
-		scs.addConstraint(compiled.SparseR1C{
-			R: cRes,
-			M: [2]compiled.Term{res, rt},
-			O: v,
-		})
-	}
-
-	// we have 16 different cases
-	var s uint8
-	if lro != 0 {
-		s |= 0b1000
-	}
-	if len(o) != 0 {
-		s |= 0b0100
-	}
-	if len(l) != 0 {
-		s |= 0b0010
-	}
-	if len(r) != 0 {
-		s |= 0b0001
-	}
-
-	switch s {
-	case 0b0000:
-		f9()
-	case 0b0001:
-		f10()
-	case 0b0010:
-		f11()
-	case 0b0011:
-		f12()
-	case 0b0100:
-		f13()
-	case 0b0101:
-		f14()
-	case 0b0110:
-		f15()
-	case 0b0111:
-		f16()
-	case 0b1000:
-		f1()
-	case 0b1001:
-		f2()
-	case 0b1010:
-		f3()
-	case 0b1011:
-		f4()
-	case 0b1100:
-		f5()
-	case 0b1101:
-		f6()
-	case 0b1110:
-		f7()
-	case 0b1111:
-		f8()
-	}
-
-}
-
-// splitR1C splits a r1c assertion (meaning that
-// it's a r1c constraint that is not used to solve a variable,
-// like a boolean constraint).
-// (l + cL)*(r + cR) = o + cO
-func (scs *sparseR1CS) splitR1C(r1c compiled.R1C) {
-
-	l := r1c.L
-	r := r1c.R
-	o := r1c.O
-
-	sort.Sort(l)
-	sort.Sort(r)
-	sort.Sort(o)
-
-	l, cL := scs.popConstantTerm(l)
-	r, cR := scs.popConstantTerm(r)
-	o, cO := scs.popConstantTerm(o)
-
-	var cK big.Int
-
-	if len(o) == 0 {
-
-		if len(l) == 0 {
-
-			if len(r) == 0 { // cL*cR = cO (should never happen...)
-
-				cK.Mul(&cL, &cR)
-				cK.Sub(&cK, &cO)
-
-				scs.addConstraint(compiled.SparseR1C{K: scs.coeffID(&cK)})
-
-			} else { // cL*(r + cR) = cO
-
-				//rt := scs.split(0, r)
-				rt := scs.split(r)
-
-				cRLT := scs.multiply(rt, &cL)
-				cK.Mul(&cL, &cR)
-				cK.Sub(&cK, &cO)
-
-				scs.addConstraint(compiled.SparseR1C{R: cRLT, K: scs.coeffID(&cK)})
-			}
-
-		} else {
-
-			if len(r) == 0 { // (l + cL)*cR = cO
-				//lt := scs.split(0, l)
-				lt := scs.split(l)
-
-				cRLT := scs.multiply(lt, &cR)
-				cK.Mul(&cL, &cR)
-				cK.Sub(&cK, &cO)
-
-				scs.addConstraint(compiled.SparseR1C{L: cRLT, K: scs.coeffID(&cK)})
-
-			} else { // (l + cL)*(r + cR) = cO
-
-				// lt := scs.split(0, l)
-				// rt := scs.split(0, r)
-				lt := scs.split(l)
-				rt := scs.split(r)
-
-				cRLT := scs.multiply(lt, &cR)
-				cRT := scs.multiply(rt, &cL)
-				cK.Mul(&cL, &cR)
-				cK.Sub(&cK, &cO)
-
-				scs.addConstraint(compiled.SparseR1C{
-					L: cRLT,
-					R: cRT,
-					M: [2]compiled.Term{lt, rt},
-					K: scs.coeffID(&cK),
-				})
+	// a*b=c case, where a, b, o are of length 1. It's either an assertion
+	// or a operation of type Mul, Div, Inv.
+	if lro == -1 || s == 1 {
+
+		// l, r, o := r1c.L.LinExp[0], r1c.R.LinExp[0], r1c.O.LinExp[0]
+		l := r1c.L.LinExp[0]
+		r := r1c.R.LinExp[0]
+		o := r1c.O.LinExp[0]
+
+		// if the unsolved variable in not in o,
+		// ensure that it is in r1c.L
+		if lro != -1 {
+			scs.solvedVariables[idCS] = true
+			if lro == 1 {
+				l, r = r, l
+				lro = 0
 			}
 		}
 
+		lCoeffID, lID, lVis := l.Unpack()
+		rCoeffID, rID, rVis := r.Unpack()
+		oCoeffID, oID, oVis := o.Unpack()
+
+		lConst := (lVis == compiled.Public && lID == 0)
+		rConst := (rVis == compiled.Public && rID == 0)
+		oConst := (oVis == compiled.Public && oID == 0)
+
+		if lConst && rConst && oConst {
+			var c big.Int
+			c.Mul(&scs.coeffs[lCoeffID], &scs.coeffs[rCoeffID]).
+				Sub(&c, &scs.coeffs[oCoeffID])
+			coeffID := scs.coeffID(&c)
+			var lz, rz, oz compiled.Term
+			lz.SetCoeffID(compiled.CoeffIdZero)
+			rz.SetCoeffID(compiled.CoeffIdZero)
+			oz.SetCoeffID(compiled.CoeffIdZero)
+			scs.addConstraint(compiled.SparseR1C{
+				L: lz,
+				R: rz,
+				M: [2]compiled.Term{lz, rz},
+				O: oz,
+				K: coeffID,
+			})
+		} else if !lConst && rConst && oConst {
+			l := scs.multiply(l, &scs.coeffs[rCoeffID])
+			o = scs.negate(o)
+			oCoeffID, _, _ = o.Unpack()
+			o.SetCoeffID(compiled.CoeffIdZero)
+			var rz, oz compiled.Term
+			rz.SetCoeffID(compiled.CoeffIdZero)
+			oz.SetCoeffID(compiled.CoeffIdZero)
+			scs.addConstraint(compiled.SparseR1C{
+				L: l,
+				R: rz,
+				M: [2]compiled.Term{l, rz},
+				O: o,
+				K: oCoeffID,
+			})
+		} else if lConst && !rConst && oConst {
+			r := scs.multiply(r, &scs.coeffs[lCoeffID])
+			o = scs.negate(o)
+			oCoeffID, _, _ = o.Unpack()
+			o.SetCoeffID(compiled.CoeffIdZero)
+			var lz, oz compiled.Term
+			lz.SetCoeffID(compiled.CoeffIdZero)
+			oz.SetCoeffID(compiled.CoeffIdZero)
+			scs.addConstraint(compiled.SparseR1C{
+				L: lz,
+				R: r,
+				M: [2]compiled.Term{lz, r},
+				O: o,
+				K: oCoeffID,
+			})
+		} else if !lConst && !rConst && oConst {
+			r := scs.multiply(r, &scs.coeffs[lCoeffID])
+			o = scs.negate(o)
+			oCoeffID, _, _ = o.Unpack()
+			o.SetCoeffID(compiled.CoeffIdZero)
+			var rz, lz, oz compiled.Term
+			lz = l
+			rz = r
+			rz.SetCoeffID(compiled.CoeffIdZero)
+			lz.SetCoeffID(compiled.CoeffIdZero)
+			oz.SetCoeffID(compiled.CoeffIdZero)
+			scs.addConstraint(compiled.SparseR1C{
+				L: lz,
+				R: rz,
+				M: [2]compiled.Term{l, r},
+				O: o,
+				K: oCoeffID,
+			})
+		} else if lConst && rConst && !oConst {
+			var c big.Int
+			c.Mul(&scs.coeffs[lCoeffID], &scs.coeffs[rCoeffID])
+			var lz, rz compiled.Term
+			lz.SetCoeffID(compiled.CoeffIdZero)
+			rz.SetCoeffID(compiled.CoeffIdZero)
+			scs.addConstraint(compiled.SparseR1C{
+				L: lz,
+				R: rz,
+				M: [2]compiled.Term{lz, rz},
+				O: scs.negate(o),
+				K: scs.coeffID(&c),
+			})
+		} else if !lConst && rConst && !oConst {
+			l = scs.multiply(l, &scs.coeffs[rCoeffID])
+			var rz compiled.Term
+			rz.SetCoeffID(compiled.CoeffIdZero)
+			scs.addConstraint(compiled.SparseR1C{
+				L: l,
+				R: rz,
+				M: [2]compiled.Term{l, rz},
+				O: scs.negate(o),
+				K: compiled.CoeffIdZero,
+			})
+		} else if lConst && !rConst && !oConst {
+			r = scs.multiply(r, &scs.coeffs[lCoeffID])
+			var lz compiled.Term
+			lz.SetCoeffID(compiled.CoeffIdZero)
+			scs.addConstraint(compiled.SparseR1C{
+				L: lz,
+				R: r,
+				M: [2]compiled.Term{lz, r},
+				O: scs.negate(o),
+				K: compiled.CoeffIdZero,
+			})
+		} else {
+			lz, rz := l, r
+			lz.SetCoeffID(compiled.CoeffIdZero)
+			rz.SetCoeffID(compiled.CoeffIdZero)
+			scs.addConstraint(compiled.SparseR1C{
+				L: lz,
+				R: rz,
+				M: [2]compiled.Term{l, r},
+				O: scs.negate(o),
+				K: compiled.CoeffIdZero,
+			})
+		}
+
+		return
+	}
+
+	// Add, Sub cases, used in PLONK to factorize the linear expressions.
+	scs.solvedVariables[idCS] = true
+
+	var t compiled.Term
+
+	sort.Sort(r1c.R.LinExp)
+
+	// pop the constant term if it exists
+	coeffID, vID, visID := r1c.R.LinExp[0].Unpack()
+
+	firstTermIsPublic := (visID == compiled.Public) && vID == 0
+	if !firstTermIsPublic {
+		coeffID = compiled.CoeffIdZero
+		t = scs.split(r1c.R.LinExp[0], r1c.R.LinExp[1:s-1])
 	} else {
-		if len(l) == 0 {
-
-			if len(r) == 0 { // cL*cR = o + cO
-
-				//ot := scs.split(0, o)
-				ot := scs.split(o)
-
-				cK.Mul(&cL, &cR)
-				cK.Sub(&cK, &cO)
-
-				scs.addConstraint(compiled.SparseR1C{K: scs.coeffID(&cK), O: scs.negate(ot)})
-
-			} else { // cL * (r + cR) = o + cO
-
-				// rt := scs.split(0, r)
-				// ot := scs.split(0, o)
-				rt := scs.split(r)
-				ot := scs.split(o)
-
-				cRT := scs.multiply(rt, &cL)
-				cK.Mul(&cL, &cR)
-				cK.Sub(&cK, &cO)
-
-				scs.addConstraint(compiled.SparseR1C{
-					R: cRT,
-					K: scs.coeffID(&cK),
-					O: scs.negate(ot),
-				})
-			}
-
-		} else {
-			if len(r) == 0 { // (l + cL) * cR = o + cO
-
-				// lt := scs.split(0, l)
-				// ot := scs.split(0, o)
-				lt := scs.split(l)
-				ot := scs.split(o)
-
-				cRLT := scs.multiply(lt, &cR)
-				cK.Mul(&cL, &cR)
-				cK.Sub(&cK, &cO)
-
-				scs.addConstraint(compiled.SparseR1C{
-					L: cRLT,
-					K: scs.coeffID(&cK),
-					O: scs.negate(ot),
-				})
-
-			} else { // (l + cL)*(r + cR) = o + cO
-				// lt := scs.split(0, l)
-				// rt := scs.split(0, r)
-				// ot := scs.split(0, o)
-				lt := scs.split(l)
-				rt := scs.split(r)
-				ot := scs.split(o)
-
-				cRT := scs.multiply(rt, &cL)
-				cRLT := scs.multiply(lt, &cR)
-				cK.Mul(&cR, &cL)
-				cK.Sub(&cK, &cO)
-
-				scs.addConstraint(compiled.SparseR1C{
-					L: cRLT,
-					R: cRT,
-					M: [2]compiled.Term{lt, rt},
-					K: scs.coeffID(&cK),
-					O: scs.negate(ot),
-				})
-			}
+		if s == 2 {
+			t.SetCoeffID(compiled.CoeffIdZero)
+			scs.addConstraint(compiled.SparseR1C{
+				L: t,
+				R: r1c.R.LinExp[s-1],
+				M: [2]compiled.Term{t, r1c.R.LinExp[s-1]},
+				O: scs.negate(r1c.O.LinExp[0]),
+				K: coeffID,
+			})
+			return
 		}
+		t = scs.split(r1c.R.LinExp[1], r1c.R.LinExp[2:s-1])
 	}
+
+	m1, m2 := t, r1c.R.LinExp[s-1]
+	m1.SetCoeffID(compiled.CoeffIdZero)
+	m2.SetCoeffID(compiled.CoeffIdZero)
+	scs.addConstraint(compiled.SparseR1C{
+		L: t,
+		R: r1c.R.LinExp[s-1],
+		M: [2]compiled.Term{m1, m2},
+		O: scs.negate(r1c.O.LinExp[0]),
+		K: coeffID,
+	})
+
 }
 
 var bigIntPool = sync.Pool{
 	New: func() interface{} {
 		return new(big.Int)
 	},
-}
-
-// hashCode returns a fast hash of the linear expression; this is not collision resistant
-// but two SORTED equal linear expressions will have equal hashes.
-//
-// pre conditions: l is sorted
-func hashCode(l compiled.LinearExpression) uint64 {
-	hashcode := uint64(1)
-	for i := 0; i < len(l); i++ {
-		hashcode = hashcode*31 + uint64(l[i])
-	}
-	return hashcode
-}
-
-// same as hashCode but ignore the coeffID
-func hashCodeNC(l compiled.LinearExpression) uint64 {
-	hashcode := uint64(1)
-	for i := 0; i < len(l); i++ {
-		t := l[i]
-		t.SetCoeffID(0)
-		hashcode = hashcode*31 + uint64(t)
-	}
-	return hashcode
-}
-
-// same as hashCodeNC but return all the intermediate hash codes
-func hashCodeNC_(l compiled.LinearExpression) []uint64 {
-	r := make([]uint64, len(l))
-	hashcode := uint64(1)
-	for i := 0; i < len(l); i++ {
-		t := l[i]
-		t.SetCoeffID(0)
-		hashcode = hashcode*31 + uint64(t)
-		r[i] = hashcode
-	}
-	return r
 }

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -59,7 +59,7 @@ func Compile(curveID ecc.ID, zkpID backend.ID, circuit Circuit, opts ...func(opt
 	}
 
 	// build the constraint system (see Circuit.Define)
-	cs, err := buildCS(curveID, circuit, opt.capacity)
+	cs, err := buildCS(curveID, zkpID, circuit, opt.capacity)
 	if err != nil {
 		return nil, err
 	}
@@ -90,10 +90,10 @@ func Compile(curveID ecc.ID, zkpID backend.ID, circuit Circuit, opts ...func(opt
 // buildCS builds the constraint system. It bootstraps the inputs
 // allocations by parsing the circuit's underlying structure, then
 // it builds the constraint system using the Define method.
-func buildCS(curveID ecc.ID, circuit Circuit, initialCapacity ...int) (cs constraintSystem, err error) {
+func buildCS(curveID ecc.ID, zkpID backend.ID, circuit Circuit, initialCapacity ...int) (cs constraintSystem, err error) {
 
 	// instantiate our constraint system
-	cs = newConstraintSystem(curveID, initialCapacity...)
+	cs = newConstraintSystem(curveID, zkpID, initialCapacity...)
 
 	// leaf handlers are called when encoutering leafs in the circuit data struct
 	// leafs are Constraints that need to be initialized in the context of compiling a circuit

--- a/frontend/variable.go
+++ b/frontend/variable.go
@@ -14,14 +14,10 @@ limitations under the License.
 package frontend
 
 import (
-	"errors"
 	"math/big"
 
 	"github.com/consensys/gnark/internal/backend/compiled"
 )
-
-// errNoValue triggered when trying to access a variable that was not allocated
-var errNoValue = errors.New("can't determine API input value")
 
 // Variable represents a variable in the circuit. Any integer type (e.g. int, *big.Int, fr.Element)
 // can be assigned to it. It is also allowed to set a base-10 encoded string representing an integer value.
@@ -31,39 +27,18 @@ type Variable interface{}
 // represents a variable to a circuit, plus the  linear combination leading to it.
 // the linExp is always non empty, the PartialVariabl can be unset. It is set and allocated in the
 // circuit when there is no other choice (to avoid wasting wires doing only linear expressions)
-type variable struct {
-	visibility compiled.Visibility
-	id         int // index of the wire in the corresponding list of wires (private, public or intermediate)
-	linExp     compiled.LinearExpression
-}
+// type variable struct {
+// 	visibility compiled.Visibility
+// 	id         int // index of the wire in the corresponding list of wires (private, public or intermediate)
+// 	linExp     compiled.LinearExpression
+// }
 
-// assertIsSet panics if the variable is unset
-// this may happen if inside a Define we have
-// var a variable
-// cs.Mul(a, 1)
-// since a was not in the circuit struct it is not a secret variable
-func (v *variable) assertIsSet(cs *constraintSystem) {
-
-	if len(v.linExp) == 0 {
-		panic(errNoValue)
-	}
-
-}
-
-// isConstant returns true if the variable is ONE_WIRE * coeff
-func (v *variable) isConstant() bool {
-	if len(v.linExp) != 1 {
-		return false
-	}
-	_, vID, visibility := v.linExp[0].Unpack()
-	return vID == 0 && visibility == compiled.Public
-}
-
-func (v *variable) constantValue(cs *constraintSystem) *big.Int {
+// func (v *variable) constantValue(cs *constraintSystem) *big.Int {
+func (cs *constraintSystem) constantValue(v compiled.Variable) *big.Int {
 	// TODO this might be a good place to start hunting useless allocations.
 	// maybe through a big.Int pool.
-	if !v.isConstant() {
+	if !v.IsConstant() {
 		panic("can't get big.Int value on a non-constant variable")
 	}
-	return new(big.Int).Set(&cs.coeffs[v.linExp[0].CoeffID()])
+	return new(big.Int).Set(&cs.coeffs[v.LinExp[0].CoeffID()])
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -36,14 +36,17 @@ func TestIntegrationAPI(t *testing.T) {
 	sort.Strings(keys)
 
 	for _, k := range keys {
+
 		tData := circuits.Circuits[k]
 		t.Log(k)
 		for _, w := range tData.ValidWitnesses {
 			assert.ProverSucceeded(tData.Circuit, w, test.WithProverOpts(backend.WithHints(tData.HintFunctions...)))
+			// assert.ProverSucceeded(tData.Circuit, w, test.WithProverOpts(backend.WithHints(tData.HintFunctions...)), test.WithBackends(backend.GROTH16))
 		}
 
 		for _, w := range tData.InvalidWitnesses {
 			assert.ProverFailed(tData.Circuit, w, test.WithProverOpts(backend.WithHints(tData.HintFunctions...)))
+			// assert.ProverFailed(tData.Circuit, w, test.WithProverOpts(backend.WithHints(tData.HintFunctions...)), test.WithBackends(backend.GROTH16))
 		}
 
 		// we put that here now, but will be into a proper fuzz target with go1.18

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -163,15 +163,15 @@ func (cs *R1CS) mulByCoeff(res *fr.Element, t compiled.Term) {
 // it instantiates the l, r o part of a R1C
 func (cs *R1CS) instantiateR1C(r compiled.R1C, solution *solution) (a, b, c fr.Element) {
 	var v fr.Element
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		v = solution.computeTerm(t)
 		a.Add(&a, &v)
 	}
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		v = solution.computeTerm(t)
 		b.Add(&b, &v)
 	}
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		v = solution.computeTerm(t)
 		c.Add(&c, &v)
 	}
@@ -197,7 +197,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	var termToCompute compiled.Term
 
 	processTerm := func(t compiled.Term, val *fr.Element, locValue uint8) error {
-		vID := t.VariableID()
+		vID := t.WireID()
 
 		// wire is already computed, we just accumulate in val
 		if solution.solved[vID] {
@@ -224,19 +224,19 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 		return nil
 	}
 
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		if err := processTerm(t, &a, 1); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		if err := processTerm(t, &b, 2); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		if err := processTerm(t, &c, 3); err != nil {
 			return err
 		}
@@ -250,7 +250,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	}
 
 	// we compute the wire value and instantiate it
-	vID := termToCompute.VariableID()
+	vID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -303,11 +303,11 @@ func sub(a, b int) int {
 	return a - b
 }
 
-func toHTML(l compiled.LinearExpression, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
+func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
 	var sbb strings.Builder
-	for i := 0; i < len(l); i++ {
-		termToHTML(l[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l) {
+	for i := 0; i < len(l.LinExp); i++ {
+		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
+		if i+1 < len(l.LinExp) {
 			sbb.WriteString(" + ")
 		}
 	}
@@ -330,7 +330,7 @@ func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHin
 		sbb.WriteString("</span>*")
 	}
 
-	vID := t.VariableID()
+	vID := t.WireID()
 	class := ""
 	switch t.VariableVisibility() {
 	case compiled.Internal:
@@ -361,9 +361,9 @@ func (cs *R1CS) GetNbCoefficients() int {
 	return len(cs.Coefficients)
 }
 
-// CurveID returns curve ID as defined in gnark-crypto (ecc.BLS12-377)
+// CurveID returns curve ID as defined in gnark-crypto (ecc.BW6-761)
 func (cs *R1CS) CurveID() ecc.ID {
-	return ecc.BLS12_377
+	return ecc.BN254
 }
 
 // FrSize return fr.Limbs * 8, size in byte of a fr element

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -128,7 +128,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]f
 // else returns the wire position (L -> 0, R -> 1, O -> 2)
 func (cs *SparseR1CS) computeHints(c compiled.SparseR1C, solution *solution) (int, error) {
 	r := -1
-	lID, rID, oID := c.L.VariableID(), c.R.VariableID(), c.O.VariableID()
+	lID, rID, oID := c.L.WireID(), c.R.WireID(), c.O.WireID()
 
 	if (c.L.CoeffID() != 0 || c.M[0].CoeffID() != 0) && !solution.solved[lID] {
 		// check if it's a hint
@@ -185,14 +185,14 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 	}
 
 	if lro == 0 { // we solve for L: u1L+u2R+u3LR+u4O+k=0 => L(u1+u3R)+u2R+u4O+k = 0
-		if !solution.solved[c.R.VariableID()] {
+		if !solution.solved[c.R.WireID()] {
 			panic("R wire should be instantiated when we solve L")
 		}
 		var u1, u2, u3, den, num, v1, v2 fr.Element
 		u3.Mul(&cs.Coefficients[c.M[0].CoeffID()], &cs.Coefficients[c.M[1].CoeffID()])
 		u1.Set(&cs.Coefficients[c.L.CoeffID()])
 		u2.Set(&cs.Coefficients[c.R.CoeffID()])
-		den.Mul(&u3, &solution.values[c.R.VariableID()]).Add(&den, &u1)
+		den.Mul(&u3, &solution.values[c.R.WireID()]).Add(&den, &u1)
 
 		v1 = solution.computeTerm(c.R)
 		v2 = solution.computeTerm(c.O)
@@ -200,7 +200,7 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 		// TODO find a way to do lazy div (/ batch inversion)
 		num.Div(&num, &den).Neg(&num)
-		solution.set(c.L.VariableID(), num)
+		solution.set(c.L.WireID(), num)
 		return nil
 
 	}

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -122,8 +122,8 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 
 	for i := 0; i < len(h.Inputs); i++ {
 		// input is a linear expression, we must compute the value
-		for j := 0; j < len(h.Inputs[i]); j++ {
-			ciID, viID, visibility := h.Inputs[i][j].Unpack()
+		for j := 0; j < len(h.Inputs[i].LinExp); j++ {
+			ciID, viID, visibility := h.Inputs[i].LinExp[j].Unpack()
 			if visibility == compiled.Virtual {
 				// we have a constant, just take the coefficient value
 				s.coefficients[ciID].ToBigIntRegular(lambda)
@@ -138,7 +138,7 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 				}
 				return errors.New("expected wire to be instantiated while evaluating hint")
 			}
-			v := s.computeTerm(h.Inputs[i][j])
+			v := s.computeTerm(h.Inputs[i].LinExp[j])
 			v.ToBigIntRegular(lambda)
 			inputs[i].Add(inputs[i], lambda)
 		}

--- a/internal/backend/bls12-377/groth16/setup.go
+++ b/internal/backend/bls12-377/groth16/setup.go
@@ -336,14 +336,14 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
-		for _, t := range c.L {
-			accumulate(&A[t.VariableID()], t, &L)
+		for _, t := range c.L.LinExp {
+			accumulate(&A[t.WireID()], t, &L)
 		}
-		for _, t := range c.R {
-			accumulate(&B[t.VariableID()], t, &L)
+		for _, t := range c.R.LinExp {
+			accumulate(&B[t.WireID()], t, &L)
 		}
-		for _, t := range c.O {
-			accumulate(&C[t.VariableID()], t, &L)
+		for _, t := range c.O.LinExp {
+			accumulate(&C[t.WireID()], t, &L)
 		}
 
 		// Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
@@ -491,11 +491,11 @@ func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
 	A := make([]bool, nbWires)
 	B := make([]bool, nbWires)
 	for _, c := range r1cs.Constraints {
-		for _, t := range c.L {
-			A[t.VariableID()] = true
+		for _, t := range c.L.LinExp {
+			A[t.WireID()] = true
 		}
-		for _, t := range c.R {
-			B[t.VariableID()] = true
+		for _, t := range c.R.LinExp {
+			B[t.WireID()] = true
 		}
 	}
 	for i := 0; i < nbWires; i++ {

--- a/internal/backend/bls12-377/plonk/prove.go
+++ b/internal/backend/bls12-377/plonk/prove.go
@@ -482,9 +482,9 @@ func computeLRO(spr *cs.SparseR1CS, pk *ProvingKey, solution []fr.Element) (poly
 	}
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // constraints
-		l[offset+i] = solution[spr.Constraints[i].L.VariableID()]
-		r[offset+i] = solution[spr.Constraints[i].R.VariableID()]
-		o[offset+i] = solution[spr.Constraints[i].O.VariableID()]
+		l[offset+i] = solution[spr.Constraints[i].L.WireID()]
+		r[offset+i] = solution[spr.Constraints[i].R.WireID()]
+		o[offset+i] = solution[spr.Constraints[i].O.WireID()]
 	}
 	offset += len(spr.Constraints)
 

--- a/internal/backend/bls12-377/plonk/setup.go
+++ b/internal/backend/bls12-377/plonk/setup.go
@@ -227,9 +227,9 @@ func buildPermutation(spr *cs.SparseR1CS, pk *ProvingKey) {
 
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // IDs of LRO associated to constraints
-		lro[offset+i] = spr.Constraints[i].L.VariableID()
-		lro[sizeSolution+offset+i] = spr.Constraints[i].R.VariableID()
-		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.VariableID()
+		lro[offset+i] = spr.Constraints[i].L.WireID()
+		lro[sizeSolution+offset+i] = spr.Constraints[i].R.WireID()
+		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.WireID()
 	}
 
 	// init cycle:

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -163,15 +163,15 @@ func (cs *R1CS) mulByCoeff(res *fr.Element, t compiled.Term) {
 // it instantiates the l, r o part of a R1C
 func (cs *R1CS) instantiateR1C(r compiled.R1C, solution *solution) (a, b, c fr.Element) {
 	var v fr.Element
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		v = solution.computeTerm(t)
 		a.Add(&a, &v)
 	}
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		v = solution.computeTerm(t)
 		b.Add(&b, &v)
 	}
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		v = solution.computeTerm(t)
 		c.Add(&c, &v)
 	}
@@ -197,7 +197,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	var termToCompute compiled.Term
 
 	processTerm := func(t compiled.Term, val *fr.Element, locValue uint8) error {
-		vID := t.VariableID()
+		vID := t.WireID()
 
 		// wire is already computed, we just accumulate in val
 		if solution.solved[vID] {
@@ -224,19 +224,19 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 		return nil
 	}
 
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		if err := processTerm(t, &a, 1); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		if err := processTerm(t, &b, 2); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		if err := processTerm(t, &c, 3); err != nil {
 			return err
 		}
@@ -250,7 +250,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	}
 
 	// we compute the wire value and instantiate it
-	vID := termToCompute.VariableID()
+	vID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -303,11 +303,11 @@ func sub(a, b int) int {
 	return a - b
 }
 
-func toHTML(l compiled.LinearExpression, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
+func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
 	var sbb strings.Builder
-	for i := 0; i < len(l); i++ {
-		termToHTML(l[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l) {
+	for i := 0; i < len(l.LinExp); i++ {
+		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
+		if i+1 < len(l.LinExp) {
 			sbb.WriteString(" + ")
 		}
 	}
@@ -330,7 +330,7 @@ func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHin
 		sbb.WriteString("</span>*")
 	}
 
-	vID := t.VariableID()
+	vID := t.WireID()
 	class := ""
 	switch t.VariableVisibility() {
 	case compiled.Internal:
@@ -361,9 +361,9 @@ func (cs *R1CS) GetNbCoefficients() int {
 	return len(cs.Coefficients)
 }
 
-// CurveID returns curve ID as defined in gnark-crypto (ecc.BLS12-381)
+// CurveID returns curve ID as defined in gnark-crypto (ecc.BW6-761)
 func (cs *R1CS) CurveID() ecc.ID {
-	return ecc.BLS12_381
+	return ecc.BN254
 }
 
 // FrSize return fr.Limbs * 8, size in byte of a fr element

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -128,7 +128,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]f
 // else returns the wire position (L -> 0, R -> 1, O -> 2)
 func (cs *SparseR1CS) computeHints(c compiled.SparseR1C, solution *solution) (int, error) {
 	r := -1
-	lID, rID, oID := c.L.VariableID(), c.R.VariableID(), c.O.VariableID()
+	lID, rID, oID := c.L.WireID(), c.R.WireID(), c.O.WireID()
 
 	if (c.L.CoeffID() != 0 || c.M[0].CoeffID() != 0) && !solution.solved[lID] {
 		// check if it's a hint
@@ -185,14 +185,14 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 	}
 
 	if lro == 0 { // we solve for L: u1L+u2R+u3LR+u4O+k=0 => L(u1+u3R)+u2R+u4O+k = 0
-		if !solution.solved[c.R.VariableID()] {
+		if !solution.solved[c.R.WireID()] {
 			panic("R wire should be instantiated when we solve L")
 		}
 		var u1, u2, u3, den, num, v1, v2 fr.Element
 		u3.Mul(&cs.Coefficients[c.M[0].CoeffID()], &cs.Coefficients[c.M[1].CoeffID()])
 		u1.Set(&cs.Coefficients[c.L.CoeffID()])
 		u2.Set(&cs.Coefficients[c.R.CoeffID()])
-		den.Mul(&u3, &solution.values[c.R.VariableID()]).Add(&den, &u1)
+		den.Mul(&u3, &solution.values[c.R.WireID()]).Add(&den, &u1)
 
 		v1 = solution.computeTerm(c.R)
 		v2 = solution.computeTerm(c.O)
@@ -200,7 +200,7 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 		// TODO find a way to do lazy div (/ batch inversion)
 		num.Div(&num, &den).Neg(&num)
-		solution.set(c.L.VariableID(), num)
+		solution.set(c.L.WireID(), num)
 		return nil
 
 	}

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -122,8 +122,8 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 
 	for i := 0; i < len(h.Inputs); i++ {
 		// input is a linear expression, we must compute the value
-		for j := 0; j < len(h.Inputs[i]); j++ {
-			ciID, viID, visibility := h.Inputs[i][j].Unpack()
+		for j := 0; j < len(h.Inputs[i].LinExp); j++ {
+			ciID, viID, visibility := h.Inputs[i].LinExp[j].Unpack()
 			if visibility == compiled.Virtual {
 				// we have a constant, just take the coefficient value
 				s.coefficients[ciID].ToBigIntRegular(lambda)
@@ -138,7 +138,7 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 				}
 				return errors.New("expected wire to be instantiated while evaluating hint")
 			}
-			v := s.computeTerm(h.Inputs[i][j])
+			v := s.computeTerm(h.Inputs[i].LinExp[j])
 			v.ToBigIntRegular(lambda)
 			inputs[i].Add(inputs[i], lambda)
 		}

--- a/internal/backend/bls12-381/groth16/setup.go
+++ b/internal/backend/bls12-381/groth16/setup.go
@@ -336,14 +336,14 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
-		for _, t := range c.L {
-			accumulate(&A[t.VariableID()], t, &L)
+		for _, t := range c.L.LinExp {
+			accumulate(&A[t.WireID()], t, &L)
 		}
-		for _, t := range c.R {
-			accumulate(&B[t.VariableID()], t, &L)
+		for _, t := range c.R.LinExp {
+			accumulate(&B[t.WireID()], t, &L)
 		}
-		for _, t := range c.O {
-			accumulate(&C[t.VariableID()], t, &L)
+		for _, t := range c.O.LinExp {
+			accumulate(&C[t.WireID()], t, &L)
 		}
 
 		// Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
@@ -491,11 +491,11 @@ func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
 	A := make([]bool, nbWires)
 	B := make([]bool, nbWires)
 	for _, c := range r1cs.Constraints {
-		for _, t := range c.L {
-			A[t.VariableID()] = true
+		for _, t := range c.L.LinExp {
+			A[t.WireID()] = true
 		}
-		for _, t := range c.R {
-			B[t.VariableID()] = true
+		for _, t := range c.R.LinExp {
+			B[t.WireID()] = true
 		}
 	}
 	for i := 0; i < nbWires; i++ {

--- a/internal/backend/bls12-381/plonk/prove.go
+++ b/internal/backend/bls12-381/plonk/prove.go
@@ -482,9 +482,9 @@ func computeLRO(spr *cs.SparseR1CS, pk *ProvingKey, solution []fr.Element) (poly
 	}
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // constraints
-		l[offset+i] = solution[spr.Constraints[i].L.VariableID()]
-		r[offset+i] = solution[spr.Constraints[i].R.VariableID()]
-		o[offset+i] = solution[spr.Constraints[i].O.VariableID()]
+		l[offset+i] = solution[spr.Constraints[i].L.WireID()]
+		r[offset+i] = solution[spr.Constraints[i].R.WireID()]
+		o[offset+i] = solution[spr.Constraints[i].O.WireID()]
 	}
 	offset += len(spr.Constraints)
 

--- a/internal/backend/bls12-381/plonk/setup.go
+++ b/internal/backend/bls12-381/plonk/setup.go
@@ -227,9 +227,9 @@ func buildPermutation(spr *cs.SparseR1CS, pk *ProvingKey) {
 
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // IDs of LRO associated to constraints
-		lro[offset+i] = spr.Constraints[i].L.VariableID()
-		lro[sizeSolution+offset+i] = spr.Constraints[i].R.VariableID()
-		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.VariableID()
+		lro[offset+i] = spr.Constraints[i].L.WireID()
+		lro[sizeSolution+offset+i] = spr.Constraints[i].R.WireID()
+		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.WireID()
 	}
 
 	// init cycle:

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -163,15 +163,15 @@ func (cs *R1CS) mulByCoeff(res *fr.Element, t compiled.Term) {
 // it instantiates the l, r o part of a R1C
 func (cs *R1CS) instantiateR1C(r compiled.R1C, solution *solution) (a, b, c fr.Element) {
 	var v fr.Element
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		v = solution.computeTerm(t)
 		a.Add(&a, &v)
 	}
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		v = solution.computeTerm(t)
 		b.Add(&b, &v)
 	}
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		v = solution.computeTerm(t)
 		c.Add(&c, &v)
 	}
@@ -197,7 +197,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	var termToCompute compiled.Term
 
 	processTerm := func(t compiled.Term, val *fr.Element, locValue uint8) error {
-		vID := t.VariableID()
+		vID := t.WireID()
 
 		// wire is already computed, we just accumulate in val
 		if solution.solved[vID] {
@@ -224,19 +224,19 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 		return nil
 	}
 
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		if err := processTerm(t, &a, 1); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		if err := processTerm(t, &b, 2); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		if err := processTerm(t, &c, 3); err != nil {
 			return err
 		}
@@ -250,7 +250,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	}
 
 	// we compute the wire value and instantiate it
-	vID := termToCompute.VariableID()
+	vID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -303,11 +303,11 @@ func sub(a, b int) int {
 	return a - b
 }
 
-func toHTML(l compiled.LinearExpression, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
+func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
 	var sbb strings.Builder
-	for i := 0; i < len(l); i++ {
-		termToHTML(l[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l) {
+	for i := 0; i < len(l.LinExp); i++ {
+		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
+		if i+1 < len(l.LinExp) {
 			sbb.WriteString(" + ")
 		}
 	}
@@ -330,7 +330,7 @@ func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHin
 		sbb.WriteString("</span>*")
 	}
 
-	vID := t.VariableID()
+	vID := t.WireID()
 	class := ""
 	switch t.VariableVisibility() {
 	case compiled.Internal:
@@ -361,9 +361,9 @@ func (cs *R1CS) GetNbCoefficients() int {
 	return len(cs.Coefficients)
 }
 
-// CurveID returns curve ID as defined in gnark-crypto (ecc.BLS24-315)
+// CurveID returns curve ID as defined in gnark-crypto (ecc.BW6-761)
 func (cs *R1CS) CurveID() ecc.ID {
-	return ecc.BLS24_315
+	return ecc.BN254
 }
 
 // FrSize return fr.Limbs * 8, size in byte of a fr element

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -128,7 +128,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]f
 // else returns the wire position (L -> 0, R -> 1, O -> 2)
 func (cs *SparseR1CS) computeHints(c compiled.SparseR1C, solution *solution) (int, error) {
 	r := -1
-	lID, rID, oID := c.L.VariableID(), c.R.VariableID(), c.O.VariableID()
+	lID, rID, oID := c.L.WireID(), c.R.WireID(), c.O.WireID()
 
 	if (c.L.CoeffID() != 0 || c.M[0].CoeffID() != 0) && !solution.solved[lID] {
 		// check if it's a hint
@@ -185,14 +185,14 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 	}
 
 	if lro == 0 { // we solve for L: u1L+u2R+u3LR+u4O+k=0 => L(u1+u3R)+u2R+u4O+k = 0
-		if !solution.solved[c.R.VariableID()] {
+		if !solution.solved[c.R.WireID()] {
 			panic("R wire should be instantiated when we solve L")
 		}
 		var u1, u2, u3, den, num, v1, v2 fr.Element
 		u3.Mul(&cs.Coefficients[c.M[0].CoeffID()], &cs.Coefficients[c.M[1].CoeffID()])
 		u1.Set(&cs.Coefficients[c.L.CoeffID()])
 		u2.Set(&cs.Coefficients[c.R.CoeffID()])
-		den.Mul(&u3, &solution.values[c.R.VariableID()]).Add(&den, &u1)
+		den.Mul(&u3, &solution.values[c.R.WireID()]).Add(&den, &u1)
 
 		v1 = solution.computeTerm(c.R)
 		v2 = solution.computeTerm(c.O)
@@ -200,7 +200,7 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 		// TODO find a way to do lazy div (/ batch inversion)
 		num.Div(&num, &den).Neg(&num)
-		solution.set(c.L.VariableID(), num)
+		solution.set(c.L.WireID(), num)
 		return nil
 
 	}

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -122,8 +122,8 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 
 	for i := 0; i < len(h.Inputs); i++ {
 		// input is a linear expression, we must compute the value
-		for j := 0; j < len(h.Inputs[i]); j++ {
-			ciID, viID, visibility := h.Inputs[i][j].Unpack()
+		for j := 0; j < len(h.Inputs[i].LinExp); j++ {
+			ciID, viID, visibility := h.Inputs[i].LinExp[j].Unpack()
 			if visibility == compiled.Virtual {
 				// we have a constant, just take the coefficient value
 				s.coefficients[ciID].ToBigIntRegular(lambda)
@@ -138,7 +138,7 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 				}
 				return errors.New("expected wire to be instantiated while evaluating hint")
 			}
-			v := s.computeTerm(h.Inputs[i][j])
+			v := s.computeTerm(h.Inputs[i].LinExp[j])
 			v.ToBigIntRegular(lambda)
 			inputs[i].Add(inputs[i], lambda)
 		}

--- a/internal/backend/bls24-315/groth16/setup.go
+++ b/internal/backend/bls24-315/groth16/setup.go
@@ -336,14 +336,14 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
-		for _, t := range c.L {
-			accumulate(&A[t.VariableID()], t, &L)
+		for _, t := range c.L.LinExp {
+			accumulate(&A[t.WireID()], t, &L)
 		}
-		for _, t := range c.R {
-			accumulate(&B[t.VariableID()], t, &L)
+		for _, t := range c.R.LinExp {
+			accumulate(&B[t.WireID()], t, &L)
 		}
-		for _, t := range c.O {
-			accumulate(&C[t.VariableID()], t, &L)
+		for _, t := range c.O.LinExp {
+			accumulate(&C[t.WireID()], t, &L)
 		}
 
 		// Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
@@ -491,11 +491,11 @@ func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
 	A := make([]bool, nbWires)
 	B := make([]bool, nbWires)
 	for _, c := range r1cs.Constraints {
-		for _, t := range c.L {
-			A[t.VariableID()] = true
+		for _, t := range c.L.LinExp {
+			A[t.WireID()] = true
 		}
-		for _, t := range c.R {
-			B[t.VariableID()] = true
+		for _, t := range c.R.LinExp {
+			B[t.WireID()] = true
 		}
 	}
 	for i := 0; i < nbWires; i++ {

--- a/internal/backend/bls24-315/plonk/prove.go
+++ b/internal/backend/bls24-315/plonk/prove.go
@@ -482,9 +482,9 @@ func computeLRO(spr *cs.SparseR1CS, pk *ProvingKey, solution []fr.Element) (poly
 	}
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // constraints
-		l[offset+i] = solution[spr.Constraints[i].L.VariableID()]
-		r[offset+i] = solution[spr.Constraints[i].R.VariableID()]
-		o[offset+i] = solution[spr.Constraints[i].O.VariableID()]
+		l[offset+i] = solution[spr.Constraints[i].L.WireID()]
+		r[offset+i] = solution[spr.Constraints[i].R.WireID()]
+		o[offset+i] = solution[spr.Constraints[i].O.WireID()]
 	}
 	offset += len(spr.Constraints)
 

--- a/internal/backend/bls24-315/plonk/setup.go
+++ b/internal/backend/bls24-315/plonk/setup.go
@@ -227,9 +227,9 @@ func buildPermutation(spr *cs.SparseR1CS, pk *ProvingKey) {
 
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // IDs of LRO associated to constraints
-		lro[offset+i] = spr.Constraints[i].L.VariableID()
-		lro[sizeSolution+offset+i] = spr.Constraints[i].R.VariableID()
-		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.VariableID()
+		lro[offset+i] = spr.Constraints[i].L.WireID()
+		lro[sizeSolution+offset+i] = spr.Constraints[i].R.WireID()
+		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.WireID()
 	}
 
 	// init cycle:

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -163,15 +163,15 @@ func (cs *R1CS) mulByCoeff(res *fr.Element, t compiled.Term) {
 // it instantiates the l, r o part of a R1C
 func (cs *R1CS) instantiateR1C(r compiled.R1C, solution *solution) (a, b, c fr.Element) {
 	var v fr.Element
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		v = solution.computeTerm(t)
 		a.Add(&a, &v)
 	}
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		v = solution.computeTerm(t)
 		b.Add(&b, &v)
 	}
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		v = solution.computeTerm(t)
 		c.Add(&c, &v)
 	}
@@ -197,7 +197,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	var termToCompute compiled.Term
 
 	processTerm := func(t compiled.Term, val *fr.Element, locValue uint8) error {
-		vID := t.VariableID()
+		vID := t.WireID()
 
 		// wire is already computed, we just accumulate in val
 		if solution.solved[vID] {
@@ -224,19 +224,19 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 		return nil
 	}
 
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		if err := processTerm(t, &a, 1); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		if err := processTerm(t, &b, 2); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		if err := processTerm(t, &c, 3); err != nil {
 			return err
 		}
@@ -250,7 +250,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	}
 
 	// we compute the wire value and instantiate it
-	vID := termToCompute.VariableID()
+	vID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -303,11 +303,11 @@ func sub(a, b int) int {
 	return a - b
 }
 
-func toHTML(l compiled.LinearExpression, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
+func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
 	var sbb strings.Builder
-	for i := 0; i < len(l); i++ {
-		termToHTML(l[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l) {
+	for i := 0; i < len(l.LinExp); i++ {
+		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
+		if i+1 < len(l.LinExp) {
 			sbb.WriteString(" + ")
 		}
 	}
@@ -330,7 +330,7 @@ func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHin
 		sbb.WriteString("</span>*")
 	}
 
-	vID := t.VariableID()
+	vID := t.WireID()
 	class := ""
 	switch t.VariableVisibility() {
 	case compiled.Internal:
@@ -361,7 +361,7 @@ func (cs *R1CS) GetNbCoefficients() int {
 	return len(cs.Coefficients)
 }
 
-// CurveID returns curve ID as defined in gnark-crypto (ecc.BN254)
+// CurveID returns curve ID as defined in gnark-crypto (ecc.BW6-761)
 func (cs *R1CS) CurveID() ecc.ID {
 	return ecc.BN254
 }

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -128,7 +128,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]f
 // else returns the wire position (L -> 0, R -> 1, O -> 2)
 func (cs *SparseR1CS) computeHints(c compiled.SparseR1C, solution *solution) (int, error) {
 	r := -1
-	lID, rID, oID := c.L.VariableID(), c.R.VariableID(), c.O.VariableID()
+	lID, rID, oID := c.L.WireID(), c.R.WireID(), c.O.WireID()
 
 	if (c.L.CoeffID() != 0 || c.M[0].CoeffID() != 0) && !solution.solved[lID] {
 		// check if it's a hint
@@ -185,14 +185,14 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 	}
 
 	if lro == 0 { // we solve for L: u1L+u2R+u3LR+u4O+k=0 => L(u1+u3R)+u2R+u4O+k = 0
-		if !solution.solved[c.R.VariableID()] {
+		if !solution.solved[c.R.WireID()] {
 			panic("R wire should be instantiated when we solve L")
 		}
 		var u1, u2, u3, den, num, v1, v2 fr.Element
 		u3.Mul(&cs.Coefficients[c.M[0].CoeffID()], &cs.Coefficients[c.M[1].CoeffID()])
 		u1.Set(&cs.Coefficients[c.L.CoeffID()])
 		u2.Set(&cs.Coefficients[c.R.CoeffID()])
-		den.Mul(&u3, &solution.values[c.R.VariableID()]).Add(&den, &u1)
+		den.Mul(&u3, &solution.values[c.R.WireID()]).Add(&den, &u1)
 
 		v1 = solution.computeTerm(c.R)
 		v2 = solution.computeTerm(c.O)
@@ -200,7 +200,7 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 		// TODO find a way to do lazy div (/ batch inversion)
 		num.Div(&num, &den).Neg(&num)
-		solution.set(c.L.VariableID(), num)
+		solution.set(c.L.WireID(), num)
 		return nil
 
 	}

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -122,8 +122,8 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 
 	for i := 0; i < len(h.Inputs); i++ {
 		// input is a linear expression, we must compute the value
-		for j := 0; j < len(h.Inputs[i]); j++ {
-			ciID, viID, visibility := h.Inputs[i][j].Unpack()
+		for j := 0; j < len(h.Inputs[i].LinExp); j++ {
+			ciID, viID, visibility := h.Inputs[i].LinExp[j].Unpack()
 			if visibility == compiled.Virtual {
 				// we have a constant, just take the coefficient value
 				s.coefficients[ciID].ToBigIntRegular(lambda)
@@ -138,7 +138,7 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 				}
 				return errors.New("expected wire to be instantiated while evaluating hint")
 			}
-			v := s.computeTerm(h.Inputs[i][j])
+			v := s.computeTerm(h.Inputs[i].LinExp[j])
 			v.ToBigIntRegular(lambda)
 			inputs[i].Add(inputs[i], lambda)
 		}

--- a/internal/backend/bn254/groth16/setup.go
+++ b/internal/backend/bn254/groth16/setup.go
@@ -336,14 +336,14 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
-		for _, t := range c.L {
-			accumulate(&A[t.VariableID()], t, &L)
+		for _, t := range c.L.LinExp {
+			accumulate(&A[t.WireID()], t, &L)
 		}
-		for _, t := range c.R {
-			accumulate(&B[t.VariableID()], t, &L)
+		for _, t := range c.R.LinExp {
+			accumulate(&B[t.WireID()], t, &L)
 		}
-		for _, t := range c.O {
-			accumulate(&C[t.VariableID()], t, &L)
+		for _, t := range c.O.LinExp {
+			accumulate(&C[t.WireID()], t, &L)
 		}
 
 		// Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
@@ -491,11 +491,11 @@ func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
 	A := make([]bool, nbWires)
 	B := make([]bool, nbWires)
 	for _, c := range r1cs.Constraints {
-		for _, t := range c.L {
-			A[t.VariableID()] = true
+		for _, t := range c.L.LinExp {
+			A[t.WireID()] = true
 		}
-		for _, t := range c.R {
-			B[t.VariableID()] = true
+		for _, t := range c.R.LinExp {
+			B[t.WireID()] = true
 		}
 	}
 	for i := 0; i < nbWires; i++ {

--- a/internal/backend/bn254/plonk/prove.go
+++ b/internal/backend/bn254/plonk/prove.go
@@ -482,9 +482,9 @@ func computeLRO(spr *cs.SparseR1CS, pk *ProvingKey, solution []fr.Element) (poly
 	}
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // constraints
-		l[offset+i] = solution[spr.Constraints[i].L.VariableID()]
-		r[offset+i] = solution[spr.Constraints[i].R.VariableID()]
-		o[offset+i] = solution[spr.Constraints[i].O.VariableID()]
+		l[offset+i] = solution[spr.Constraints[i].L.WireID()]
+		r[offset+i] = solution[spr.Constraints[i].R.WireID()]
+		o[offset+i] = solution[spr.Constraints[i].O.WireID()]
 	}
 	offset += len(spr.Constraints)
 

--- a/internal/backend/bn254/plonk/setup.go
+++ b/internal/backend/bn254/plonk/setup.go
@@ -227,9 +227,9 @@ func buildPermutation(spr *cs.SparseR1CS, pk *ProvingKey) {
 
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // IDs of LRO associated to constraints
-		lro[offset+i] = spr.Constraints[i].L.VariableID()
-		lro[sizeSolution+offset+i] = spr.Constraints[i].R.VariableID()
-		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.VariableID()
+		lro[offset+i] = spr.Constraints[i].L.WireID()
+		lro[sizeSolution+offset+i] = spr.Constraints[i].R.WireID()
+		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.WireID()
 	}
 
 	// init cycle:

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -163,15 +163,15 @@ func (cs *R1CS) mulByCoeff(res *fr.Element, t compiled.Term) {
 // it instantiates the l, r o part of a R1C
 func (cs *R1CS) instantiateR1C(r compiled.R1C, solution *solution) (a, b, c fr.Element) {
 	var v fr.Element
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		v = solution.computeTerm(t)
 		a.Add(&a, &v)
 	}
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		v = solution.computeTerm(t)
 		b.Add(&b, &v)
 	}
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		v = solution.computeTerm(t)
 		c.Add(&c, &v)
 	}
@@ -197,7 +197,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	var termToCompute compiled.Term
 
 	processTerm := func(t compiled.Term, val *fr.Element, locValue uint8) error {
-		vID := t.VariableID()
+		vID := t.WireID()
 
 		// wire is already computed, we just accumulate in val
 		if solution.solved[vID] {
@@ -224,19 +224,19 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 		return nil
 	}
 
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		if err := processTerm(t, &a, 1); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		if err := processTerm(t, &b, 2); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		if err := processTerm(t, &c, 3); err != nil {
 			return err
 		}
@@ -250,7 +250,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	}
 
 	// we compute the wire value and instantiate it
-	vID := termToCompute.VariableID()
+	vID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -303,11 +303,11 @@ func sub(a, b int) int {
 	return a - b
 }
 
-func toHTML(l compiled.LinearExpression, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
+func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
 	var sbb strings.Builder
-	for i := 0; i < len(l); i++ {
-		termToHTML(l[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l) {
+	for i := 0; i < len(l.LinExp); i++ {
+		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
+		if i+1 < len(l.LinExp) {
 			sbb.WriteString(" + ")
 		}
 	}
@@ -330,7 +330,7 @@ func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHin
 		sbb.WriteString("</span>*")
 	}
 
-	vID := t.VariableID()
+	vID := t.WireID()
 	class := ""
 	switch t.VariableVisibility() {
 	case compiled.Internal:
@@ -363,7 +363,7 @@ func (cs *R1CS) GetNbCoefficients() int {
 
 // CurveID returns curve ID as defined in gnark-crypto (ecc.BW6-761)
 func (cs *R1CS) CurveID() ecc.ID {
-	return ecc.BW6_761
+	return ecc.BN254
 }
 
 // FrSize return fr.Limbs * 8, size in byte of a fr element

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -128,7 +128,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]f
 // else returns the wire position (L -> 0, R -> 1, O -> 2)
 func (cs *SparseR1CS) computeHints(c compiled.SparseR1C, solution *solution) (int, error) {
 	r := -1
-	lID, rID, oID := c.L.VariableID(), c.R.VariableID(), c.O.VariableID()
+	lID, rID, oID := c.L.WireID(), c.R.WireID(), c.O.WireID()
 
 	if (c.L.CoeffID() != 0 || c.M[0].CoeffID() != 0) && !solution.solved[lID] {
 		// check if it's a hint
@@ -185,14 +185,14 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 	}
 
 	if lro == 0 { // we solve for L: u1L+u2R+u3LR+u4O+k=0 => L(u1+u3R)+u2R+u4O+k = 0
-		if !solution.solved[c.R.VariableID()] {
+		if !solution.solved[c.R.WireID()] {
 			panic("R wire should be instantiated when we solve L")
 		}
 		var u1, u2, u3, den, num, v1, v2 fr.Element
 		u3.Mul(&cs.Coefficients[c.M[0].CoeffID()], &cs.Coefficients[c.M[1].CoeffID()])
 		u1.Set(&cs.Coefficients[c.L.CoeffID()])
 		u2.Set(&cs.Coefficients[c.R.CoeffID()])
-		den.Mul(&u3, &solution.values[c.R.VariableID()]).Add(&den, &u1)
+		den.Mul(&u3, &solution.values[c.R.WireID()]).Add(&den, &u1)
 
 		v1 = solution.computeTerm(c.R)
 		v2 = solution.computeTerm(c.O)
@@ -200,7 +200,7 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 		// TODO find a way to do lazy div (/ batch inversion)
 		num.Div(&num, &den).Neg(&num)
-		solution.set(c.L.VariableID(), num)
+		solution.set(c.L.WireID(), num)
 		return nil
 
 	}

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -122,8 +122,8 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 
 	for i := 0; i < len(h.Inputs); i++ {
 		// input is a linear expression, we must compute the value
-		for j := 0; j < len(h.Inputs[i]); j++ {
-			ciID, viID, visibility := h.Inputs[i][j].Unpack()
+		for j := 0; j < len(h.Inputs[i].LinExp); j++ {
+			ciID, viID, visibility := h.Inputs[i].LinExp[j].Unpack()
 			if visibility == compiled.Virtual {
 				// we have a constant, just take the coefficient value
 				s.coefficients[ciID].ToBigIntRegular(lambda)
@@ -138,7 +138,7 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 				}
 				return errors.New("expected wire to be instantiated while evaluating hint")
 			}
-			v := s.computeTerm(h.Inputs[i][j])
+			v := s.computeTerm(h.Inputs[i].LinExp[j])
 			v.ToBigIntRegular(lambda)
 			inputs[i].Add(inputs[i], lambda)
 		}

--- a/internal/backend/bw6-761/groth16/setup.go
+++ b/internal/backend/bw6-761/groth16/setup.go
@@ -336,14 +336,14 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
-		for _, t := range c.L {
-			accumulate(&A[t.VariableID()], t, &L)
+		for _, t := range c.L.LinExp {
+			accumulate(&A[t.WireID()], t, &L)
 		}
-		for _, t := range c.R {
-			accumulate(&B[t.VariableID()], t, &L)
+		for _, t := range c.R.LinExp {
+			accumulate(&B[t.WireID()], t, &L)
 		}
-		for _, t := range c.O {
-			accumulate(&C[t.VariableID()], t, &L)
+		for _, t := range c.O.LinExp {
+			accumulate(&C[t.WireID()], t, &L)
 		}
 
 		// Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
@@ -491,11 +491,11 @@ func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
 	A := make([]bool, nbWires)
 	B := make([]bool, nbWires)
 	for _, c := range r1cs.Constraints {
-		for _, t := range c.L {
-			A[t.VariableID()] = true
+		for _, t := range c.L.LinExp {
+			A[t.WireID()] = true
 		}
-		for _, t := range c.R {
-			B[t.VariableID()] = true
+		for _, t := range c.R.LinExp {
+			B[t.WireID()] = true
 		}
 	}
 	for i := 0; i < nbWires; i++ {

--- a/internal/backend/bw6-761/plonk/prove.go
+++ b/internal/backend/bw6-761/plonk/prove.go
@@ -482,9 +482,9 @@ func computeLRO(spr *cs.SparseR1CS, pk *ProvingKey, solution []fr.Element) (poly
 	}
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // constraints
-		l[offset+i] = solution[spr.Constraints[i].L.VariableID()]
-		r[offset+i] = solution[spr.Constraints[i].R.VariableID()]
-		o[offset+i] = solution[spr.Constraints[i].O.VariableID()]
+		l[offset+i] = solution[spr.Constraints[i].L.WireID()]
+		r[offset+i] = solution[spr.Constraints[i].R.WireID()]
+		o[offset+i] = solution[spr.Constraints[i].O.WireID()]
 	}
 	offset += len(spr.Constraints)
 

--- a/internal/backend/bw6-761/plonk/setup.go
+++ b/internal/backend/bw6-761/plonk/setup.go
@@ -227,9 +227,9 @@ func buildPermutation(spr *cs.SparseR1CS, pk *ProvingKey) {
 
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // IDs of LRO associated to constraints
-		lro[offset+i] = spr.Constraints[i].L.VariableID()
-		lro[sizeSolution+offset+i] = spr.Constraints[i].R.VariableID()
-		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.VariableID()
+		lro[offset+i] = spr.Constraints[i].L.WireID()
+		lro[sizeSolution+offset+i] = spr.Constraints[i].R.WireID()
+		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.WireID()
 	}
 
 	// init cycle:

--- a/internal/backend/compiled/cs.go
+++ b/internal/backend/compiled/cs.go
@@ -50,8 +50,8 @@ const (
 // it enables the solver to compute a Wire with a function provided at solving time
 // using pre-defined inputs
 type Hint struct {
-	ID     hint.ID            // hint function id
-	Inputs []LinearExpression // terms to inject in the hint function
+	ID     hint.ID    // hint function id
+	Inputs []Variable // terms to inject in the hint function
 }
 
 // GetNbVariables return number of internal, secret and public variables

--- a/internal/backend/compiled/log.go
+++ b/internal/backend/compiled/log.go
@@ -12,20 +12,20 @@ type LogEntry struct {
 	ToResolve []Term
 }
 
-func (l *LogEntry) WriteLinearExpression(le LinearExpression, sbb *strings.Builder) {
-	sbb.Grow(len(le) * len(" + (xx + xxxxxxxxxxxx"))
+func (l *LogEntry) WriteVariable(le Variable, sbb *strings.Builder) {
+	sbb.Grow(len(le.LinExp) * len(" + (xx + xxxxxxxxxxxx"))
 
-	for i := 0; i < len(le); i++ {
+	for i := 0; i < len(le.LinExp); i++ {
 		if i > 0 {
 			sbb.WriteString(" + ")
 		}
-		l.WriteTerm(le[i], sbb)
+		l.WriteTerm(le.LinExp[i], sbb)
 	}
 }
 
 func (l *LogEntry) WriteTerm(t Term, sbb *strings.Builder) {
 	// virtual == only a coeff, we discard the wire
-	if t.VariableVisibility() == Public && t.VariableID() == 0 {
+	if t.VariableVisibility() == Public && t.WireID() == 0 {
 		sbb.WriteString("%s")
 		t.SetVariableVisibility(Virtual)
 		l.ToResolve = append(l.ToResolve, t)

--- a/internal/backend/compiled/r1c.go
+++ b/internal/backend/compiled/r1c.go
@@ -21,55 +21,7 @@ import (
 
 // R1C used to compute the wires
 type R1C struct {
-	L, R, O LinearExpression
-}
-
-// LinearExpression represent a linear expression of variables
-type LinearExpression []Term
-
-// Clone returns a copy of the underlying slice
-func (l LinearExpression) Clone() LinearExpression {
-	res := make(LinearExpression, len(l))
-	copy(res, l)
-	return res
-}
-
-// Len return the lenght of the LinearExpression (implements Sort interface)
-func (l LinearExpression) Len() int {
-	return len(l)
-}
-
-// Equals returns true if both SORTED expressions are the same
-//
-// pre conditions: l and o are sorted
-func (l LinearExpression) Equal(o LinearExpression) bool {
-	if len(l) != len(o) {
-		return false
-	}
-	if (l == nil) != (o == nil) {
-		return false
-	}
-	for i := 0; i < len(l); i++ {
-		if l[i] != o[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// Swap swaps terms in the LinearExpression (implements Sort interface)
-func (l LinearExpression) Swap(i, j int) {
-	l[i], l[j] = l[j], l[i]
-}
-
-// Less returns true if variableID for term at i is less than variableID for term at j (implements Sort interface)
-func (l LinearExpression) Less(i, j int) bool {
-	_, iID, iVis := l[i].Unpack()
-	_, jID, jVis := l[j].Unpack()
-	if iVis == jVis {
-		return iID < jID
-	}
-	return iVis > jVis
+	L, R, O Variable
 }
 
 func (r1c *R1C) String(coeffs []big.Int) string {
@@ -83,13 +35,4 @@ func (r1c *R1C) String(coeffs []big.Int) string {
 	sbb.WriteString("]")
 
 	return sbb.String()
-}
-
-func (l LinearExpression) string(sbb *strings.Builder, coeffs []big.Int) {
-	for i := 0; i < len(l); i++ {
-		l[i].string(sbb, coeffs)
-		if i+1 < len(l) {
-			sbb.WriteString(" + ")
-		}
-	}
 }

--- a/internal/backend/compiled/term.go
+++ b/internal/backend/compiled/term.go
@@ -44,7 +44,7 @@ const (
 )
 
 const (
-	nbBitsVariableID         = 29
+	nbBitsWireID             = 29
 	nbBitsCoeffID            = 30
 	nbBitsDelimitor          = 1
 	nbBitsFutureUse          = 1
@@ -56,15 +56,15 @@ const (
 const TermDelimitor Term = Term(maskDelimitor)
 
 const (
-	shiftVariableID         = 0
-	shiftCoeffID            = nbBitsVariableID
+	shiftWireID             = 0
+	shiftCoeffID            = nbBitsWireID
 	shiftDelimitor          = shiftCoeffID + nbBitsCoeffID
 	shiftFutureUse          = shiftDelimitor + nbBitsDelimitor
 	shiftVariableVisibility = shiftFutureUse + nbBitsFutureUse
 )
 
 const (
-	maskVariableID         = uint64((1 << nbBitsVariableID) - 1)
+	maskWireID             = uint64((1 << nbBitsWireID) - 1)
 	maskCoeffID            = uint64((1<<nbBitsCoeffID)-1) << shiftCoeffID
 	maskDelimitor          = uint64((1<<nbBitsDelimitor)-1) << shiftDelimitor
 	maskFutureUse          = uint64((1<<nbBitsFutureUse)-1) << shiftFutureUse
@@ -78,7 +78,7 @@ const (
 // if we support more than 500 millions constraints, this breaks (not so soon.)
 func Pack(variableID, coeffID int, variableVisiblity Visibility) Term {
 	var t Term
-	t.SetVariableID(variableID)
+	t.SetWireID(variableID)
 	t.SetCoeffID(coeffID)
 	t.SetVariableVisibility(variableVisiblity)
 	return t
@@ -87,7 +87,7 @@ func Pack(variableID, coeffID int, variableVisiblity Visibility) Term {
 // Unpack returns coeffID, variableID and visibility
 func (t Term) Unpack() (coeffID, variableID int, variableVisiblity Visibility) {
 	coeffID = t.CoeffID()
-	variableID = t.VariableID()
+	variableID = t.WireID()
 	variableVisiblity = t.VariableVisibility()
 	return
 }
@@ -138,18 +138,18 @@ func (t *Term) SetCoeffID(cID int) {
 	*t = Term((uint64(*t) & (^maskCoeffID)) | _coeffID)
 }
 
-// SetVariableID update the bits correponding to the variableID with cID
-func (t *Term) SetVariableID(cID int) {
+// SetWireID update the bits correponding to the variableID with cID
+func (t *Term) SetWireID(cID int) {
 	_variableID := uint64(cID)
-	if (_variableID & maskVariableID) != uint64(cID) {
+	if (_variableID & maskWireID) != uint64(cID) {
 		panic("variableID is too large, unsupported")
 	}
-	*t = Term((uint64(*t) & (^maskVariableID)) | _variableID)
+	*t = Term((uint64(*t) & (^maskWireID)) | _variableID)
 }
 
-// VariableID returns the variableID (see R1CS data structure)
-func (t Term) VariableID() int {
-	return int((uint64(t) & maskVariableID))
+// WireID returns the variableID (see R1CS data structure)
+func (t Term) WireID() int {
+	return int((uint64(t) & maskWireID))
 }
 
 // CoeffID returns the coefficient id (see R1CS data structure)
@@ -174,5 +174,5 @@ func (t Term) string(sbb *strings.Builder, coeffs []big.Int) {
 	default:
 		panic("not implemented")
 	}
-	sbb.WriteString(strconv.Itoa(t.VariableID()))
+	sbb.WriteString(strconv.Itoa(t.WireID()))
 }

--- a/internal/backend/compiled/variable.go
+++ b/internal/backend/compiled/variable.go
@@ -1,0 +1,110 @@
+// Copyright 2020 ConsenSys AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiled
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+)
+
+// errNoValue triggered when trying to access a variable that was not allocated
+var errNoValue = errors.New("can't determine API input value")
+
+type LinearExpression []Term
+
+// Variable represent a linear expression of wires
+type Variable struct {
+	LinExp    LinearExpression
+	IsBoolean *bool
+}
+
+// Clone returns a copy of the underlying slice
+func (v Variable) Clone() Variable {
+	var res Variable
+	res.IsBoolean = v.IsBoolean
+	res.LinExp = make([]Term, len(v.LinExp))
+	copy(res.LinExp, v.LinExp)
+	return res
+}
+
+// Len return the lenght of the Variable (implements Sort interface)
+func (v LinearExpression) Len() int {
+	return len(v)
+}
+
+// Equals returns true if both SORTED expressions are the same
+//
+// pre conditions: l and o are sorted
+func (v LinearExpression) Equal(o LinearExpression) bool {
+	if len(v) != len(o) {
+		return false
+	}
+	if (v == nil) != (o == nil) {
+		return false
+	}
+	for i := 0; i < len(v); i++ {
+		if v[i] != o[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Swap swaps terms in the Variable (implements Sort interface)
+func (v LinearExpression) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+// Less returns true if variableID for term at i is less than variableID for term at j (implements Sort interface)
+func (v LinearExpression) Less(i, j int) bool {
+	_, iID, iVis := v[i].Unpack()
+	_, jID, jVis := v[j].Unpack()
+	if iVis == jVis {
+		return iID < jID
+	}
+	return iVis > jVis
+}
+
+func (v Variable) string(sbb *strings.Builder, coeffs []big.Int) {
+	for i := 0; i < len(v.LinExp); i++ {
+		v.LinExp[i].string(sbb, coeffs)
+		if i+1 < len(v.LinExp) {
+			sbb.WriteString(" + ")
+		}
+	}
+}
+
+// assertIsSet panics if the variable is unset
+// this may happen if inside a Define we have
+// var a variable
+// cs.Mul(a, 1)
+// since a was not in the circuit struct it is not a secret variable
+func (v Variable) AssertIsSet() {
+
+	if len(v.LinExp) == 0 {
+		panic(errNoValue)
+	}
+
+}
+
+// isConstant returns true if the variable is ONE_WIRE * coeff
+func (v *Variable) IsConstant() bool {
+	if len(v.LinExp) != 1 {
+		return false
+	}
+	_, vID, visibility := v.LinExp[0].Unpack()
+	return vID == 0 && visibility == Public
+}

--- a/internal/generator/backend/main.go
+++ b/internal/generator/backend/main.go
@@ -106,6 +106,7 @@ func main() {
 			if err := bgen.Generate(d, "groth16", "./template/zkpschemes/", entries...); err != nil {
 				panic(err) // TODO handle
 			}
+			bgen.Generate(d, "groth16", "./template/zkpschemes/", entries...)
 
 			entries = []bavard.Entry{
 				{File: filepath.Join(groth16Dir, "groth16_test.go"), Templates: []string{"groth16/tests/groth16.go.tmpl", importCurve}},

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -21,22 +21,21 @@ import (
 // R1CS decsribes a set of R1CS constraint
 type R1CS struct {
 	compiled.R1CS
-	Coefficients    []fr.Element // R1C coefficients indexes point here
+	Coefficients []fr.Element // R1C coefficients indexes point here
 }
 
 // NewR1CS returns a new R1CS and sets cs.Coefficient (fr.Element) from provided big.Int values
 func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 	r := R1CS{
-		R1CS: cs,
+		R1CS:         cs,
 		Coefficients: make([]fr.Element, len(coefficients)),
 	}
 	for i := 0; i < len(coefficients); i++ {
 		r.Coefficients[i].SetBigInt(&coefficients[i])
 	}
 
-	return &r 
+	return &r
 }
-
 
 // Solve sets all the wires and returns the a, b, c vectors.
 // the cs system should have been compiled before. The entries in a, b, c are in Montgomery form.
@@ -44,9 +43,9 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 // returns  [publicWires | secretWires | internalWires ]
 func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
-	
+
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
-	solution, err  := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
 	if err != nil {
 		return make([]fr.Element, nbWires), err
 	}
@@ -55,14 +54,10 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}
 
-	
-
 	// compute the wires and the a, b, c polynomials
-	if len(a) != len(cs.Constraints) || len(b) != len(cs.Constraints) || len(c) != len(cs.Constraints){
+	if len(a) != len(cs.Constraints) || len(b) != len(cs.Constraints) || len(c) != len(cs.Constraints) {
 		return solution.values, errors.New("invalid input size: len(a, b, c) == len(Constraints)")
 	}
-
-
 
 	solution.solved[0] = true // ONE_WIRE
 	solution.values[0].SetOne()
@@ -73,16 +68,14 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness) + 1 
+	solution.nbSolved += len(witness) + 1
 
 	// now that we know all inputs are set, defer log printing once all solution.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-
 	// check if there is an inconsistant constraint
 	var check fr.Element
-
 
 	// for each constraint
 	// we are guaranteed that each R1C contains at most one unsolved wire
@@ -94,7 +87,7 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 		if err := cs.solveConstraint(cs.Constraints[i], &solution); err != nil {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values,  fmt.Errorf("%w: %s", err, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
 			}
 			return solution.values, err
 		}
@@ -107,19 +100,18 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 		if !check.Equal(&c[i]) {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values,  fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
 			}
 			return solution.values, ErrUnsatisfiedConstraint
 		}
 	}
-
 
 	// sanity check; ensure all wires are marked as "instantiated"
 	if !solution.isValid() {
 		panic("solver didn't instantiate all wires")
 	}
 
-	return solution.values, nil 
+	return solution.values, nil
 }
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise
@@ -129,13 +121,11 @@ func (cs *R1CS) IsSolved(witness []fr.Element, opt backend.ProverOption) error {
 	b := make([]fr.Element, len(cs.Constraints))
 	c := make([]fr.Element, len(cs.Constraints))
 	_, err := cs.Solve(witness, a, b, c, opt)
-	return err 
+	return err
 }
 
-
-
 // mulByCoeff sets res = res * t.Coeff
-func (cs *R1CS) mulByCoeff(res *fr.Element, t compiled.Term)  {
+func (cs *R1CS) mulByCoeff(res *fr.Element, t compiled.Term) {
 	cID := t.CoeffID()
 	switch cID {
 	case compiled.CoeffIdOne:
@@ -156,21 +146,20 @@ func (cs *R1CS) mulByCoeff(res *fr.Element, t compiled.Term)  {
 // it instantiates the l, r o part of a R1C
 func (cs *R1CS) instantiateR1C(r compiled.R1C, solution *solution) (a, b, c fr.Element) {
 	var v fr.Element
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		v = solution.computeTerm(t)
 		a.Add(&a, &v)
 	}
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		v = solution.computeTerm(t)
 		b.Add(&b, &v)
 	}
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		v = solution.computeTerm(t)
 		c.Add(&c, &v)
 	}
 	return
 }
-
 
 // solveR1c computes a wire by solving a cs
 // the function searches for the unset wire (either the unset wire is
@@ -191,13 +180,13 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	var termToCompute compiled.Term
 
 	processTerm := func(t compiled.Term, val *fr.Element, locValue uint8) error {
-		vID := t.VariableID()
+		vID := t.WireID()
 
 		// wire is already computed, we just accumulate in val
 		if solution.solved[vID] {
 			v := solution.computeTerm(t)
 			val.Add(val, &v)
-			return nil 
+			return nil
 		}
 
 		// first we check if this is a hint wire
@@ -215,22 +204,22 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 		}
 		termToCompute = t
 		loc = locValue
-		return nil 
+		return nil
 	}
 
-	for _, t := range r.L {
+	for _, t := range r.L.LinExp {
 		if err := processTerm(t, &a, 1); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.R {
+	for _, t := range r.R.LinExp {
 		if err := processTerm(t, &b, 2); err != nil {
 			return err
 		}
 	}
 
-	for _, t := range r.O {
+	for _, t := range r.O.LinExp {
 		if err := processTerm(t, &c, 3); err != nil {
 			return err
 		}
@@ -240,11 +229,11 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 		// there is nothing to solve, may happen if we have an assertion
 		// (ie a constraints that doesn't yield any output)
 		// or if we solved the unsolved wires with hint functions
-		return nil 
+		return nil
 	}
 
 	// we compute the wire value and instantiate it
-	vID := termToCompute.VariableID()
+	vID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -270,10 +259,8 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 
 	solution.set(vID, wire)
 
-	return nil 
+	return nil
 }
-
-
 
 // TODO @gbotrel clean logs and html see https://github.com/ConsenSys/gnark/issues/140
 
@@ -281,30 +268,29 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 func (cs *R1CS) ToHTML(w io.Writer) error {
 	t, err := template.New("cs.html").Funcs(template.FuncMap{
 		"toHTML": toHTML,
-		"add": add,
-		"sub": sub,
+		"add":    add,
+		"sub":    sub,
 	}).Parse(compiled.R1CSTemplate)
 	if err != nil {
 		return err
 	}
 
-
 	return t.Execute(w, cs)
 }
 
 func add(a, b int) int {
-	return a+b
+	return a + b
 }
 
 func sub(a, b int) int {
-	return a-b
+	return a - b
 }
 
-func toHTML(l compiled.LinearExpression, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
+func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
 	var sbb strings.Builder
-	for i := 0; i < len(l); i++ {
-		termToHTML(l[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l) {
+	for i := 0; i < len(l.LinExp); i++ {
+		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
+		if i+1 < len(l.LinExp) {
 			sbb.WriteString(" + ")
 		}
 	}
@@ -320,14 +306,14 @@ func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHin
 		sbb.WriteString("<span class=\"coefficient\">-</span>")
 	} else if tID == compiled.CoeffIdZero {
 		sbb.WriteString("<span class=\"coefficient\">0</span>")
-		return 
+		return
 	} else {
 		sbb.WriteString("<span class=\"coefficient\">")
 		sbb.WriteString(coeffs[tID].String())
 		sbb.WriteString("</span>*")
 	}
 
-	vID := t.VariableID()
+	vID := t.WireID()
 	class := ""
 	switch t.VariableVisibility() {
 	case compiled.Internal:
@@ -353,24 +339,20 @@ func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHin
 
 }
 
-
-
-
 // GetNbCoefficients return the number of unique coefficients needed in the R1CS
 func (cs *R1CS) GetNbCoefficients() int {
 	return len(cs.Coefficients)
 }
 
-// CurveID returns curve ID as defined in gnark-crypto (ecc.{{.Curve}})
+// CurveID returns curve ID as defined in gnark-crypto (ecc.BW6-761)
 func (cs *R1CS) CurveID() ecc.ID {
-	return ecc.{{.CurveID}}
+	return ecc.BN254
 }
 
 // FrSize return fr.Limbs * 8, size in byte of a fr element
 func (cs *R1CS) FrSize() int {
 	return fr.Limbs * 8
 }
-
 
 // WriteTo encodes R1CS into provided io.Writer using cbor
 func (cs *R1CS) WriteTo(w io.Writer) (int64, error) {
@@ -392,7 +374,7 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 		MaxArrayElements: 134217728,
 		MaxMapPairs:      134217728,
 	}.DecMode()
-	
+
 	if err != nil {
 		return 0, err
 	}

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -118,7 +118,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]f
 // else returns the wire position (L -> 0, R -> 1, O -> 2)
 func (cs *SparseR1CS) computeHints(c compiled.SparseR1C, solution *solution) ( int, error) {
 	r := -1
-	lID, rID, oID := c.L.VariableID(), c.R.VariableID(), c.O.VariableID()
+	lID, rID, oID := c.L.WireID(), c.R.WireID(), c.O.WireID()
 
 	if (c.L.CoeffID() != 0 || c.M[0].CoeffID() != 0) && !solution.solved[lID] {
 		// check if it's a hint
@@ -176,14 +176,14 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 	}
 
 	if lro == 0 { // we solve for L: u1L+u2R+u3LR+u4O+k=0 => L(u1+u3R)+u2R+u4O+k = 0
-		if !solution.solved[c.R.VariableID()] {
+		if !solution.solved[c.R.WireID()] {
 			panic("R wire should be instantiated when we solve L")
 		}
 		var u1, u2, u3, den, num, v1, v2 fr.Element
 		u3.Mul(&cs.Coefficients[c.M[0].CoeffID()], &cs.Coefficients[c.M[1].CoeffID()])
 		u1.Set(&cs.Coefficients[c.L.CoeffID()])
 		u2.Set(&cs.Coefficients[c.R.CoeffID()])
-		den.Mul(&u3, &solution.values[c.R.VariableID()]).Add(&den, &u1)
+		den.Mul(&u3, &solution.values[c.R.WireID()]).Add(&den, &u1)
 
 		v1 = solution.computeTerm(c.R)
 		v2 = solution.computeTerm(c.O)
@@ -191,7 +191,7 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 		// TODO find a way to do lazy div (/ batch inversion)
 		num.Div(&num, &den).Neg(&num)
-		solution.set(c.L.VariableID(), num)
+		solution.set(c.L.WireID(), num)
 		return nil 
 
 	} 

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -20,10 +20,10 @@ var ErrUnsatisfiedConstraint = errors.New("constraint is not satisfied")
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {
-    values, coefficients []fr.Element 
-    solved []bool
-    nbSolved int 
-    mHintsFunctions map[hint.ID]hint.Function
+	values, coefficients []fr.Element
+	solved               []bool
+	nbSolved             int
+	mHintsFunctions      map[hint.ID]hint.Function
 }
 
 func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
@@ -43,61 +43,57 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		s.mHintsFunctions[id] = hintFunctions[i]
 	}
 
-
-    return s, nil 
+	return s, nil
 }
 
 func (s *solution) set(id int, value fr.Element) {
-    if s.solved[id] {
+	if s.solved[id] {
 		panic("solving the same wire twice should never happen.")
 	}
 	s.values[id] = value
-	s.solved[id] = true 
-    s.nbSolved++
+	s.solved[id] = true
+	s.nbSolved++
 }
-
 
 func (s *solution) isValid() bool {
-    return s.nbSolved == len(s.values)
+	return s.nbSolved == len(s.values)
 }
-
 
 // computeTerm computes coef*variable
 func (s *solution) computeTerm(t compiled.Term) fr.Element {
 	cID, vID, _ := t.Unpack()
-    if cID != 0 && !s.solved[vID] {
-        panic("computing a term with an unsolved wire")
-    }
+	if cID != 0 && !s.solved[vID] {
+		panic("computing a term with an unsolved wire")
+	}
 	switch cID {
-		case compiled.CoeffIdZero:
-			return fr.Element{}
-		case compiled.CoeffIdOne:
-			return s.values[vID]
-		case compiled.CoeffIdTwo:
-			var res fr.Element
-			res.Double(&s.values[vID])
-			return res 
-		case compiled.CoeffIdMinusOne:
-			var res fr.Element
-			res.Neg(&s.values[vID])
-			return res
-		default:
-			var res fr.Element
-			res.Mul(&s.coefficients[cID], &s.values[vID])
-			return res
+	case compiled.CoeffIdZero:
+		return fr.Element{}
+	case compiled.CoeffIdOne:
+		return s.values[vID]
+	case compiled.CoeffIdTwo:
+		var res fr.Element
+		res.Double(&s.values[vID])
+		return res
+	case compiled.CoeffIdMinusOne:
+		var res fr.Element
+		res.Neg(&s.values[vID])
+		return res
+	default:
+		var res fr.Element
+		res.Mul(&s.coefficients[cID], &s.values[vID])
+		return res
 	}
 }
-
 
 // solveHint compute solution.values[vID] using provided solver hint
 func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 	// ensure hint function was provided
 	f, ok := s.mHintsFunctions[h.ID]
 	if !ok {
-		return  errors.New("missing hint function")
+		return errors.New("missing hint function")
 	}
 
-	// compute values for all inputs. 
+	// compute values for all inputs.
 	inputs := make([]*big.Int, len(h.Inputs))
 	for i := 0; i < len(inputs); i++ {
 		inputs[i] = bigIntPool.Get().(*big.Int)
@@ -105,10 +101,10 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 	}
 	lambda := bigIntPool.Get().(*big.Int)
 
-	for i:=0;i<len(h.Inputs);i++ {
+	for i := 0; i < len(h.Inputs); i++ {
 		// input is a linear expression, we must compute the value
-		for j:=0; j < len(h.Inputs[i]); j++ {
-			ciID , viID, visibility := h.Inputs[i][j].Unpack()
+		for j := 0; j < len(h.Inputs[i].LinExp); j++ {
+			ciID, viID, visibility := h.Inputs[i].LinExp[j].Unpack()
 			if visibility == compiled.Virtual {
 				// we have a constant, just take the coefficient value
 				s.coefficients[ciID].ToBigIntRegular(lambda)
@@ -123,47 +119,45 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 				}
 				return errors.New("expected wire to be instantiated while evaluating hint")
 			}
-			v := s.computeTerm(h.Inputs[i][j])
+			v := s.computeTerm(h.Inputs[i].LinExp[j])
 			v.ToBigIntRegular(lambda)
 			inputs[i].Add(inputs[i], lambda)
 		}
 	}
 
-	// use lambda as the result. 
+	// use lambda as the result.
 	lambda.SetUint64(0)
 
-	// ensure our inputs are mod q 
+	// ensure our inputs are mod q
 	q := fr.Modulus()
 	for i := 0; i < len(inputs); i++ {
-		// note since we're only doing additions up there, we may want to avoid the use of Mod 
+		// note since we're only doing additions up there, we may want to avoid the use of Mod
 		// here in favor of Cmp & Sub
 		inputs[i].Mod(inputs[i], q)
 	}
 
 	err := f(curve.ID, inputs, lambda)
-	
+
 	var v fr.Element
 	v.SetBigInt(lambda)
-	
+
 	// release objects into pool
 	bigIntPool.Put(lambda)
 	for i := 0; i < len(inputs); i++ {
 		bigIntPool.Put(inputs[i])
 	}
-	
+
 	if err != nil {
 		return err
 	}
 
 	s.set(vID, v)
-	return nil 
+	return nil
 }
-
-
 
 func (s *solution) printLogs(w io.Writer, logs []compiled.LogEntry) {
 	if w == nil {
-		return 
+		return
 	}
 
 	for i := 0; i < len(logs); i++ {
@@ -172,33 +166,32 @@ func (s *solution) printLogs(w io.Writer, logs []compiled.LogEntry) {
 	}
 }
 
-const unsolvedVariable  = "<unsolved>"
-
+const unsolvedVariable = "<unsolved>"
 
 func (s *solution) logValue(log compiled.LogEntry) string {
 	var toResolve []interface{}
 	var (
-		isEval bool 
-		eval fr.Element 
-		missingValue bool 
+		isEval       bool
+		eval         fr.Element
+		missingValue bool
 	)
 	for j := 0; j < len(log.ToResolve); j++ {
 		if log.ToResolve[j] == compiled.TermDelimitor {
 			// this is a special case where we want to evaluate the following terms until the next delimitor.
 			if !isEval {
-				isEval = true 
-				missingValue = false 
+				isEval = true
+				missingValue = false
 				eval.SetZero()
-				continue 
+				continue
 			}
-			isEval = false 
+			isEval = false
 			if missingValue {
 				toResolve = append(toResolve, unsolvedVariable)
 			} else {
 				// we have to append our accumulator
 				toResolve = append(toResolve, eval.String())
 			}
-			continue 
+			continue
 		}
 		cID, vID, visibility := log.ToResolve[j].Unpack()
 
@@ -207,25 +200,25 @@ func (s *solution) logValue(log compiled.LogEntry) string {
 			if visibility == compiled.Virtual {
 				// just add the constant
 				eval.Add(&eval, &s.coefficients[cID])
-				continue 
+				continue
 			}
 			if !s.solved[vID] {
-				missingValue = true 
-				continue 
+				missingValue = true
+				continue
 			}
 			tv := s.computeTerm(log.ToResolve[j])
 			eval.Add(&eval, &tv)
-			continue 
+			continue
 		}
 
 		if visibility == compiled.Virtual {
-			// it's just a constant 
+			// it's just a constant
 			if cID == compiled.CoeffIdMinusOne {
-				toResolve = append(toResolve, "-1")	
+				toResolve = append(toResolve, "-1")
 			} else {
 				toResolve = append(toResolve, s.coefficients[cID].String())
 			}
-			continue 
+			continue
 		}
 		if !(cID == compiled.CoeffIdMinusOne || cID == compiled.CoeffIdOne) {
 			toResolve = append(toResolve, s.coefficients[cID].String())
@@ -238,7 +231,6 @@ func (s *solution) logValue(log compiled.LogEntry) string {
 	}
 	return fmt.Sprintf(log.Format, toResolve...)
 }
-
 
 var bigIntPool = sync.Pool{
 	New: func() interface{} {

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -30,7 +30,7 @@ type ProvingKey struct {
 	}
 
 	// if InfinityA[i] == true, the point G1.A[i] == infinity
-	InfinityA, InfinityB []bool
+	InfinityA, InfinityB     []bool
 	NbInfinityA, NbInfinityB uint64
 }
 
@@ -159,25 +159,24 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	for i, e := range A {
 		if e.IsZero() {
 			pk.InfinityA[i] = true
-			continue 
+			continue
 		}
 		A[n] = A[i]
 		n++
 	}
 	A = A[:n]
-	pk.NbInfinityA = uint64(nbWires - n )
+	pk.NbInfinityA = uint64(nbWires - n)
 	n = 0
 	for i, e := range B {
 		if e.IsZero() {
 			pk.InfinityB[i] = true
-			continue 
+			continue
 		}
 		B[n] = B[i]
 		n++
 	}
 	B = B[:n]
-	pk.NbInfinityB = uint64(nbWires - n )
-	
+	pk.NbInfinityB = uint64(nbWires - n)
 
 	// compute our batch scalar multiplication with g1 elements
 	g1Scalars := make([]fr.Element, 0, (nbWires*3)+int(domain.Cardinality)+3)
@@ -253,8 +252,6 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// set domain
 	pk.Domain = *domain
 
-
-
 	return nil
 }
 
@@ -268,13 +265,12 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 
 	one := fr.One()
 
-
 	// first we compute [t-w^i] and its inverse
 	var w fr.Element
 	w.Set(&domain.Generator)
 	wi := fr.One()
-	t := make([]fr.Element, len(r1cs.Constraints) +1 )
-	for i:=0; i < len(t);i++ {
+	t := make([]fr.Element, len(r1cs.Constraints)+1)
+	for i := 0; i < len(t); i++ {
 		t[i].Sub(&toxicWaste.t, &wi)
 		wi.Mul(&wi, &w) // TODO this is already pre computed in fft.Domain
 	}
@@ -291,9 +287,7 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 	L.Mul(&L, &tInv[0]).
 		Mul(&L, &domain.CardinalityInv)
 
-
-
-	accumulate := func (res *fr.Element, t compiled.Term, value *fr.Element)  {
+	accumulate := func(res *fr.Element, t compiled.Term, value *fr.Element) {
 		cID := t.CoeffID()
 		switch cID {
 		case compiled.CoeffIdZero:
@@ -313,23 +307,22 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 		}
 	}
 
-
-	// each constraint is in the form 
+	// each constraint is in the form
 	// L * R == O
 	// L, R and O being linear expressions
-	// for each term appearing in the linear expression, 
+	// for each term appearing in the linear expression,
 	// we compute term.Coefficient * L, and cumulate it in
 	// A, B or C at the indice of the variable
 	for i, c := range r1cs.Constraints {
 
-		for _, t := range c.L {
-			accumulate(&A[t.VariableID()], t, &L)
+		for _, t := range c.L.LinExp {
+			accumulate(&A[t.WireID()], t, &L)
 		}
-		for _, t := range c.R {
-			accumulate(&B[t.VariableID()], t, &L)
+		for _, t := range c.R.LinExp {
+			accumulate(&B[t.WireID()], t, &L)
 		}
-		for _, t := range c.O {
-			accumulate(&C[t.VariableID()], t, &L)
+		for _, t := range c.O.LinExp {
+			accumulate(&C[t.WireID()], t, &L)
 		}
 
 		// Li+1 = w*Li*(t-w^i)/(t-w^(i+1))
@@ -341,15 +334,12 @@ func setupABC(r1cs *cs.R1CS, domain *fft.Domain, toxicWaste toxicWaste) (A []fr.
 
 }
 
-
-
-
 // toxicWaste toxic waste
 type toxicWaste struct {
 
 	// Montgomery form of params
 	t, alpha, beta, gamma, delta fr.Element
-	gammaInv, deltaInv fr.Element 
+	gammaInv, deltaInv           fr.Element
 
 	// Non Montgomery form of params
 	alphaReg, betaReg, gammaReg, deltaReg fr.Element
@@ -422,11 +412,11 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	pk.InfinityB = make([]bool, nbWires)
 	pk.NbInfinityA = uint64(nbZeroesA)
 	pk.NbInfinityB = uint64(nbZeroesB)
-	for i:=0; i <nbZeroesA;i++ {
-		pk.InfinityA[i] = true 
+	for i := 0; i < nbZeroesA; i++ {
+		pk.InfinityA[i] = true
 	}
-	for i:=0; i <nbZeroesB;i++ {
-		pk.InfinityB[i] = true 
+	for i := 0; i < nbZeroesB; i++ {
+		pk.InfinityB[i] = true
 	}
 
 	// samples toxic waste
@@ -445,13 +435,13 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r2Aff curve.G2Affine
 	r2Jac.ScalarMultiplication(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
-	for i:=0; i < len(pk.G1.A); i++ {
+	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff
 	}
-	for i:=0; i < len(pk.G1.B); i++ {
+	for i := 0; i < len(pk.G1.B); i++ {
 		pk.G1.B[i] = r1Aff
 	}
-	for i:=0; i < len(pk.G2.B); i++ {
+	for i := 0; i < len(pk.G2.B); i++ {
 		pk.G2.B[i] = r2Aff
 	}
 	for i := 0; i < len(pk.G1.Z); i++ {
@@ -480,14 +470,14 @@ func dummyInfinityCount(r1cs *cs.R1CS) (nbZeroesA, nbZeroesB int) {
 	A := make([]bool, nbWires)
 	B := make([]bool, nbWires)
 	for _, c := range r1cs.Constraints {
-		for _, t := range c.L {
-			A[t.VariableID()] = true 
+		for _, t := range c.L.LinExp {
+			A[t.WireID()] = true
 		}
-		for _, t := range c.R {
-			B[t.VariableID()] = true 
+		for _, t := range c.R.LinExp {
+			B[t.WireID()] = true
 		}
 	}
-	for i:=0; i < nbWires;i++ {
+	for i := 0; i < nbWires; i++ {
 		if !A[i] {
 			nbZeroesA++
 		}
@@ -563,7 +553,7 @@ func (vk *VerifyingKey) NbG2() int {
 
 // NbG1 returns the number of G1 elements in the ProvingKey
 func (pk *ProvingKey) NbG1() int {
-	return 3 + len(pk.G1.A)+ len(pk.G1.B) + len(pk.G1.Z) + len(pk.G1.K)
+	return 3 + len(pk.G1.A) + len(pk.G1.B) + len(pk.G1.Z) + len(pk.G1.K)
 }
 
 // NbG2 returns the number of G2 elements in the ProvingKey

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
@@ -458,9 +458,9 @@ func computeLRO(spr *cs.SparseR1CS, pk *ProvingKey, solution []fr.Element) (poly
 	}
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // constraints
-		l[offset+i] = solution[spr.Constraints[i].L.VariableID()]
-		r[offset+i] = solution[spr.Constraints[i].R.VariableID()]
-		o[offset+i] = solution[spr.Constraints[i].O.VariableID()]
+		l[offset+i] = solution[spr.Constraints[i].L.WireID()]
+		r[offset+i] = solution[spr.Constraints[i].R.WireID()]
+		o[offset+i] = solution[spr.Constraints[i].O.WireID()]
 	}
 	offset += len(spr.Constraints)
 

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.setup.go.tmpl
@@ -209,9 +209,9 @@ func buildPermutation(spr *cs.SparseR1CS, pk *ProvingKey) {
 
 	offset := spr.NbPublicVariables
 	for i := 0; i < len(spr.Constraints); i++ { // IDs of LRO associated to constraints
-		lro[offset+i] = spr.Constraints[i].L.VariableID()
-		lro[sizeSolution+offset+i] = spr.Constraints[i].R.VariableID()
-		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.VariableID()
+		lro[offset+i] = spr.Constraints[i].L.WireID()
+		lro[sizeSolution+offset+i] = spr.Constraints[i].R.WireID()
+		lro[2*sizeSolution+offset+i] = spr.Constraints[i].O.WireID()
 	}
 
 	// init cycle:

--- a/std/algebra/sw/pairing_test.go
+++ b/std/algebra/sw/pairing_test.go
@@ -163,6 +163,10 @@ func TestTriplePairingBLS377(t *testing.T) {
 
 func BenchmarkPairing(b *testing.B) {
 	var c pairingBLS377
-	ccsBench, _ = frontend.Compile(ecc.BW6_761, backend.GROTH16, &c)
-	b.Log("groth16", ccsBench.GetNbConstraints())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		frontend.Compile(ecc.BW6_761, backend.PLONK, &c)
+	}
+	// ccsBench, _ = frontend.Compile(ecc.BW6_761, backend.GROTH16, &c)
+	// b.Log("groth16", ccsBench.GetNbConstraints())
 }

--- a/test/engine.go
+++ b/test/engine.go
@@ -386,3 +386,7 @@ func (e *engine) modulus() *big.Int {
 func (e *engine) CurveID() ecc.ID {
 	return e.curveID
 }
+
+func (e *engine) Backend() backend.ID {
+	return backend.UNKNOWN
+}


### PR DESCRIPTION
The boolean operations (AND, OR, XOR) already check that the inputs are
boolean constrained. The outputs of these operations are also always
boolean. We mark them in the constraint system as such so that further
boolean operations on them wouldn't introduce additional constraints.