### PR TITLE
Group functional options in frontend, backend and test

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -72,9 +72,11 @@ type ProverConfig struct {
 // should complete, even if constraint system is not solved.
 // In that case, Prove will output an invalid Proof, but will execute all algorithms
 // which is useful for test and benchmarking purposes
-func IgnoreSolverError(opt *ProverConfig) error {
-	opt.Force = true
-	return nil
+func IgnoreSolverError() ProverOption {
+	return func(opt *ProverConfig) error {
+		opt.Force = true
+		return nil
+	}
 }
 
 // WithHints is a Prover option that specifies additional hint functions to be used

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -48,7 +48,8 @@ func (id ID) String() string {
 	}
 }
 
-// NewProverConfig returns a default ProverOption with given options applied
+// NewProverConfig returns a default ProverConfig with given prover options opts
+// applied.
 func NewProverConfig(opts ...ProverOption) (ProverConfig, error) {
 	opt := ProverConfig{LoggerOut: os.Stdout, HintFunctions: hint.GetAll()}
 	for _, option := range opts {
@@ -59,19 +60,22 @@ func NewProverConfig(opts ...ProverOption) (ProverConfig, error) {
 	return opt, nil
 }
 
+// ProverOption defines option for altering the behaviour of the prover in
+// Prove, ReadAndProve and IsSolved methods. See the descriptions of functions
+// returning instances of this type for implemented options.
 type ProverOption func(*ProverConfig) error
 
-// ProverConfig is shared accross backends to parametrize calls to xxx.Prove(...)
+// ProverConfig is the configuration for the prover with the options applied.
 type ProverConfig struct {
-	Force         bool            // default to false
-	HintFunctions []hint.Function // default to nil (use only solver std hints)
-	LoggerOut     io.Writer       // default to os.Stdout
+	Force         bool            // defaults to false
+	HintFunctions []hint.Function // defaults to all built-in hint functions
+	LoggerOut     io.Writer       // defaults to os.Stdout
 }
 
-// IgnoreSolverError is a ProverOption that indicates that the Prove algorithm
-// should complete, even if constraint system is not solved.
-// In that case, Prove will output an invalid Proof, but will execute all algorithms
-// which is useful for test and benchmarking purposes
+// IgnoreSolverError is a prover option that indicates that the Prove algorithm
+// should complete even if constraint system is not solved. In that case, Prove
+// will output an invalid Proof, but will execute all algorithms which is useful
+// for test and benchmarking purposes.
 func IgnoreSolverError() ProverOption {
 	return func(opt *ProverConfig) error {
 		opt.Force = true
@@ -79,17 +83,19 @@ func IgnoreSolverError() ProverOption {
 	}
 }
 
-// WithHints is a Prover option that specifies additional hint functions to be used
-// by the constraint solver
+// WithHints is a prover option that specifies additional hint functions to be used
+// by the constraint solver.
 func WithHints(hintFunctions ...hint.Function) ProverOption {
 	return func(opt *ProverConfig) error {
+		// it is an error to register hint function several times, but as the
+		// prover already checks it then omit here.
 		opt.HintFunctions = append(opt.HintFunctions, hintFunctions...)
 		return nil
 	}
 }
 
-// WithOutput is a Prover option that specifies an io.Writer as destination for logs printed by
-// api.Println(). If set to nil, no logs are printed.
+// WithOutput is a prover option that specifies an io.Writer as destination for
+// logs printed by api.Println(). If set to nil, no logs are printed.
 func WithOutput(w io.Writer) ProverOption {
 	return func(opt *ProverConfig) error {
 		opt.LoggerOut = w

--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -164,10 +164,10 @@ func Verify(proof Proof, vk VerifyingKey, publicWitness *witness.Witness) error 
 // 	will executes all the prover computations, even if the witness is invalid
 //  will produce an invalid proof
 //	internally, the solution vector to the R1CS will be filled with random values which may impact benchmarking
-func Prove(r1cs frontend.CompiledConstraintSystem, pk ProvingKey, fullWitness *witness.Witness, opts ...func(opt *backend.ProverOption) error) (Proof, error) {
+func Prove(r1cs frontend.CompiledConstraintSystem, pk ProvingKey, fullWitness *witness.Witness, opts ...backend.ProverOption) (Proof, error) {
 
 	// apply options
-	opt, err := backend.NewProverOption(opts...)
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plonk/plonk.go
+++ b/backend/plonk/plonk.go
@@ -117,10 +117,10 @@ func Setup(ccs frontend.CompiledConstraintSystem, kzgSRS kzg.SRS) (ProvingKey, V
 // 	will executes all the prover computations, even if the witness is invalid
 //  will produce an invalid proof
 //	internally, the solution vector to the SparseR1CS will be filled with random values which may impact benchmarking
-func Prove(ccs frontend.CompiledConstraintSystem, pk ProvingKey, fullWitness *witness.Witness, opts ...func(opt *backend.ProverOption) error) (Proof, error) {
+func Prove(ccs frontend.CompiledConstraintSystem, pk ProvingKey, fullWitness *witness.Witness, opts ...backend.ProverOption) (Proof, error) {
 
 	// apply options
-	opt, err := backend.NewProverOption(opts...)
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/rollup/circuit_test.go
+++ b/examples/rollup/circuit_test.go
@@ -77,7 +77,7 @@ func TestCircuitSignature(t *testing.T) {
 	assert := test.NewAssert(t)
 
 	var signatureCircuit circuitSignature
-	assert.ProverSucceeded(&signatureCircuit, &operator.witnesses, test.WithCurves(ecc.BN254), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs))
+	assert.ProverSucceeded(&signatureCircuit, &operator.witnesses, test.WithCurves(ecc.BN254), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
 
 }
 
@@ -141,7 +141,7 @@ func TestCircuitInclusionProof(t *testing.T) {
 
 	var inclusionProofCircuit circuitInclusionProof
 
-	assert.ProverSucceeded(&inclusionProofCircuit, &operator.witnesses, test.WithCurves(ecc.BN254), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs))
+	assert.ProverSucceeded(&inclusionProofCircuit, &operator.witnesses, test.WithCurves(ecc.BN254), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
 
 }
 
@@ -196,7 +196,7 @@ func TestCircuitUpdateAccount(t *testing.T) {
 
 	var updateAccountCircuit circuitUpdateAccount
 
-	assert.ProverSucceeded(&updateAccountCircuit, &operator.witnesses, test.WithCurves(ecc.BN254), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs))
+	assert.ProverSucceeded(&updateAccountCircuit, &operator.witnesses, test.WithCurves(ecc.BN254), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
 
 }
 
@@ -241,6 +241,6 @@ func TestCircuitFull(t *testing.T) {
 	var rollupCircuit Circuit
 
 	// TODO full circuit has some unconstrained inputs, that's odd.
-	assert.ProverSucceeded(&rollupCircuit, &operator.witnesses, test.WithCurves(ecc.BN254), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs))
+	assert.ProverSucceeded(&rollupCircuit, &operator.witnesses, test.WithCurves(ecc.BN254), test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
 
 }

--- a/frontend/ccs.go
+++ b/frontend/ccs.go
@@ -31,7 +31,7 @@ type CompiledConstraintSystem interface {
 	io.ReaderFrom
 
 	// IsSolved returns nil if given witness solves the constraint system and error otherwise
-	IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error
+	IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error
 
 	// GetNbVariables return number of internal, secret and public Variables
 	GetNbVariables() (internal, secret, public int)

--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -153,9 +153,11 @@ func WithCapacity(capacity int) CompileOption {
 }
 
 // IgnoreUnconstrainedInputs when set, the Compile function doesn't check for unconstrained inputs
-func IgnoreUnconstrainedInputs(opt *compileConfig) error {
-	opt.ignoreUnconstrainedInputs = true
-	return nil
+func IgnoreUnconstrainedInputs() CompileOption {
+	return func(opt *compileConfig) error {
+		opt.ignoreUnconstrainedInputs = true
+		return nil
+	}
 }
 
 // WithBuilder enables the compiler to build the constraint system with a user-defined builder

--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -135,16 +135,20 @@ func bootstrap(builder Builder, circuit Circuit) (err error) {
 	return
 }
 
+// CompileOption defines option for altering the behaviour of the Compile
+// method. See the descriptions of the functions returning instances of this
+// type for available options.
 type CompileOption func(opt *compileConfig) error
 
-// CompileOption enables to set optional argument to call of frontend.Compile()
 type compileConfig struct {
 	capacity                  int
 	ignoreUnconstrainedInputs bool
 	newBuilder                NewBuilder
 }
 
-// WithOutput is a Compile option that specifies the estimated capacity needed for internal variables and constraints
+// WithCapacity is a compile option that specifies the estimated capacity needed
+// for internal variables and constraints. If not set, then the initial capacity
+// is 0 and is dynamically allocated as needed.
 func WithCapacity(capacity int) CompileOption {
 	return func(opt *compileConfig) error {
 		opt.capacity = capacity
@@ -152,7 +156,13 @@ func WithCapacity(capacity int) CompileOption {
 	}
 }
 
-// IgnoreUnconstrainedInputs when set, the Compile function doesn't check for unconstrained inputs
+// IgnoreUnconstrainedInputs is a compile option which allow compiling input
+// circuits where not all inputs are not constrained. If not set, then the
+// compiler returns an error if there exists an unconstrained input.
+//
+// This option is useful for debugging circuits, but should not be used in
+// production settings as it means that there is a potential error in the
+// circuit definition or that it is possible to optimize witness size.
 func IgnoreUnconstrainedInputs() CompileOption {
 	return func(opt *compileConfig) error {
 		opt.ignoreUnconstrainedInputs = true
@@ -160,7 +170,8 @@ func IgnoreUnconstrainedInputs() CompileOption {
 	}
 }
 
-// WithBuilder enables the compiler to build the constraint system with a user-defined builder
+// WithBuilder is a compile option which enables the compiler to build the
+// constraint system with a user-defined builder.
 //
 // /!\ This is highly experimental and may change in upcoming releases /!\
 func WithBuilder(builder NewBuilder) CompileOption {

--- a/frontend/witness.go
+++ b/frontend/witness.go
@@ -10,7 +10,7 @@ import (
 // else returns [public | secret]. The result can then be serialized to / from json & binary
 //
 // Returns an error if the assignment has missing entries
-func NewWitness(assignment Circuit, curveID ecc.ID, opts ...func(opt *witnessConfig) error) (*witness.Witness, error) {
+func NewWitness(assignment Circuit, curveID ecc.ID, opts ...WitnessOption) (*witness.Witness, error) {
 	opt, err := options(opts...)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func NewWitness(assignment Circuit, curveID ecc.ID, opts ...func(opt *witnessCon
 }
 
 // default options
-func options(opts ...func(*witnessConfig) error) (witnessConfig, error) {
+func options(opts ...WitnessOption) (witnessConfig, error) {
 	// apply options
 	opt := witnessConfig{
 		publicOnly: false,

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -63,7 +63,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 // a, b, c vectors: ab-c = hz
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 // returns  [publicWires | secretWires | internalWires ]
-func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
 	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
@@ -137,8 +137,8 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -62,7 +62,7 @@ func NewSparseR1CS(ccs compiled.SparseR1CS, coefficients []big.Int) *SparseR1CS 
 // solution.values =  [publicInputs | secretInputs | internalVariables ]
 // witness: contains the input variables
 // it returns the full slice of wires
-func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	// set the slices holding the solution.values and monitoring which variables have been solved
 	nbVariables := cs.NbInternalVariables + cs.NbSecretVariables + cs.NbPublicVariables
@@ -243,8 +243,8 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 // IsSolved returns nil if given witness solves the SparseR1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bls12-377/groth16/groth16_test.go
+++ b/internal/backend/bls12-377/groth16/groth16_test.go
@@ -107,7 +107,7 @@ func BenchmarkProver(b *testing.B) {
 	b.ResetTimer()
 	b.Run("prover", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _ = bls12_377groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+			_, _ = bls12_377groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 		}
 	})
 }
@@ -128,7 +128,7 @@ func BenchmarkVerifier(b *testing.B) {
 	var pk bls12_377groth16.ProvingKey
 	var vk bls12_377groth16.VerifyingKey
 	bls12_377groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bls12_377groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bls12_377groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -152,7 +152,7 @@ func BenchmarkProofSerialization(b *testing.B) {
 	var pk bls12_377groth16.ProvingKey
 	var vk bls12_377groth16.VerifyingKey
 	bls12_377groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bls12_377groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bls12_377groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bls12-377/groth16/prove.go
+++ b/internal/backend/bls12-377/groth16/prove.go
@@ -53,7 +53,7 @@ func (proof *Proof) CurveID() ecc.ID {
 }
 
 // Prove generates the proof of knoweldge of a r1cs with full witness (secret + public part).
-func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) {
 		return nil, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables, r1cs.NbSecretVariables)
 	}

--- a/internal/backend/bls12-377/plonk/plonk_test.go
+++ b/internal/backend/bls12-377/plonk/plonk_test.go
@@ -114,7 +114,7 @@ func BenchmarkProver(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = bls12_377plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+		_, err = bls12_377plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -139,7 +139,7 @@ func BenchmarkVerifier(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bls12_377plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bls12_377plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -163,7 +163,7 @@ func BenchmarkSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bls12_377plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bls12_377plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bls12-377/plonk/prove.go
+++ b/internal/backend/bls12-377/plonk/prove.go
@@ -60,7 +60,7 @@ type Proof struct {
 }
 
 // Prove from the public data
-func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls12_377witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls12_377witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 
 	// pick a hash function that will be used to derive the challenges
 	hFunc := sha256.New()

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -63,7 +63,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 // a, b, c vectors: ab-c = hz
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 // returns  [publicWires | secretWires | internalWires ]
-func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
 	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
@@ -137,8 +137,8 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -62,7 +62,7 @@ func NewSparseR1CS(ccs compiled.SparseR1CS, coefficients []big.Int) *SparseR1CS 
 // solution.values =  [publicInputs | secretInputs | internalVariables ]
 // witness: contains the input variables
 // it returns the full slice of wires
-func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	// set the slices holding the solution.values and monitoring which variables have been solved
 	nbVariables := cs.NbInternalVariables + cs.NbSecretVariables + cs.NbPublicVariables
@@ -243,8 +243,8 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 // IsSolved returns nil if given witness solves the SparseR1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bls12-381/groth16/groth16_test.go
+++ b/internal/backend/bls12-381/groth16/groth16_test.go
@@ -107,7 +107,7 @@ func BenchmarkProver(b *testing.B) {
 	b.ResetTimer()
 	b.Run("prover", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _ = bls12_381groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+			_, _ = bls12_381groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 		}
 	})
 }
@@ -128,7 +128,7 @@ func BenchmarkVerifier(b *testing.B) {
 	var pk bls12_381groth16.ProvingKey
 	var vk bls12_381groth16.VerifyingKey
 	bls12_381groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bls12_381groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bls12_381groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -152,7 +152,7 @@ func BenchmarkProofSerialization(b *testing.B) {
 	var pk bls12_381groth16.ProvingKey
 	var vk bls12_381groth16.VerifyingKey
 	bls12_381groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bls12_381groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bls12_381groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bls12-381/groth16/prove.go
+++ b/internal/backend/bls12-381/groth16/prove.go
@@ -53,7 +53,7 @@ func (proof *Proof) CurveID() ecc.ID {
 }
 
 // Prove generates the proof of knoweldge of a r1cs with full witness (secret + public part).
-func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) {
 		return nil, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables, r1cs.NbSecretVariables)
 	}

--- a/internal/backend/bls12-381/plonk/plonk_test.go
+++ b/internal/backend/bls12-381/plonk/plonk_test.go
@@ -114,7 +114,7 @@ func BenchmarkProver(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = bls12_381plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+		_, err = bls12_381plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -139,7 +139,7 @@ func BenchmarkVerifier(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bls12_381plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bls12_381plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -163,7 +163,7 @@ func BenchmarkSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bls12_381plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bls12_381plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bls12-381/plonk/prove.go
+++ b/internal/backend/bls12-381/plonk/prove.go
@@ -60,7 +60,7 @@ type Proof struct {
 }
 
 // Prove from the public data
-func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls12_381witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls12_381witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 
 	// pick a hash function that will be used to derive the challenges
 	hFunc := sha256.New()

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -63,7 +63,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 // a, b, c vectors: ab-c = hz
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 // returns  [publicWires | secretWires | internalWires ]
-func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
 	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
@@ -137,8 +137,8 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -62,7 +62,7 @@ func NewSparseR1CS(ccs compiled.SparseR1CS, coefficients []big.Int) *SparseR1CS 
 // solution.values =  [publicInputs | secretInputs | internalVariables ]
 // witness: contains the input variables
 // it returns the full slice of wires
-func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	// set the slices holding the solution.values and monitoring which variables have been solved
 	nbVariables := cs.NbInternalVariables + cs.NbSecretVariables + cs.NbPublicVariables
@@ -243,8 +243,8 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 // IsSolved returns nil if given witness solves the SparseR1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bls24-315/groth16/groth16_test.go
+++ b/internal/backend/bls24-315/groth16/groth16_test.go
@@ -107,7 +107,7 @@ func BenchmarkProver(b *testing.B) {
 	b.ResetTimer()
 	b.Run("prover", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _ = bls24_315groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+			_, _ = bls24_315groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 		}
 	})
 }
@@ -128,7 +128,7 @@ func BenchmarkVerifier(b *testing.B) {
 	var pk bls24_315groth16.ProvingKey
 	var vk bls24_315groth16.VerifyingKey
 	bls24_315groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bls24_315groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bls24_315groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -152,7 +152,7 @@ func BenchmarkProofSerialization(b *testing.B) {
 	var pk bls24_315groth16.ProvingKey
 	var vk bls24_315groth16.VerifyingKey
 	bls24_315groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bls24_315groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bls24_315groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bls24-315/groth16/prove.go
+++ b/internal/backend/bls24-315/groth16/prove.go
@@ -53,7 +53,7 @@ func (proof *Proof) CurveID() ecc.ID {
 }
 
 // Prove generates the proof of knoweldge of a r1cs with full witness (secret + public part).
-func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) {
 		return nil, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables, r1cs.NbSecretVariables)
 	}

--- a/internal/backend/bls24-315/plonk/plonk_test.go
+++ b/internal/backend/bls24-315/plonk/plonk_test.go
@@ -114,7 +114,7 @@ func BenchmarkProver(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = bls24_315plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+		_, err = bls24_315plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -139,7 +139,7 @@ func BenchmarkVerifier(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bls24_315plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bls24_315plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -163,7 +163,7 @@ func BenchmarkSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bls24_315plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bls24_315plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bls24-315/plonk/prove.go
+++ b/internal/backend/bls24-315/plonk/prove.go
@@ -60,7 +60,7 @@ type Proof struct {
 }
 
 // Prove from the public data
-func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls24_315witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls24_315witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 
 	// pick a hash function that will be used to derive the challenges
 	hFunc := sha256.New()

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -63,7 +63,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 // a, b, c vectors: ab-c = hz
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 // returns  [publicWires | secretWires | internalWires ]
-func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
 	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
@@ -137,8 +137,8 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -62,7 +62,7 @@ func NewSparseR1CS(ccs compiled.SparseR1CS, coefficients []big.Int) *SparseR1CS 
 // solution.values =  [publicInputs | secretInputs | internalVariables ]
 // witness: contains the input variables
 // it returns the full slice of wires
-func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	// set the slices holding the solution.values and monitoring which variables have been solved
 	nbVariables := cs.NbInternalVariables + cs.NbSecretVariables + cs.NbPublicVariables
@@ -243,8 +243,8 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 // IsSolved returns nil if given witness solves the SparseR1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bn254/groth16/groth16_test.go
+++ b/internal/backend/bn254/groth16/groth16_test.go
@@ -107,7 +107,7 @@ func BenchmarkProver(b *testing.B) {
 	b.ResetTimer()
 	b.Run("prover", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _ = bn254groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+			_, _ = bn254groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 		}
 	})
 }
@@ -128,7 +128,7 @@ func BenchmarkVerifier(b *testing.B) {
 	var pk bn254groth16.ProvingKey
 	var vk bn254groth16.VerifyingKey
 	bn254groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bn254groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bn254groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -152,7 +152,7 @@ func BenchmarkProofSerialization(b *testing.B) {
 	var pk bn254groth16.ProvingKey
 	var vk bn254groth16.VerifyingKey
 	bn254groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bn254groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bn254groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bn254/groth16/prove.go
+++ b/internal/backend/bn254/groth16/prove.go
@@ -53,7 +53,7 @@ func (proof *Proof) CurveID() ecc.ID {
 }
 
 // Prove generates the proof of knoweldge of a r1cs with full witness (secret + public part).
-func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) {
 		return nil, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables, r1cs.NbSecretVariables)
 	}

--- a/internal/backend/bn254/plonk/plonk_test.go
+++ b/internal/backend/bn254/plonk/plonk_test.go
@@ -114,7 +114,7 @@ func BenchmarkProver(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = bn254plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+		_, err = bn254plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -139,7 +139,7 @@ func BenchmarkVerifier(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bn254plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bn254plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -163,7 +163,7 @@ func BenchmarkSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bn254plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bn254plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bn254/plonk/prove.go
+++ b/internal/backend/bn254/plonk/prove.go
@@ -60,7 +60,7 @@ type Proof struct {
 }
 
 // Prove from the public data
-func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bn254witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bn254witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 
 	// pick a hash function that will be used to derive the challenges
 	hFunc := sha256.New()

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -63,7 +63,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 // a, b, c vectors: ab-c = hz
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 // returns  [publicWires | secretWires | internalWires ]
-func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
 	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
@@ -137,8 +137,8 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -62,7 +62,7 @@ func NewSparseR1CS(ccs compiled.SparseR1CS, coefficients []big.Int) *SparseR1CS 
 // solution.values =  [publicInputs | secretInputs | internalVariables ]
 // witness: contains the input variables
 // it returns the full slice of wires
-func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	// set the slices holding the solution.values and monitoring which variables have been solved
 	nbVariables := cs.NbInternalVariables + cs.NbSecretVariables + cs.NbPublicVariables
@@ -243,8 +243,8 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 // IsSolved returns nil if given witness solves the SparseR1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bw6-633/groth16/groth16_test.go
+++ b/internal/backend/bw6-633/groth16/groth16_test.go
@@ -107,7 +107,7 @@ func BenchmarkProver(b *testing.B) {
 	b.ResetTimer()
 	b.Run("prover", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _ = bw6_633groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+			_, _ = bw6_633groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 		}
 	})
 }
@@ -128,7 +128,7 @@ func BenchmarkVerifier(b *testing.B) {
 	var pk bw6_633groth16.ProvingKey
 	var vk bw6_633groth16.VerifyingKey
 	bw6_633groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bw6_633groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bw6_633groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -152,7 +152,7 @@ func BenchmarkProofSerialization(b *testing.B) {
 	var pk bw6_633groth16.ProvingKey
 	var vk bw6_633groth16.VerifyingKey
 	bw6_633groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bw6_633groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bw6_633groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bw6-633/groth16/prove.go
+++ b/internal/backend/bw6-633/groth16/prove.go
@@ -53,7 +53,7 @@ func (proof *Proof) CurveID() ecc.ID {
 }
 
 // Prove generates the proof of knoweldge of a r1cs with full witness (secret + public part).
-func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_633witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_633witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) {
 		return nil, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables, r1cs.NbSecretVariables)
 	}

--- a/internal/backend/bw6-633/plonk/plonk_test.go
+++ b/internal/backend/bw6-633/plonk/plonk_test.go
@@ -114,7 +114,7 @@ func BenchmarkProver(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = bw6_633plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+		_, err = bw6_633plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -139,7 +139,7 @@ func BenchmarkVerifier(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bw6_633plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bw6_633plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -163,7 +163,7 @@ func BenchmarkSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bw6_633plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bw6_633plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bw6-633/plonk/prove.go
+++ b/internal/backend/bw6-633/plonk/prove.go
@@ -60,7 +60,7 @@ type Proof struct {
 }
 
 // Prove from the public data
-func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bw6_633witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bw6_633witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 
 	// pick a hash function that will be used to derive the challenges
 	hFunc := sha256.New()

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -63,7 +63,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 // a, b, c vectors: ab-c = hz
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 // returns  [publicWires | secretWires | internalWires ]
-func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
 	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
@@ -137,8 +137,8 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -62,7 +62,7 @@ func NewSparseR1CS(ccs compiled.SparseR1CS, coefficients []big.Int) *SparseR1CS 
 // solution.values =  [publicInputs | secretInputs | internalVariables ]
 // witness: contains the input variables
 // it returns the full slice of wires
-func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	// set the slices holding the solution.values and monitoring which variables have been solved
 	nbVariables := cs.NbInternalVariables + cs.NbSecretVariables + cs.NbPublicVariables
@@ -243,8 +243,8 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 // IsSolved returns nil if given witness solves the SparseR1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bw6-761/groth16/groth16_test.go
+++ b/internal/backend/bw6-761/groth16/groth16_test.go
@@ -107,7 +107,7 @@ func BenchmarkProver(b *testing.B) {
 	b.ResetTimer()
 	b.Run("prover", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _ = bw6_761groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+			_, _ = bw6_761groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 		}
 	})
 }
@@ -128,7 +128,7 @@ func BenchmarkVerifier(b *testing.B) {
 	var pk bw6_761groth16.ProvingKey
 	var vk bw6_761groth16.VerifyingKey
 	bw6_761groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bw6_761groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bw6_761groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -152,7 +152,7 @@ func BenchmarkProofSerialization(b *testing.B) {
 	var pk bw6_761groth16.ProvingKey
 	var vk bw6_761groth16.VerifyingKey
 	bw6_761groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := bw6_761groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+	proof, err := bw6_761groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bw6-761/groth16/prove.go
+++ b/internal/backend/bw6-761/groth16/prove.go
@@ -53,7 +53,7 @@ func (proof *Proof) CurveID() ecc.ID {
 }
 
 // Prove generates the proof of knoweldge of a r1cs with full witness (secret + public part).
-func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) {
 		return nil, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables, r1cs.NbSecretVariables)
 	}

--- a/internal/backend/bw6-761/plonk/plonk_test.go
+++ b/internal/backend/bw6-761/plonk/plonk_test.go
@@ -114,7 +114,7 @@ func BenchmarkProver(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = bw6_761plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+		_, err = bw6_761plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -139,7 +139,7 @@ func BenchmarkVerifier(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bw6_761plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bw6_761plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -163,7 +163,7 @@ func BenchmarkSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := bw6_761plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := bw6_761plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bw6-761/plonk/prove.go
+++ b/internal/backend/bw6-761/plonk/prove.go
@@ -60,7 +60,7 @@ type Proof struct {
 }
 
 // Prove from the public data
-func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bw6_761witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bw6_761witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 
 	// pick a hash function that will be used to derive the challenges
 	hFunc := sha256.New()

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -45,7 +45,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 // a, b, c vectors: ab-c = hz
 // witness = [publicWires | secretWires] (without the ONE_WIRE !)
 // returns  [publicWires | secretWires | internalWires ]
-func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
 	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
@@ -119,8 +119,8 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverOption) (
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *R1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -44,7 +44,7 @@ func NewSparseR1CS(ccs compiled.SparseR1CS, coefficients []big.Int) *SparseR1CS 
 // solution.values =  [publicInputs | secretInputs | internalVariables ]
 // witness: contains the input variables
 // it returns the full slice of wires
-func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverOption) ([]fr.Element, error) {
+func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 
 	// set the slices holding the solution.values and monitoring which variables have been solved
@@ -233,8 +233,8 @@ func (cs *SparseR1CS) solveConstraint(c compiled.SparseR1C, solution *solution, 
 
 // IsSolved returns nil if given witness solves the SparseR1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs
-func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...func(opt *backend.ProverOption) error) error {
-	opt, err := backend.NewProverOption(opts...)
+func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverOption) error {
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -31,7 +31,7 @@ func (proof *Proof) CurveID() ecc.ID {
 }
 
 // Prove generates the proof of knoweldge of a r1cs with full witness (secret + public part).
-func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 	if len(witness) != int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables) {
 		return nil, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(r1cs.NbPublicVariables-1+r1cs.NbSecretVariables), r1cs.NbPublicVariables, r1cs.NbSecretVariables)
 	}

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
@@ -88,7 +88,7 @@ func BenchmarkProver(b *testing.B) {
 	b.ResetTimer()
 	b.Run("prover", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _ = {{toLower .CurveID}}groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverOption{})
+			_, _ = {{toLower .CurveID}}groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness, backend.ProverConfig{})
 		}
 	})
 }
@@ -109,7 +109,7 @@ func BenchmarkVerifier(b *testing.B) {
 	var pk {{toLower .CurveID}}groth16.ProvingKey
 	var vk {{toLower .CurveID}}groth16.VerifyingKey
 	{{toLower .CurveID}}groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := {{toLower .CurveID}}groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness,backend.ProverOption{})
+	proof, err := {{toLower .CurveID}}groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness,backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -135,7 +135,7 @@ func BenchmarkProofSerialization(b *testing.B) {
 	var pk {{toLower .CurveID}}groth16.ProvingKey
 	var vk {{toLower .CurveID}}groth16.VerifyingKey
 	{{toLower .CurveID}}groth16.Setup(r1cs.(*cs.R1CS), &pk, &vk)
-	proof, err := {{toLower .CurveID}}groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness,backend.ProverOption{})
+	proof, err := {{toLower .CurveID}}groth16.Prove(r1cs.(*cs.R1CS), &pk, fullWitness,backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
@@ -36,7 +36,7 @@ type Proof struct {
 }
 
 // Prove from the public data
-func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness {{ toLower .CurveID }}witness.Witness, opt backend.ProverOption) (*Proof, error) {
+func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness {{ toLower .CurveID }}witness.Witness, opt backend.ProverConfig) (*Proof, error) {
 
 	// pick a hash function that will be used to derive the challenges
 	hFunc := sha256.New()

--- a/internal/generator/backend/template/zkpschemes/plonk/tests/plonk.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/tests/plonk.go.tmpl
@@ -95,7 +95,7 @@ func BenchmarkProver(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = {{toLower .CurveID}}plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness,backend.ProverOption{})
+		_, err = {{toLower .CurveID}}plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness,backend.ProverConfig{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -120,7 +120,7 @@ func BenchmarkVerifier(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := {{toLower .CurveID}}plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{})
+	proof, err := {{toLower .CurveID}}plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{})
 	if err != nil {
 		panic(err)
 	}
@@ -146,7 +146,7 @@ func BenchmarkSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	proof, err := {{toLower .CurveID}}plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverOption{} )
+	proof, err := {{toLower .CurveID}}plonk.Prove(ccs.(*cs.SparseR1CS), pk, fullWitness, backend.ProverConfig{} )
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/std/groth16_bls12377/verifier_test.go
+++ b/std/groth16_bls12377/verifier_test.go
@@ -80,7 +80,7 @@ func generateBls12377InnerProof(t *testing.T, vk *groth16_bls12377.VerifyingKey,
 	// generate the data to return for the bls12377 proof
 	var pk groth16_bls12377.ProvingKey
 	groth16_bls12377.Setup(r1cs.(*backend_bls12377.R1CS), &pk, vk)
-	_proof, err := groth16_bls12377.Prove(r1cs.(*backend_bls12377.R1CS), &pk, correctAssignment, backend.ProverOption{})
+	_proof, err := groth16_bls12377.Prove(r1cs.(*backend_bls12377.R1CS), &pk, correctAssignment, backend.ProverConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/std/groth16_bls24315/verifier_test.go
+++ b/std/groth16_bls24315/verifier_test.go
@@ -80,7 +80,7 @@ func generateBls24315InnerProof(t *testing.T, vk *groth16_bls24315.VerifyingKey,
 	// generate the data to return for the bls24315 proof
 	var pk groth16_bls24315.ProvingKey
 	groth16_bls24315.Setup(r1cs.(*backend_bls24315.R1CS), &pk, vk)
-	_proof, err := groth16_bls24315.Prove(r1cs.(*backend_bls24315.R1CS), &pk, correctAssignment, backend.ProverOption{})
+	_proof, err := groth16_bls24315.Prove(r1cs.(*backend_bls24315.R1CS), &pk, correctAssignment, backend.ProverConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/assert.go
+++ b/test/assert.go
@@ -84,7 +84,7 @@ func (assert *Assert) Log(v ...interface{}) {
 // 4. if set, (de)serializes the witness and call ReadAndProve and ReadAndVerify on the backend
 //
 // By default, this tests on all curves and proving schemes supported by gnark. See available TestingOption.
-func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment frontend.Circuit, opts ...func(opt *TestingOption) error) {
+func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment frontend.Circuit, opts ...TestingOption) {
 	opt := assert.options(opts...)
 
 	// for each {curve, backend} tuple
@@ -175,7 +175,7 @@ func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment 
 // 3. run Setup / Prove / Verify with the backend (must fail)
 //
 // By default, this tests on all curves and proving schemes supported by gnark. See available TestingOption.
-func (assert *Assert) ProverFailed(circuit frontend.Circuit, invalidAssignment frontend.Circuit, opts ...func(opt *TestingOption) error) {
+func (assert *Assert) ProverFailed(circuit frontend.Circuit, invalidAssignment frontend.Circuit, opts ...TestingOption) {
 	opt := assert.options(opts...)
 
 	popts := append(opt.proverOpts, backend.IgnoreSolverError())
@@ -236,7 +236,7 @@ func (assert *Assert) ProverFailed(circuit frontend.Circuit, invalidAssignment f
 	}
 }
 
-func (assert *Assert) SolvingSucceeded(circuit frontend.Circuit, validWitness frontend.Circuit, opts ...func(opt *TestingOption) error) {
+func (assert *Assert) SolvingSucceeded(circuit frontend.Circuit, validWitness frontend.Circuit, opts ...TestingOption) {
 	opt := assert.options(opts...)
 
 	for _, curve := range opt.curves {
@@ -250,7 +250,7 @@ func (assert *Assert) SolvingSucceeded(circuit frontend.Circuit, validWitness fr
 	}
 }
 
-func (assert *Assert) solvingSucceeded(circuit frontend.Circuit, validAssignment frontend.Circuit, b backend.ID, curve ecc.ID, opt *TestingOption) {
+func (assert *Assert) solvingSucceeded(circuit frontend.Circuit, validAssignment frontend.Circuit, b backend.ID, curve ecc.ID, opt *testingConfig) {
 	// parse assignment
 	validWitness, err := frontend.NewWitness(validAssignment, curve)
 	assert.NoError(err, "can't parse valid assignment")
@@ -270,7 +270,7 @@ func (assert *Assert) solvingSucceeded(circuit frontend.Circuit, validAssignment
 
 }
 
-func (assert *Assert) SolvingFailed(circuit frontend.Circuit, invalidWitness frontend.Circuit, opts ...func(opt *TestingOption) error) {
+func (assert *Assert) SolvingFailed(circuit frontend.Circuit, invalidWitness frontend.Circuit, opts ...TestingOption) {
 	opt := assert.options(opts...)
 
 	for _, curve := range opt.curves {
@@ -284,7 +284,7 @@ func (assert *Assert) SolvingFailed(circuit frontend.Circuit, invalidWitness fro
 	}
 }
 
-func (assert *Assert) solvingFailed(circuit frontend.Circuit, invalidAssignment frontend.Circuit, b backend.ID, curve ecc.ID, opt *TestingOption) {
+func (assert *Assert) solvingFailed(circuit frontend.Circuit, invalidAssignment frontend.Circuit, b backend.ID, curve ecc.ID, opt *testingConfig) {
 	// parse assignment
 	invalidWitness, err := frontend.NewWitness(invalidAssignment, curve)
 	assert.NoError(err, "can't parse invalid assignment")
@@ -310,7 +310,7 @@ func (assert *Assert) solvingFailed(circuit frontend.Circuit, invalidAssignment 
 
 // GetCounters compiles (or fetch from the compiled circuit cache) the circuit with set backends and curves
 // and returns measured counters
-func (assert *Assert) GetCounters(circuit frontend.Circuit, opts ...func(opt *TestingOption) error) []compiled.Counter {
+func (assert *Assert) GetCounters(circuit frontend.Circuit, opts ...TestingOption) []compiled.Counter {
 	opt := assert.options(opts...)
 
 	var r []compiled.Counter
@@ -334,7 +334,7 @@ func (assert *Assert) GetCounters(circuit frontend.Circuit, opts ...func(opt *Te
 // execution result between constraint system solver and big.Int test execution engine
 //
 // note: this is experimental and will be more tightly integrated with go1.18 built-in fuzzing
-func (assert *Assert) Fuzz(circuit frontend.Circuit, fuzzCount int, opts ...func(opt *TestingOption) error) {
+func (assert *Assert) Fuzz(circuit frontend.Circuit, fuzzCount int, opts ...TestingOption) {
 	opt := assert.options(opts...)
 
 	// first we clone the circuit
@@ -372,7 +372,7 @@ func (assert *Assert) Fuzz(circuit frontend.Circuit, fuzzCount int, opts ...func
 	}
 }
 
-func (assert *Assert) fuzzer(fuzzer filler, circuit, w frontend.Circuit, b backend.ID, curve ecc.ID, opt *TestingOption) int {
+func (assert *Assert) fuzzer(fuzzer filler, circuit, w frontend.Circuit, b backend.ID, curve ecc.ID, opt *testingConfig) int {
 	// fuzz a witness
 	fuzzer(w, curve)
 
@@ -424,9 +424,9 @@ func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendI
 }
 
 // default options
-func (assert *Assert) options(opts ...func(*TestingOption) error) TestingOption {
+func (assert *Assert) options(opts ...TestingOption) testingConfig {
 	// apply options
-	opt := TestingOption{
+	opt := testingConfig{
 		witnessSerialization: true,
 		backends:             backend.Implemented(),
 		curves:               ecc.Implemented(),

--- a/test/assert.go
+++ b/test/assert.go
@@ -178,7 +178,7 @@ func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment 
 func (assert *Assert) ProverFailed(circuit frontend.Circuit, invalidAssignment frontend.Circuit, opts ...func(opt *TestingOption) error) {
 	opt := assert.options(opts...)
 
-	popts := append(opt.proverOpts, backend.IgnoreSolverError)
+	popts := append(opt.proverOpts, backend.IgnoreSolverError())
 
 	for _, curve := range opt.curves {
 

--- a/test/assert.go
+++ b/test/assert.go
@@ -390,7 +390,7 @@ func (assert *Assert) fuzzer(fuzzer filler, circuit, w frontend.Circuit, b backe
 }
 
 // compile the given circuit for given curve and backend, if not already present in cache
-func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendID backend.ID, compileOpts []func(opt *frontend.CompileOption) error) (frontend.CompiledConstraintSystem, error) {
+func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendID backend.ID, compileOpts []frontend.CompileOption) (frontend.CompiledConstraintSystem, error) {
 	key := curveID.String() + backendID.String() + reflect.TypeOf(circuit).String()
 
 	// check if we already compiled it

--- a/test/engine.go
+++ b/test/engine.go
@@ -42,7 +42,7 @@ import (
 type engine struct {
 	backendID backend.ID
 	curveID   ecc.ID
-	opt       backend.ProverOption
+	opt       backend.ProverConfig
 	// mHintsFunctions map[hint.ID]hintFunction
 }
 
@@ -52,9 +52,9 @@ type engine struct {
 // The test execution engine implements frontend.API using big.Int operations.
 //
 // This is an experimental feature.
-func IsSolved(circuit, witness frontend.Circuit, curveID ecc.ID, b backend.ID, opts ...func(opt *backend.ProverOption) error) (err error) {
+func IsSolved(circuit, witness frontend.Circuit, curveID ecc.ID, b backend.ID, opts ...backend.ProverOption) (err error) {
 	// apply options
-	opt, err := backend.NewProverOption(opts...)
+	opt, err := backend.NewProverConfig(opts...)
 	if err != nil {
 		return err
 	}

--- a/test/options.go
+++ b/test/options.go
@@ -22,12 +22,14 @@ import (
 	"github.com/consensys/gnark/frontend"
 )
 
-// TestingOption enables calls to assert.ProverSucceeded and assert.ProverFailed to run with various features
+type TestingOption func(*testingConfig) error
+
+// testingConfig enables calls to assert.ProverSucceeded and assert.ProverFailed to run with various features
 //
 // In particular: chose the curve, chose the backend and execute serialization tests on the witness
 //
 // Default values to all supported curves, backends and execute serialization tests = true
-type TestingOption struct {
+type testingConfig struct {
 	backends             []backend.ID
 	curves               []ecc.ID
 	witnessSerialization bool
@@ -38,8 +40,8 @@ type TestingOption struct {
 // WithBackends enables calls to assert.ProverSucceeded and assert.ProverFailed to run on specific backends only
 //
 // (defaults to all gnark supported backends)
-func WithBackends(b backend.ID, backends ...backend.ID) func(opt *TestingOption) error {
-	return func(opt *TestingOption) error {
+func WithBackends(b backend.ID, backends ...backend.ID) TestingOption {
+	return func(opt *testingConfig) error {
 		opt.backends = []backend.ID{b}
 		opt.backends = append(opt.backends, backends...)
 		return nil
@@ -49,8 +51,8 @@ func WithBackends(b backend.ID, backends ...backend.ID) func(opt *TestingOption)
 // WithCurves enables calls to assert.ProverSucceeded and assert.ProverFailed to run on specific curves only
 //
 // (defaults to all gnark supported curves)
-func WithCurves(c ecc.ID, curves ...ecc.ID) func(opt *TestingOption) error {
-	return func(opt *TestingOption) error {
+func WithCurves(c ecc.ID, curves ...ecc.ID) TestingOption {
+	return func(opt *testingConfig) error {
 		opt.curves = []ecc.ID{c}
 		opt.curves = append(opt.curves, curves...)
 		return nil
@@ -58,8 +60,8 @@ func WithCurves(c ecc.ID, curves ...ecc.ID) func(opt *TestingOption) error {
 }
 
 // NoSerialization enables calls to assert.ProverSucceeded and assert.ProverFailed to skip witness serialization tests
-func NoSerialization() func(opt *TestingOption) error {
-	return func(opt *TestingOption) error {
+func NoSerialization() TestingOption {
+	return func(opt *testingConfig) error {
 		opt.witnessSerialization = false
 		return nil
 	}
@@ -67,8 +69,8 @@ func NoSerialization() func(opt *TestingOption) error {
 
 // WithProverOpts enables calls to assert.ProverSucceeded and assert.ProverFailed to forward backend.Prover option
 // to backend.Prove and backend.ReadAndProve calls
-func WithProverOpts(proverOpts ...backend.ProverOption) func(opt *TestingOption) error {
-	return func(opt *TestingOption) error {
+func WithProverOpts(proverOpts ...backend.ProverOption) TestingOption {
+	return func(opt *testingConfig) error {
 		opt.proverOpts = proverOpts
 		return nil
 	}
@@ -76,8 +78,8 @@ func WithProverOpts(proverOpts ...backend.ProverOption) func(opt *TestingOption)
 
 // WithCompileOpts enables calls to assert.ProverSucceeded and assert.ProverFailed to forward compiler.Compile option
 // to compiler.Compile calls
-func WithCompileOpts(compileOpts ...frontend.CompileOption) func(opt *TestingOption) error {
-	return func(opt *TestingOption) error {
+func WithCompileOpts(compileOpts ...frontend.CompileOption) TestingOption {
+	return func(opt *testingConfig) error {
 		opt.compileOpts = compileOpts
 		return nil
 	}

--- a/test/options.go
+++ b/test/options.go
@@ -22,13 +22,11 @@ import (
 	"github.com/consensys/gnark/frontend"
 )
 
+// TestingOption defines option for altering the behaviour of Assert methods.
+// See the descriptions of functions returning instances of this type for
+// particular options.
 type TestingOption func(*testingConfig) error
 
-// testingConfig enables calls to assert.ProverSucceeded and assert.ProverFailed to run with various features
-//
-// In particular: chose the curve, chose the backend and execute serialization tests on the witness
-//
-// Default values to all supported curves, backends and execute serialization tests = true
 type testingConfig struct {
 	backends             []backend.ID
 	curves               []ecc.ID
@@ -37,9 +35,8 @@ type testingConfig struct {
 	compileOpts          []frontend.CompileOption
 }
 
-// WithBackends enables calls to assert.ProverSucceeded and assert.ProverFailed to run on specific backends only
-//
-// (defaults to all gnark supported backends)
+// WithBackends is testing option which restricts the backends the assertions are
+// run. When not given, runs on all implemented backends.
 func WithBackends(b backend.ID, backends ...backend.ID) TestingOption {
 	return func(opt *testingConfig) error {
 		opt.backends = []backend.ID{b}
@@ -48,9 +45,8 @@ func WithBackends(b backend.ID, backends ...backend.ID) TestingOption {
 	}
 }
 
-// WithCurves enables calls to assert.ProverSucceeded and assert.ProverFailed to run on specific curves only
-//
-// (defaults to all gnark supported curves)
+// WithCurves is a testing option which restricts the curves the assertions are
+// run. When not given, runs on all implemented curves.
 func WithCurves(c ecc.ID, curves ...ecc.ID) TestingOption {
 	return func(opt *testingConfig) error {
 		opt.curves = []ecc.ID{c}
@@ -59,7 +55,8 @@ func WithCurves(c ecc.ID, curves ...ecc.ID) TestingOption {
 	}
 }
 
-// NoSerialization enables calls to assert.ProverSucceeded and assert.ProverFailed to skip witness serialization tests
+// NoSerialization is a testing option which disables witness serialization tests
+// in assertions.
 func NoSerialization() TestingOption {
 	return func(opt *testingConfig) error {
 		opt.witnessSerialization = false
@@ -67,8 +64,9 @@ func NoSerialization() TestingOption {
 	}
 }
 
-// WithProverOpts enables calls to assert.ProverSucceeded and assert.ProverFailed to forward backend.Prover option
-// to backend.Prove and backend.ReadAndProve calls
+// WithProverOpts is a testing option which uses the given proverOpts when
+// calling backend.Prover, backend.ReadAndProve and backend.IsSolved methods in
+// assertions.
 func WithProverOpts(proverOpts ...backend.ProverOption) TestingOption {
 	return func(opt *testingConfig) error {
 		opt.proverOpts = proverOpts
@@ -76,8 +74,8 @@ func WithProverOpts(proverOpts ...backend.ProverOption) TestingOption {
 	}
 }
 
-// WithCompileOpts enables calls to assert.ProverSucceeded and assert.ProverFailed to forward compiler.Compile option
-// to compiler.Compile calls
+// WithCompileOpts is a testing option which uses the given compileOpts when
+// calling frontend.Compile in assertions.
 func WithCompileOpts(compileOpts ...frontend.CompileOption) TestingOption {
 	return func(opt *testingConfig) error {
 		opt.compileOpts = compileOpts

--- a/test/options.go
+++ b/test/options.go
@@ -32,7 +32,7 @@ type TestingOption struct {
 	curves               []ecc.ID
 	witnessSerialization bool
 	proverOpts           []func(opt *backend.ProverOption) error
-	compileOpts          []func(opt *frontend.CompileOption) error
+	compileOpts          []frontend.CompileOption
 }
 
 // WithBackends enables calls to assert.ProverSucceeded and assert.ProverFailed to run on specific backends only
@@ -76,7 +76,7 @@ func WithProverOpts(proverOpts ...func(opt *backend.ProverOption) error) func(op
 
 // WithCompileOpts enables calls to assert.ProverSucceeded and assert.ProverFailed to forward compiler.Compile option
 // to compiler.Compile calls
-func WithCompileOpts(compileOpts ...func(opt *frontend.CompileOption) error) func(opt *TestingOption) error {
+func WithCompileOpts(compileOpts ...frontend.CompileOption) func(opt *TestingOption) error {
 	return func(opt *TestingOption) error {
 		opt.compileOpts = compileOpts
 		return nil

--- a/test/options.go
+++ b/test/options.go
@@ -31,7 +31,7 @@ type TestingOption struct {
 	backends             []backend.ID
 	curves               []ecc.ID
 	witnessSerialization bool
-	proverOpts           []func(opt *backend.ProverOption) error
+	proverOpts           []backend.ProverOption
 	compileOpts          []frontend.CompileOption
 }
 
@@ -67,7 +67,7 @@ func NoSerialization() func(opt *TestingOption) error {
 
 // WithProverOpts enables calls to assert.ProverSucceeded and assert.ProverFailed to forward backend.Prover option
 // to backend.Prove and backend.ReadAndProve calls
-func WithProverOpts(proverOpts ...func(opt *backend.ProverOption) error) func(opt *TestingOption) error {
+func WithProverOpts(proverOpts ...backend.ProverOption) func(opt *TestingOption) error {
 	return func(opt *TestingOption) error {
 		opt.proverOpts = proverOpts
 		return nil


### PR DESCRIPTION
Following the framework of functional options as described in https://sagikazarmark.hu/blog/functional-options-on-steroids/ and https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis with slight changes. Namely, didn't rename a few methods to `Set/With...` pattern and didn't define `Option` to be `interface{ apply(*config) error}` to be backwards compatible.

Closes #231 