### PR TITLE
Re-exposed frontend.CompiledConstraintSystem

### DIFF
--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -33,7 +33,6 @@ import (
 	backend_bn254 "github.com/consensys/gnark/internal/backend/bn254/cs"
 	backend_bw6633 "github.com/consensys/gnark/internal/backend/bw6-633/cs"
 	backend_bw6761 "github.com/consensys/gnark/internal/backend/bw6-761/cs"
-	"github.com/consensys/gnark/internal/backend/compiled"
 
 	witness_bls12377 "github.com/consensys/gnark/internal/backend/bls12-377/witness"
 	witness_bls12381 "github.com/consensys/gnark/internal/backend/bls12-381/witness"
@@ -211,7 +210,7 @@ func ReadAndVerify(proof Proof, vk VerifyingKey, publicWitness io.Reader) error 
 // 	will executes all the prover computations, even if the witness is invalid
 //  will produce an invalid proof
 //	internally, the solution vector to the R1CS will be filled with random values which may impact benchmarking
-func Prove(r1cs compiled.ConstraintSystem, pk ProvingKey, witness frontend.Circuit, opts ...func(opt *backend.ProverOption) error) (Proof, error) {
+func Prove(r1cs frontend.CompiledConstraintSystem, pk ProvingKey, witness frontend.Circuit, opts ...func(opt *backend.ProverOption) error) (Proof, error) {
 
 	// apply options
 	opt, err := backend.NewProverOption(opts...)
@@ -264,7 +263,7 @@ func Prove(r1cs compiled.ConstraintSystem, pk ProvingKey, witness frontend.Circu
 // ReadAndProve behaves like Prove, , except witness is read from a io.Reader
 // witness must be encoded following the binary serialization protocol described in
 // gnark/backend/witness package
-func ReadAndProve(r1cs compiled.ConstraintSystem, pk ProvingKey, witness io.Reader, opts ...func(opt *backend.ProverOption) error) (Proof, error) {
+func ReadAndProve(r1cs frontend.CompiledConstraintSystem, pk ProvingKey, witness io.Reader, opts ...func(opt *backend.ProverOption) error) (Proof, error) {
 
 	// apply options
 	opt, err := backend.NewProverOption(opts...)
@@ -325,7 +324,7 @@ func ReadAndProve(r1cs compiled.ConstraintSystem, pk ProvingKey, witness io.Read
 //
 // Two main solutions to this deployment issues are: running the Setup through a MPC (multi party computation)
 // or using a ZKP backend like PLONK where the per-circuit Setup is deterministic.
-func Setup(r1cs compiled.ConstraintSystem) (ProvingKey, VerifyingKey, error) {
+func Setup(r1cs frontend.CompiledConstraintSystem) (ProvingKey, VerifyingKey, error) {
 
 	switch _r1cs := r1cs.(type) {
 	case *backend_bls12377.R1CS:
@@ -377,7 +376,7 @@ func Setup(r1cs compiled.ConstraintSystem) (ProvingKey, VerifyingKey, error) {
 
 // DummySetup create a random ProvingKey with provided R1CS
 // it doesn't return a VerifyingKey and is use for benchmarking or test purposes only.
-func DummySetup(r1cs compiled.ConstraintSystem) (ProvingKey, error) {
+func DummySetup(r1cs frontend.CompiledConstraintSystem) (ProvingKey, error) {
 	switch _r1cs := r1cs.(type) {
 	case *backend_bls12377.R1CS:
 		var pk groth16_bls12377.ProvingKey
@@ -493,8 +492,8 @@ func NewProof(curveID ecc.ID) Proof {
 
 // NewCS instantiate a concrete curved-typed R1CS and return a R1CS interface
 // This method exists for (de)serialization purposes
-func NewCS(curveID ecc.ID) compiled.ConstraintSystem {
-	var r1cs compiled.ConstraintSystem
+func NewCS(curveID ecc.ID) frontend.CompiledConstraintSystem {
+	var r1cs frontend.CompiledConstraintSystem
 	switch curveID {
 	case ecc.BN254:
 		r1cs = &backend_bn254.R1CS{}
@@ -516,7 +515,7 @@ func NewCS(curveID ecc.ID) compiled.ConstraintSystem {
 
 // IsSolved attempts to solve the constraint system with provided witness
 // returns nil if it succeeds, error otherwise.
-func IsSolved(r1cs compiled.ConstraintSystem, witness frontend.Circuit, opts ...func(opt *backend.ProverOption) error) error {
+func IsSolved(r1cs frontend.CompiledConstraintSystem, witness frontend.Circuit, opts ...func(opt *backend.ProverOption) error) error {
 
 	// apply options
 	opt, err := backend.NewProverOption(opts...)

--- a/backend/plonk/plonk.go
+++ b/backend/plonk/plonk.go
@@ -34,7 +34,6 @@ import (
 	cs_bn254 "github.com/consensys/gnark/internal/backend/bn254/cs"
 	cs_bw6633 "github.com/consensys/gnark/internal/backend/bw6-633/cs"
 	cs_bw6761 "github.com/consensys/gnark/internal/backend/bw6-761/cs"
-	"github.com/consensys/gnark/internal/backend/compiled"
 
 	plonk_bls12377 "github.com/consensys/gnark/internal/backend/bls12-377/plonk"
 	plonk_bls12381 "github.com/consensys/gnark/internal/backend/bls12-381/plonk"
@@ -91,7 +90,7 @@ type VerifyingKey interface {
 }
 
 // Setup prepares the public data associated to a circuit + public inputs.
-func Setup(ccs compiled.ConstraintSystem, kzgSRS kzg.SRS) (ProvingKey, VerifyingKey, error) {
+func Setup(ccs frontend.CompiledConstraintSystem, kzgSRS kzg.SRS) (ProvingKey, VerifyingKey, error) {
 
 	switch tccs := ccs.(type) {
 	case *cs_bn254.SparseR1CS:
@@ -117,7 +116,7 @@ func Setup(ccs compiled.ConstraintSystem, kzgSRS kzg.SRS) (ProvingKey, Verifying
 // 	will executes all the prover computations, even if the witness is invalid
 //  will produce an invalid proof
 //	internally, the solution vector to the SparseR1CS will be filled with random values which may impact benchmarking
-func Prove(ccs compiled.ConstraintSystem, pk ProvingKey, fullWitness frontend.Circuit, opts ...func(opt *backend.ProverOption) error) (Proof, error) {
+func Prove(ccs frontend.CompiledConstraintSystem, pk ProvingKey, fullWitness frontend.Circuit, opts ...func(opt *backend.ProverOption) error) (Proof, error) {
 
 	// apply options
 	opt, err := backend.NewProverOption(opts...)
@@ -227,8 +226,8 @@ func Verify(proof Proof, vk VerifyingKey, publicWitness frontend.Circuit) error 
 
 // NewCS instantiate a concrete curved-typed SparseR1CS and return a ConstraintSystem interface
 // This method exists for (de)serialization purposes
-func NewCS(curveID ecc.ID) compiled.ConstraintSystem {
-	var r1cs compiled.ConstraintSystem
+func NewCS(curveID ecc.ID) frontend.CompiledConstraintSystem {
+	var r1cs frontend.CompiledConstraintSystem
 	switch curveID {
 	case ecc.BN254:
 		r1cs = &cs_bn254.SparseR1CS{}
@@ -321,7 +320,7 @@ func NewVerifyingKey(curveID ecc.ID) VerifyingKey {
 }
 
 // ReadAndProve generates PLONK proof from a circuit, associated proving key, and the full witness
-func ReadAndProve(ccs compiled.ConstraintSystem, pk ProvingKey, witness io.Reader, opts ...func(opt *backend.ProverOption) error) (Proof, error) {
+func ReadAndProve(ccs frontend.CompiledConstraintSystem, pk ProvingKey, witness io.Reader, opts ...func(opt *backend.ProverOption) error) (Proof, error) {
 
 	// apply options
 	opt, err := backend.NewProverOption(opts...)
@@ -471,7 +470,7 @@ func ReadAndVerify(proof Proof, vk VerifyingKey, witness io.Reader) error {
 
 // IsSolved attempts to solve the constraint system with provided witness
 // returns nil if it succeeds, error otherwise.
-func IsSolved(ccs compiled.ConstraintSystem, witness frontend.Circuit, opts ...func(opt *backend.ProverOption) error) error {
+func IsSolved(ccs frontend.CompiledConstraintSystem, witness frontend.Circuit, opts ...func(opt *backend.ProverOption) error) error {
 
 	opt, err := backend.NewProverOption(opts...)
 	if err != nil {

--- a/frontend/ccs.go
+++ b/frontend/ccs.go
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compiled
+package frontend
 
 import (
 	"io"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
-// ConstraintSystem interface that a compiled (=typed, and correctly routed)
+// CompiledConstraintSystem interface that a compiled (=typed, and correctly routed)
 // should implement.
-type ConstraintSystem interface {
+type CompiledConstraintSystem interface {
 	io.WriterTo
 	io.ReaderFrom
 
@@ -38,5 +39,5 @@ type ConstraintSystem interface {
 	ToHTML(w io.Writer) error
 
 	// GetCounters return the collected constraint counters, if any
-	GetCounters() []Counter
+	GetCounters() []compiled.Counter
 }

--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -24,7 +24,7 @@ type Builder interface {
 	CheckVariables() error
 	NewPublicVariable(name string) Variable
 	NewSecretVariable(name string) Variable
-	Compile() (compiled.ConstraintSystem, error)
+	Compile() (CompiledConstraintSystem, error)
 }
 
 type NewBuilder func(ecc.ID) (Builder, error)
@@ -47,7 +47,7 @@ type NewBuilder func(ecc.ID) (Builder, error)
 //
 // initialCapacity is an optional parameter that reserves memory in slices
 // it should be set to the estimated number of constraints in the circuit, if known.
-func Compile(curveID ecc.ID, zkpID backend.ID, circuit Circuit, opts ...func(opt *CompileOption) error) (compiled.ConstraintSystem, error) {
+func Compile(curveID ecc.ID, zkpID backend.ID, circuit Circuit, opts ...func(opt *CompileOption) error) (CompiledConstraintSystem, error) {
 	// setup option
 	opt := CompileOption{}
 	for _, o := range opts {

--- a/frontend/cs/plonk/conversion.go
+++ b/frontend/cs/plonk/conversion.go
@@ -18,6 +18,7 @@ package plonk
 
 import (
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
 	bls12377r1cs "github.com/consensys/gnark/internal/backend/bls12-377/cs"
 	bls12381r1cs "github.com/consensys/gnark/internal/backend/bls12-381/cs"
 	bls24315r1cs "github.com/consensys/gnark/internal/backend/bls24-315/cs"
@@ -27,7 +28,7 @@ import (
 	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
-func (cs *sparseR1CS) Compile() (compiled.ConstraintSystem, error) {
+func (cs *sparseR1CS) Compile() (frontend.CompiledConstraintSystem, error) {
 
 	res := compiled.SparseR1CS{
 		CS:          cs.CS,

--- a/frontend/cs/r1cs/conversion.go
+++ b/frontend/cs/r1cs/conversion.go
@@ -18,6 +18,7 @@ package r1cs
 
 import (
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
 	bls12377r1cs "github.com/consensys/gnark/internal/backend/bls12-377/cs"
 	bls12381r1cs "github.com/consensys/gnark/internal/backend/bls12-381/cs"
 	bls24315r1cs "github.com/consensys/gnark/internal/backend/bls24-315/cs"
@@ -28,7 +29,7 @@ import (
 )
 
 // Compile constructs a rank-1 constraint sytem
-func (cs *r1CS) Compile() (compiled.ConstraintSystem, error) {
+func (cs *r1CS) Compile() (frontend.CompiledConstraintSystem, error) {
 
 	// wires = public wires  | secret wires | internal wires
 

--- a/internal/backend/bls12-377/groth16/groth16_test.go
+++ b/internal/backend/bls12-377/groth16/groth16_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -53,7 +52,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bls12-377/plonk/plonk_test.go
+++ b/internal/backend/bls12-377/plonk/plonk_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/plonk"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -57,7 +56,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit, *kzg.SRS) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *kzg.SRS) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bls12-381/groth16/groth16_test.go
+++ b/internal/backend/bls12-381/groth16/groth16_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -53,7 +52,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bls12-381/plonk/plonk_test.go
+++ b/internal/backend/bls12-381/plonk/plonk_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/plonk"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -57,7 +56,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit, *kzg.SRS) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *kzg.SRS) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bls24-315/groth16/groth16_test.go
+++ b/internal/backend/bls24-315/groth16/groth16_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -53,7 +52,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bls24-315/plonk/plonk_test.go
+++ b/internal/backend/bls24-315/plonk/plonk_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/plonk"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -57,7 +56,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit, *kzg.SRS) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *kzg.SRS) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bn254/groth16/groth16_test.go
+++ b/internal/backend/bn254/groth16/groth16_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -53,7 +52,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bn254/plonk/plonk_test.go
+++ b/internal/backend/bn254/plonk/plonk_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/plonk"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -57,7 +56,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit, *kzg.SRS) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *kzg.SRS) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bw6-633/groth16/groth16_test.go
+++ b/internal/backend/bw6-633/groth16/groth16_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -53,7 +52,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bw6-633/plonk/plonk_test.go
+++ b/internal/backend/bw6-633/plonk/plonk_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/plonk"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -57,7 +56,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit, *kzg.SRS) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *kzg.SRS) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bw6-761/groth16/groth16_test.go
+++ b/internal/backend/bw6-761/groth16/groth16_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -53,7 +52,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/backend/bw6-761/plonk/plonk_test.go
+++ b/internal/backend/bw6-761/plonk/plonk_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/plonk"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 //--------------------//
@@ -57,7 +56,7 @@ func (circuit *refCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit, *kzg.SRS) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *kzg.SRS) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
@@ -10,7 +10,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/internal/backend/compiled"
 )
 
 
@@ -33,7 +32,7 @@ func (circuit *refCircuit) Define( api frontend.API) error {
 	return nil 
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/internal/generator/backend/template/zkpschemes/plonk/tests/plonk.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/tests/plonk.go.tmpl
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark/backend"
-	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/plonk"
@@ -38,7 +37,7 @@ func (circuit *refCircuit) Define( api frontend.API) error {
 	return nil 
 }
 
-func referenceCircuit() (compiled.ConstraintSystem, frontend.Circuit, *kzg.SRS) {
+func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *kzg.SRS) {
 	const nbConstraints = 40000
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,

--- a/std/algebra/fields_bls24315/e24_test.go
+++ b/std/algebra/fields_bls24315/e24_test.go
@@ -23,7 +23,6 @@ import (
 	bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/test"
 )
 
@@ -409,7 +408,7 @@ func TestExpFinalExpoFp24(t *testing.T) {
 }
 
 // benches
-var ccsBench compiled.ConstraintSystem
+var ccsBench frontend.CompiledConstraintSystem
 
 func BenchmarkMulE24(b *testing.B) {
 	var c fp24Mul

--- a/std/algebra/sw_bls12377/g1_test.go
+++ b/std/algebra/sw_bls12377/g1_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/test"
 
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
@@ -300,7 +299,7 @@ func randomPointG1() bls12377.G1Jac {
 	return p1
 }
 
-var ccsBench compiled.ConstraintSystem
+var ccsBench frontend.CompiledConstraintSystem
 
 func BenchmarkScalarMulG1(b *testing.B) {
 	var c g1ScalarMul

--- a/std/algebra/sw_bls24315/g1_test.go
+++ b/std/algebra/sw_bls24315/g1_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/test"
 
 	bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315"
@@ -300,7 +299,7 @@ func randomPointG1() bls24315.G1Jac {
 	return p1
 }
 
-var ccsBench compiled.ConstraintSystem
+var ccsBench frontend.CompiledConstraintSystem
 
 func BenchmarkScalarMulG1(b *testing.B) {
 	var c g1ScalarMul

--- a/std/algebra/twistededwards/bandersnatch/point_test.go
+++ b/std/algebra/twistededwards/bandersnatch/point_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards/bandersnatch"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/test"
 )
 
@@ -354,7 +353,7 @@ func TestNeg(t *testing.T) {
 
 // benches
 
-var ccsBench compiled.ConstraintSystem
+var ccsBench frontend.CompiledConstraintSystem
 
 func BenchmarkScalarMulG1(b *testing.B) {
 	var c scalarMulGeneric

--- a/std/fiat-shamir/transcript_test.go
+++ b/std/fiat-shamir/transcript_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/consensys/gnark-crypto/hash"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/std/hash/mimc"
 	"github.com/consensys/gnark/test"
 )
@@ -154,7 +153,7 @@ func BenchmarkCompile(b *testing.B) {
 	// create an empty cs
 	var circuit FiatShamirCircuit
 
-	var ccs compiled.ConstraintSystem
+	var ccs frontend.CompiledConstraintSystem
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ccs, _ = frontend.Compile(ecc.BN254, backend.PLONK, &circuit)

--- a/std/groth16_bls12377/verifier_test.go
+++ b/std/groth16_bls12377/verifier_test.go
@@ -26,7 +26,6 @@ import (
 	backend_bls12377 "github.com/consensys/gnark/internal/backend/bls12-377/cs"
 	groth16_bls12377 "github.com/consensys/gnark/internal/backend/bls12-377/groth16"
 	"github.com/consensys/gnark/internal/backend/bls12-377/witness"
-	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/std/algebra/fields_bls12377"
 	"github.com/consensys/gnark/std/algebra/sw_bls12377"
 	"github.com/consensys/gnark/std/hash/mimc"
@@ -196,7 +195,7 @@ func BenchmarkCompile(b *testing.B) {
 	var circuit verifierCircuit
 	circuit.InnerVk.G1 = make([]sw_bls12377.G1Affine, len(innerVk.G1.K))
 
-	var ccs compiled.ConstraintSystem
+	var ccs frontend.CompiledConstraintSystem
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ccs, _ = frontend.Compile(ecc.BW6_761, backend.GROTH16, &circuit)

--- a/std/groth16_bls24315/verifier_test.go
+++ b/std/groth16_bls24315/verifier_test.go
@@ -26,7 +26,6 @@ import (
 	backend_bls24315 "github.com/consensys/gnark/internal/backend/bls24-315/cs"
 	groth16_bls24315 "github.com/consensys/gnark/internal/backend/bls24-315/groth16"
 	"github.com/consensys/gnark/internal/backend/bls24-315/witness"
-	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/std/algebra/fields_bls24315"
 	"github.com/consensys/gnark/std/algebra/sw_bls24315"
 	"github.com/consensys/gnark/std/hash/mimc"
@@ -198,7 +197,7 @@ func BenchmarkCompile(b *testing.B) {
 	var circuit verifierCircuit
 	circuit.InnerVk.G1 = make([]sw_bls24315.G1Affine, len(innerVk.G1.K))
 
-	var ccs compiled.ConstraintSystem
+	var ccs frontend.CompiledConstraintSystem
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ccs, _ = frontend.Compile(ecc.BW6_633, backend.GROTH16, &circuit)

--- a/test/assert.go
+++ b/test/assert.go
@@ -45,7 +45,7 @@ var (
 type Assert struct {
 	t *testing.T
 	*require.Assertions
-	compiled map[string]compiled.ConstraintSystem // cache compilation
+	compiled map[string]frontend.CompiledConstraintSystem // cache compilation
 }
 
 // NewAssert returns an Assert helper embedding a testify/require object for convenience
@@ -55,7 +55,7 @@ type Assert struct {
 // the first call to assert.ProverSucceeded/Failed will compile the circuit for n curves, m backends
 // and subsequent calls will re-use the result of the compilation, if available.
 func NewAssert(t *testing.T) *Assert {
-	return &Assert{t, require.New(t), make(map[string]compiled.ConstraintSystem)}
+	return &Assert{t, require.New(t), make(map[string]frontend.CompiledConstraintSystem)}
 }
 
 // Run runs the test function fn as a subtest. The subtest is parametrized by
@@ -409,7 +409,7 @@ func (assert *Assert) fuzzer(fuzzer filler, circuit, w frontend.Circuit, b backe
 }
 
 // compile the given circuit for given curve and backend, if not already present in cache
-func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendID backend.ID, compileOpts []func(opt *frontend.CompileOption) error) (compiled.ConstraintSystem, error) {
+func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendID backend.ID, compileOpts []func(opt *frontend.CompileOption) error) (frontend.CompiledConstraintSystem, error) {
 	key := curveID.String() + backendID.String() + reflect.TypeOf(circuit).String()
 
 	// check if we already compiled it

--- a/test/kzg_srs.go
+++ b/test/kzg_srs.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/kzg"
-	"github.com/consensys/gnark/internal/backend/compiled"
+	"github.com/consensys/gnark/frontend"
 
 	kzg_bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377/fr/kzg"
 	kzg_bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381/fr/kzg"
@@ -37,7 +37,7 @@ const srsCachedSize = (1 << 14) + 3
 // for sizes < 2^15, returns a pre-computed cached SRS
 //
 // /!\ warning /!\: this method is here for convenience only: in production, a SRS generated through MPC should be used.
-func NewKZGSRS(ccs compiled.ConstraintSystem) (kzg.SRS, error) {
+func NewKZGSRS(ccs frontend.CompiledConstraintSystem) (kzg.SRS, error) {
 
 	nbConstraints := ccs.GetNbConstraints()
 	_, _, public := ccs.GetNbVariables()
@@ -57,7 +57,7 @@ var srsCache map[ecc.ID]kzg.SRS
 func init() {
 	srsCache = make(map[ecc.ID]kzg.SRS)
 }
-func getCachedSRS(ccs compiled.ConstraintSystem) (kzg.SRS, error) {
+func getCachedSRS(ccs frontend.CompiledConstraintSystem) (kzg.SRS, error) {
 	if srs, ok := srsCache[ccs.CurveID()]; ok {
 		return srs, nil
 	}


### PR DESCRIPTION
Introduced by #200  --> 
`frontend.CompiledConstraintSystem` became `compiled.ConstraintSystem`, but `compiled` is `internal/` . 

Note that `GetCounters() []compiled.Counter` in the interface returns something from `internal` which may be impractical  / need revisit. 