### PR TITLE
Add subtests to test.Assert

### DIFF
--- a/circuitstats_test.go
+++ b/circuitstats_test.go
@@ -37,7 +37,7 @@ func TestCircuitStatistics(t *testing.T) {
 					// ensure we didn't introduce regressions that make circuits less efficient
 					nbConstraints := ccs.GetNbConstraints()
 					internal, secret, public := ccs.GetNbVariables()
-					checkStats(t, name, nbConstraints, internal, secret, public, curve, b)
+					checkStats(assert, name, nbConstraints, internal, secret, public, curve, b)
 				}, name, curve.String(), b.String())
 			}
 		}
@@ -61,7 +61,7 @@ type circuitStats struct {
 
 var mStats map[string][backend.PLONK + 1][ecc.BW6_633 + 1]circuitStats
 
-func checkStats(t *testing.T, circuitName string, nbConstraints, internal, secret, public int, curve ecc.ID, backendID backend.ID) {
+func checkStats(assert *test.Assert, circuitName string, nbConstraints, internal, secret, public int, curve ecc.ID, backendID backend.ID) {
 	statsM.Lock()
 	defer statsM.Unlock()
 	if generateNewStats {
@@ -71,20 +71,20 @@ func checkStats(t *testing.T, circuitName string, nbConstraints, internal, secre
 		return
 	}
 	if referenceStats, ok := mStats[circuitName]; !ok {
-		t.Log("warning: no stats for circuit", circuitName)
+		assert.Log("warning: no stats for circuit", circuitName)
 	} else {
 		ref := referenceStats[backendID][curve]
 		if ref.NbConstraints != nbConstraints {
-			t.Errorf("expected %d nbConstraints (reference), got %d. %s, %s, %s", ref.NbConstraints, nbConstraints, circuitName, backendID.String(), curve.String())
+			assert.Failf("unexpected constraint count", "expected %d nbConstraints (reference), got %d. %s, %s, %s", ref.NbConstraints, nbConstraints, circuitName, backendID.String(), curve.String())
 		}
 		if ref.Internal != internal {
-			t.Errorf("expected %d internal (reference), got %d. %s, %s, %s", ref.Internal, internal, circuitName, backendID.String(), curve.String())
+			assert.Failf("unexpected internal variable count", "expected %d internal (reference), got %d. %s, %s, %s", ref.Internal, internal, circuitName, backendID.String(), curve.String())
 		}
 		if ref.Secret != secret {
-			t.Errorf("expected %d secret (reference), got %d. %s, %s, %s", ref.Secret, secret, circuitName, backendID.String(), curve.String())
+			assert.Failf("unexpected secret variable count", "expected %d secret (reference), got %d. %s, %s, %s", ref.Secret, secret, circuitName, backendID.String(), curve.String())
 		}
 		if ref.Public != public {
-			t.Errorf("expected %d public (reference), got %d. %s, %s, %s", ref.Public, public, circuitName, backendID.String(), curve.String())
+			assert.Failf("unexpected public variable count", "expected %d public (reference), got %d. %s, %s, %s", ref.Public, public, circuitName, backendID.String(), curve.String())
 		}
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gnark
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -35,26 +36,22 @@ func TestIntegrationAPI(t *testing.T) {
 	}
 	sort.Strings(keys)
 
-	for _, k := range keys {
+	for i := range keys {
+		name := keys[i]
+		tData := circuits.Circuits[name]
+		assert.Run(func(assert *test.Assert) {
+			for i := range tData.ValidWitnesses {
+				assert.Run(func(assert *test.Assert) {
+					assert.ProverSucceeded(tData.Circuit, tData.ValidWitnesses[i], test.WithProverOpts(backend.WithHints(tData.HintFunctions...)), test.WithCurves(tData.Curves[0], tData.Curves[1:]...))
+				}, fmt.Sprintf("valid-%d", i))
+			}
 
-		tData := circuits.Circuits[k]
-		t.Log(k)
-		for _, w := range tData.ValidWitnesses {
-			// assert.ProverSucceeded(tData.Circuit, w, test.WithProverOpts(backend.WithHints(tData.HintFunctions...)))
-			assert.ProverSucceeded(
-				tData.Circuit,
-				w,
-				test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
-				test.WithCurves(tData.Curves[0], tData.Curves[1:]...))
-		}
-
-		for _, w := range tData.InvalidWitnesses {
-			assert.ProverFailed(
-				tData.Circuit,
-				w,
-				test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
-				test.WithCurves(tData.Curves[0], tData.Curves[1:]...))
-		}
+			for i := range tData.InvalidWitnesses {
+				assert.Run(func(assert *test.Assert) {
+					assert.ProverFailed(tData.Circuit, tData.InvalidWitnesses[i], test.WithProverOpts(backend.WithHints(tData.HintFunctions...)), test.WithCurves(tData.Curves[0], tData.Curves[1:]...))
+				}, fmt.Sprintf("invalid-%d", i))
+			}
+		}, name)
 	}
 
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -55,10 +55,6 @@ func TestIntegrationAPI(t *testing.T) {
 				test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
 				test.WithCurves(tData.Curves[0], tData.Curves[1:]...))
 		}
-
-		// we put that here now, but will be into a proper fuzz target with go1.18
-		const fuzzCount = 30
-		assert.Fuzz(tData.Circuit, fuzzCount, test.WithProverOpts(backend.WithHints(tData.HintFunctions...)), test.WithBackends(backend.GROTH16))
 	}
 
 }

--- a/internal/backend/bls12-377/cs/r1cs_test.go
+++ b/internal/backend/bls12-377/cs/r1cs_test.go
@@ -33,84 +33,86 @@ func TestSerialization(t *testing.T) {
 
 	var buffer, buffer2 bytes.Buffer
 
-	for name, circuit := range circuits.Circuits {
+	for name := range circuits.Circuits {
+		t.Run(name, func(t *testing.T) {
+			tc := circuits.Circuits[name]
 
-		r1cs1, err := frontend.Compile(ecc.BLS12_377, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if testing.Short() && r1cs1.GetNbConstraints() > 50 {
-			continue
-		}
-
-		// copmpile a second time to ensure determinism
-		r1cs2, err := frontend.Compile(ecc.BLS12_377, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		{
-			buffer.Reset()
-			t.Log(name)
-			var err error
-			var written, read int64
-			written, err = r1cs1.WriteTo(&buffer)
+			r1cs1, err := frontend.Compile(ecc.BLS12_377, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
-			var reconstructed cs.R1CS
-			read, err = reconstructed.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if written != read {
-				t.Fatal("didn't read same number of bytes we wrote")
-			}
-			// compare original and reconstructed
-			if !reflect.DeepEqual(r1cs1, &reconstructed) {
-				t.Fatal("round trip serialization failed")
-			}
-		}
-
-		// ensure determinism in compilation / serialization / reconstruction
-		{
-			buffer.Reset()
-			n, err := r1cs1.WriteTo(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are written")
+			if testing.Short() && r1cs1.GetNbConstraints() > 50 {
+				return
 			}
 
-			buffer2.Reset()
-			_, err = r1cs2.WriteTo(&buffer2)
+			// copmpile a second time to ensure determinism
+			r1cs2, err := frontend.Compile(ecc.BLS12_377, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
-				t.Fatal("compilation of R1CS is not deterministic")
+			{
+				buffer.Reset()
+				t.Log(name)
+				var err error
+				var written, read int64
+				written, err = r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var reconstructed cs.R1CS
+				read, err = reconstructed.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if written != read {
+					t.Fatal("didn't read same number of bytes we wrote")
+				}
+				// compare original and reconstructed
+				if !reflect.DeepEqual(r1cs1, &reconstructed) {
+					t.Fatal("round trip serialization failed")
+				}
 			}
 
-			var r, r2 cs.R1CS
-			n, err = r.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(nil)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are read")
-			}
-			_, err = r2.ReadFrom(&buffer2)
-			if err != nil {
-				t.Fatal(nil)
-			}
+			// ensure determinism in compilation / serialization / reconstruction
+			{
+				buffer.Reset()
+				n, err := r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are written")
+				}
 
-			if !reflect.DeepEqual(r, r2) {
-				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				buffer2.Reset()
+				_, err = r1cs2.WriteTo(&buffer2)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
+					t.Fatal("compilation of R1CS is not deterministic")
+				}
+
+				var r, r2 cs.R1CS
+				n, err = r.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(nil)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are read")
+				}
+				_, err = r2.ReadFrom(&buffer2)
+				if err != nil {
+					t.Fatal(nil)
+				}
+
+				if !reflect.DeepEqual(r, r2) {
+					t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				}
 			}
-		}
+		})
+
 	}
 }

--- a/internal/backend/bls12-381/cs/r1cs_test.go
+++ b/internal/backend/bls12-381/cs/r1cs_test.go
@@ -33,84 +33,86 @@ func TestSerialization(t *testing.T) {
 
 	var buffer, buffer2 bytes.Buffer
 
-	for name, circuit := range circuits.Circuits {
+	for name := range circuits.Circuits {
+		t.Run(name, func(t *testing.T) {
+			tc := circuits.Circuits[name]
 
-		r1cs1, err := frontend.Compile(ecc.BLS12_381, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if testing.Short() && r1cs1.GetNbConstraints() > 50 {
-			continue
-		}
-
-		// copmpile a second time to ensure determinism
-		r1cs2, err := frontend.Compile(ecc.BLS12_381, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		{
-			buffer.Reset()
-			t.Log(name)
-			var err error
-			var written, read int64
-			written, err = r1cs1.WriteTo(&buffer)
+			r1cs1, err := frontend.Compile(ecc.BLS12_381, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
-			var reconstructed cs.R1CS
-			read, err = reconstructed.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if written != read {
-				t.Fatal("didn't read same number of bytes we wrote")
-			}
-			// compare original and reconstructed
-			if !reflect.DeepEqual(r1cs1, &reconstructed) {
-				t.Fatal("round trip serialization failed")
-			}
-		}
-
-		// ensure determinism in compilation / serialization / reconstruction
-		{
-			buffer.Reset()
-			n, err := r1cs1.WriteTo(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are written")
+			if testing.Short() && r1cs1.GetNbConstraints() > 50 {
+				return
 			}
 
-			buffer2.Reset()
-			_, err = r1cs2.WriteTo(&buffer2)
+			// copmpile a second time to ensure determinism
+			r1cs2, err := frontend.Compile(ecc.BLS12_381, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
-				t.Fatal("compilation of R1CS is not deterministic")
+			{
+				buffer.Reset()
+				t.Log(name)
+				var err error
+				var written, read int64
+				written, err = r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var reconstructed cs.R1CS
+				read, err = reconstructed.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if written != read {
+					t.Fatal("didn't read same number of bytes we wrote")
+				}
+				// compare original and reconstructed
+				if !reflect.DeepEqual(r1cs1, &reconstructed) {
+					t.Fatal("round trip serialization failed")
+				}
 			}
 
-			var r, r2 cs.R1CS
-			n, err = r.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(nil)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are read")
-			}
-			_, err = r2.ReadFrom(&buffer2)
-			if err != nil {
-				t.Fatal(nil)
-			}
+			// ensure determinism in compilation / serialization / reconstruction
+			{
+				buffer.Reset()
+				n, err := r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are written")
+				}
 
-			if !reflect.DeepEqual(r, r2) {
-				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				buffer2.Reset()
+				_, err = r1cs2.WriteTo(&buffer2)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
+					t.Fatal("compilation of R1CS is not deterministic")
+				}
+
+				var r, r2 cs.R1CS
+				n, err = r.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(nil)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are read")
+				}
+				_, err = r2.ReadFrom(&buffer2)
+				if err != nil {
+					t.Fatal(nil)
+				}
+
+				if !reflect.DeepEqual(r, r2) {
+					t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				}
 			}
-		}
+		})
+
 	}
 }

--- a/internal/backend/bls24-315/cs/r1cs_test.go
+++ b/internal/backend/bls24-315/cs/r1cs_test.go
@@ -33,84 +33,86 @@ func TestSerialization(t *testing.T) {
 
 	var buffer, buffer2 bytes.Buffer
 
-	for name, circuit := range circuits.Circuits {
+	for name := range circuits.Circuits {
+		t.Run(name, func(t *testing.T) {
+			tc := circuits.Circuits[name]
 
-		r1cs1, err := frontend.Compile(ecc.BLS24_315, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if testing.Short() && r1cs1.GetNbConstraints() > 50 {
-			continue
-		}
-
-		// copmpile a second time to ensure determinism
-		r1cs2, err := frontend.Compile(ecc.BLS24_315, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		{
-			buffer.Reset()
-			t.Log(name)
-			var err error
-			var written, read int64
-			written, err = r1cs1.WriteTo(&buffer)
+			r1cs1, err := frontend.Compile(ecc.BLS24_315, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
-			var reconstructed cs.R1CS
-			read, err = reconstructed.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if written != read {
-				t.Fatal("didn't read same number of bytes we wrote")
-			}
-			// compare original and reconstructed
-			if !reflect.DeepEqual(r1cs1, &reconstructed) {
-				t.Fatal("round trip serialization failed")
-			}
-		}
-
-		// ensure determinism in compilation / serialization / reconstruction
-		{
-			buffer.Reset()
-			n, err := r1cs1.WriteTo(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are written")
+			if testing.Short() && r1cs1.GetNbConstraints() > 50 {
+				return
 			}
 
-			buffer2.Reset()
-			_, err = r1cs2.WriteTo(&buffer2)
+			// copmpile a second time to ensure determinism
+			r1cs2, err := frontend.Compile(ecc.BLS24_315, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
-				t.Fatal("compilation of R1CS is not deterministic")
+			{
+				buffer.Reset()
+				t.Log(name)
+				var err error
+				var written, read int64
+				written, err = r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var reconstructed cs.R1CS
+				read, err = reconstructed.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if written != read {
+					t.Fatal("didn't read same number of bytes we wrote")
+				}
+				// compare original and reconstructed
+				if !reflect.DeepEqual(r1cs1, &reconstructed) {
+					t.Fatal("round trip serialization failed")
+				}
 			}
 
-			var r, r2 cs.R1CS
-			n, err = r.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(nil)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are read")
-			}
-			_, err = r2.ReadFrom(&buffer2)
-			if err != nil {
-				t.Fatal(nil)
-			}
+			// ensure determinism in compilation / serialization / reconstruction
+			{
+				buffer.Reset()
+				n, err := r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are written")
+				}
 
-			if !reflect.DeepEqual(r, r2) {
-				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				buffer2.Reset()
+				_, err = r1cs2.WriteTo(&buffer2)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
+					t.Fatal("compilation of R1CS is not deterministic")
+				}
+
+				var r, r2 cs.R1CS
+				n, err = r.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(nil)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are read")
+				}
+				_, err = r2.ReadFrom(&buffer2)
+				if err != nil {
+					t.Fatal(nil)
+				}
+
+				if !reflect.DeepEqual(r, r2) {
+					t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				}
 			}
-		}
+		})
+
 	}
 }

--- a/internal/backend/bn254/cs/r1cs_test.go
+++ b/internal/backend/bn254/cs/r1cs_test.go
@@ -33,84 +33,86 @@ func TestSerialization(t *testing.T) {
 
 	var buffer, buffer2 bytes.Buffer
 
-	for name, circuit := range circuits.Circuits {
+	for name := range circuits.Circuits {
+		t.Run(name, func(t *testing.T) {
+			tc := circuits.Circuits[name]
 
-		r1cs1, err := frontend.Compile(ecc.BN254, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if testing.Short() && r1cs1.GetNbConstraints() > 50 {
-			continue
-		}
-
-		// copmpile a second time to ensure determinism
-		r1cs2, err := frontend.Compile(ecc.BN254, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		{
-			buffer.Reset()
-			t.Log(name)
-			var err error
-			var written, read int64
-			written, err = r1cs1.WriteTo(&buffer)
+			r1cs1, err := frontend.Compile(ecc.BN254, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
-			var reconstructed cs.R1CS
-			read, err = reconstructed.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if written != read {
-				t.Fatal("didn't read same number of bytes we wrote")
-			}
-			// compare original and reconstructed
-			if !reflect.DeepEqual(r1cs1, &reconstructed) {
-				t.Fatal("round trip serialization failed")
-			}
-		}
-
-		// ensure determinism in compilation / serialization / reconstruction
-		{
-			buffer.Reset()
-			n, err := r1cs1.WriteTo(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are written")
+			if testing.Short() && r1cs1.GetNbConstraints() > 50 {
+				return
 			}
 
-			buffer2.Reset()
-			_, err = r1cs2.WriteTo(&buffer2)
+			// copmpile a second time to ensure determinism
+			r1cs2, err := frontend.Compile(ecc.BN254, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
-				t.Fatal("compilation of R1CS is not deterministic")
+			{
+				buffer.Reset()
+				t.Log(name)
+				var err error
+				var written, read int64
+				written, err = r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var reconstructed cs.R1CS
+				read, err = reconstructed.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if written != read {
+					t.Fatal("didn't read same number of bytes we wrote")
+				}
+				// compare original and reconstructed
+				if !reflect.DeepEqual(r1cs1, &reconstructed) {
+					t.Fatal("round trip serialization failed")
+				}
 			}
 
-			var r, r2 cs.R1CS
-			n, err = r.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(nil)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are read")
-			}
-			_, err = r2.ReadFrom(&buffer2)
-			if err != nil {
-				t.Fatal(nil)
-			}
+			// ensure determinism in compilation / serialization / reconstruction
+			{
+				buffer.Reset()
+				n, err := r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are written")
+				}
 
-			if !reflect.DeepEqual(r, r2) {
-				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				buffer2.Reset()
+				_, err = r1cs2.WriteTo(&buffer2)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
+					t.Fatal("compilation of R1CS is not deterministic")
+				}
+
+				var r, r2 cs.R1CS
+				n, err = r.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(nil)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are read")
+				}
+				_, err = r2.ReadFrom(&buffer2)
+				if err != nil {
+					t.Fatal(nil)
+				}
+
+				if !reflect.DeepEqual(r, r2) {
+					t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				}
 			}
-		}
+		})
+
 	}
 }

--- a/internal/backend/bw6-633/cs/r1cs_test.go
+++ b/internal/backend/bw6-633/cs/r1cs_test.go
@@ -33,84 +33,86 @@ func TestSerialization(t *testing.T) {
 
 	var buffer, buffer2 bytes.Buffer
 
-	for name, circuit := range circuits.Circuits {
+	for name := range circuits.Circuits {
+		t.Run(name, func(t *testing.T) {
+			tc := circuits.Circuits[name]
 
-		r1cs1, err := frontend.Compile(ecc.BW6_633, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if testing.Short() && r1cs1.GetNbConstraints() > 50 {
-			continue
-		}
-
-		// copmpile a second time to ensure determinism
-		r1cs2, err := frontend.Compile(ecc.BW6_633, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		{
-			buffer.Reset()
-			t.Log(name)
-			var err error
-			var written, read int64
-			written, err = r1cs1.WriteTo(&buffer)
+			r1cs1, err := frontend.Compile(ecc.BW6_633, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
-			var reconstructed cs.R1CS
-			read, err = reconstructed.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if written != read {
-				t.Fatal("didn't read same number of bytes we wrote")
-			}
-			// compare original and reconstructed
-			if !reflect.DeepEqual(r1cs1, &reconstructed) {
-				t.Fatal("round trip serialization failed")
-			}
-		}
-
-		// ensure determinism in compilation / serialization / reconstruction
-		{
-			buffer.Reset()
-			n, err := r1cs1.WriteTo(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are written")
+			if testing.Short() && r1cs1.GetNbConstraints() > 50 {
+				return
 			}
 
-			buffer2.Reset()
-			_, err = r1cs2.WriteTo(&buffer2)
+			// copmpile a second time to ensure determinism
+			r1cs2, err := frontend.Compile(ecc.BW6_633, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
-				t.Fatal("compilation of R1CS is not deterministic")
+			{
+				buffer.Reset()
+				t.Log(name)
+				var err error
+				var written, read int64
+				written, err = r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var reconstructed cs.R1CS
+				read, err = reconstructed.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if written != read {
+					t.Fatal("didn't read same number of bytes we wrote")
+				}
+				// compare original and reconstructed
+				if !reflect.DeepEqual(r1cs1, &reconstructed) {
+					t.Fatal("round trip serialization failed")
+				}
 			}
 
-			var r, r2 cs.R1CS
-			n, err = r.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(nil)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are read")
-			}
-			_, err = r2.ReadFrom(&buffer2)
-			if err != nil {
-				t.Fatal(nil)
-			}
+			// ensure determinism in compilation / serialization / reconstruction
+			{
+				buffer.Reset()
+				n, err := r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are written")
+				}
 
-			if !reflect.DeepEqual(r, r2) {
-				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				buffer2.Reset()
+				_, err = r1cs2.WriteTo(&buffer2)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
+					t.Fatal("compilation of R1CS is not deterministic")
+				}
+
+				var r, r2 cs.R1CS
+				n, err = r.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(nil)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are read")
+				}
+				_, err = r2.ReadFrom(&buffer2)
+				if err != nil {
+					t.Fatal(nil)
+				}
+
+				if !reflect.DeepEqual(r, r2) {
+					t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				}
 			}
-		}
+		})
+
 	}
 }

--- a/internal/backend/bw6-761/cs/r1cs_test.go
+++ b/internal/backend/bw6-761/cs/r1cs_test.go
@@ -33,88 +33,90 @@ func TestSerialization(t *testing.T) {
 
 	var buffer, buffer2 bytes.Buffer
 
-	for name, circuit := range circuits.Circuits {
+	for name := range circuits.Circuits {
+		t.Run(name, func(t *testing.T) {
+			tc := circuits.Circuits[name]
 
-		if testing.Short() && name != "reference_small" {
-			continue
-		}
+			if testing.Short() && name != "reference_small" {
+				return
+			}
 
-		r1cs1, err := frontend.Compile(ecc.BW6_761, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if testing.Short() && r1cs1.GetNbConstraints() > 50 {
-			continue
-		}
-
-		// copmpile a second time to ensure determinism
-		r1cs2, err := frontend.Compile(ecc.BW6_761, backend.UNKNOWN,
-			circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		{
-			buffer.Reset()
-			t.Log(name)
-			var err error
-			var written, read int64
-			written, err = r1cs1.WriteTo(&buffer)
+			r1cs1, err := frontend.Compile(ecc.BW6_761, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
-			var reconstructed cs.R1CS
-			read, err = reconstructed.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if written != read {
-				t.Fatal("didn't read same number of bytes we wrote")
-			}
-			// compare original and reconstructed
-			if !reflect.DeepEqual(r1cs1, &reconstructed) {
-				t.Fatal("round trip serialization failed")
-			}
-		}
-
-		// ensure determinism in compilation / serialization / reconstruction
-		{
-			buffer.Reset()
-			n, err := r1cs1.WriteTo(&buffer)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are written")
+			if testing.Short() && r1cs1.GetNbConstraints() > 50 {
+				return
 			}
 
-			buffer2.Reset()
-			_, err = r1cs2.WriteTo(&buffer2)
+			// copmpile a second time to ensure determinism
+			r1cs2, err := frontend.Compile(ecc.BW6_761, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
-				t.Fatal("compilation of R1CS is not deterministic")
+			{
+				buffer.Reset()
+				t.Log(name)
+				var err error
+				var written, read int64
+				written, err = r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var reconstructed cs.R1CS
+				read, err = reconstructed.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if written != read {
+					t.Fatal("didn't read same number of bytes we wrote")
+				}
+				// compare original and reconstructed
+				if !reflect.DeepEqual(r1cs1, &reconstructed) {
+					t.Fatal("round trip serialization failed")
+				}
 			}
 
-			var r, r2 cs.R1CS
-			n, err = r.ReadFrom(&buffer)
-			if err != nil {
-				t.Fatal(nil)
-			}
-			if n == 0 {
-				t.Fatal("No bytes are read")
-			}
-			_, err = r2.ReadFrom(&buffer2)
-			if err != nil {
-				t.Fatal(nil)
-			}
+			// ensure determinism in compilation / serialization / reconstruction
+			{
+				buffer.Reset()
+				n, err := r1cs1.WriteTo(&buffer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are written")
+				}
 
-			if !reflect.DeepEqual(r, r2) {
-				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				buffer2.Reset()
+				_, err = r1cs2.WriteTo(&buffer2)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !bytes.Equal(buffer.Bytes(), buffer2.Bytes()) {
+					t.Fatal("compilation of R1CS is not deterministic")
+				}
+
+				var r, r2 cs.R1CS
+				n, err = r.ReadFrom(&buffer)
+				if err != nil {
+					t.Fatal(nil)
+				}
+				if n == 0 {
+					t.Fatal("No bytes are read")
+				}
+				_, err = r2.ReadFrom(&buffer2)
+				if err != nil {
+					t.Fatal(nil)
+				}
+
+				if !reflect.DeepEqual(r, r2) {
+					t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
+				}
 			}
-		}
+		})
+
 	}
 }

--- a/internal/backend/circuits/lookup2.go
+++ b/internal/backend/circuits/lookup2.go
@@ -1,8 +1,6 @@
 package circuits
 
 import (
-	"fmt"
-
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
@@ -21,21 +19,16 @@ func (c *lookup2Circuit) Define(api frontend.API) error {
 
 func init() {
 	v0, v1, v2, v3 := 0, 1, 2, 3
+	good := []frontend.Circuit{}
+	bad := []frontend.Circuit{}
 	for _, tc := range []struct {
 		b0, b1     int
 		expected   int
 		unexpected int
-	}{
-		{0, 0, 0, 1},
-		{1, 0, 1, 0},
-		{0, 1, 2, 0},
-		{1, 1, 3, 0}} {
-		addEntry(
-			fmt.Sprintf("lookup2-%d%d", tc.b0, tc.b1),
-			&lookup2Circuit{},
-			&lookup2Circuit{v0, v1, v2, v3, tc.b0, tc.b1, tc.expected},
-			&lookup2Circuit{v0, v1, v2, v3, tc.b0, tc.b1, tc.unexpected},
-			ecc.Implemented(),
-		)
+	}{{0, 0, 0, 1}, {1, 0, 1, 0}, {0, 1, 2, 0}, {1, 1, 3, 0}} {
+		good = append(good, &lookup2Circuit{v0, v1, v2, v3, tc.b0, tc.b1, tc.expected})
+		bad = append(bad, &lookup2Circuit{v0, v1, v2, v3, tc.b0, tc.b1, tc.unexpected})
 	}
+
+	addNewEntry("lookup2", &lookup2Circuit{}, good, bad, ecc.Implemented())
 }

--- a/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
@@ -16,26 +16,25 @@ func TestSerialization(t *testing.T) {
 	
 	var buffer, buffer2 bytes.Buffer
 	
-	for name, circuit := range circuits.Circuits {
-
+	for name := range circuits.Circuits {
+		t.Run(name, func(t *testing.T) {
+		tc := circuits.Circuits[name]
 		{{if eq .Curve "BW6-761"}}
 			if testing.Short() && name != "reference_small" {
-				continue
+				return
 			}
 		{{end}}
 
-		r1cs1, err := frontend.Compile(ecc.{{ .CurveID }}, backend.UNKNOWN,
-		circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
+		r1cs1, err := frontend.Compile(ecc.{{ .CurveID }}, backend.UNKNOWN,	tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 		if err != nil {
 			t.Fatal(err)
 		}
 		if testing.Short() && r1cs1.GetNbConstraints() > 50 {
-			continue
+			return
 		}
 
 		// copmpile a second time to ensure determinism
-		r1cs2, err := frontend.Compile(ecc.{{ .CurveID }}, backend.UNKNOWN,
-		circuit.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
+		r1cs2, err := frontend.Compile(ecc.{{ .CurveID }}, backend.UNKNOWN, tc.Circuit, frontend.WithBuilder(r1cs.NewBuilder))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -101,5 +100,7 @@ func TestSerialization(t *testing.T) {
 				t.Fatal("compilation of R1CS is not deterministic (reconstruction)")
 			}
 		}
+		})
+
 	}
 }

--- a/test/assert.go
+++ b/test/assert.go
@@ -72,6 +72,11 @@ func (assert *Assert) Run(fn func(assert *Assert), descs ...string) {
 	})
 }
 
+// Log logs using the test instance logger.
+func (assert *Assert) Log(v ...interface{}) {
+	assert.t.Log(v...)
+}
+
 // ProverSucceeded fails the test if any of the following step errored:
 //
 // 1. compiles the circuit (or fetch it from the cache)


### PR DESCRIPTION
Added method `Run(fn func(assert *test.Assert), descs ...string)` to Assert type. This is similar to the `Run` method in Go's standard testing package to allow running subtests. Refactored tests in places to use subtests.

Removed explicit `Fuzz` call in integration tests as Fuzz is already called in `Assert.ProverSucceeded`.

An potential added benefit of using subtests is better coverage with race detector and enabling running subtests in parallel. I didn't implement it now though as Assert uses unsynchronized cache for compiled circuits.