### PR TITLE
feat(std): add LessThan() and IsEqual()

### DIFF
--- a/std/math/math.go
+++ b/std/math/math.go
@@ -1,0 +1,52 @@
+package math
+
+import "github.com/consensys/gnark/frontend"
+
+type Math struct {
+	api frontend.API // underlying constraint system
+}
+
+func NewMath(api frontend.API) (Math, error) {
+	return Math{api}, nil
+}
+
+// Returns 1 if a < b
+func (m *Math) LessThan(a, b frontend.Variable) frontend.Variable {
+	aBits := m.api.ToBinary(a)
+	bBits := m.api.ToBinary(b)
+
+	var output frontend.Variable
+	output = 0
+
+	// This section performs Compare()
+	// Output is 1 if a > b
+	// Output is 0 if a == b
+	// Output is -1 if a < b
+
+	// Backwards due to little endian
+	for i := len(aBits) - 1; i >= 0; i-- {
+		m.api.AssertIsBoolean(aBits[i])
+		m.api.AssertIsBoolean(bBits[i])
+
+		aIsOne := aBits[i]
+		bIsOne := bBits[i]
+
+		aIsNotOne := m.api.IsZero(aBits[i])
+		bIsNotOne := m.api.IsZero(bBits[i])
+
+		aBeatsB := m.api.And(aIsOne, bIsNotOne)
+		bBeatsA := m.api.And(bIsOne, aIsNotOne)
+
+		newOutput := m.api.Select(aBeatsB, 1, 0)
+		newOutput = m.api.Select(bBeatsA, -1, newOutput)
+
+		output = m.api.Select(m.api.IsZero(output), newOutput, output)
+	}
+
+	// Now, convert output of Convert() into LessThan()
+	return m.IsEqual(output, -1)
+}
+
+func (m *Math) IsEqual(a, b frontend.Variable) frontend.Variable {
+	return m.api.IsZero(m.api.Sub(a, b))
+}

--- a/std/math/math_test.go
+++ b/std/math/math_test.go
@@ -1,0 +1,80 @@
+package math
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+)
+
+type LessThanCircuit struct {
+	A              frontend.Variable `gnark:",public"`
+	B              frontend.Variable `gnark:",public"`
+	ExpectedOutput frontend.Variable `gnark:",public"`
+}
+
+func (c *LessThanCircuit) Define(api frontend.API) error {
+	math, _ := NewMath(api)
+	output := math.LessThan(c.A, c.B)
+
+	api.AssertIsEqual(output, c.ExpectedOutput)
+
+	return nil
+}
+
+func TestLessThan(t *testing.T) {
+	assert := test.NewAssert(t)
+
+	var lessThanCircuit LessThanCircuit
+
+	assert.ProverSucceeded(&lessThanCircuit, &LessThanCircuit{
+		A:              9,
+		B:              10,
+		ExpectedOutput: 1,
+	})
+
+	assert.ProverSucceeded(&lessThanCircuit, &LessThanCircuit{
+		A:              10,
+		B:              10,
+		ExpectedOutput: 0,
+	})
+
+	assert.ProverSucceeded(&lessThanCircuit, &LessThanCircuit{
+		A:              11,
+		B:              10,
+		ExpectedOutput: 0,
+	})
+}
+
+type IsEqualCircuit struct {
+	A              frontend.Variable `gnark:",public"`
+	B              frontend.Variable `gnark:",public"`
+	ExpectedOutput frontend.Variable `gnark:",public"`
+}
+
+func (c *IsEqualCircuit) Define(api frontend.API) error {
+	math, _ := NewMath(api)
+	output := math.IsEqual(c.A, c.B)
+
+	api.AssertIsEqual(output, c.ExpectedOutput)
+
+	return nil
+}
+
+func TestIsEqual(t *testing.T) {
+	assert := test.NewAssert(t)
+
+	var isEqualCircuit IsEqualCircuit
+
+	assert.ProverSucceeded(&isEqualCircuit, &IsEqualCircuit{
+		A:              10,
+		B:              10,
+		ExpectedOutput: 1,
+	})
+
+	assert.ProverSucceeded(&isEqualCircuit, &IsEqualCircuit{
+		A:              9,
+		B:              10,
+		ExpectedOutput: 0,
+	})
+}


### PR DESCRIPTION
Hi guys,

I've found some time to give this a go :). 

I have implemented `LessThan()` and `IsEqual()` as a new `math` package under `std`. Currently, this implementation gives it great isolation and builds on top of the current `frontend.api` without touching it. 

I was hoping to simplify `LessThan()` to compute `a < b`, however, I found that I still needed the full functionality of `Compare()`. If b is greater than a, it needs to be recorded too and persisted to the end of the loop. Without this, if `a` has a less significant bit set where `b`'s is not, then it will appear as though `a > b` incorrectly. 

As such, I wanted to ask whether you guys wanted to relax the feature from `LessThan()` to `Compare()` given both require the same amount of work, but `Compare()` gives more functionality to the user. I can also see the benefit of simplifying the interface and keeping it as `LessThan()`, so also happy to keep it just as is and include the reduction done in the final lines of the current implementation:
```
	// Now, convert output of Convert() into LessThan()
	return m.IsEqual(output, -1)
```

Another thing I was hoping to do was to add it directly into `frontend.api`. However, I had some issues getting the tests to run. Here is the link to my attempted commit on my fork: [LINK](https://github.com/vck3000/gnark/commit/7e80eb89cef507aa68e6b549a01f66e7b1c84400)

An example of the error is:
```
=== RUN   TestCompare/fuzz/bw6_761/plonk
    assert.go:356:
                Error Trace:    assert.go:356
                                                        assert.go:70
                Error:          Received unexpected error:
                                compilation is not deterministic
                Test:           TestCompare/fuzz/bw6_761/plonk
```

However, this implementation also means that the code has to be duplicated thrice across `r1cs`, `plonk` and `engine`. I could not work out a way to prevent code duplication here if I added it straight into `frontend.api`. 

What do you guys think? I like the idea of having `api.LessThan()` and `api.IsEqual()`; however it may be cleaner to have these in a new `std/math` package. 

Open to suggestions and feedback!