### PR TITLE
feat: addition of Cmp in the API

### DIFF
--- a/frontend/api.go
+++ b/frontend/api.go
@@ -32,11 +32,11 @@ type API interface {
 	// Add returns res = i1+i2+...in
 	Add(i1, i2 Variable, in ...Variable) Variable
 
-	// Sub returns res = i1 - i2 - ...in
-	Sub(i1, i2 Variable, in ...Variable) Variable
-
 	// Neg returns -i
 	Neg(i1 Variable) Variable
+
+	// Sub returns res = i1 - i2 - ...in
+	Sub(i1, i2 Variable, in ...Variable) Variable
 
 	// Mul returns res = i1 * i2 * ... in
 	Mul(i1, i2 Variable, in ...Variable) Variable
@@ -88,6 +88,9 @@ type API interface {
 
 	// IsZero returns 1 if a is zero, 0 otherwise
 	IsZero(i1 Variable) Variable
+
+	// Cmp returns 1 if i1>i2, 0 if i1=i2, -1 if i1<i2
+	Cmp(i1, i2 Variable) Variable
 
 	// ---------------------------------------------------------------------------------------------
 	// Assertions

--- a/frontend/cs/plonk/api.go
+++ b/frontend/cs/plonk/api.go
@@ -426,6 +426,32 @@ func (system *sparseR1CS) IsZero(i1 frontend.Variable) frontend.Variable {
 	return m
 }
 
+// Cmp returns 1 if i1>i2, 0 if i1=i2, -1 if i1<i2
+func (system *sparseR1CS) Cmp(i1, i2 frontend.Variable) frontend.Variable {
+
+	bi1 := system.ToBinary(i1, system.BitLen())
+	bi2 := system.ToBinary(i2, system.BitLen())
+
+	var res frontend.Variable
+	res = 0
+
+	for i := system.BitLen() - 1; i >= 0; i-- {
+
+		iszeroi1 := system.IsZero(bi1[i])
+		iszeroi2 := system.IsZero(bi2[i])
+
+		i1i2 := system.And(bi1[i], iszeroi2)
+		i2i1 := system.And(bi2[i], iszeroi1)
+
+		n := system.Select(i2i1, -1, 0)
+		m := system.Select(i1i2, 1, n)
+
+		res = system.Select(system.IsZero(res), m, res)
+
+	}
+	return res
+}
+
 // Println behaves like fmt.Println but accepts Variable as parameter
 // whose value will be resolved at runtime when computed by the solver
 // Println enables circuit debugging and behaves almost like fmt.Println()

--- a/integration_test.go
+++ b/integration_test.go
@@ -37,6 +37,7 @@ func TestIntegrationAPI(t *testing.T) {
 	sort.Strings(keys)
 
 	for i := range keys {
+
 		name := keys[i]
 		tData := circuits.Circuits[name]
 		assert.Run(func(assert *test.Assert) {

--- a/internal/backend/circuits/cmp.go
+++ b/internal/backend/circuits/cmp.go
@@ -1,0 +1,59 @@
+package circuits
+
+import (
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+)
+
+type cmpCircuit struct {
+	A frontend.Variable
+	B frontend.Variable `gnark:",public"`
+	R frontend.Variable
+}
+
+func (circuit *cmpCircuit) Define(api frontend.API) error {
+	r := api.Cmp(circuit.A, circuit.B)
+	api.AssertIsEqual(r, circuit.R)
+	return nil
+}
+
+func init() {
+
+	good := []frontend.Circuit{
+		&cmpCircuit{
+			A: 12346,
+			B: 12345,
+			R: 1,
+		},
+		&cmpCircuit{
+			A: 12345,
+			B: 12346,
+			R: -1,
+		},
+		&cmpCircuit{
+			A: 12345,
+			B: 12345,
+			R: 0,
+		},
+	}
+
+	bad := []frontend.Circuit{
+		&cmpCircuit{
+			A: 12345,
+			B: 12346,
+			R: 1,
+		},
+		&cmpCircuit{
+			A: 12346,
+			B: 12345,
+			R: -1,
+		},
+		&cmpCircuit{
+			A: 12345,
+			B: 12345,
+			R: 1,
+		},
+	}
+
+	addNewEntry("cmp", &cmpCircuit{}, good, bad, []ecc.ID{ecc.BW6_761})
+}

--- a/test/engine.go
+++ b/test/engine.go
@@ -266,6 +266,13 @@ func (e *engine) IsZero(i1 frontend.Variable) frontend.Variable {
 	return (0)
 }
 
+// Cmp returns 1 if i1>i2, 0 if i1==i2, -1 if i1<i2
+func (e *engine) Cmp(i1, i2 frontend.Variable) frontend.Variable {
+	b1 := e.toBigInt(i1)
+	b2 := e.toBigInt(i2)
+	return e.toBigInt(b1.Cmp(&b2))
+}
+
 func (e *engine) AssertIsEqual(i1, i2 frontend.Variable) {
 	b1, b2 := e.toBigInt(i1), e.toBigInt(i2)
 	if b1.Cmp(&b2) != 0 {


### PR DESCRIPTION
This PR adds the Cmp function to the api:
```
// Cmp returns 1 if i1>i2, 0 if i1=i2, -1 if i1<i2
Cmp(i1, i2 Variable) Variable
```

following [this](https://github.com/ConsenSys/gnark/discussions/199) discussion.

~4k constraints for BN254.