### PR TITLE
Add multiple outputs for a hint function

### DIFF
--- a/backend/hint/builtin.go
+++ b/backend/hint/builtin.go
@@ -1,7 +1,6 @@
 package hint
 
 import (
-	"errors"
 	"math/big"
 	"sync"
 
@@ -12,9 +11,9 @@ var initBuiltinOnce sync.Once
 
 func init() {
 	initBuiltinOnce.Do(func() {
-		IsZero = builtinIsZero
+		IsZero = NewStaticHint(builtinIsZero, 1, 1)
 		Register(IsZero)
-		IthBit = builtinIthBit
+		IthBit = NewStaticHint(builtinIthBit, 2, 1)
 		Register(IthBit)
 	})
 }
@@ -33,10 +32,8 @@ var (
 	IthBit Function
 )
 
-func builtinIsZero(curveID ecc.ID, inputs []*big.Int, result *big.Int) error {
-	if len(inputs) != 1 {
-		return errors.New("IsZero expects one input")
-	}
+func builtinIsZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error {
+	result := results[0]
 
 	// get fr modulus
 	q := curveID.Info().Fr.Modulus()
@@ -56,10 +53,8 @@ func builtinIsZero(curveID ecc.ID, inputs []*big.Int, result *big.Int) error {
 	return nil
 }
 
-func builtinIthBit(_ ecc.ID, inputs []*big.Int, result *big.Int) error {
-	if len(inputs) != 2 {
-		return errors.New("ithBit expects 2 inputs; inputs[0] == value, inputs[1] == bit position")
-	}
+func builtinIthBit(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
+	result := results[0]
 	if !inputs[1].IsUint64() {
 		result.SetUint64(0)
 		return nil

--- a/backend/hint/hint.go
+++ b/backend/hint/hint.go
@@ -85,19 +85,11 @@ type Function interface {
 	// lookup of the hint function.
 	UUID() ID
 
-	// Call is invoked by the framework to obtain the result from inputs. It is
-	// ensured that the number of inputs is exactly TotalInputs() if it is
-	// non-negative. If TotalInputs() is negative, then the length of inputs is
-	// not bounded. The length of res is TotalOutputs() and every element is
+	// Call is invoked by the framework to obtain the result from inputs.
+	// The length of res is TotalOutputs() and every element is
 	// already initialized (but not necessarily to zero as the elements may be
 	// obtained from cache). A returned non-nil error will be propagated.
 	Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error
-
-	// TotalInputs returns the total number of inputs accepted by the function
-	// when invoked on the curveID. If the returned value is negative, then the
-	// function takes any number of inputs. If it is zero, then the function
-	// does not take any inputs.
-	TotalInputs(curveID ecc.ID) (nInputs int)
 
 	// TotalOutputs returns the total number of outputs by the function when
 	// invoked on the curveID with nInputs number of inputs. The number of
@@ -163,10 +155,6 @@ func (h *staticArgumentsFunction) Call(curveID ecc.ID, inputs []*big.Int, res []
 		return fmt.Errorf("result has %d elements, expected %d", len(res), h.nOut)
 	}
 	return h.fn(curveID, inputs, res)
-}
-
-func (h *staticArgumentsFunction) TotalInputs(_ ecc.ID) int {
-	return h.nIn
 }
 
 func (h *staticArgumentsFunction) TotalOutputs(_ ecc.ID, _ int) int {

--- a/backend/hint/hint.go
+++ b/backend/hint/hint.go
@@ -78,6 +78,11 @@ import (
 // ID is a unique identifier for a hint function used for lookup.
 type ID uint32
 
+// StaticFunction is a function which takes a constant number of inputs and
+// returns a constant number of outputs. Use NewStaticHint() to construct an
+// instance compatible with Function interface.
+type StaticFunction func(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error
+
 // Function defines an annotated hint function. To initialize a hint function
 // with static number of inputs and outputs, use NewStaticHint().
 type Function interface {
@@ -86,15 +91,15 @@ type Function interface {
 	UUID() ID
 
 	// Call is invoked by the framework to obtain the result from inputs.
-	// The length of res is TotalOutputs() and every element is
+	// The length of res is NbOutputs() and every element is
 	// already initialized (but not necessarily to zero as the elements may be
 	// obtained from cache). A returned non-nil error will be propagated.
 	Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error
 
-	// TotalOutputs returns the total number of outputs by the function when
+	// NbOutputs returns the total number of outputs by the function when
 	// invoked on the curveID with nInputs number of inputs. The number of
 	// outputs must be at least one and the framework errors otherwise.
-	TotalOutputs(curveID ecc.ID, nInputs int) (nOutputs int)
+	NbOutputs(curveID ecc.ID, nInputs int) (nOutputs int)
 
 	// String returns a human-readable description of the function used in logs
 	// and debug messages.
@@ -121,11 +126,6 @@ func UUID(fn StaticFunction, ctx ...uint64) ID {
 	}
 	return ID(hf.Sum32())
 }
-
-// StaticFunction is a function which takes a constant number of inputs and
-// returns a constant number of outputs. Use NewStaticHint() to construct an
-// instance compatible with Function interface.
-type StaticFunction func(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error
 
 // staticArgumentsFunction defines a function where the number of inputs and
 // outputs is constant.
@@ -157,7 +157,7 @@ func (h *staticArgumentsFunction) Call(curveID ecc.ID, inputs []*big.Int, res []
 	return h.fn(curveID, inputs, res)
 }
 
-func (h *staticArgumentsFunction) TotalOutputs(_ ecc.ID, _ int) int {
+func (h *staticArgumentsFunction) NbOutputs(_ ecc.ID, _ int) int {
 	return h.nOut
 }
 

--- a/backend/hint/hint.go
+++ b/backend/hint/hint.go
@@ -32,11 +32,11 @@ constructing the proof must be extremely cautious when using hints.
 Using hint functions in circuits
 
 To use a hint function in a circuit, the developer first needs to define a hint
-function hintFn according to the Function type. Then, in a circuit, the
+function hintFn according to the Function interface. Then, in a circuit, the
 developer applies the hint function with frontend.API.NewHint(hintFn, vars...),
 where vars are the variables the hint function will be applied to (and
 correspond to the argument inputs in the Function type) which returns a new
-unconstrained variable. The returned variable must be constrained using
+unconstrained variable. The returned variables must be constrained using
 frontend.API.Assert[.*] methods.
 
 As explained, the hints are essentially black boxes from the circuit point of
@@ -65,6 +65,8 @@ the hint function hintFn to register a hint function in the package registry.
 package hint
 
 import (
+	"encoding/binary"
+	"fmt"
 	"hash/fnv"
 	"math/big"
 	"reflect"
@@ -73,20 +75,110 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 )
 
-// ID is a unique identifier for an hint function. It is set by the package in
-// is used for lookup.
+// ID is a unique identifier for a hint function used for lookup.
 type ID uint32
 
-// Function defines how a hint is computed from the inputs. The hint value is
-// stored in result. If the hint is computable, then the functio must return a
-// nil error and non-nil error otherwise.
-type Function func(curveID ecc.ID, inputs []*big.Int, result *big.Int) error
+// Function defines an annotated hint function. To initialize a hint function
+// with static number of inputs and outputs, use NewStaticHint().
+type Function interface {
+	// UUID returns an unique identifier for the hint function. UUID is used for
+	// lookup of the hint function.
+	UUID() ID
 
-// UUID returns a unique ID for the hint function. Multiple calls using same
-// function return the same ID.
-func UUID(hintFn Function) ID {
-	name := runtime.FuncForPC(reflect.ValueOf(hintFn).Pointer()).Name()
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(name))
-	return ID(h.Sum32())
+	// Call is invoked by the framework to obtain the result from inputs. It is
+	// ensured that the number of inputs is exactly TotalInputs() if it is
+	// non-negative. If TotalInputs() is negative, then the length of inputs is
+	// not bounded. The length of res is TotalOutputs() and every element is
+	// already initialized (but not necessarily to zero as the elements may be
+	// obtained from cache). A returned non-nil error will be propagated.
+	Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error
+
+	// TotalInputs returns the total number of inputs accepted by the function
+	// when invoked on the curveID. If the returned value is negative, then the
+	// function takes any number of inputs. If it is zero, then the function
+	// does not take any inputs.
+	TotalInputs(curveID ecc.ID) (nInputs int)
+
+	// TotalOutputs returns the total number of outputs by the function when
+	// invoked on the curveID with nInputs number of inputs. The number of
+	// outputs must be at least one and the framework errors otherwise.
+	TotalOutputs(curveID ecc.ID, nInputs int) (nOutputs int)
+
+	// String returns a human-readable description of the function used in logs
+	// and debug messages.
+	String() string
+}
+
+// UUID is a reference function for computing the hint ID based on a function
+// and additional context values ctx. A change in any of the inputs modifies the
+// returned value and thus this function can be used to compute the hint ID for
+// same function in different contexts (for example, for different number of
+// inputs and outputs).
+func UUID(fn StaticFunction, ctx ...uint64) ID {
+	var buf [8]byte
+	hf := fnv.New32a()
+	name := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	// using a name for identifying different hints should be enough as we get a
+	// solve-time error when there are duplicate hints with the same signature.
+	hf.Write([]byte(name)) // #nosec G104 -- does not err
+	// also feed all context values into the checksum do differentiate different
+	// hints based on the same function.
+	for _, ct := range ctx {
+		binary.BigEndian.PutUint64(buf[:], uint64(ct))
+		hf.Write(buf[:]) // #nosec G104 -- does not err
+	}
+	return ID(hf.Sum32())
+}
+
+// StaticFunction is a function which takes a constant number of inputs and
+// returns a constant number of outputs. Use NewStaticHint() to construct an
+// instance compatible with Function interface.
+type StaticFunction func(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error
+
+// staticArgumentsFunction defines a function where the number of inputs and
+// outputs is constant.
+type staticArgumentsFunction struct {
+	fn   StaticFunction
+	nIn  int
+	nOut int
+}
+
+// NewStaticHint returns an Function where the number of inputs and outputs is
+// constant. UUID is computed by combining fn, nIn and nOut and thus it is legal
+// to defined multiple AnnotatedFunctions on the same fn with different nIn and
+// nOut.
+func NewStaticHint(fn StaticFunction, nIn, nOut int) Function {
+	return &staticArgumentsFunction{
+		fn:   fn,
+		nIn:  nIn,
+		nOut: nOut,
+	}
+}
+
+func (h *staticArgumentsFunction) Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error {
+	if len(inputs) != h.nIn {
+		return fmt.Errorf("input has %d elements, expected %d", len(inputs), h.nIn)
+	}
+	if len(res) != h.nOut {
+		return fmt.Errorf("result has %d elements, expected %d", len(res), h.nOut)
+	}
+	return h.fn(curveID, inputs, res)
+}
+
+func (h *staticArgumentsFunction) TotalInputs(_ ecc.ID) int {
+	return h.nIn
+}
+
+func (h *staticArgumentsFunction) TotalOutputs(_ ecc.ID, _ int) int {
+	return h.nOut
+}
+
+func (h *staticArgumentsFunction) UUID() ID {
+	return UUID(h.fn, uint64(h.nIn), uint64(h.nOut))
+}
+
+func (h *staticArgumentsFunction) String() string {
+	fnptr := reflect.ValueOf(h.fn).Pointer()
+	name := runtime.FuncForPC(fnptr).Name()
+	return fmt.Sprintf("%s([%d]*big.Int, [%d]*big.Int) at (%x)", name, h.nIn, h.nOut, fnptr)
 }

--- a/backend/hint/registry.go
+++ b/backend/hint/registry.go
@@ -8,15 +8,15 @@ import (
 var registry = make(map[ID]Function)
 var registryM sync.RWMutex
 
-// Register registers a hint function in the global registry. All registered
-// hint functions can be retrieved with a call to GetAll(). It is an error to
-// register a single function twice and results in a panic.
+// Register registers an annotated hint function in the global registry. All
+// registered hint functions can be retrieved with a call to GetAll(). It is an
+// error to register a single function twice and results in a panic.
 func Register(hintFn Function) {
 	registryM.Lock()
 	defer registryM.Unlock()
-	key := UUID(hintFn)
+	key := hintFn.UUID()
 	if _, ok := registry[key]; ok {
-		panic(fmt.Sprintf("function %d registered twice", key))
+		panic(fmt.Sprintf("function %s registered twice", hintFn))
 	}
 	registry[key] = hintFn
 }

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -108,9 +108,10 @@ type API interface {
 	// whose value will be resolved at runtime when computed by the solver
 	Println(a ...Variable)
 
-	// NewHint initializes an internal variable whose value will be evaluated
+	// NewHint initializes internal variables whose value will be evaluated
 	// using the provided hint function at run time from the inputs. Inputs must
-	// be either variables or convertible to *big.Int.
+	// be either variables or convertible to *big.Int. The function returns an
+	// error if the number of inputs is not compatible with f.
 	//
 	// The hint function is provided at the proof creation time and is not
 	// embedded into the circuit. From the backend point of view, the variable
@@ -119,7 +120,7 @@ type API interface {
 	//
 	// No new constraints are added to the newly created wire and must be added
 	// manually in the circuit. Failing to do so leads to solver failure.
-	NewHint(f hint.Function, inputs ...Variable) Variable
+	NewHint(f hint.Function, inputs ...Variable) ([]Variable, error)
 
 	// Tag creates a tag at a given place in a circuit. The state of the tag may contain informations needed to
 	// measure constraints, variables and coefficients creations through AddCounter

--- a/frontend/cs/plonk/api.go
+++ b/frontend/cs/plonk/api.go
@@ -548,9 +548,7 @@ func (system *sparseR1CS) AddCounter(from, to frontend.Tag) {
 // No new constraints are added to the newly created wire and must be added
 // manually in the circuit. Failing to do so leads to solver failure.
 func (system *sparseR1CS) NewHint(f hint.Function, inputs ...frontend.Variable) ([]frontend.Variable, error) {
-	if nIn := f.TotalInputs(system.Curve()); nIn >= 0 && nIn != len(inputs) {
-		return nil, fmt.Errorf("expected %d inputs, got %d", nIn, len(inputs))
-	}
+
 	if f.TotalOutputs(system.Curve(), len(inputs)) <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}

--- a/frontend/cs/plonk/api.go
+++ b/frontend/cs/plonk/api.go
@@ -549,7 +549,7 @@ func (system *sparseR1CS) AddCounter(from, to frontend.Tag) {
 // manually in the circuit. Failing to do so leads to solver failure.
 func (system *sparseR1CS) NewHint(f hint.Function, inputs ...frontend.Variable) ([]frontend.Variable, error) {
 
-	if f.TotalOutputs(system.Curve(), len(inputs)) <= 0 {
+	if f.NbOutputs(system.Curve(), len(inputs)) <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}
 
@@ -566,7 +566,7 @@ func (system *sparseR1CS) NewHint(f hint.Function, inputs ...frontend.Variable) 
 	}
 
 	// prepare wires
-	varIDs := make([]int, f.TotalOutputs(system.Curve(), len(inputs)))
+	varIDs := make([]int, f.NbOutputs(system.Curve(), len(inputs)))
 	res := make([]frontend.Variable, len(varIDs))
 	for i := range varIDs {
 		r := system.newInternalVariable()

--- a/frontend/cs/plonk/conversion.go
+++ b/frontend/cs/plonk/conversion.go
@@ -85,9 +85,18 @@ func (cs *sparseR1CS) Compile() (frontend.CompiledConstraintSystem, error) {
 	}
 
 	// we need to offset the ids in the hints
-	shiftedMap := make(map[int]compiled.Hint)
-	for VID, hint := range cs.MHints {
-		k := shiftVID(VID, compiled.Internal)
+	shiftedMap := make(map[int]*compiled.Hint)
+HINTLOOP:
+	for _, hint := range cs.MHints {
+		ws := make([]int, len(hint.Wires))
+		// we set for all outputs in shiftedMap. If one shifted output
+		// is in shiftedMap, then all are
+		for i, vID := range hint.Wires {
+			ws[i] = shiftVID(vID, compiled.Internal)
+			if _, ok := shiftedMap[ws[i]]; i == 0 && ok {
+				continue HINTLOOP
+			}
+		}
 		inputs := make([]interface{}, len(hint.Inputs))
 		copy(inputs, hint.Inputs)
 		for j := 0; j < len(inputs); j++ {
@@ -99,7 +108,10 @@ func (cs *sparseR1CS) Compile() (frontend.CompiledConstraintSystem, error) {
 				inputs[j] = t
 			}
 		}
-		shiftedMap[k] = compiled.Hint{ID: hint.ID, Inputs: inputs}
+		ch := &compiled.Hint{ID: hint.ID, Inputs: inputs, Wires: ws}
+		for _, vID := range ws {
+			shiftedMap[vID] = ch
+		}
 	}
 	res.MHints = shiftedMap
 

--- a/frontend/cs/plonk/sparse_r1cs.go
+++ b/frontend/cs/plonk/sparse_r1cs.go
@@ -52,7 +52,7 @@ func newSparseR1CS(curveID ecc.ID, initialCapacity ...int) *sparseR1CS {
 
 			CS: compiled.CS{
 				MDebug: make(map[int]int),
-				MHints: make(map[int]compiled.Hint),
+				MHints: make(map[int]*compiled.Hint),
 			},
 
 			Coeffs:         make([]big.Int, 4),

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -673,9 +673,7 @@ func (system *r1CS) AddCounter(from, to frontend.Tag) {
 // No new constraints are added to the newly created wire and must be added
 // manually in the circuit. Failing to do so leads to solver failure.
 func (system *r1CS) NewHint(f hint.Function, inputs ...frontend.Variable) ([]frontend.Variable, error) {
-	if nIn := f.TotalInputs(system.Curve()); nIn >= 0 && nIn != len(inputs) {
-		return nil, fmt.Errorf("expected %d inputs, got %d", nIn, len(inputs))
-	}
+
 	if f.TotalOutputs(system.Curve(), len(inputs)) <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -674,7 +674,7 @@ func (system *r1CS) AddCounter(from, to frontend.Tag) {
 // manually in the circuit. Failing to do so leads to solver failure.
 func (system *r1CS) NewHint(f hint.Function, inputs ...frontend.Variable) ([]frontend.Variable, error) {
 
-	if f.TotalOutputs(system.Curve(), len(inputs)) <= 0 {
+	if f.NbOutputs(system.Curve(), len(inputs)) <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}
 	hintInputs := make([]interface{}, len(inputs))
@@ -695,7 +695,7 @@ func (system *r1CS) NewHint(f hint.Function, inputs ...frontend.Variable) ([]fro
 	}
 
 	// prepare wires
-	varIDs := make([]int, f.TotalOutputs(system.Curve(), len(inputs)))
+	varIDs := make([]int, f.NbOutputs(system.Curve(), len(inputs)))
 	res := make([]frontend.Variable, len(varIDs))
 	for i := range varIDs {
 		r := system.newInternalVariable()

--- a/frontend/cs/r1cs/r1cs.go
+++ b/frontend/cs/r1cs/r1cs.go
@@ -52,7 +52,7 @@ func newR1CS(curveID ecc.ID, initialCapacity ...int) *r1CS {
 
 			CS: compiled.CS{
 				MDebug: make(map[int]int),
-				MHints: make(map[int]compiled.Hint),
+				MHints: make(map[int]*compiled.Hint),
 			},
 
 			Coeffs:         make([]big.Int, 4),

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"reflect"
-	"runtime"
 	"sync"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -55,14 +53,11 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
 	}
 
-	for i := 0; i < len(hintFunctions); i++ {
-
-		id := hint.UUID(hintFunctions[i])
-		if _, ok := s.mHintsFunctions[id]; ok {
-			name := runtime.FuncForPC(reflect.ValueOf(hintFunctions[i]).Pointer()).Name()
-			return solution{}, fmt.Errorf("duplicate hint function with id %d - name %s", uint32(id), name)
+	for _, h := range hintFunctions {
+		if _, ok := s.mHintsFunctions[h.UUID()]; ok {
+			return solution{}, fmt.Errorf("duplicate hint function %s", h)
 		}
-		s.mHintsFunctions[id] = hintFunctions[i]
+		s.mHintsFunctions[h.UUID()] = h
 	}
 
 	return s, nil
@@ -117,7 +112,12 @@ func (s *solution) computeLinearExpression(l compiled.LinearExpression) fr.Eleme
 }
 
 // solveHint compute solution.values[vID] using provided solver hint
-func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
+func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
+	// skip if the wire is already solved by a call to the same hint
+	// function on the same inputs
+	if s.solved[vID] {
+		return nil
+	}
 	// ensure hint function was provided
 	f, ok := s.mHintsFunctions[h.ID]
 	if !ok {
@@ -150,8 +150,12 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		}
 	}
 
+	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
-	lambda.SetUint64(0)
+	outputs[0] = lambda
+	for i := 1; i < len(outputs); i++ {
+		outputs[i] = bigIntPool.Get().(*big.Int)
+	}
 
 	// ensure our inputs are mod q
 	q := fr.Modulus()
@@ -161,22 +165,27 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		inputs[i].Mod(inputs[i], q)
 	}
 
-	err := f(curve.ID, inputs, lambda)
+	err := f.Call(curve.ID, inputs, outputs)
 
 	var v fr.Element
-	v.SetBigInt(lambda)
+	for i := range outputs {
+		v.SetBigInt(outputs[i])
+		s.set(h.Wires[i], v)
+	}
 
 	// release objects into pool
-	bigIntPool.Put(lambda)
 	for i := 0; i < len(inputs); i++ {
 		bigIntPool.Put(inputs[i])
+	}
+
+	for i := 0; i < len(outputs); i++ {
+		bigIntPool.Put(outputs[i])
 	}
 
 	if err != nil {
 		return err
 	}
 
-	s.set(vID, v)
 	return nil
 }
 

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -150,7 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		}
 	}
 
-	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
+	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
 	outputs[0] = lambda
 	for i := 1; i < len(outputs); i++ {

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -130,7 +130,6 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		inputs[i] = bigIntPool.Get().(*big.Int)
 		inputs[i].SetUint64(0)
 	}
-	lambda := bigIntPool.Get().(*big.Int)
 
 	for i := 0; i < len(h.Inputs); i++ {
 
@@ -151,9 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	}
 
 	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
-	// use lambda as the result.
-	outputs[0] = lambda
-	for i := 1; i < len(outputs); i++ {
+	for i := 0; i < len(outputs); i++ {
 		outputs[i] = bigIntPool.Get().(*big.Int)
 	}
 

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"reflect"
-	"runtime"
 	"sync"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -55,14 +53,11 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
 	}
 
-	for i := 0; i < len(hintFunctions); i++ {
-
-		id := hint.UUID(hintFunctions[i])
-		if _, ok := s.mHintsFunctions[id]; ok {
-			name := runtime.FuncForPC(reflect.ValueOf(hintFunctions[i]).Pointer()).Name()
-			return solution{}, fmt.Errorf("duplicate hint function with id %d - name %s", uint32(id), name)
+	for _, h := range hintFunctions {
+		if _, ok := s.mHintsFunctions[h.UUID()]; ok {
+			return solution{}, fmt.Errorf("duplicate hint function %s", h)
 		}
-		s.mHintsFunctions[id] = hintFunctions[i]
+		s.mHintsFunctions[h.UUID()] = h
 	}
 
 	return s, nil
@@ -117,7 +112,12 @@ func (s *solution) computeLinearExpression(l compiled.LinearExpression) fr.Eleme
 }
 
 // solveHint compute solution.values[vID] using provided solver hint
-func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
+func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
+	// skip if the wire is already solved by a call to the same hint
+	// function on the same inputs
+	if s.solved[vID] {
+		return nil
+	}
 	// ensure hint function was provided
 	f, ok := s.mHintsFunctions[h.ID]
 	if !ok {
@@ -150,8 +150,12 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		}
 	}
 
+	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
-	lambda.SetUint64(0)
+	outputs[0] = lambda
+	for i := 1; i < len(outputs); i++ {
+		outputs[i] = bigIntPool.Get().(*big.Int)
+	}
 
 	// ensure our inputs are mod q
 	q := fr.Modulus()
@@ -161,22 +165,27 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		inputs[i].Mod(inputs[i], q)
 	}
 
-	err := f(curve.ID, inputs, lambda)
+	err := f.Call(curve.ID, inputs, outputs)
 
 	var v fr.Element
-	v.SetBigInt(lambda)
+	for i := range outputs {
+		v.SetBigInt(outputs[i])
+		s.set(h.Wires[i], v)
+	}
 
 	// release objects into pool
-	bigIntPool.Put(lambda)
 	for i := 0; i < len(inputs); i++ {
 		bigIntPool.Put(inputs[i])
+	}
+
+	for i := 0; i < len(outputs); i++ {
+		bigIntPool.Put(outputs[i])
 	}
 
 	if err != nil {
 		return err
 	}
 
-	s.set(vID, v)
 	return nil
 }
 

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -150,7 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		}
 	}
 
-	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
+	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
 	outputs[0] = lambda
 	for i := 1; i < len(outputs); i++ {

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -130,7 +130,6 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		inputs[i] = bigIntPool.Get().(*big.Int)
 		inputs[i].SetUint64(0)
 	}
-	lambda := bigIntPool.Get().(*big.Int)
 
 	for i := 0; i < len(h.Inputs); i++ {
 
@@ -151,9 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	}
 
 	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
-	// use lambda as the result.
-	outputs[0] = lambda
-	for i := 1; i < len(outputs); i++ {
+	for i := 0; i < len(outputs); i++ {
 		outputs[i] = bigIntPool.Get().(*big.Int)
 	}
 

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"reflect"
-	"runtime"
 	"sync"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -55,14 +53,11 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
 	}
 
-	for i := 0; i < len(hintFunctions); i++ {
-
-		id := hint.UUID(hintFunctions[i])
-		if _, ok := s.mHintsFunctions[id]; ok {
-			name := runtime.FuncForPC(reflect.ValueOf(hintFunctions[i]).Pointer()).Name()
-			return solution{}, fmt.Errorf("duplicate hint function with id %d - name %s", uint32(id), name)
+	for _, h := range hintFunctions {
+		if _, ok := s.mHintsFunctions[h.UUID()]; ok {
+			return solution{}, fmt.Errorf("duplicate hint function %s", h)
 		}
-		s.mHintsFunctions[id] = hintFunctions[i]
+		s.mHintsFunctions[h.UUID()] = h
 	}
 
 	return s, nil
@@ -117,7 +112,12 @@ func (s *solution) computeLinearExpression(l compiled.LinearExpression) fr.Eleme
 }
 
 // solveHint compute solution.values[vID] using provided solver hint
-func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
+func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
+	// skip if the wire is already solved by a call to the same hint
+	// function on the same inputs
+	if s.solved[vID] {
+		return nil
+	}
 	// ensure hint function was provided
 	f, ok := s.mHintsFunctions[h.ID]
 	if !ok {
@@ -150,8 +150,12 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		}
 	}
 
+	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
-	lambda.SetUint64(0)
+	outputs[0] = lambda
+	for i := 1; i < len(outputs); i++ {
+		outputs[i] = bigIntPool.Get().(*big.Int)
+	}
 
 	// ensure our inputs are mod q
 	q := fr.Modulus()
@@ -161,22 +165,27 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		inputs[i].Mod(inputs[i], q)
 	}
 
-	err := f(curve.ID, inputs, lambda)
+	err := f.Call(curve.ID, inputs, outputs)
 
 	var v fr.Element
-	v.SetBigInt(lambda)
+	for i := range outputs {
+		v.SetBigInt(outputs[i])
+		s.set(h.Wires[i], v)
+	}
 
 	// release objects into pool
-	bigIntPool.Put(lambda)
 	for i := 0; i < len(inputs); i++ {
 		bigIntPool.Put(inputs[i])
+	}
+
+	for i := 0; i < len(outputs); i++ {
+		bigIntPool.Put(outputs[i])
 	}
 
 	if err != nil {
 		return err
 	}
 
-	s.set(vID, v)
 	return nil
 }
 

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -150,7 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		}
 	}
 
-	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
+	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
 	outputs[0] = lambda
 	for i := 1; i < len(outputs); i++ {

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -130,7 +130,6 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		inputs[i] = bigIntPool.Get().(*big.Int)
 		inputs[i].SetUint64(0)
 	}
-	lambda := bigIntPool.Get().(*big.Int)
 
 	for i := 0; i < len(h.Inputs); i++ {
 
@@ -151,9 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	}
 
 	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
-	// use lambda as the result.
-	outputs[0] = lambda
-	for i := 1; i < len(outputs); i++ {
+	for i := 0; i < len(outputs); i++ {
 		outputs[i] = bigIntPool.Get().(*big.Int)
 	}
 

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"reflect"
-	"runtime"
 	"sync"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -55,14 +53,11 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
 	}
 
-	for i := 0; i < len(hintFunctions); i++ {
-
-		id := hint.UUID(hintFunctions[i])
-		if _, ok := s.mHintsFunctions[id]; ok {
-			name := runtime.FuncForPC(reflect.ValueOf(hintFunctions[i]).Pointer()).Name()
-			return solution{}, fmt.Errorf("duplicate hint function with id %d - name %s", uint32(id), name)
+	for _, h := range hintFunctions {
+		if _, ok := s.mHintsFunctions[h.UUID()]; ok {
+			return solution{}, fmt.Errorf("duplicate hint function %s", h)
 		}
-		s.mHintsFunctions[id] = hintFunctions[i]
+		s.mHintsFunctions[h.UUID()] = h
 	}
 
 	return s, nil
@@ -117,7 +112,12 @@ func (s *solution) computeLinearExpression(l compiled.LinearExpression) fr.Eleme
 }
 
 // solveHint compute solution.values[vID] using provided solver hint
-func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
+func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
+	// skip if the wire is already solved by a call to the same hint
+	// function on the same inputs
+	if s.solved[vID] {
+		return nil
+	}
 	// ensure hint function was provided
 	f, ok := s.mHintsFunctions[h.ID]
 	if !ok {
@@ -150,8 +150,12 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		}
 	}
 
+	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
-	lambda.SetUint64(0)
+	outputs[0] = lambda
+	for i := 1; i < len(outputs); i++ {
+		outputs[i] = bigIntPool.Get().(*big.Int)
+	}
 
 	// ensure our inputs are mod q
 	q := fr.Modulus()
@@ -161,22 +165,27 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		inputs[i].Mod(inputs[i], q)
 	}
 
-	err := f(curve.ID, inputs, lambda)
+	err := f.Call(curve.ID, inputs, outputs)
 
 	var v fr.Element
-	v.SetBigInt(lambda)
+	for i := range outputs {
+		v.SetBigInt(outputs[i])
+		s.set(h.Wires[i], v)
+	}
 
 	// release objects into pool
-	bigIntPool.Put(lambda)
 	for i := 0; i < len(inputs); i++ {
 		bigIntPool.Put(inputs[i])
+	}
+
+	for i := 0; i < len(outputs); i++ {
+		bigIntPool.Put(outputs[i])
 	}
 
 	if err != nil {
 		return err
 	}
 
-	s.set(vID, v)
 	return nil
 }
 

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -150,7 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		}
 	}
 
-	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
+	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
 	outputs[0] = lambda
 	for i := 1; i < len(outputs); i++ {

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -130,7 +130,6 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		inputs[i] = bigIntPool.Get().(*big.Int)
 		inputs[i].SetUint64(0)
 	}
-	lambda := bigIntPool.Get().(*big.Int)
 
 	for i := 0; i < len(h.Inputs); i++ {
 
@@ -151,9 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	}
 
 	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
-	// use lambda as the result.
-	outputs[0] = lambda
-	for i := 1; i < len(outputs); i++ {
+	for i := 0; i < len(outputs); i++ {
 		outputs[i] = bigIntPool.Get().(*big.Int)
 	}
 

--- a/internal/backend/bw6-633/cs/solution.go
+++ b/internal/backend/bw6-633/cs/solution.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"reflect"
-	"runtime"
 	"sync"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -55,14 +53,11 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
 	}
 
-	for i := 0; i < len(hintFunctions); i++ {
-
-		id := hint.UUID(hintFunctions[i])
-		if _, ok := s.mHintsFunctions[id]; ok {
-			name := runtime.FuncForPC(reflect.ValueOf(hintFunctions[i]).Pointer()).Name()
-			return solution{}, fmt.Errorf("duplicate hint function with id %d - name %s", uint32(id), name)
+	for _, h := range hintFunctions {
+		if _, ok := s.mHintsFunctions[h.UUID()]; ok {
+			return solution{}, fmt.Errorf("duplicate hint function %s", h)
 		}
-		s.mHintsFunctions[id] = hintFunctions[i]
+		s.mHintsFunctions[h.UUID()] = h
 	}
 
 	return s, nil
@@ -117,7 +112,12 @@ func (s *solution) computeLinearExpression(l compiled.LinearExpression) fr.Eleme
 }
 
 // solveHint compute solution.values[vID] using provided solver hint
-func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
+func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
+	// skip if the wire is already solved by a call to the same hint
+	// function on the same inputs
+	if s.solved[vID] {
+		return nil
+	}
 	// ensure hint function was provided
 	f, ok := s.mHintsFunctions[h.ID]
 	if !ok {
@@ -150,8 +150,12 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		}
 	}
 
+	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
-	lambda.SetUint64(0)
+	outputs[0] = lambda
+	for i := 1; i < len(outputs); i++ {
+		outputs[i] = bigIntPool.Get().(*big.Int)
+	}
 
 	// ensure our inputs are mod q
 	q := fr.Modulus()
@@ -161,22 +165,27 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		inputs[i].Mod(inputs[i], q)
 	}
 
-	err := f(curve.ID, inputs, lambda)
+	err := f.Call(curve.ID, inputs, outputs)
 
 	var v fr.Element
-	v.SetBigInt(lambda)
+	for i := range outputs {
+		v.SetBigInt(outputs[i])
+		s.set(h.Wires[i], v)
+	}
 
 	// release objects into pool
-	bigIntPool.Put(lambda)
 	for i := 0; i < len(inputs); i++ {
 		bigIntPool.Put(inputs[i])
+	}
+
+	for i := 0; i < len(outputs); i++ {
+		bigIntPool.Put(outputs[i])
 	}
 
 	if err != nil {
 		return err
 	}
 
-	s.set(vID, v)
 	return nil
 }
 

--- a/internal/backend/bw6-633/cs/solution.go
+++ b/internal/backend/bw6-633/cs/solution.go
@@ -150,7 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		}
 	}
 
-	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
+	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
 	outputs[0] = lambda
 	for i := 1; i < len(outputs); i++ {

--- a/internal/backend/bw6-633/cs/solution.go
+++ b/internal/backend/bw6-633/cs/solution.go
@@ -130,7 +130,6 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		inputs[i] = bigIntPool.Get().(*big.Int)
 		inputs[i].SetUint64(0)
 	}
-	lambda := bigIntPool.Get().(*big.Int)
 
 	for i := 0; i < len(h.Inputs); i++ {
 
@@ -151,9 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	}
 
 	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
-	// use lambda as the result.
-	outputs[0] = lambda
-	for i := 1; i < len(outputs); i++ {
+	for i := 0; i < len(outputs); i++ {
 		outputs[i] = bigIntPool.Get().(*big.Int)
 	}
 

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"reflect"
-	"runtime"
 	"sync"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -55,14 +53,11 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
 	}
 
-	for i := 0; i < len(hintFunctions); i++ {
-
-		id := hint.UUID(hintFunctions[i])
-		if _, ok := s.mHintsFunctions[id]; ok {
-			name := runtime.FuncForPC(reflect.ValueOf(hintFunctions[i]).Pointer()).Name()
-			return solution{}, fmt.Errorf("duplicate hint function with id %d - name %s", uint32(id), name)
+	for _, h := range hintFunctions {
+		if _, ok := s.mHintsFunctions[h.UUID()]; ok {
+			return solution{}, fmt.Errorf("duplicate hint function %s", h)
 		}
-		s.mHintsFunctions[id] = hintFunctions[i]
+		s.mHintsFunctions[h.UUID()] = h
 	}
 
 	return s, nil
@@ -117,7 +112,12 @@ func (s *solution) computeLinearExpression(l compiled.LinearExpression) fr.Eleme
 }
 
 // solveHint compute solution.values[vID] using provided solver hint
-func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
+func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
+	// skip if the wire is already solved by a call to the same hint
+	// function on the same inputs
+	if s.solved[vID] {
+		return nil
+	}
 	// ensure hint function was provided
 	f, ok := s.mHintsFunctions[h.ID]
 	if !ok {
@@ -150,8 +150,12 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		}
 	}
 
+	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
-	lambda.SetUint64(0)
+	outputs[0] = lambda
+	for i := 1; i < len(outputs); i++ {
+		outputs[i] = bigIntPool.Get().(*big.Int)
+	}
 
 	// ensure our inputs are mod q
 	q := fr.Modulus()
@@ -161,22 +165,27 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		inputs[i].Mod(inputs[i], q)
 	}
 
-	err := f(curve.ID, inputs, lambda)
+	err := f.Call(curve.ID, inputs, outputs)
 
 	var v fr.Element
-	v.SetBigInt(lambda)
+	for i := range outputs {
+		v.SetBigInt(outputs[i])
+		s.set(h.Wires[i], v)
+	}
 
 	// release objects into pool
-	bigIntPool.Put(lambda)
 	for i := 0; i < len(inputs); i++ {
 		bigIntPool.Put(inputs[i])
+	}
+
+	for i := 0; i < len(outputs); i++ {
+		bigIntPool.Put(outputs[i])
 	}
 
 	if err != nil {
 		return err
 	}
 
-	s.set(vID, v)
 	return nil
 }
 

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -150,7 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		}
 	}
 
-	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
+	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
 	outputs[0] = lambda
 	for i := 1; i < len(outputs); i++ {

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -130,7 +130,6 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		inputs[i] = bigIntPool.Get().(*big.Int)
 		inputs[i].SetUint64(0)
 	}
-	lambda := bigIntPool.Get().(*big.Int)
 
 	for i := 0; i < len(h.Inputs); i++ {
 
@@ -151,9 +150,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	}
 
 	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
-	// use lambda as the result.
-	outputs[0] = lambda
-	for i := 1; i < len(outputs); i++ {
+	for i := 0; i < len(outputs); i++ {
 		outputs[i] = bigIntPool.Get().(*big.Int)
 	}
 

--- a/internal/backend/circuits/hint.go
+++ b/internal/backend/circuits/hint.go
@@ -33,23 +33,69 @@ func (circuit *hintCircuit) Define(api frontend.API) error {
 	return nil
 }
 
+type vectorDoubleCircuit struct {
+	A []frontend.Variable
+	B []frontend.Variable
+}
+
+func (c *vectorDoubleCircuit) Define(api frontend.API) error {
+	res, err := api.NewHint(dvHint, c.A...)
+	if err != nil {
+		return fmt.Errorf("double newhint: %w", err)
+	}
+	if len(res) != len(c.B) {
+		return fmt.Errorf("expected len %d, got %d", len(c.B), len(res))
+	}
+	for i := range res {
+		api.AssertIsEqual(api.Mul(2, c.A[i]), c.B[i])
+		api.AssertIsEqual(res[i], c.B[i])
+	}
+	return nil
+}
+
 func init() {
+	{
+		good := []frontend.Circuit{
+			&hintCircuit{
+				A: 42,
+				B: 42 * 7,
+			},
+		}
 
-	good := []frontend.Circuit{
-		&hintCircuit{
-			A: (42),
-			B: (42 * 7),
-		},
+		bad := []frontend.Circuit{
+			&hintCircuit{
+				A: 42,
+				B: 42,
+			},
+		}
+
+		addNewEntry("hint", &hintCircuit{}, good, bad, ecc.Implemented(), mulBy7, make3)
 	}
 
-	bad := []frontend.Circuit{
-		&hintCircuit{
-			A: (42),
-			B: (42),
-		},
-	}
+	{
+		good := []frontend.Circuit{
+			&vectorDoubleCircuit{
+				A: []frontend.Variable{
+					1, 2, 3, 4, 5, 6, 7, 8,
+				},
+				B: []frontend.Variable{
+					2, 4, 6, 8, 10, 12, 14, 16,
+				},
+			},
+		}
 
-	addNewEntry("hint", &hintCircuit{}, good, bad, ecc.Implemented(), mulBy7, make3)
+		bad := []frontend.Circuit{
+			&vectorDoubleCircuit{
+				A: []frontend.Variable{
+					1, 2, 3, 4, 5, 6, 7, 8,
+				},
+				B: []frontend.Variable{
+					1, 2, 3, 4, 5, 6, 7, 8,
+				},
+			},
+		}
+		addNewEntry("multi-output-hint", &vectorDoubleCircuit{A: make([]frontend.Variable, 8), B: make([]frontend.Variable, 8)}, good, bad, ecc.Implemented(), dvHint)
+	}
 }
 
 var mulBy7 = hint.NewStaticHint(func(curveID ecc.ID, inputs []*big.Int, result []*big.Int) error {
@@ -61,3 +107,31 @@ var make3 = hint.NewStaticHint(func(curveID ecc.ID, inputs []*big.Int, result []
 	result[0].SetUint64(3)
 	return nil
 }, 0, 1)
+
+var dvHint = &doubleVector{}
+
+type doubleVector struct{}
+
+func (dv *doubleVector) UUID() hint.ID {
+	return hint.UUID(dv.Call)
+}
+
+func (dv *doubleVector) Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error {
+	two := big.NewInt(2)
+	for i := range inputs {
+		res[i].Mul(two, inputs[i])
+	}
+	return nil
+}
+
+func (dv *doubleVector) TotalInputs(curveID ecc.ID) (nInputs int) {
+	return -1
+}
+
+func (dv *doubleVector) TotalOutputs(curveID ecc.ID, nInputs int) (nOutputs int) {
+	return nInputs
+}
+
+func (dv *doubleVector) String() string {
+	return "double"
+}

--- a/internal/backend/circuits/hint.go
+++ b/internal/backend/circuits/hint.go
@@ -124,7 +124,7 @@ func (dv *doubleVector) Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) 
 	return nil
 }
 
-func (dv *doubleVector) TotalOutputs(curveID ecc.ID, nInputs int) (nOutputs int) {
+func (dv *doubleVector) NbOutputs(curveID ecc.ID, nInputs int) (nOutputs int) {
 	return nInputs
 }
 

--- a/internal/backend/circuits/hint.go
+++ b/internal/backend/circuits/hint.go
@@ -124,10 +124,6 @@ func (dv *doubleVector) Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) 
 	return nil
 }
 
-func (dv *doubleVector) TotalInputs(curveID ecc.ID) (nInputs int) {
-	return -1
-}
-
 func (dv *doubleVector) TotalOutputs(curveID ecc.ID, nInputs int) (nOutputs int) {
 	return nInputs
 }

--- a/internal/backend/compiled/cs.go
+++ b/internal/backend/compiled/cs.go
@@ -108,7 +108,7 @@ func (h Hint) MarshalCBOR() ([]byte, error) {
 			inputs[i] = h.Inputs[i]
 		}
 	}
-	v := vt{ID: h.ID, Inputs: inputs}
+	v := vt{ID: h.ID, Inputs: inputs, Wires: h.Wires}
 	return enc.Marshal(v)
 }
 
@@ -125,6 +125,7 @@ func (h *Hint) UnmarshalCBOR(b []byte) error {
 	type vt struct {
 		ID     hint.ID
 		Inputs []cbor.RawTag
+		Wires  []int
 	}
 	var v vt
 	if err := dec.Unmarshal(b, &v); err != nil {
@@ -173,6 +174,7 @@ func (h *Hint) UnmarshalCBOR(b []byte) error {
 	}
 	h.ID = v.ID
 	h.Inputs = inputs
+	h.Wires = v.Wires
 	return nil
 }
 

--- a/internal/backend/compiled/cs.go
+++ b/internal/backend/compiled/cs.go
@@ -34,7 +34,7 @@ type CS struct {
 	// maps wire id to hint
 
 	// a wire may point to at most one hint
-	MHints map[int]Hint
+	MHints map[int]*Hint
 }
 
 // Visibility encodes a Variable (or wire) visibility
@@ -55,6 +55,7 @@ const (
 type Hint struct {
 	ID     hint.ID       // hint function id
 	Inputs []interface{} // terms to inject in the hint function
+	Wires  []int         // IDs of wires the hint outputs map to
 }
 
 func (h Hint) inputsCBORTags() (cbor.TagSet, error) {

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -2,10 +2,8 @@ import (
 	"io"
 	"errors"
     "fmt"
-	"runtime"
 	"math/big"
 	"sync"
-	"reflect"
 
     "github.com/consensys/gnark/backend/hint"
     "github.com/consensys/gnark/internal/backend/compiled"
@@ -30,20 +28,17 @@ type solution struct {
 func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
 
   s := solution{
-      values: make([]fr.Element, nbWires),
-      coefficients: coefficients,
-      solved: make([]bool, nbWires),
-      mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
+		values: make([]fr.Element, nbWires),
+		coefficients: coefficients,
+		solved: make([]bool, nbWires),
+		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
   }
 	
-	for i := 0; i < len(hintFunctions);i++ {
-
-		id := hint.UUID(hintFunctions[i])
-		if _, ok := s.mHintsFunctions[id]; ok {
-			name := runtime.FuncForPC(reflect.ValueOf(hintFunctions[i]).Pointer()).Name()
-			return solution{}, fmt.Errorf("duplicate hint function with id %d - name %s", uint32(id), name)
-		}
-		s.mHintsFunctions[id] = hintFunctions[i]
+	for _, h := range hintFunctions {
+		if _, ok := s.mHintsFunctions[h.UUID()]; ok {
+			return solution{}, fmt.Errorf("duplicate hint function %s", h)
+ 		}
+		s.mHintsFunctions[h.UUID()] = h
 	}
 
 	return s, nil
@@ -98,7 +93,12 @@ func (s *solution) computeLinearExpression(l compiled.LinearExpression) fr.Eleme
 }
 
 // solveHint compute solution.values[vID] using provided solver hint
-func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
+func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
+	// skip if the wire is already solved by a call to the same hint
+	// function on the same inputs
+	if s.solved[vID] {
+	    return nil
+	}
 	// ensure hint function was provided
 	f, ok := s.mHintsFunctions[h.ID]
 	if !ok {
@@ -131,8 +131,12 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		}
 	}
 
+	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
-	lambda.SetUint64(0)
+	outputs[0] = lambda
+	for i := 1; i < len(outputs); i++ {
+		outputs[i] = bigIntPool.Get().(*big.Int)
+	}
 
 	// ensure our inputs are mod q
 	q := fr.Modulus()
@@ -142,22 +146,27 @@ func (s *solution) solveWithHint(vID int, h compiled.Hint) error {
 		inputs[i].Mod(inputs[i], q)
 	}
 
-	err := f(curve.ID, inputs, lambda)
+	err := f.Call(curve.ID, inputs, outputs)
 
 	var v fr.Element
-	v.SetBigInt(lambda)
+	for i := range outputs {
+		v.SetBigInt(outputs[i])
+		s.set(h.Wires[i], v)
+	}
 
 	// release objects into pool
-	bigIntPool.Put(lambda)
 	for i := 0; i < len(inputs); i++ {
 		bigIntPool.Put(inputs[i])
+	}
+
+	for i := 0; i < len(outputs); i++ {
+		bigIntPool.Put(outputs[i])
 	}
 
 	if err != nil {
 		return err
 	}
 
-	s.set(vID, v)
 	return nil
 }
 

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -111,7 +111,6 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		inputs[i] = bigIntPool.Get().(*big.Int)
 		inputs[i].SetUint64(0)
 	}
-	lambda := bigIntPool.Get().(*big.Int)
 
 	for i := 0; i < len(h.Inputs); i++ {
 
@@ -132,9 +131,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	}
 
 	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
-	// use lambda as the result.
-	outputs[0] = lambda
-	for i := 1; i < len(outputs); i++ {
+	for i := 0; i < len(outputs); i++ {
 		outputs[i] = bigIntPool.Get().(*big.Int)
 	}
 

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -131,7 +131,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		}
 	}
 
-	outputs := make([]*big.Int, f.TotalOutputs(curve.ID, len(inputs)))
+	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
 	// use lambda as the result.
 	outputs[0] = lambda
 	for i := 1; i < len(outputs); i++ {

--- a/test/engine.go
+++ b/test/engine.go
@@ -319,9 +319,7 @@ func (e *engine) Println(a ...frontend.Variable) {
 }
 
 func (e *engine) NewHint(f hint.Function, inputs ...frontend.Variable) ([]frontend.Variable, error) {
-	if nIn := f.TotalInputs(e.Curve()); nIn >= 0 && nIn != len(inputs) {
-		return nil, fmt.Errorf("expected %d inputs, got %d", nIn, len(inputs))
-	}
+
 	if f.TotalOutputs(e.Curve(), len(inputs)) <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}

--- a/test/engine.go
+++ b/test/engine.go
@@ -320,7 +320,7 @@ func (e *engine) Println(a ...frontend.Variable) {
 
 func (e *engine) NewHint(f hint.Function, inputs ...frontend.Variable) ([]frontend.Variable, error) {
 
-	if f.TotalOutputs(e.Curve(), len(inputs)) <= 0 {
+	if f.NbOutputs(e.Curve(), len(inputs)) <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}
 
@@ -330,7 +330,7 @@ func (e *engine) NewHint(f hint.Function, inputs ...frontend.Variable) ([]fronte
 		v := e.toBigInt(inputs[i])
 		in[i] = &v
 	}
-	res := make([]*big.Int, f.TotalOutputs(e.Curve(), len(inputs)))
+	res := make([]*big.Int, f.NbOutputs(e.Curve(), len(inputs)))
 	for i := range res {
 		res[i] = new(big.Int)
 	}

--- a/test/engine.go
+++ b/test/engine.go
@@ -318,22 +318,37 @@ func (e *engine) Println(a ...frontend.Variable) {
 	fmt.Println(sbb.String())
 }
 
-func (e *engine) NewHint(f hint.Function, inputs ...frontend.Variable) frontend.Variable {
+func (e *engine) NewHint(f hint.Function, inputs ...frontend.Variable) ([]frontend.Variable, error) {
+	if nIn := f.TotalInputs(e.Curve()); nIn >= 0 && nIn != len(inputs) {
+		return nil, fmt.Errorf("expected %d inputs, got %d", nIn, len(inputs))
+	}
+	if f.TotalOutputs(e.Curve(), len(inputs)) <= 0 {
+		return nil, fmt.Errorf("hint function must return at least one output")
+	}
+
 	in := make([]*big.Int, len(inputs))
 
 	for i := 0; i < len(inputs); i++ {
 		v := e.toBigInt(inputs[i])
 		in[i] = &v
 	}
+	res := make([]*big.Int, f.TotalOutputs(e.Curve(), len(inputs)))
+	for i := range res {
+		res[i] = new(big.Int)
+	}
 
-	var result big.Int
-	err := f(e.curveID, in, &result)
+	err := f.Call(e.curveID, in, res)
 
 	if err != nil {
 		panic("NewHint: " + err.Error())
 	}
 
-	return (result)
+	out := make([]frontend.Variable, len(res))
+	for i := range res {
+		out[i] = res[i]
+	}
+
+	return out, nil
 }
 
 // IsConstant returns true if v is a constant known at compile time

--- a/test/engine_test.go
+++ b/test/engine_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -14,10 +15,26 @@ type hintCircuit struct {
 }
 
 func (circuit *hintCircuit) Define(api frontend.API) error {
-	a3b := api.NewHint(hint.IthBit, circuit.A, 3)
-	a25b := api.NewHint(hint.IthBit, circuit.A, 25)
-	aisZero := api.NewHint(hint.IsZero, circuit.A)
-	bisZero := api.NewHint(hint.IsZero, circuit.B)
+	res, err := api.NewHint(hint.IthBit, circuit.A, 3)
+	if err != nil {
+		return fmt.Errorf("IthBit circuitA 3: %w", err)
+	}
+	a3b := res[0]
+	res, err = api.NewHint(hint.IthBit, circuit.A, 25)
+	if err != nil {
+		return fmt.Errorf("IthBit circuitA 25: %w", err)
+	}
+	a25b := res[0]
+	res, err = api.NewHint(hint.IsZero, circuit.A)
+	if err != nil {
+		return fmt.Errorf("IsZero CircuitA: %w", err)
+	}
+	aisZero := res[0]
+	res, err = api.NewHint(hint.IsZero, circuit.B)
+	if err != nil {
+		return fmt.Errorf("IsZero, CircuitB")
+	}
+	bisZero := res[0]
 
 	api.AssertIsEqual(aisZero, 0)
 	api.AssertIsEqual(bisZero, 1)


### PR DESCRIPTION
This is an API breaking PR - the `frontend.API` interface changes to allow multiple outputs and now also returns errors (in case the inputs do not correspond to the hint signature).

This is still a draft PR - some tests fail with PLONK backend, but waiting for the refactoring and then will try again.

It is based on top of #191. As it is not yet merged, then this PR also contains commits from that PR but will be rebased later.