### PR TITLE
`ccs.GetConstraints` readable output

### DIFF
--- a/debug_test.go
+++ b/debug_test.go
@@ -83,7 +83,7 @@ func TestTraceDivBy0(t *testing.T) {
 	{
 		_, err := getGroth16Trace(&circuit, &witness)
 		assert.Error(err)
-		assert.Contains(err.Error(), "constraint is not satisfied: [div] 2/(-2 + 2) == <unsolved>")
+		assert.Contains(err.Error(), "constraint #0 is not satisfied: [div] 2/(-2 + 2) == <unsolved>")
 		assert.Contains(err.Error(), "(*divBy0Trace).Define")
 		assert.Contains(err.Error(), "debug_test.go:")
 	}
@@ -91,7 +91,7 @@ func TestTraceDivBy0(t *testing.T) {
 	{
 		_, err := getPlonkTrace(&circuit, &witness)
 		assert.Error(err)
-		assert.Contains(err.Error(), "constraint is not satisfied: [inverse] 1/0 < ∞")
+		assert.Contains(err.Error(), "constraint #1 is not satisfied: [inverse] 1/0 < ∞")
 		assert.Contains(err.Error(), "(*divBy0Trace).Define")
 		assert.Contains(err.Error(), "debug_test.go:")
 	}
@@ -120,7 +120,7 @@ func TestTraceNotEqual(t *testing.T) {
 	{
 		_, err := getGroth16Trace(&circuit, &witness)
 		assert.Error(err)
-		assert.Contains(err.Error(), "constraint is not satisfied: [assertIsEqual] 1 == (24 + 42)")
+		assert.Contains(err.Error(), "constraint #0 is not satisfied: [assertIsEqual] 1 == (24 + 42)")
 		assert.Contains(err.Error(), "(*notEqualTrace).Define")
 		assert.Contains(err.Error(), "debug_test.go:")
 	}
@@ -128,7 +128,7 @@ func TestTraceNotEqual(t *testing.T) {
 	{
 		_, err := getPlonkTrace(&circuit, &witness)
 		assert.Error(err)
-		assert.Contains(err.Error(), "constraint is not satisfied: [assertIsEqual] 1 + -66 == 0")
+		assert.Contains(err.Error(), "constraint #1 is not satisfied: [assertIsEqual] 1 + -66 == 0")
 		assert.Contains(err.Error(), "(*notEqualTrace).Define")
 		assert.Contains(err.Error(), "debug_test.go:")
 	}
@@ -157,7 +157,7 @@ func TestTraceNotBoolean(t *testing.T) {
 	{
 		_, err := getGroth16Trace(&circuit, &witness)
 		assert.Error(err)
-		assert.Contains(err.Error(), "constraint is not satisfied: [assertIsBoolean] (24 + 42) == (0|1)")
+		assert.Contains(err.Error(), "constraint #0 is not satisfied: [assertIsBoolean] (24 + 42) == (0|1)")
 		assert.Contains(err.Error(), "(*notBooleanTrace).Define")
 		assert.Contains(err.Error(), "debug_test.go:")
 	}
@@ -165,7 +165,7 @@ func TestTraceNotBoolean(t *testing.T) {
 	{
 		_, err := getPlonkTrace(&circuit, &witness)
 		assert.Error(err)
-		assert.Contains(err.Error(), "constraint is not satisfied: [assertIsBoolean] 66 == (0|1)")
+		assert.Contains(err.Error(), "constraint #1 is not satisfied: [assertIsBoolean] 66 == (0|1)")
 		assert.Contains(err.Error(), "(*notBooleanTrace).Define")
 		assert.Contains(err.Error(), "debug_test.go:")
 	}

--- a/frontend/ccs.go
+++ b/frontend/ccs.go
@@ -41,9 +41,6 @@ type CompiledConstraintSystem interface {
 	CurveID() ecc.ID
 	FrSize() int
 
-	// ToHTML generates a human readable representation of the constraint system
-	ToHTML(w io.Writer) error
-
 	// GetCounters return the collected constraint counters, if any
 	GetCounters() []compiled.Counter
 

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"text/template"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 
@@ -289,30 +288,8 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	return nil
 }
 
-// TODO @gbotrel clean logs and html see https://github.com/ConsenSys/gnark/issues/140
-
-// ToHTML returns an HTML human-readable representation of the constraint system
-func (cs *R1CS) ToHTML(w io.Writer) error {
-	t, err := template.New("cs.html").Funcs(template.FuncMap{
-		"toHTML": toHTML,
-		"add":    add,
-		"sub":    sub,
-	}).Parse(compiled.R1CSTemplate)
-	if err != nil {
-		return err
-	}
-
-	return t.Execute(w, cs)
-}
-
-func add(a, b int) int {
-	return a + b
-}
-
-func sub(a, b int) int {
-	return a - b
-}
-
+// GetConstraints return a list of constraint formatted as L⋅R == O
+// such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
@@ -373,59 +350,6 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 	default:
 		sbb.WriteString("<?>")
 	}
-}
-
-func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
-	var sbb strings.Builder
-	for i := 0; i < len(l.LinExp); i++ {
-		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l.LinExp) {
-			sbb.WriteString(" + ")
-		}
-	}
-	return sbb.String()
-}
-
-func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHints map[int]compiled.Hint, offset bool) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteString("<span class=\"coefficient\">-</span>")
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteString("<span class=\"coefficient\">0</span>")
-		return
-	} else {
-		sbb.WriteString("<span class=\"coefficient\">")
-		sbb.WriteString(coeffs[tID].String())
-		sbb.WriteString("</span>*")
-	}
-
-	vID := t.WireID()
-	class := ""
-	switch t.VariableVisibility() {
-	case schema.Internal:
-		class = "internal"
-		if _, ok := MHints[vID]; ok {
-			class = "hint"
-		}
-	case schema.Public:
-		class = "public"
-	case schema.Secret:
-		class = "secret"
-	case schema.Virtual:
-		class = "virtual"
-	case schema.Unset:
-		class = "unset"
-	default:
-		panic("not implemented")
-	}
-	if offset {
-		vID++ // for sparse R1CS, we offset to have same variable numbers as in R1CS
-	}
-	sbb.WriteString(fmt.Sprintf("<span class=\"%s\">v%d</span>", class, vID))
-
 }
 
 // GetNbCoefficients return the number of unique coefficients needed in the R1CS

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -121,9 +121,9 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		if !check.Equal(&c[i]) {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, errUnsatisfiedConstraint(i)
 		}
 	}
 

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -291,7 +291,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 // GetConstraints return a list of constraint formatted as L⋅R == O
 // such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
-	var r [][]string
+	r := make([][]string, len(cs.Constraints))
 	for _, c := range cs.Constraints {
 		// for each constraint, we build a string representation of it's L, R and O part
 		// if we are worried about perf for large cs, we could do a string builder + csv format.

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -350,7 +350,7 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 		return
 	} else {
 		sbb.WriteString(cs.Coefficients[tID].String())
-		sbb.WriteByte('*')
+		sbb.WriteString("⋅")
 	}
 	vID := t.WireID()
 	visibility := t.VariableVisibility()

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -118,11 +118,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		// ensure a[i] * b[i] == c[i]
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
+			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			return solution.values, errUnsatisfiedConstraint(i)
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -273,31 +273,29 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
 	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var A, M, k, O string
+	var AM, k, O string
 	var sbb strings.Builder
 
-	if isZeroA {
-		A = "0"
+	if isZeroA && isZeroM {
+		AM = "0"
 	} else {
-		sbb.Reset()
-		cs.termToString(c.L, &sbb, false)
-		sbb.WriteString(" + ")
-		cs.termToString(c.R, &sbb, false)
-		A = sbb.String()
-	}
-
-	if isZeroM {
-		M = "0"
-	} else {
-		sbb.Reset()
-		cs.termToString(c.M[0], &sbb, false)
-		sbb.WriteString(" * ")
-		cs.termToString(c.M[1], &sbb, false)
-		M = sbb.String()
+		if isZeroA {
+			sbb.Reset()
+			cs.termToString(c.M[0], &sbb, false)
+			sbb.WriteString(" * ")
+			cs.termToString(c.M[1], &sbb, false)
+			AM = sbb.String()
+		} else {
+			sbb.Reset()
+			cs.termToString(c.L, &sbb, false)
+			sbb.WriteString(" + ")
+			cs.termToString(c.R, &sbb, false)
+			AM = sbb.String()
+		}
 	}
 
 	k = cs.Coefficients[c.K].String()
@@ -307,7 +305,7 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
 	cs.termToString(c.O, &sbb, true)
 	O = sbb.String()
 
-	return [4]string{A, M, k, O}
+	return [3]string{AM, k, O}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
-	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/internal/backend/ioutils"
@@ -110,17 +109,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
 		}
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				if debug.Debug {
-					return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
-				}
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			if debug.Debug {
-				return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
-			}
-			return solution.values, fmt.Errorf("%w", errUnsatisfiedConstraint(i))
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -258,32 +258,85 @@ func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverO
 func (cs *SparseR1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
-		// if we are worried about perf for large cs, we could do a string builder + csv format.
-		var line [6]string
-		line[0] = cs.termToString(c.L)
-		line[1] = cs.termToString(c.R)
-		line[2] = cs.termToString(c.M[0])
-		line[3] = cs.termToString(c.M[1])
-		line[4] = cs.termToString(c.O)
-		line[5] = cs.Coefficients[c.K].String()
-		r = append(r, line[:])
+		fc := cs.formatConstraint(c)
+		r = append(r, fc[:])
 	}
 	return r
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term) string {
+// formatConstraint return a human readable representation of a constraint
+// in the form A + M + k == O
+// where
+// A = c1 * v1 + c2 *v2
+// M = c1 * v1 * v2
+// k = c1
+// If A is set, then M == 0 . If M is set, A == 0 .
+// k can be set for both A and M
+// cX are constants
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
+
+	var A, M, k, O string
 	var sbb strings.Builder
+
+	if isZeroA {
+		A = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.L, &sbb, false)
+		sbb.WriteString(" + ")
+		cs.termToString(c.R, &sbb, false)
+		A = sbb.String()
+	}
+
+	if isZeroM {
+		M = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
+	}
+
+	k = cs.Coefficients[c.K].String()
+
+	// we need to negate O
+	sbb.Reset()
+	cs.termToString(c.O, &sbb, true)
+	O = sbb.String()
+
+	return [4]string{A, M, k, O}
+}
+
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {
 	tID := t.CoeffID()
 	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
+		if negate {
+			sbb.WriteByte('-')
+		} else {
+			// do nothing, just print the variable
+		}
 	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
+		if negate {
+			// do nothing, just print the variable
+		} else {
+			// print neg sign
+			sbb.WriteByte('-')
+		}
 	} else if tID == compiled.CoeffIdZero {
 		sbb.WriteByte('0')
-		return sbb.String()
+		return
 	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+		if negate {
+			var cNeg fr.Element
+			cNeg.Neg(&cs.Coefficients[tID])
+			sbb.WriteString(cNeg.String())
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
+
 		sbb.WriteByte('*')
 	}
 	vID := t.WireID()
@@ -303,7 +356,6 @@ func (cs *SparseR1CS) termToString(t compiled.Term) string {
 	default:
 		sbb.WriteString("<?>")
 	}
-	return sbb.String()
 }
 
 // checkConstraint verifies that the constraint holds

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -112,9 +112,9 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
 		}
 	}
 
@@ -318,7 +318,7 @@ func (cs *SparseR1CS) checkConstraint(c compiled.SparseR1C, solution *solution) 
 	var t fr.Element
 	t.Mul(&m0, &m1).Add(&t, &l).Add(&t, &r).Add(&t, &o).Add(&t, &cs.Coefficients[c.K])
 	if !t.IsZero() {
-		return fmt.Errorf("%w\n%s + %s + (%s * %s) + %s + %s != 0", ErrUnsatisfiedConstraint,
+		return fmt.Errorf("%s + %s + (%s * %s) + %s + %s != 0",
 			l.String(),
 			r.String(),
 			m0.String(),

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -273,39 +273,37 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
-	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var AM, k, O string
+	var A0, A1, M, k, O string
 	var sbb strings.Builder
 
-	if isZeroA && isZeroM {
-		AM = "0"
+	sbb.Reset()
+	cs.termToString(c.L, &sbb, false)
+	A0 = sbb.String()
+	sbb.Reset()
+	cs.termToString(c.R, &sbb, false)
+	A1 = sbb.String()
+
+	if isZeroM {
+		M = "0"
 	} else {
-		if isZeroA {
-			sbb.Reset()
-			cs.termToString(c.M[0], &sbb, false)
-			sbb.WriteString(" * ")
-			cs.termToString(c.M[1], &sbb, false)
-			AM = sbb.String()
-		} else {
-			sbb.Reset()
-			cs.termToString(c.L, &sbb, false)
-			sbb.WriteString(" + ")
-			cs.termToString(c.R, &sbb, false)
-			AM = sbb.String()
-		}
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	// we need to negate O
 	sbb.Reset()
-	cs.termToString(c.O, &sbb, true)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
-	return [3]string{AM, k, O}
+	return [5]string{A0, A1, M, O, k}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -274,56 +274,53 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	var sbb strings.Builder
 
 	sbb.Reset()
-	cs.termToString(c.L, &sbb)
+	cs.termToString(c.L, &sbb, false)
 	A0 = sbb.String()
 	sbb.Reset()
-	cs.termToString(c.R, &sbb)
+	cs.termToString(c.R, &sbb, false)
 	A1 = sbb.String()
 
 	if isZeroM {
 		M = "0"
 	} else {
 		sbb.Reset()
-		cm0 := c.M[0]
-		addParenthesis := cm0.CoeffID() != compiled.CoeffIdOne
-		if addParenthesis {
-			sbb.WriteString(cs.Coefficients[cm0.CoeffID()].String())
-			sbb.WriteString("⋅")
-			sbb.WriteByte('(')
-		}
-		cm0.SetCoeffID(compiled.CoeffIdOne)
-		cs.termToString(cm0, &sbb)
+		sbb.WriteString(cs.Coefficients[c.M[0].CoeffID()].String())
+		sbb.WriteString("⋅")
+		sbb.WriteByte('(')
+		cs.termToString(c.M[0], &sbb, true)
 		sbb.WriteString(" × ")
-		cs.termToString(c.M[1], &sbb)
-		if addParenthesis {
-			sbb.WriteByte(')')
-		}
+		cs.termToString(c.M[1], &sbb, true)
+		sbb.WriteByte(')')
 		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	sbb.Reset()
-	cs.termToString(c.O, &sbb)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
 	return [5]string{A0, A1, O, M, k}
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteByte('0')
-		return
-	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, vOnly bool) {
+	if !vOnly {
+		tID := t.CoeffID()
+		if tID == compiled.CoeffIdOne {
+			// do nothing, just print the variable
+			sbb.WriteString("1")
+		} else if tID == compiled.CoeffIdMinusOne {
+			// print neg sign
+			sbb.WriteString("-1")
+		} else if tID == compiled.CoeffIdZero {
+			sbb.WriteByte('0')
+			return
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
 		sbb.WriteString("⋅")
 	}
+
 	vID := t.WireID()
 	visibility := t.VariableVisibility()
 

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -33,8 +33,10 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-377"
 )
 
-// ErrUnsatisfiedConstraint can be generated when solving a R1CS
-var ErrUnsatisfiedConstraint = errors.New("constraint is not satisfied")
+// errUnsatisfiedConstraint can be generated when solving a R1CS
+func errUnsatisfiedConstraint(i int) error {
+	return fmt.Errorf("constraint #%d is not satisfied", i)
+}
 
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -33,11 +33,6 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-377"
 )
 
-// errUnsatisfiedConstraint can be generated when solving a R1CS
-func errUnsatisfiedConstraint(i int) error {
-	return fmt.Errorf("constraint #%d is not satisfied", i)
-}
-
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -121,9 +121,9 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		if !check.Equal(&c[i]) {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, errUnsatisfiedConstraint(i)
 		}
 	}
 

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -291,7 +291,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 // GetConstraints return a list of constraint formatted as L⋅R == O
 // such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
-	var r [][]string
+	r := make([][]string, len(cs.Constraints))
 	for _, c := range cs.Constraints {
 		// for each constraint, we build a string representation of it's L, R and O part
 		// if we are worried about perf for large cs, we could do a string builder + csv format.

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -350,7 +350,7 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 		return
 	} else {
 		sbb.WriteString(cs.Coefficients[tID].String())
-		sbb.WriteByte('*')
+		sbb.WriteString("⋅")
 	}
 	vID := t.WireID()
 	visibility := t.VariableVisibility()

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -118,11 +118,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		// ensure a[i] * b[i] == c[i]
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
+			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			return solution.values, errUnsatisfiedConstraint(i)
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"text/template"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 
@@ -289,30 +288,8 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	return nil
 }
 
-// TODO @gbotrel clean logs and html see https://github.com/ConsenSys/gnark/issues/140
-
-// ToHTML returns an HTML human-readable representation of the constraint system
-func (cs *R1CS) ToHTML(w io.Writer) error {
-	t, err := template.New("cs.html").Funcs(template.FuncMap{
-		"toHTML": toHTML,
-		"add":    add,
-		"sub":    sub,
-	}).Parse(compiled.R1CSTemplate)
-	if err != nil {
-		return err
-	}
-
-	return t.Execute(w, cs)
-}
-
-func add(a, b int) int {
-	return a + b
-}
-
-func sub(a, b int) int {
-	return a - b
-}
-
+// GetConstraints return a list of constraint formatted as L⋅R == O
+// such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
@@ -373,59 +350,6 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 	default:
 		sbb.WriteString("<?>")
 	}
-}
-
-func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
-	var sbb strings.Builder
-	for i := 0; i < len(l.LinExp); i++ {
-		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l.LinExp) {
-			sbb.WriteString(" + ")
-		}
-	}
-	return sbb.String()
-}
-
-func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHints map[int]compiled.Hint, offset bool) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteString("<span class=\"coefficient\">-</span>")
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteString("<span class=\"coefficient\">0</span>")
-		return
-	} else {
-		sbb.WriteString("<span class=\"coefficient\">")
-		sbb.WriteString(coeffs[tID].String())
-		sbb.WriteString("</span>*")
-	}
-
-	vID := t.WireID()
-	class := ""
-	switch t.VariableVisibility() {
-	case schema.Internal:
-		class = "internal"
-		if _, ok := MHints[vID]; ok {
-			class = "hint"
-		}
-	case schema.Public:
-		class = "public"
-	case schema.Secret:
-		class = "secret"
-	case schema.Virtual:
-		class = "virtual"
-	case schema.Unset:
-		class = "unset"
-	default:
-		panic("not implemented")
-	}
-	if offset {
-		vID++ // for sparse R1CS, we offset to have same variable numbers as in R1CS
-	}
-	sbb.WriteString(fmt.Sprintf("<span class=\"%s\">v%d</span>", class, vID))
-
 }
 
 // GetNbCoefficients return the number of unique coefficients needed in the R1CS

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -273,31 +273,29 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
 	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var A, M, k, O string
+	var AM, k, O string
 	var sbb strings.Builder
 
-	if isZeroA {
-		A = "0"
+	if isZeroA && isZeroM {
+		AM = "0"
 	} else {
-		sbb.Reset()
-		cs.termToString(c.L, &sbb, false)
-		sbb.WriteString(" + ")
-		cs.termToString(c.R, &sbb, false)
-		A = sbb.String()
-	}
-
-	if isZeroM {
-		M = "0"
-	} else {
-		sbb.Reset()
-		cs.termToString(c.M[0], &sbb, false)
-		sbb.WriteString(" * ")
-		cs.termToString(c.M[1], &sbb, false)
-		M = sbb.String()
+		if isZeroA {
+			sbb.Reset()
+			cs.termToString(c.M[0], &sbb, false)
+			sbb.WriteString(" * ")
+			cs.termToString(c.M[1], &sbb, false)
+			AM = sbb.String()
+		} else {
+			sbb.Reset()
+			cs.termToString(c.L, &sbb, false)
+			sbb.WriteString(" + ")
+			cs.termToString(c.R, &sbb, false)
+			AM = sbb.String()
+		}
 	}
 
 	k = cs.Coefficients[c.K].String()
@@ -307,7 +305,7 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
 	cs.termToString(c.O, &sbb, true)
 	O = sbb.String()
 
-	return [4]string{A, M, k, O}
+	return [3]string{AM, k, O}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
-	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/internal/backend/ioutils"
@@ -110,17 +109,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
 		}
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				if debug.Debug {
-					return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
-				}
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			if debug.Debug {
-				return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
-			}
-			return solution.values, fmt.Errorf("%w", errUnsatisfiedConstraint(i))
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -258,32 +258,85 @@ func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverO
 func (cs *SparseR1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
-		// if we are worried about perf for large cs, we could do a string builder + csv format.
-		var line [6]string
-		line[0] = cs.termToString(c.L)
-		line[1] = cs.termToString(c.R)
-		line[2] = cs.termToString(c.M[0])
-		line[3] = cs.termToString(c.M[1])
-		line[4] = cs.termToString(c.O)
-		line[5] = cs.Coefficients[c.K].String()
-		r = append(r, line[:])
+		fc := cs.formatConstraint(c)
+		r = append(r, fc[:])
 	}
 	return r
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term) string {
+// formatConstraint return a human readable representation of a constraint
+// in the form A + M + k == O
+// where
+// A = c1 * v1 + c2 *v2
+// M = c1 * v1 * v2
+// k = c1
+// If A is set, then M == 0 . If M is set, A == 0 .
+// k can be set for both A and M
+// cX are constants
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
+
+	var A, M, k, O string
 	var sbb strings.Builder
+
+	if isZeroA {
+		A = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.L, &sbb, false)
+		sbb.WriteString(" + ")
+		cs.termToString(c.R, &sbb, false)
+		A = sbb.String()
+	}
+
+	if isZeroM {
+		M = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
+	}
+
+	k = cs.Coefficients[c.K].String()
+
+	// we need to negate O
+	sbb.Reset()
+	cs.termToString(c.O, &sbb, true)
+	O = sbb.String()
+
+	return [4]string{A, M, k, O}
+}
+
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {
 	tID := t.CoeffID()
 	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
+		if negate {
+			sbb.WriteByte('-')
+		} else {
+			// do nothing, just print the variable
+		}
 	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
+		if negate {
+			// do nothing, just print the variable
+		} else {
+			// print neg sign
+			sbb.WriteByte('-')
+		}
 	} else if tID == compiled.CoeffIdZero {
 		sbb.WriteByte('0')
-		return sbb.String()
+		return
 	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+		if negate {
+			var cNeg fr.Element
+			cNeg.Neg(&cs.Coefficients[tID])
+			sbb.WriteString(cNeg.String())
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
+
 		sbb.WriteByte('*')
 	}
 	vID := t.WireID()
@@ -303,7 +356,6 @@ func (cs *SparseR1CS) termToString(t compiled.Term) string {
 	default:
 		sbb.WriteString("<?>")
 	}
-	return sbb.String()
 }
 
 // checkConstraint verifies that the constraint holds

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -112,9 +112,9 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
 		}
 	}
 
@@ -318,7 +318,7 @@ func (cs *SparseR1CS) checkConstraint(c compiled.SparseR1C, solution *solution) 
 	var t fr.Element
 	t.Mul(&m0, &m1).Add(&t, &l).Add(&t, &r).Add(&t, &o).Add(&t, &cs.Coefficients[c.K])
 	if !t.IsZero() {
-		return fmt.Errorf("%w\n%s + %s + (%s * %s) + %s + %s != 0", ErrUnsatisfiedConstraint,
+		return fmt.Errorf("%s + %s + (%s * %s) + %s + %s != 0",
 			l.String(),
 			r.String(),
 			m0.String(),

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -273,39 +273,37 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
-	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var AM, k, O string
+	var A0, A1, M, k, O string
 	var sbb strings.Builder
 
-	if isZeroA && isZeroM {
-		AM = "0"
+	sbb.Reset()
+	cs.termToString(c.L, &sbb, false)
+	A0 = sbb.String()
+	sbb.Reset()
+	cs.termToString(c.R, &sbb, false)
+	A1 = sbb.String()
+
+	if isZeroM {
+		M = "0"
 	} else {
-		if isZeroA {
-			sbb.Reset()
-			cs.termToString(c.M[0], &sbb, false)
-			sbb.WriteString(" * ")
-			cs.termToString(c.M[1], &sbb, false)
-			AM = sbb.String()
-		} else {
-			sbb.Reset()
-			cs.termToString(c.L, &sbb, false)
-			sbb.WriteString(" + ")
-			cs.termToString(c.R, &sbb, false)
-			AM = sbb.String()
-		}
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	// we need to negate O
 	sbb.Reset()
-	cs.termToString(c.O, &sbb, true)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
-	return [3]string{AM, k, O}
+	return [5]string{A0, A1, M, O, k}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -274,56 +274,53 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	var sbb strings.Builder
 
 	sbb.Reset()
-	cs.termToString(c.L, &sbb)
+	cs.termToString(c.L, &sbb, false)
 	A0 = sbb.String()
 	sbb.Reset()
-	cs.termToString(c.R, &sbb)
+	cs.termToString(c.R, &sbb, false)
 	A1 = sbb.String()
 
 	if isZeroM {
 		M = "0"
 	} else {
 		sbb.Reset()
-		cm0 := c.M[0]
-		addParenthesis := cm0.CoeffID() != compiled.CoeffIdOne
-		if addParenthesis {
-			sbb.WriteString(cs.Coefficients[cm0.CoeffID()].String())
-			sbb.WriteString("⋅")
-			sbb.WriteByte('(')
-		}
-		cm0.SetCoeffID(compiled.CoeffIdOne)
-		cs.termToString(cm0, &sbb)
+		sbb.WriteString(cs.Coefficients[c.M[0].CoeffID()].String())
+		sbb.WriteString("⋅")
+		sbb.WriteByte('(')
+		cs.termToString(c.M[0], &sbb, true)
 		sbb.WriteString(" × ")
-		cs.termToString(c.M[1], &sbb)
-		if addParenthesis {
-			sbb.WriteByte(')')
-		}
+		cs.termToString(c.M[1], &sbb, true)
+		sbb.WriteByte(')')
 		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	sbb.Reset()
-	cs.termToString(c.O, &sbb)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
 	return [5]string{A0, A1, O, M, k}
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteByte('0')
-		return
-	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, vOnly bool) {
+	if !vOnly {
+		tID := t.CoeffID()
+		if tID == compiled.CoeffIdOne {
+			// do nothing, just print the variable
+			sbb.WriteString("1")
+		} else if tID == compiled.CoeffIdMinusOne {
+			// print neg sign
+			sbb.WriteString("-1")
+		} else if tID == compiled.CoeffIdZero {
+			sbb.WriteByte('0')
+			return
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
 		sbb.WriteString("⋅")
 	}
+
 	vID := t.WireID()
 	visibility := t.VariableVisibility()
 

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -33,11 +33,6 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-381"
 )
 
-// errUnsatisfiedConstraint can be generated when solving a R1CS
-func errUnsatisfiedConstraint(i int) error {
-	return fmt.Errorf("constraint #%d is not satisfied", i)
-}
-
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -33,8 +33,10 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-381"
 )
 
-// ErrUnsatisfiedConstraint can be generated when solving a R1CS
-var ErrUnsatisfiedConstraint = errors.New("constraint is not satisfied")
+// errUnsatisfiedConstraint can be generated when solving a R1CS
+func errUnsatisfiedConstraint(i int) error {
+	return fmt.Errorf("constraint #%d is not satisfied", i)
+}
 
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -121,9 +121,9 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		if !check.Equal(&c[i]) {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, errUnsatisfiedConstraint(i)
 		}
 	}
 

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -291,7 +291,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 // GetConstraints return a list of constraint formatted as L⋅R == O
 // such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
-	var r [][]string
+	r := make([][]string, len(cs.Constraints))
 	for _, c := range cs.Constraints {
 		// for each constraint, we build a string representation of it's L, R and O part
 		// if we are worried about perf for large cs, we could do a string builder + csv format.

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -350,7 +350,7 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 		return
 	} else {
 		sbb.WriteString(cs.Coefficients[tID].String())
-		sbb.WriteByte('*')
+		sbb.WriteString("⋅")
 	}
 	vID := t.WireID()
 	visibility := t.VariableVisibility()

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -118,11 +118,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		// ensure a[i] * b[i] == c[i]
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
+			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			return solution.values, errUnsatisfiedConstraint(i)
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"text/template"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 
@@ -289,30 +288,8 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	return nil
 }
 
-// TODO @gbotrel clean logs and html see https://github.com/ConsenSys/gnark/issues/140
-
-// ToHTML returns an HTML human-readable representation of the constraint system
-func (cs *R1CS) ToHTML(w io.Writer) error {
-	t, err := template.New("cs.html").Funcs(template.FuncMap{
-		"toHTML": toHTML,
-		"add":    add,
-		"sub":    sub,
-	}).Parse(compiled.R1CSTemplate)
-	if err != nil {
-		return err
-	}
-
-	return t.Execute(w, cs)
-}
-
-func add(a, b int) int {
-	return a + b
-}
-
-func sub(a, b int) int {
-	return a - b
-}
-
+// GetConstraints return a list of constraint formatted as L⋅R == O
+// such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
@@ -373,59 +350,6 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 	default:
 		sbb.WriteString("<?>")
 	}
-}
-
-func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
-	var sbb strings.Builder
-	for i := 0; i < len(l.LinExp); i++ {
-		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l.LinExp) {
-			sbb.WriteString(" + ")
-		}
-	}
-	return sbb.String()
-}
-
-func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHints map[int]compiled.Hint, offset bool) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteString("<span class=\"coefficient\">-</span>")
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteString("<span class=\"coefficient\">0</span>")
-		return
-	} else {
-		sbb.WriteString("<span class=\"coefficient\">")
-		sbb.WriteString(coeffs[tID].String())
-		sbb.WriteString("</span>*")
-	}
-
-	vID := t.WireID()
-	class := ""
-	switch t.VariableVisibility() {
-	case schema.Internal:
-		class = "internal"
-		if _, ok := MHints[vID]; ok {
-			class = "hint"
-		}
-	case schema.Public:
-		class = "public"
-	case schema.Secret:
-		class = "secret"
-	case schema.Virtual:
-		class = "virtual"
-	case schema.Unset:
-		class = "unset"
-	default:
-		panic("not implemented")
-	}
-	if offset {
-		vID++ // for sparse R1CS, we offset to have same variable numbers as in R1CS
-	}
-	sbb.WriteString(fmt.Sprintf("<span class=\"%s\">v%d</span>", class, vID))
-
 }
 
 // GetNbCoefficients return the number of unique coefficients needed in the R1CS

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -273,31 +273,29 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
 	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var A, M, k, O string
+	var AM, k, O string
 	var sbb strings.Builder
 
-	if isZeroA {
-		A = "0"
+	if isZeroA && isZeroM {
+		AM = "0"
 	} else {
-		sbb.Reset()
-		cs.termToString(c.L, &sbb, false)
-		sbb.WriteString(" + ")
-		cs.termToString(c.R, &sbb, false)
-		A = sbb.String()
-	}
-
-	if isZeroM {
-		M = "0"
-	} else {
-		sbb.Reset()
-		cs.termToString(c.M[0], &sbb, false)
-		sbb.WriteString(" * ")
-		cs.termToString(c.M[1], &sbb, false)
-		M = sbb.String()
+		if isZeroA {
+			sbb.Reset()
+			cs.termToString(c.M[0], &sbb, false)
+			sbb.WriteString(" * ")
+			cs.termToString(c.M[1], &sbb, false)
+			AM = sbb.String()
+		} else {
+			sbb.Reset()
+			cs.termToString(c.L, &sbb, false)
+			sbb.WriteString(" + ")
+			cs.termToString(c.R, &sbb, false)
+			AM = sbb.String()
+		}
 	}
 
 	k = cs.Coefficients[c.K].String()
@@ -307,7 +305,7 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
 	cs.termToString(c.O, &sbb, true)
 	O = sbb.String()
 
-	return [4]string{A, M, k, O}
+	return [3]string{AM, k, O}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
-	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/internal/backend/ioutils"
@@ -110,17 +109,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
 		}
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				if debug.Debug {
-					return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
-				}
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			if debug.Debug {
-				return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
-			}
-			return solution.values, fmt.Errorf("%w", errUnsatisfiedConstraint(i))
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -258,32 +258,85 @@ func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverO
 func (cs *SparseR1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
-		// if we are worried about perf for large cs, we could do a string builder + csv format.
-		var line [6]string
-		line[0] = cs.termToString(c.L)
-		line[1] = cs.termToString(c.R)
-		line[2] = cs.termToString(c.M[0])
-		line[3] = cs.termToString(c.M[1])
-		line[4] = cs.termToString(c.O)
-		line[5] = cs.Coefficients[c.K].String()
-		r = append(r, line[:])
+		fc := cs.formatConstraint(c)
+		r = append(r, fc[:])
 	}
 	return r
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term) string {
+// formatConstraint return a human readable representation of a constraint
+// in the form A + M + k == O
+// where
+// A = c1 * v1 + c2 *v2
+// M = c1 * v1 * v2
+// k = c1
+// If A is set, then M == 0 . If M is set, A == 0 .
+// k can be set for both A and M
+// cX are constants
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
+
+	var A, M, k, O string
 	var sbb strings.Builder
+
+	if isZeroA {
+		A = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.L, &sbb, false)
+		sbb.WriteString(" + ")
+		cs.termToString(c.R, &sbb, false)
+		A = sbb.String()
+	}
+
+	if isZeroM {
+		M = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
+	}
+
+	k = cs.Coefficients[c.K].String()
+
+	// we need to negate O
+	sbb.Reset()
+	cs.termToString(c.O, &sbb, true)
+	O = sbb.String()
+
+	return [4]string{A, M, k, O}
+}
+
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {
 	tID := t.CoeffID()
 	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
+		if negate {
+			sbb.WriteByte('-')
+		} else {
+			// do nothing, just print the variable
+		}
 	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
+		if negate {
+			// do nothing, just print the variable
+		} else {
+			// print neg sign
+			sbb.WriteByte('-')
+		}
 	} else if tID == compiled.CoeffIdZero {
 		sbb.WriteByte('0')
-		return sbb.String()
+		return
 	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+		if negate {
+			var cNeg fr.Element
+			cNeg.Neg(&cs.Coefficients[tID])
+			sbb.WriteString(cNeg.String())
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
+
 		sbb.WriteByte('*')
 	}
 	vID := t.WireID()
@@ -303,7 +356,6 @@ func (cs *SparseR1CS) termToString(t compiled.Term) string {
 	default:
 		sbb.WriteString("<?>")
 	}
-	return sbb.String()
 }
 
 // checkConstraint verifies that the constraint holds

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -112,9 +112,9 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
 		}
 	}
 
@@ -318,7 +318,7 @@ func (cs *SparseR1CS) checkConstraint(c compiled.SparseR1C, solution *solution) 
 	var t fr.Element
 	t.Mul(&m0, &m1).Add(&t, &l).Add(&t, &r).Add(&t, &o).Add(&t, &cs.Coefficients[c.K])
 	if !t.IsZero() {
-		return fmt.Errorf("%w\n%s + %s + (%s * %s) + %s + %s != 0", ErrUnsatisfiedConstraint,
+		return fmt.Errorf("%s + %s + (%s * %s) + %s + %s != 0",
 			l.String(),
 			r.String(),
 			m0.String(),

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -273,39 +273,37 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
-	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var AM, k, O string
+	var A0, A1, M, k, O string
 	var sbb strings.Builder
 
-	if isZeroA && isZeroM {
-		AM = "0"
+	sbb.Reset()
+	cs.termToString(c.L, &sbb, false)
+	A0 = sbb.String()
+	sbb.Reset()
+	cs.termToString(c.R, &sbb, false)
+	A1 = sbb.String()
+
+	if isZeroM {
+		M = "0"
 	} else {
-		if isZeroA {
-			sbb.Reset()
-			cs.termToString(c.M[0], &sbb, false)
-			sbb.WriteString(" * ")
-			cs.termToString(c.M[1], &sbb, false)
-			AM = sbb.String()
-		} else {
-			sbb.Reset()
-			cs.termToString(c.L, &sbb, false)
-			sbb.WriteString(" + ")
-			cs.termToString(c.R, &sbb, false)
-			AM = sbb.String()
-		}
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	// we need to negate O
 	sbb.Reset()
-	cs.termToString(c.O, &sbb, true)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
-	return [3]string{AM, k, O}
+	return [5]string{A0, A1, M, O, k}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -274,56 +274,53 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	var sbb strings.Builder
 
 	sbb.Reset()
-	cs.termToString(c.L, &sbb)
+	cs.termToString(c.L, &sbb, false)
 	A0 = sbb.String()
 	sbb.Reset()
-	cs.termToString(c.R, &sbb)
+	cs.termToString(c.R, &sbb, false)
 	A1 = sbb.String()
 
 	if isZeroM {
 		M = "0"
 	} else {
 		sbb.Reset()
-		cm0 := c.M[0]
-		addParenthesis := cm0.CoeffID() != compiled.CoeffIdOne
-		if addParenthesis {
-			sbb.WriteString(cs.Coefficients[cm0.CoeffID()].String())
-			sbb.WriteString("⋅")
-			sbb.WriteByte('(')
-		}
-		cm0.SetCoeffID(compiled.CoeffIdOne)
-		cs.termToString(cm0, &sbb)
+		sbb.WriteString(cs.Coefficients[c.M[0].CoeffID()].String())
+		sbb.WriteString("⋅")
+		sbb.WriteByte('(')
+		cs.termToString(c.M[0], &sbb, true)
 		sbb.WriteString(" × ")
-		cs.termToString(c.M[1], &sbb)
-		if addParenthesis {
-			sbb.WriteByte(')')
-		}
+		cs.termToString(c.M[1], &sbb, true)
+		sbb.WriteByte(')')
 		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	sbb.Reset()
-	cs.termToString(c.O, &sbb)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
 	return [5]string{A0, A1, O, M, k}
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteByte('0')
-		return
-	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, vOnly bool) {
+	if !vOnly {
+		tID := t.CoeffID()
+		if tID == compiled.CoeffIdOne {
+			// do nothing, just print the variable
+			sbb.WriteString("1")
+		} else if tID == compiled.CoeffIdMinusOne {
+			// print neg sign
+			sbb.WriteString("-1")
+		} else if tID == compiled.CoeffIdZero {
+			sbb.WriteByte('0')
+			return
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
 		sbb.WriteString("⋅")
 	}
+
 	vID := t.WireID()
 	visibility := t.VariableVisibility()
 

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -33,11 +33,6 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-315"
 )
 
-// errUnsatisfiedConstraint can be generated when solving a R1CS
-func errUnsatisfiedConstraint(i int) error {
-	return fmt.Errorf("constraint #%d is not satisfied", i)
-}
-
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -33,8 +33,10 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-315"
 )
 
-// ErrUnsatisfiedConstraint can be generated when solving a R1CS
-var ErrUnsatisfiedConstraint = errors.New("constraint is not satisfied")
+// errUnsatisfiedConstraint can be generated when solving a R1CS
+func errUnsatisfiedConstraint(i int) error {
+	return fmt.Errorf("constraint #%d is not satisfied", i)
+}
 
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -121,9 +121,9 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		if !check.Equal(&c[i]) {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, errUnsatisfiedConstraint(i)
 		}
 	}
 

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -291,7 +291,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 // GetConstraints return a list of constraint formatted as L⋅R == O
 // such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
-	var r [][]string
+	r := make([][]string, len(cs.Constraints))
 	for _, c := range cs.Constraints {
 		// for each constraint, we build a string representation of it's L, R and O part
 		// if we are worried about perf for large cs, we could do a string builder + csv format.

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"text/template"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 
@@ -289,30 +288,8 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	return nil
 }
 
-// TODO @gbotrel clean logs and html see https://github.com/ConsenSys/gnark/issues/140
-
-// ToHTML returns an HTML human-readable representation of the constraint system
-func (cs *R1CS) ToHTML(w io.Writer) error {
-	t, err := template.New("cs.html").Funcs(template.FuncMap{
-		"toHTML": toHTML,
-		"add":    add,
-		"sub":    sub,
-	}).Parse(compiled.R1CSTemplate)
-	if err != nil {
-		return err
-	}
-
-	return t.Execute(w, cs)
-}
-
-func add(a, b int) int {
-	return a + b
-}
-
-func sub(a, b int) int {
-	return a - b
-}
-
+// GetConstraints return a list of constraint formatted as L⋅R == O
+// such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
@@ -373,59 +350,6 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 	default:
 		sbb.WriteString("<?>")
 	}
-}
-
-func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
-	var sbb strings.Builder
-	for i := 0; i < len(l.LinExp); i++ {
-		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l.LinExp) {
-			sbb.WriteString(" + ")
-		}
-	}
-	return sbb.String()
-}
-
-func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHints map[int]compiled.Hint, offset bool) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteString("<span class=\"coefficient\">-</span>")
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteString("<span class=\"coefficient\">0</span>")
-		return
-	} else {
-		sbb.WriteString("<span class=\"coefficient\">")
-		sbb.WriteString(coeffs[tID].String())
-		sbb.WriteString("</span>*")
-	}
-
-	vID := t.WireID()
-	class := ""
-	switch t.VariableVisibility() {
-	case schema.Internal:
-		class = "internal"
-		if _, ok := MHints[vID]; ok {
-			class = "hint"
-		}
-	case schema.Public:
-		class = "public"
-	case schema.Secret:
-		class = "secret"
-	case schema.Virtual:
-		class = "virtual"
-	case schema.Unset:
-		class = "unset"
-	default:
-		panic("not implemented")
-	}
-	if offset {
-		vID++ // for sparse R1CS, we offset to have same variable numbers as in R1CS
-	}
-	sbb.WriteString(fmt.Sprintf("<span class=\"%s\">v%d</span>", class, vID))
-
 }
 
 // GetNbCoefficients return the number of unique coefficients needed in the R1CS

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -350,7 +350,7 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 		return
 	} else {
 		sbb.WriteString(cs.Coefficients[tID].String())
-		sbb.WriteByte('*')
+		sbb.WriteString("⋅")
 	}
 	vID := t.WireID()
 	visibility := t.VariableVisibility()

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -118,11 +118,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		// ensure a[i] * b[i] == c[i]
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
+			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			return solution.values, errUnsatisfiedConstraint(i)
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -273,31 +273,29 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
 	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var A, M, k, O string
+	var AM, k, O string
 	var sbb strings.Builder
 
-	if isZeroA {
-		A = "0"
+	if isZeroA && isZeroM {
+		AM = "0"
 	} else {
-		sbb.Reset()
-		cs.termToString(c.L, &sbb, false)
-		sbb.WriteString(" + ")
-		cs.termToString(c.R, &sbb, false)
-		A = sbb.String()
-	}
-
-	if isZeroM {
-		M = "0"
-	} else {
-		sbb.Reset()
-		cs.termToString(c.M[0], &sbb, false)
-		sbb.WriteString(" * ")
-		cs.termToString(c.M[1], &sbb, false)
-		M = sbb.String()
+		if isZeroA {
+			sbb.Reset()
+			cs.termToString(c.M[0], &sbb, false)
+			sbb.WriteString(" * ")
+			cs.termToString(c.M[1], &sbb, false)
+			AM = sbb.String()
+		} else {
+			sbb.Reset()
+			cs.termToString(c.L, &sbb, false)
+			sbb.WriteString(" + ")
+			cs.termToString(c.R, &sbb, false)
+			AM = sbb.String()
+		}
 	}
 
 	k = cs.Coefficients[c.K].String()
@@ -307,7 +305,7 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
 	cs.termToString(c.O, &sbb, true)
 	O = sbb.String()
 
-	return [4]string{A, M, k, O}
+	return [3]string{AM, k, O}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
-	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/internal/backend/ioutils"
@@ -110,17 +109,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
 		}
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				if debug.Debug {
-					return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
-				}
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			if debug.Debug {
-				return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
-			}
-			return solution.values, fmt.Errorf("%w", errUnsatisfiedConstraint(i))
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -258,32 +258,85 @@ func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverO
 func (cs *SparseR1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
-		// if we are worried about perf for large cs, we could do a string builder + csv format.
-		var line [6]string
-		line[0] = cs.termToString(c.L)
-		line[1] = cs.termToString(c.R)
-		line[2] = cs.termToString(c.M[0])
-		line[3] = cs.termToString(c.M[1])
-		line[4] = cs.termToString(c.O)
-		line[5] = cs.Coefficients[c.K].String()
-		r = append(r, line[:])
+		fc := cs.formatConstraint(c)
+		r = append(r, fc[:])
 	}
 	return r
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term) string {
+// formatConstraint return a human readable representation of a constraint
+// in the form A + M + k == O
+// where
+// A = c1 * v1 + c2 *v2
+// M = c1 * v1 * v2
+// k = c1
+// If A is set, then M == 0 . If M is set, A == 0 .
+// k can be set for both A and M
+// cX are constants
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
+
+	var A, M, k, O string
 	var sbb strings.Builder
+
+	if isZeroA {
+		A = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.L, &sbb, false)
+		sbb.WriteString(" + ")
+		cs.termToString(c.R, &sbb, false)
+		A = sbb.String()
+	}
+
+	if isZeroM {
+		M = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
+	}
+
+	k = cs.Coefficients[c.K].String()
+
+	// we need to negate O
+	sbb.Reset()
+	cs.termToString(c.O, &sbb, true)
+	O = sbb.String()
+
+	return [4]string{A, M, k, O}
+}
+
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {
 	tID := t.CoeffID()
 	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
+		if negate {
+			sbb.WriteByte('-')
+		} else {
+			// do nothing, just print the variable
+		}
 	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
+		if negate {
+			// do nothing, just print the variable
+		} else {
+			// print neg sign
+			sbb.WriteByte('-')
+		}
 	} else if tID == compiled.CoeffIdZero {
 		sbb.WriteByte('0')
-		return sbb.String()
+		return
 	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+		if negate {
+			var cNeg fr.Element
+			cNeg.Neg(&cs.Coefficients[tID])
+			sbb.WriteString(cNeg.String())
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
+
 		sbb.WriteByte('*')
 	}
 	vID := t.WireID()
@@ -303,7 +356,6 @@ func (cs *SparseR1CS) termToString(t compiled.Term) string {
 	default:
 		sbb.WriteString("<?>")
 	}
-	return sbb.String()
 }
 
 // checkConstraint verifies that the constraint holds

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -112,9 +112,9 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
 		}
 	}
 
@@ -318,7 +318,7 @@ func (cs *SparseR1CS) checkConstraint(c compiled.SparseR1C, solution *solution) 
 	var t fr.Element
 	t.Mul(&m0, &m1).Add(&t, &l).Add(&t, &r).Add(&t, &o).Add(&t, &cs.Coefficients[c.K])
 	if !t.IsZero() {
-		return fmt.Errorf("%w\n%s + %s + (%s * %s) + %s + %s != 0", ErrUnsatisfiedConstraint,
+		return fmt.Errorf("%s + %s + (%s * %s) + %s + %s != 0",
 			l.String(),
 			r.String(),
 			m0.String(),

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -273,39 +273,37 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
-	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var AM, k, O string
+	var A0, A1, M, k, O string
 	var sbb strings.Builder
 
-	if isZeroA && isZeroM {
-		AM = "0"
+	sbb.Reset()
+	cs.termToString(c.L, &sbb, false)
+	A0 = sbb.String()
+	sbb.Reset()
+	cs.termToString(c.R, &sbb, false)
+	A1 = sbb.String()
+
+	if isZeroM {
+		M = "0"
 	} else {
-		if isZeroA {
-			sbb.Reset()
-			cs.termToString(c.M[0], &sbb, false)
-			sbb.WriteString(" * ")
-			cs.termToString(c.M[1], &sbb, false)
-			AM = sbb.String()
-		} else {
-			sbb.Reset()
-			cs.termToString(c.L, &sbb, false)
-			sbb.WriteString(" + ")
-			cs.termToString(c.R, &sbb, false)
-			AM = sbb.String()
-		}
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	// we need to negate O
 	sbb.Reset()
-	cs.termToString(c.O, &sbb, true)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
-	return [3]string{AM, k, O}
+	return [5]string{A0, A1, M, O, k}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -274,56 +274,53 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	var sbb strings.Builder
 
 	sbb.Reset()
-	cs.termToString(c.L, &sbb)
+	cs.termToString(c.L, &sbb, false)
 	A0 = sbb.String()
 	sbb.Reset()
-	cs.termToString(c.R, &sbb)
+	cs.termToString(c.R, &sbb, false)
 	A1 = sbb.String()
 
 	if isZeroM {
 		M = "0"
 	} else {
 		sbb.Reset()
-		cm0 := c.M[0]
-		addParenthesis := cm0.CoeffID() != compiled.CoeffIdOne
-		if addParenthesis {
-			sbb.WriteString(cs.Coefficients[cm0.CoeffID()].String())
-			sbb.WriteString("⋅")
-			sbb.WriteByte('(')
-		}
-		cm0.SetCoeffID(compiled.CoeffIdOne)
-		cs.termToString(cm0, &sbb)
+		sbb.WriteString(cs.Coefficients[c.M[0].CoeffID()].String())
+		sbb.WriteString("⋅")
+		sbb.WriteByte('(')
+		cs.termToString(c.M[0], &sbb, true)
 		sbb.WriteString(" × ")
-		cs.termToString(c.M[1], &sbb)
-		if addParenthesis {
-			sbb.WriteByte(')')
-		}
+		cs.termToString(c.M[1], &sbb, true)
+		sbb.WriteByte(')')
 		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	sbb.Reset()
-	cs.termToString(c.O, &sbb)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
 	return [5]string{A0, A1, O, M, k}
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteByte('0')
-		return
-	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, vOnly bool) {
+	if !vOnly {
+		tID := t.CoeffID()
+		if tID == compiled.CoeffIdOne {
+			// do nothing, just print the variable
+			sbb.WriteString("1")
+		} else if tID == compiled.CoeffIdMinusOne {
+			// print neg sign
+			sbb.WriteString("-1")
+		} else if tID == compiled.CoeffIdZero {
+			sbb.WriteByte('0')
+			return
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
 		sbb.WriteString("⋅")
 	}
+
 	vID := t.WireID()
 	visibility := t.VariableVisibility()
 

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -33,11 +33,6 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
 )
 
-// errUnsatisfiedConstraint can be generated when solving a R1CS
-func errUnsatisfiedConstraint(i int) error {
-	return fmt.Errorf("constraint #%d is not satisfied", i)
-}
-
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -33,8 +33,10 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
 )
 
-// ErrUnsatisfiedConstraint can be generated when solving a R1CS
-var ErrUnsatisfiedConstraint = errors.New("constraint is not satisfied")
+// errUnsatisfiedConstraint can be generated when solving a R1CS
+func errUnsatisfiedConstraint(i int) error {
+	return fmt.Errorf("constraint #%d is not satisfied", i)
+}
 
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -121,9 +121,9 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		if !check.Equal(&c[i]) {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, errUnsatisfiedConstraint(i)
 		}
 	}
 

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -291,7 +291,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 // GetConstraints return a list of constraint formatted as L⋅R == O
 // such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
-	var r [][]string
+	r := make([][]string, len(cs.Constraints))
 	for _, c := range cs.Constraints {
 		// for each constraint, we build a string representation of it's L, R and O part
 		// if we are worried about perf for large cs, we could do a string builder + csv format.

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -350,7 +350,7 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 		return
 	} else {
 		sbb.WriteString(cs.Coefficients[tID].String())
-		sbb.WriteByte('*')
+		sbb.WriteString("⋅")
 	}
 	vID := t.WireID()
 	visibility := t.VariableVisibility()

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -118,11 +118,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		// ensure a[i] * b[i] == c[i]
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
+			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			return solution.values, errUnsatisfiedConstraint(i)
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"text/template"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 
@@ -289,30 +288,8 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	return nil
 }
 
-// TODO @gbotrel clean logs and html see https://github.com/ConsenSys/gnark/issues/140
-
-// ToHTML returns an HTML human-readable representation of the constraint system
-func (cs *R1CS) ToHTML(w io.Writer) error {
-	t, err := template.New("cs.html").Funcs(template.FuncMap{
-		"toHTML": toHTML,
-		"add":    add,
-		"sub":    sub,
-	}).Parse(compiled.R1CSTemplate)
-	if err != nil {
-		return err
-	}
-
-	return t.Execute(w, cs)
-}
-
-func add(a, b int) int {
-	return a + b
-}
-
-func sub(a, b int) int {
-	return a - b
-}
-
+// GetConstraints return a list of constraint formatted as L⋅R == O
+// such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
@@ -373,59 +350,6 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 	default:
 		sbb.WriteString("<?>")
 	}
-}
-
-func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
-	var sbb strings.Builder
-	for i := 0; i < len(l.LinExp); i++ {
-		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l.LinExp) {
-			sbb.WriteString(" + ")
-		}
-	}
-	return sbb.String()
-}
-
-func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHints map[int]compiled.Hint, offset bool) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteString("<span class=\"coefficient\">-</span>")
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteString("<span class=\"coefficient\">0</span>")
-		return
-	} else {
-		sbb.WriteString("<span class=\"coefficient\">")
-		sbb.WriteString(coeffs[tID].String())
-		sbb.WriteString("</span>*")
-	}
-
-	vID := t.WireID()
-	class := ""
-	switch t.VariableVisibility() {
-	case schema.Internal:
-		class = "internal"
-		if _, ok := MHints[vID]; ok {
-			class = "hint"
-		}
-	case schema.Public:
-		class = "public"
-	case schema.Secret:
-		class = "secret"
-	case schema.Virtual:
-		class = "virtual"
-	case schema.Unset:
-		class = "unset"
-	default:
-		panic("not implemented")
-	}
-	if offset {
-		vID++ // for sparse R1CS, we offset to have same variable numbers as in R1CS
-	}
-	sbb.WriteString(fmt.Sprintf("<span class=\"%s\">v%d</span>", class, vID))
-
 }
 
 // GetNbCoefficients return the number of unique coefficients needed in the R1CS

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -273,31 +273,29 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
 	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var A, M, k, O string
+	var AM, k, O string
 	var sbb strings.Builder
 
-	if isZeroA {
-		A = "0"
+	if isZeroA && isZeroM {
+		AM = "0"
 	} else {
-		sbb.Reset()
-		cs.termToString(c.L, &sbb, false)
-		sbb.WriteString(" + ")
-		cs.termToString(c.R, &sbb, false)
-		A = sbb.String()
-	}
-
-	if isZeroM {
-		M = "0"
-	} else {
-		sbb.Reset()
-		cs.termToString(c.M[0], &sbb, false)
-		sbb.WriteString(" * ")
-		cs.termToString(c.M[1], &sbb, false)
-		M = sbb.String()
+		if isZeroA {
+			sbb.Reset()
+			cs.termToString(c.M[0], &sbb, false)
+			sbb.WriteString(" * ")
+			cs.termToString(c.M[1], &sbb, false)
+			AM = sbb.String()
+		} else {
+			sbb.Reset()
+			cs.termToString(c.L, &sbb, false)
+			sbb.WriteString(" + ")
+			cs.termToString(c.R, &sbb, false)
+			AM = sbb.String()
+		}
 	}
 
 	k = cs.Coefficients[c.K].String()
@@ -307,7 +305,7 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
 	cs.termToString(c.O, &sbb, true)
 	O = sbb.String()
 
-	return [4]string{A, M, k, O}
+	return [3]string{AM, k, O}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
-	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/internal/backend/ioutils"
@@ -110,17 +109,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
 		}
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				if debug.Debug {
-					return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
-				}
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			if debug.Debug {
-				return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
-			}
-			return solution.values, fmt.Errorf("%w", errUnsatisfiedConstraint(i))
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -258,32 +258,85 @@ func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverO
 func (cs *SparseR1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
-		// if we are worried about perf for large cs, we could do a string builder + csv format.
-		var line [6]string
-		line[0] = cs.termToString(c.L)
-		line[1] = cs.termToString(c.R)
-		line[2] = cs.termToString(c.M[0])
-		line[3] = cs.termToString(c.M[1])
-		line[4] = cs.termToString(c.O)
-		line[5] = cs.Coefficients[c.K].String()
-		r = append(r, line[:])
+		fc := cs.formatConstraint(c)
+		r = append(r, fc[:])
 	}
 	return r
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term) string {
+// formatConstraint return a human readable representation of a constraint
+// in the form A + M + k == O
+// where
+// A = c1 * v1 + c2 *v2
+// M = c1 * v1 * v2
+// k = c1
+// If A is set, then M == 0 . If M is set, A == 0 .
+// k can be set for both A and M
+// cX are constants
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
+
+	var A, M, k, O string
 	var sbb strings.Builder
+
+	if isZeroA {
+		A = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.L, &sbb, false)
+		sbb.WriteString(" + ")
+		cs.termToString(c.R, &sbb, false)
+		A = sbb.String()
+	}
+
+	if isZeroM {
+		M = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
+	}
+
+	k = cs.Coefficients[c.K].String()
+
+	// we need to negate O
+	sbb.Reset()
+	cs.termToString(c.O, &sbb, true)
+	O = sbb.String()
+
+	return [4]string{A, M, k, O}
+}
+
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {
 	tID := t.CoeffID()
 	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
+		if negate {
+			sbb.WriteByte('-')
+		} else {
+			// do nothing, just print the variable
+		}
 	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
+		if negate {
+			// do nothing, just print the variable
+		} else {
+			// print neg sign
+			sbb.WriteByte('-')
+		}
 	} else if tID == compiled.CoeffIdZero {
 		sbb.WriteByte('0')
-		return sbb.String()
+		return
 	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+		if negate {
+			var cNeg fr.Element
+			cNeg.Neg(&cs.Coefficients[tID])
+			sbb.WriteString(cNeg.String())
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
+
 		sbb.WriteByte('*')
 	}
 	vID := t.WireID()
@@ -303,7 +356,6 @@ func (cs *SparseR1CS) termToString(t compiled.Term) string {
 	default:
 		sbb.WriteString("<?>")
 	}
-	return sbb.String()
 }
 
 // checkConstraint verifies that the constraint holds

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -112,9 +112,9 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
 		}
 	}
 
@@ -318,7 +318,7 @@ func (cs *SparseR1CS) checkConstraint(c compiled.SparseR1C, solution *solution) 
 	var t fr.Element
 	t.Mul(&m0, &m1).Add(&t, &l).Add(&t, &r).Add(&t, &o).Add(&t, &cs.Coefficients[c.K])
 	if !t.IsZero() {
-		return fmt.Errorf("%w\n%s + %s + (%s * %s) + %s + %s != 0", ErrUnsatisfiedConstraint,
+		return fmt.Errorf("%s + %s + (%s * %s) + %s + %s != 0",
 			l.String(),
 			r.String(),
 			m0.String(),

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -273,39 +273,37 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
-	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var AM, k, O string
+	var A0, A1, M, k, O string
 	var sbb strings.Builder
 
-	if isZeroA && isZeroM {
-		AM = "0"
+	sbb.Reset()
+	cs.termToString(c.L, &sbb, false)
+	A0 = sbb.String()
+	sbb.Reset()
+	cs.termToString(c.R, &sbb, false)
+	A1 = sbb.String()
+
+	if isZeroM {
+		M = "0"
 	} else {
-		if isZeroA {
-			sbb.Reset()
-			cs.termToString(c.M[0], &sbb, false)
-			sbb.WriteString(" * ")
-			cs.termToString(c.M[1], &sbb, false)
-			AM = sbb.String()
-		} else {
-			sbb.Reset()
-			cs.termToString(c.L, &sbb, false)
-			sbb.WriteString(" + ")
-			cs.termToString(c.R, &sbb, false)
-			AM = sbb.String()
-		}
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	// we need to negate O
 	sbb.Reset()
-	cs.termToString(c.O, &sbb, true)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
-	return [3]string{AM, k, O}
+	return [5]string{A0, A1, M, O, k}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -274,56 +274,53 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	var sbb strings.Builder
 
 	sbb.Reset()
-	cs.termToString(c.L, &sbb)
+	cs.termToString(c.L, &sbb, false)
 	A0 = sbb.String()
 	sbb.Reset()
-	cs.termToString(c.R, &sbb)
+	cs.termToString(c.R, &sbb, false)
 	A1 = sbb.String()
 
 	if isZeroM {
 		M = "0"
 	} else {
 		sbb.Reset()
-		cm0 := c.M[0]
-		addParenthesis := cm0.CoeffID() != compiled.CoeffIdOne
-		if addParenthesis {
-			sbb.WriteString(cs.Coefficients[cm0.CoeffID()].String())
-			sbb.WriteString("⋅")
-			sbb.WriteByte('(')
-		}
-		cm0.SetCoeffID(compiled.CoeffIdOne)
-		cs.termToString(cm0, &sbb)
+		sbb.WriteString(cs.Coefficients[c.M[0].CoeffID()].String())
+		sbb.WriteString("⋅")
+		sbb.WriteByte('(')
+		cs.termToString(c.M[0], &sbb, true)
 		sbb.WriteString(" × ")
-		cs.termToString(c.M[1], &sbb)
-		if addParenthesis {
-			sbb.WriteByte(')')
-		}
+		cs.termToString(c.M[1], &sbb, true)
+		sbb.WriteByte(')')
 		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	sbb.Reset()
-	cs.termToString(c.O, &sbb)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
 	return [5]string{A0, A1, O, M, k}
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteByte('0')
-		return
-	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, vOnly bool) {
+	if !vOnly {
+		tID := t.CoeffID()
+		if tID == compiled.CoeffIdOne {
+			// do nothing, just print the variable
+			sbb.WriteString("1")
+		} else if tID == compiled.CoeffIdMinusOne {
+			// print neg sign
+			sbb.WriteString("-1")
+		} else if tID == compiled.CoeffIdZero {
+			sbb.WriteByte('0')
+			return
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
 		sbb.WriteString("⋅")
 	}
+
 	vID := t.WireID()
 	visibility := t.VariableVisibility()
 

--- a/internal/backend/bw6-633/cs/solution.go
+++ b/internal/backend/bw6-633/cs/solution.go
@@ -33,8 +33,10 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-633"
 )
 
-// ErrUnsatisfiedConstraint can be generated when solving a R1CS
-var ErrUnsatisfiedConstraint = errors.New("constraint is not satisfied")
+// errUnsatisfiedConstraint can be generated when solving a R1CS
+func errUnsatisfiedConstraint(i int) error {
+	return fmt.Errorf("constraint #%d is not satisfied", i)
+}
 
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS

--- a/internal/backend/bw6-633/cs/solution.go
+++ b/internal/backend/bw6-633/cs/solution.go
@@ -33,11 +33,6 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-633"
 )
 
-// errUnsatisfiedConstraint can be generated when solving a R1CS
-func errUnsatisfiedConstraint(i int) error {
-	return fmt.Errorf("constraint #%d is not satisfied", i)
-}
-
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -121,9 +121,9 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		if !check.Equal(&c[i]) {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, errUnsatisfiedConstraint(i)
 		}
 	}
 

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -291,7 +291,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 // GetConstraints return a list of constraint formatted as L⋅R == O
 // such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
-	var r [][]string
+	r := make([][]string, len(cs.Constraints))
 	for _, c := range cs.Constraints {
 		// for each constraint, we build a string representation of it's L, R and O part
 		// if we are worried about perf for large cs, we could do a string builder + csv format.

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -32,7 +32,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"text/template"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 
@@ -289,30 +288,8 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	return nil
 }
 
-// TODO @gbotrel clean logs and html see https://github.com/ConsenSys/gnark/issues/140
-
-// ToHTML returns an HTML human-readable representation of the constraint system
-func (cs *R1CS) ToHTML(w io.Writer) error {
-	t, err := template.New("cs.html").Funcs(template.FuncMap{
-		"toHTML": toHTML,
-		"add":    add,
-		"sub":    sub,
-	}).Parse(compiled.R1CSTemplate)
-	if err != nil {
-		return err
-	}
-
-	return t.Execute(w, cs)
-}
-
-func add(a, b int) int {
-	return a + b
-}
-
-func sub(a, b int) int {
-	return a - b
-}
-
+// GetConstraints return a list of constraint formatted as L⋅R == O
+// such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
@@ -373,59 +350,6 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 	default:
 		sbb.WriteString("<?>")
 	}
-}
-
-func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
-	var sbb strings.Builder
-	for i := 0; i < len(l.LinExp); i++ {
-		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l.LinExp) {
-			sbb.WriteString(" + ")
-		}
-	}
-	return sbb.String()
-}
-
-func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHints map[int]compiled.Hint, offset bool) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteString("<span class=\"coefficient\">-</span>")
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteString("<span class=\"coefficient\">0</span>")
-		return
-	} else {
-		sbb.WriteString("<span class=\"coefficient\">")
-		sbb.WriteString(coeffs[tID].String())
-		sbb.WriteString("</span>*")
-	}
-
-	vID := t.WireID()
-	class := ""
-	switch t.VariableVisibility() {
-	case schema.Internal:
-		class = "internal"
-		if _, ok := MHints[vID]; ok {
-			class = "hint"
-		}
-	case schema.Public:
-		class = "public"
-	case schema.Secret:
-		class = "secret"
-	case schema.Virtual:
-		class = "virtual"
-	case schema.Unset:
-		class = "unset"
-	default:
-		panic("not implemented")
-	}
-	if offset {
-		vID++ // for sparse R1CS, we offset to have same variable numbers as in R1CS
-	}
-	sbb.WriteString(fmt.Sprintf("<span class=\"%s\">v%d</span>", class, vID))
-
 }
 
 // GetNbCoefficients return the number of unique coefficients needed in the R1CS

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -350,7 +350,7 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 		return
 	} else {
 		sbb.WriteString(cs.Coefficients[tID].String())
-		sbb.WriteByte('*')
+		sbb.WriteString("⋅")
 	}
 	vID := t.WireID()
 	visibility := t.VariableVisibility()

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -118,11 +118,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		// ensure a[i] * b[i] == c[i]
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
+			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			return solution.values, errUnsatisfiedConstraint(i)
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -273,31 +273,29 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
 	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var A, M, k, O string
+	var AM, k, O string
 	var sbb strings.Builder
 
-	if isZeroA {
-		A = "0"
+	if isZeroA && isZeroM {
+		AM = "0"
 	} else {
-		sbb.Reset()
-		cs.termToString(c.L, &sbb, false)
-		sbb.WriteString(" + ")
-		cs.termToString(c.R, &sbb, false)
-		A = sbb.String()
-	}
-
-	if isZeroM {
-		M = "0"
-	} else {
-		sbb.Reset()
-		cs.termToString(c.M[0], &sbb, false)
-		sbb.WriteString(" * ")
-		cs.termToString(c.M[1], &sbb, false)
-		M = sbb.String()
+		if isZeroA {
+			sbb.Reset()
+			cs.termToString(c.M[0], &sbb, false)
+			sbb.WriteString(" * ")
+			cs.termToString(c.M[1], &sbb, false)
+			AM = sbb.String()
+		} else {
+			sbb.Reset()
+			cs.termToString(c.L, &sbb, false)
+			sbb.WriteString(" + ")
+			cs.termToString(c.R, &sbb, false)
+			AM = sbb.String()
+		}
 	}
 
 	k = cs.Coefficients[c.K].String()
@@ -307,7 +305,7 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
 	cs.termToString(c.O, &sbb, true)
 	O = sbb.String()
 
-	return [4]string{A, M, k, O}
+	return [3]string{AM, k, O}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
-	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/internal/backend/ioutils"
@@ -110,17 +109,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
 		}
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				if debug.Debug {
-					return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
-				}
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			if debug.Debug {
-				return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
-			}
-			return solution.values, fmt.Errorf("%w", errUnsatisfiedConstraint(i))
+			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -258,32 +258,85 @@ func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverO
 func (cs *SparseR1CS) GetConstraints() [][]string {
 	var r [][]string
 	for _, c := range cs.Constraints {
-		// if we are worried about perf for large cs, we could do a string builder + csv format.
-		var line [6]string
-		line[0] = cs.termToString(c.L)
-		line[1] = cs.termToString(c.R)
-		line[2] = cs.termToString(c.M[0])
-		line[3] = cs.termToString(c.M[1])
-		line[4] = cs.termToString(c.O)
-		line[5] = cs.Coefficients[c.K].String()
-		r = append(r, line[:])
+		fc := cs.formatConstraint(c)
+		r = append(r, fc[:])
 	}
 	return r
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term) string {
+// formatConstraint return a human readable representation of a constraint
+// in the form A + M + k == O
+// where
+// A = c1 * v1 + c2 *v2
+// M = c1 * v1 * v2
+// k = c1
+// If A is set, then M == 0 . If M is set, A == 0 .
+// k can be set for both A and M
+// cX are constants
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
+
+	var A, M, k, O string
 	var sbb strings.Builder
+
+	if isZeroA {
+		A = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.L, &sbb, false)
+		sbb.WriteString(" + ")
+		cs.termToString(c.R, &sbb, false)
+		A = sbb.String()
+	}
+
+	if isZeroM {
+		M = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
+	}
+
+	k = cs.Coefficients[c.K].String()
+
+	// we need to negate O
+	sbb.Reset()
+	cs.termToString(c.O, &sbb, true)
+	O = sbb.String()
+
+	return [4]string{A, M, k, O}
+}
+
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {
 	tID := t.CoeffID()
 	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
+		if negate {
+			sbb.WriteByte('-')
+		} else {
+			// do nothing, just print the variable
+		}
 	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
+		if negate {
+			// do nothing, just print the variable
+		} else {
+			// print neg sign
+			sbb.WriteByte('-')
+		}
 	} else if tID == compiled.CoeffIdZero {
 		sbb.WriteByte('0')
-		return sbb.String()
+		return
 	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+		if negate {
+			var cNeg fr.Element
+			cNeg.Neg(&cs.Coefficients[tID])
+			sbb.WriteString(cNeg.String())
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
+
 		sbb.WriteByte('*')
 	}
 	vID := t.WireID()
@@ -303,7 +356,6 @@ func (cs *SparseR1CS) termToString(t compiled.Term) string {
 	default:
 		sbb.WriteString("<?>")
 	}
-	return sbb.String()
 }
 
 // checkConstraint verifies that the constraint holds

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -112,9 +112,9 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
 		}
 	}
 
@@ -318,7 +318,7 @@ func (cs *SparseR1CS) checkConstraint(c compiled.SparseR1C, solution *solution) 
 	var t fr.Element
 	t.Mul(&m0, &m1).Add(&t, &l).Add(&t, &r).Add(&t, &o).Add(&t, &cs.Coefficients[c.K])
 	if !t.IsZero() {
-		return fmt.Errorf("%w\n%s + %s + (%s * %s) + %s + %s != 0", ErrUnsatisfiedConstraint,
+		return fmt.Errorf("%s + %s + (%s * %s) + %s + %s != 0",
 			l.String(),
 			r.String(),
 			m0.String(),

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -273,39 +273,37 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
-	isZeroA := (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	isZeroM := (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var AM, k, O string
+	var A0, A1, M, k, O string
 	var sbb strings.Builder
 
-	if isZeroA && isZeroM {
-		AM = "0"
+	sbb.Reset()
+	cs.termToString(c.L, &sbb, false)
+	A0 = sbb.String()
+	sbb.Reset()
+	cs.termToString(c.R, &sbb, false)
+	A1 = sbb.String()
+
+	if isZeroM {
+		M = "0"
 	} else {
-		if isZeroA {
-			sbb.Reset()
-			cs.termToString(c.M[0], &sbb, false)
-			sbb.WriteString(" * ")
-			cs.termToString(c.M[1], &sbb, false)
-			AM = sbb.String()
-		} else {
-			sbb.Reset()
-			cs.termToString(c.L, &sbb, false)
-			sbb.WriteString(" + ")
-			cs.termToString(c.R, &sbb, false)
-			AM = sbb.String()
-		}
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	// we need to negate O
 	sbb.Reset()
-	cs.termToString(c.O, &sbb, true)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
-	return [3]string{AM, k, O}
+	return [5]string{A0, A1, M, O, k}
 }
 
 func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool) {

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -274,56 +274,53 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	var sbb strings.Builder
 
 	sbb.Reset()
-	cs.termToString(c.L, &sbb)
+	cs.termToString(c.L, &sbb, false)
 	A0 = sbb.String()
 	sbb.Reset()
-	cs.termToString(c.R, &sbb)
+	cs.termToString(c.R, &sbb, false)
 	A1 = sbb.String()
 
 	if isZeroM {
 		M = "0"
 	} else {
 		sbb.Reset()
-		cm0 := c.M[0]
-		addParenthesis := cm0.CoeffID() != compiled.CoeffIdOne
-		if addParenthesis {
-			sbb.WriteString(cs.Coefficients[cm0.CoeffID()].String())
-			sbb.WriteString("⋅")
-			sbb.WriteByte('(')
-		}
-		cm0.SetCoeffID(compiled.CoeffIdOne)
-		cs.termToString(cm0, &sbb)
+		sbb.WriteString(cs.Coefficients[c.M[0].CoeffID()].String())
+		sbb.WriteString("⋅")
+		sbb.WriteByte('(')
+		cs.termToString(c.M[0], &sbb, true)
 		sbb.WriteString(" × ")
-		cs.termToString(c.M[1], &sbb)
-		if addParenthesis {
-			sbb.WriteByte(')')
-		}
+		cs.termToString(c.M[1], &sbb, true)
+		sbb.WriteByte(')')
 		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	sbb.Reset()
-	cs.termToString(c.O, &sbb)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 
 	return [5]string{A0, A1, O, M, k}
 }
 
-func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteByte('0')
-		return
-	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, vOnly bool) {
+	if !vOnly {
+		tID := t.CoeffID()
+		if tID == compiled.CoeffIdOne {
+			// do nothing, just print the variable
+			sbb.WriteString("1")
+		} else if tID == compiled.CoeffIdMinusOne {
+			// print neg sign
+			sbb.WriteString("-1")
+		} else if tID == compiled.CoeffIdZero {
+			sbb.WriteByte('0')
+			return
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
 		sbb.WriteString("⋅")
 	}
+
 	vID := t.WireID()
 	visibility := t.VariableVisibility()
 

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -33,11 +33,6 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-761"
 )
 
-// errUnsatisfiedConstraint can be generated when solving a R1CS
-func errUnsatisfiedConstraint(i int) error {
-	return fmt.Errorf("constraint #%d is not satisfied", i)
-}
-
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -33,8 +33,10 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-761"
 )
 
-// ErrUnsatisfiedConstraint can be generated when solving a R1CS
-var ErrUnsatisfiedConstraint = errors.New("constraint is not satisfied")
+// errUnsatisfiedConstraint can be generated when solving a R1CS
+func errUnsatisfiedConstraint(i int) error {
+	return fmt.Errorf("constraint #%d is not satisfied", i)
+}
 
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS

--- a/internal/backend/circuits/cmp.go
+++ b/internal/backend/circuits/cmp.go
@@ -55,5 +55,5 @@ func init() {
 		},
 	}
 
-	addNewEntry("cmp", &cmpCircuit{}, good, bad, []ecc.ID{ecc.BN254})
+	addNewEntry("cmp", &cmpCircuit{}, good, bad, ecc.Implemented())
 }

--- a/internal/backend/circuits/cmp.go
+++ b/internal/backend/circuits/cmp.go
@@ -55,5 +55,5 @@ func init() {
 		},
 	}
 
-	addNewEntry("cmp", &cmpCircuit{}, good, bad, []ecc.ID{ecc.BW6_761})
+	addNewEntry("cmp", &cmpCircuit{}, good, bad, []ecc.ID{ecc.BN254})
 }

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -273,7 +273,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 // GetConstraints return a list of constraint formatted as L⋅R == O
 // such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
-	var r [][]string 
+	r  := make([][]string , len(cs.Constraints))
 	for _, c := range cs.Constraints {
 		// for each constraint, we build a string representation of it's L, R and O part 
 		// if we are worried about perf for large cs, we could do a string builder + csv format.

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -100,11 +100,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		// ensure a[i] * b[i] == c[i]
 		check.Mul(&a[i], &b[i])
 		if !check.Equal(&c[i]) {
+			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			return solution.values, errUnsatisfiedConstraint(i)
+			return solution.values,  fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -103,9 +103,9 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		if !check.Equal(&c[i]) {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values, fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, errUnsatisfiedConstraint(i)
 		}
 	}
 

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -14,7 +14,6 @@ import (
 	"github.com/consensys/gnark/backend/witness"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"text/template"
 
 	{{ template "import_fr" . }}
 	{{ template "import_witness" . }}
@@ -271,30 +270,8 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) error {
 	return nil
 }
 
-// TODO @gbotrel clean logs and html see https://github.com/ConsenSys/gnark/issues/140
-
-// ToHTML returns an HTML human-readable representation of the constraint system
-func (cs *R1CS) ToHTML(w io.Writer) error {
-	t, err := template.New("cs.html").Funcs(template.FuncMap{
-		"toHTML": toHTML,
-		"add":    add,
-		"sub":    sub,
-	}).Parse(compiled.R1CSTemplate)
-	if err != nil {
-		return err
-	}
-
-	return t.Execute(w, cs)
-}
-
-func add(a, b int) int {
-	return a + b
-}
-
-func sub(a, b int) int {
-	return a - b
-}
-
+// GetConstraints return a list of constraint formatted as L⋅R == O
+// such that [0] -> L, [1] -> R, [2] -> O
 func (cs *R1CS) GetConstraints() [][]string {
 	var r [][]string 
 	for _, c := range cs.Constraints {
@@ -357,59 +334,6 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 	}
 }
 
-
-func toHTML(l compiled.Variable, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
-	var sbb strings.Builder
-	for i := 0; i < len(l.LinExp); i++ {
-		termToHTML(l.LinExp[i], &sbb, coeffs, MHints, false)
-		if i+1 < len(l.LinExp) {
-			sbb.WriteString(" + ")
-		}
-	}
-	return sbb.String()
-}
-
-func termToHTML(t compiled.Term, sbb *strings.Builder, coeffs []fr.Element, MHints map[int]compiled.Hint, offset bool) {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteString("<span class=\"coefficient\">-</span>")
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteString("<span class=\"coefficient\">0</span>")
-		return
-	} else {
-		sbb.WriteString("<span class=\"coefficient\">")
-		sbb.WriteString(coeffs[tID].String())
-		sbb.WriteString("</span>*")
-	}
-
-	vID := t.WireID()
-	class := ""
-	switch t.VariableVisibility() {
-	case schema.Internal:
-		class = "internal"
-		if _, ok := MHints[vID]; ok {
-			class = "hint"
-		}
-	case schema.Public:
-		class = "public"
-	case schema.Secret:
-		class = "secret"
-	case schema.Virtual:
-		class = "virtual"
-	case schema.Unset:
-		class = "unset"
-	default:
-		panic("not implemented")
-	}
-	if offset {
-		vID++ // for sparse R1CS, we offset to have same variable numbers as in R1CS
-	}
-	sbb.WriteString(fmt.Sprintf("<span class=\"%s\">v%d</span>", class, vID))
-
-}
 
 // GetNbCoefficients return the number of unique coefficients needed in the R1CS
 func (cs *R1CS) GetNbCoefficients() int {

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -332,7 +332,7 @@ func (cs *R1CS) termToString(t compiled.Term, sbb *strings.Builder) {
 		return
 	} else {
 		sbb.WriteString(cs.Coefficients[tID].String())
-		sbb.WriteByte('*')
+		sbb.WriteString("⋅")
 	}
 	vID := t.WireID()
 	visibility := t.VariableVisibility()

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -263,41 +263,38 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
-	isZeroA :=  (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	isZeroM :=  (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var AM, k, O string 
+	var A0, A1, M, k, O string 
 	var sbb strings.Builder
+	
+	sbb.Reset()
+	cs.termToString(c.L, &sbb, false)
+	A0 = sbb.String()
+	sbb.Reset()
+	cs.termToString(c.R, &sbb, false)
+	A1 = sbb.String()
 
-	if isZeroA && isZeroM {
-		AM = "0"
+	if isZeroM {
+		M = "0"
 	} else {
-		if isZeroA {
-			sbb.Reset()
+		sbb.Reset()
 		cs.termToString(c.M[0], &sbb, false)
 		sbb.WriteString(" * ")
 		cs.termToString(c.M[1], &sbb, false)
-		AM = sbb.String()
-		} else {
-			sbb.Reset()
-		cs.termToString(c.L, &sbb, false)
-		sbb.WriteString(" + ")
-		cs.termToString(c.R, &sbb, false)
-		AM = sbb.String()
-		}
+		M = sbb.String()
 	}
-	
 
 	k = cs.Coefficients[c.K].String()
 
 	// we need to negate O
 	sbb.Reset()
-	cs.termToString(c.O, &sbb, true)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 	
 
-	return [3]string{AM, k, O}
+	return [5]string{A0, A1, M,O, k}
 }
 
 

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -264,37 +264,30 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	var sbb strings.Builder
 	
 	sbb.Reset()
-	cs.termToString(c.L, &sbb)
+	cs.termToString(c.L, &sbb, false)
 	A0 = sbb.String()
 	sbb.Reset()
-	cs.termToString(c.R, &sbb)
+	cs.termToString(c.R, &sbb, false)
 	A1 = sbb.String()
 
 	if isZeroM {
 		M = "0"
 	} else {
 		sbb.Reset()
-		cm0 := c.M[0]
-		addParenthesis := cm0.CoeffID() != compiled.CoeffIdOne
-		if addParenthesis {
-			sbb.WriteString(cs.Coefficients[cm0.CoeffID()].String())
-			sbb.WriteString("⋅")
-			sbb.WriteByte('(')
-		}
-		cm0.SetCoeffID(compiled.CoeffIdOne)
-		cs.termToString(cm0, &sbb)
+		sbb.WriteString(cs.Coefficients[c.M[0].CoeffID()].String())
+		sbb.WriteString("⋅")
+		sbb.WriteByte('(')
+		cs.termToString(c.M[0], &sbb, true)
 		sbb.WriteString(" × ")
-		cs.termToString(c.M[1], &sbb)
-		if addParenthesis {
-			sbb.WriteByte(')')
-		}
+		cs.termToString(c.M[1], &sbb, true)
+		sbb.WriteByte(')')
 		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
 	sbb.Reset()
-	cs.termToString(c.O, &sbb)
+	cs.termToString(c.O, &sbb, false)
 	O = sbb.String()
 	
 
@@ -302,20 +295,24 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 }
 
 
-func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder)   {
-	tID := t.CoeffID()
-	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
-	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
-	} else if tID == compiled.CoeffIdZero {
-		sbb.WriteByte('0')
-		return
-	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, vOnly bool)   {
+	if !vOnly {
+		tID := t.CoeffID()
+		if tID == compiled.CoeffIdOne {
+			// do nothing, just print the variable
+			sbb.WriteString("1")
+		} else if tID == compiled.CoeffIdMinusOne {
+			// print neg sign
+			sbb.WriteString("-1")
+		} else if tID == compiled.CoeffIdZero {
+			sbb.WriteByte('0')
+			return
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
 		sbb.WriteString("⋅")
 	}
+
 	vID := t.WireID()
 	visibility := t.VariableVisibility()
 

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -248,33 +248,87 @@ func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverO
 func (cs *SparseR1CS) GetConstraints() [][]string {
 	var r [][]string 
 	for _, c := range cs.Constraints {
-		// if we are worried about perf for large cs, we could do a string builder + csv format.
-		var line [6]string
-		line[0] = cs.termToString(c.L)
-		line[1] = cs.termToString(c.R)
-		line[2] = cs.termToString(c.M[0])
-		line[3] = cs.termToString(c.M[1])
-		line[4] = cs.termToString(c.O)
-		line[5] = cs.Coefficients[c.K].String()
-		r = append(r, line[:])
+		fc := cs.formatConstraint(c)
+		r = append(r, fc[:])
 	}
 	return r
 }
 
+// formatConstraint return a human readable representation of a constraint
+// in the form A + M + k == O
+// where
+// A = c1 * v1 + c2 *v2
+// M = c1 * v1 * v2
+// k = c1
+// If A is set, then M == 0 . If M is set, A == 0 .
+// k can be set for both A and M
+// cX are constants
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+	isZeroA :=  (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
+	isZeroM :=  (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-func (cs *SparseR1CS) termToString(t compiled.Term) string  {
+	var A, M, k, O string 
 	var sbb strings.Builder
+	
+	if isZeroA {
+		A = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.L, &sbb, false)
+		sbb.WriteString(" + ")
+		cs.termToString(c.R, &sbb, false)
+		A = sbb.String()
+	}
+
+	if isZeroM {
+		M = "0"
+	} else {
+		sbb.Reset()
+		cs.termToString(c.M[0], &sbb, false)
+		sbb.WriteString(" * ")
+		cs.termToString(c.M[1], &sbb, false)
+		M = sbb.String()
+	}
+
+	k = cs.Coefficients[c.K].String()
+
+	// we need to negate O
+	sbb.Reset()
+	cs.termToString(c.O, &sbb, true)
+	O = sbb.String()
+	
+
+	return [4]string{A, M, k, O}
+}
+
+
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool)   {
 	tID := t.CoeffID()
 	if tID == compiled.CoeffIdOne {
-		// do nothing, just print the variable
+		if negate {
+			sbb.WriteByte('-')	
+		} else {
+			// do nothing, just print the variable
+		}
 	} else if tID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		sbb.WriteByte('-')
+		if negate {
+			// do nothing, just print the variable
+		} else {
+			// print neg sign
+			sbb.WriteByte('-')
+		}
 	} else if tID == compiled.CoeffIdZero {
 		sbb.WriteByte('0')
-		return sbb.String()
+		return
 	} else {
-		sbb.WriteString(cs.Coefficients[tID].String())
+		if negate {
+			var cNeg fr.Element 
+			cNeg.Neg(&cs.Coefficients[tID])
+			sbb.WriteString(cNeg.String())
+		} else {
+			sbb.WriteString(cs.Coefficients[tID].String())
+		}
+		
 		sbb.WriteByte('*')
 	}
 	vID := t.WireID()
@@ -294,7 +348,6 @@ func (cs *SparseR1CS) termToString(t compiled.Term) string  {
 	default:
 		sbb.WriteString("<?>")
 	}
-	return sbb.String()
 }
 
 

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -10,7 +10,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/backend"
-	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/backend/witness"
 
@@ -97,17 +96,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
 		}
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
 			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				if debug.Debug {
-					return solution.values,  fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
-				}
-				return solution.values,  fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
+				errMsg = solution.logValue(cs.DebugInfo[dID])
 			}
-			if debug.Debug {
-				return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
-			}
-			return solution.values, fmt.Errorf("%w", errUnsatisfiedConstraint(i))
+			return solution.values,  fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
 		}
 	}
 
@@ -359,12 +352,12 @@ func (cs *SparseR1CS) checkConstraint(c compiled.SparseR1C, solution *solution) 
 	t.Mul(&m0, &m1).Add(&t, &l).Add(&t, &r).Add(&t, &o).Add(&t, &cs.Coefficients[c.K])
 	if !t.IsZero() {
 		return fmt.Errorf("qL⋅xa + qR⋅xb + qO⋅xc + qM⋅(xaxb) + qC != 0 → %s + %s + %s + (%s × %s) + %s != 0",
-		l.String(),
-		r.String(),
-		o.String(),
-		m0.String(),
-		m1.String(),
-		cs.Coefficients[c.K].String(),
+			l.String(),
+			r.String(),
+			o.String(),
+			m0.String(),
+			m1.String(),
+			cs.Coefficients[c.K].String(),
 		)
 	}
 	return nil 

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -5,12 +5,12 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/consensys/gnark-crypto/ecc"
 	"strings"
-	"text/template"
 	"os"
 	
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/internal/backend/compiled"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/backend/witness"
 
@@ -99,9 +99,15 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values,  fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
+				if debug.Debug {
+					return solution.values,  fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
+				}
+				return solution.values,  fmt.Errorf("%w: %s", errUnsatisfiedConstraint(i), debugInfoStr)
 			}
-			return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
+			if debug.Debug {
+				return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
+			}
+			return solution.values, fmt.Errorf("%w", errUnsatisfiedConstraint(i))
 		}
 	}
 
@@ -246,8 +252,14 @@ func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverO
 }
 
 // GetConstraints return a list of constraint formatted as in the paper
-// https://eprint.iacr.org/2019/953.pdf section 6
+// https://eprint.iacr.org/2019/953.pdf section 6 such that
 // qL⋅xa + qR⋅xb + qO⋅xc + qM⋅(xaxb) + qC == 0
+// each constraint is thus decomposed in [5]string with
+// 		[0] = qL⋅xa
+//		[1] = qR⋅xb
+//		[2] = qO⋅xc
+//		[3] = qM⋅(xaxb)
+//		[4] = qC
 func (cs *SparseR1CS) GetConstraints() [][]string {
 	var r [][]string 
 	for _, c := range cs.Constraints {
@@ -346,52 +358,17 @@ func (cs *SparseR1CS) checkConstraint(c compiled.SparseR1C, solution *solution) 
 	var t fr.Element 
 	t.Mul(&m0, &m1).Add(&t, &l).Add(&t, &r).Add(&t, &o).Add(&t, &cs.Coefficients[c.K])
 	if !t.IsZero() {
-		return fmt.Errorf("%s + %s + (%s * %s) + %s + %s != 0",
+		return fmt.Errorf("qL⋅xa + qR⋅xb + qO⋅xc + qM⋅(xaxb) + qC != 0 → %s + %s + %s + (%s × %s) + %s != 0",
 		l.String(),
 		r.String(),
+		o.String(),
 		m0.String(),
 		m1.String(),
-		o.String(),
 		cs.Coefficients[c.K].String(),
 		)
 	}
 	return nil 
 
-}
-
-
-// ToHTML returns an HTML human-readable representation of the constraint system
-func (cs *SparseR1CS) ToHTML(w io.Writer) error {
-	t, err := template.New("scs.html").Funcs(template.FuncMap{
-		"toHTML": toHTMLTerm,
-		"toHTMLCoeff": toHTMLCoeff,
-		"add": add,
-		"sub": sub,
-	}).Parse(compiled.SparseR1CSTemplate)
-	if err != nil {
-		return err
-	}
-
-	return t.Execute(w, cs)
-}
-
-
-func toHTMLTerm(t compiled.Term, coeffs []fr.Element, MHints map[int]compiled.Hint) string {
-	var sbb strings.Builder
-	termToHTML(t, &sbb, coeffs, MHints, true)
-	return sbb.String()
-}
-
-func toHTMLCoeff(cID int, coeffs []fr.Element) string {
-	if cID == compiled.CoeffIdMinusOne {
-		// print neg sign
-		return "<span class=\"coefficient\">-1</span>"
-	}
-	var sbb strings.Builder 
-	sbb.WriteString("<span class=\"coefficient\">")
-	sbb.WriteString(coeffs[cID].String())
-	sbb.WriteString("</span>")
-	return sbb.String()
 }
 
 // FrSize return fr.Limbs * 8, size in byte of a fr element

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -99,9 +99,9 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values,  fmt.Errorf("%w: %s", ErrUnsatisfiedConstraint, debugInfoStr)
+				return solution.values,  fmt.Errorf("%w: %s\n%v", errUnsatisfiedConstraint(i), debugInfoStr, err)
 			}
-			return solution.values, ErrUnsatisfiedConstraint
+			return solution.values, fmt.Errorf("%w: %v", errUnsatisfiedConstraint(i), err)
 		}
 	}
 
@@ -311,7 +311,7 @@ func (cs *SparseR1CS) checkConstraint(c compiled.SparseR1C, solution *solution) 
 	var t fr.Element 
 	t.Mul(&m0, &m1).Add(&t, &l).Add(&t, &r).Add(&t, &o).Add(&t, &cs.Coefficients[c.K])
 	if !t.IsZero() {
-		return fmt.Errorf("%w\n%s + %s + (%s * %s) + %s + %s != 0",ErrUnsatisfiedConstraint, 
+		return fmt.Errorf("%s + %s + (%s * %s) + %s + %s != 0",
 		l.String(),
 		r.String(),
 		m0.String(),

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -254,7 +254,7 @@ func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverO
 //		[3] = qM⋅(xaxb)
 //		[4] = qC
 func (cs *SparseR1CS) GetConstraints() [][]string {
-	var r [][]string 
+	r := make([][]string , 0, len(cs.Constraints))
 	for _, c := range cs.Constraints {
 		fc := cs.formatConstraint(c)
 		r = append(r, fc[:])
@@ -262,21 +262,28 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 	return r
 }
 
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
+// r[0] = qL⋅xa
+// r[1] = qR⋅xb
+// r[2] = qO⋅xc
+// r[3] = qM⋅(xaxb)
+// r[4] = qC
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) (r [5]string) {
 	isZeroM :=  (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var A0, A1, M, k, O string 
 	var sbb strings.Builder
-	
-	sbb.Reset()
 	cs.termToString(c.L, &sbb, false)
-	A0 = sbb.String()
+	r[0] = sbb.String()
+
 	sbb.Reset()
 	cs.termToString(c.R, &sbb, false)
-	A1 = sbb.String()
+	r[1] = sbb.String()
+
+	sbb.Reset()
+	cs.termToString(c.O, &sbb, false)
+	r[2] = sbb.String()
 
 	if isZeroM {
-		M = "0"
+		r[3] = "0"
 	} else {
 		sbb.Reset()
 		sbb.WriteString(cs.Coefficients[c.M[0].CoeffID()].String())
@@ -286,17 +293,12 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 		sbb.WriteString(" × ")
 		cs.termToString(c.M[1], &sbb, true)
 		sbb.WriteByte(')')
-		M = sbb.String()
+		r[3] = sbb.String()
 	}
 
-	k = cs.Coefficients[c.K].String()
+	r[4] = cs.Coefficients[c.K].String()
 
-	sbb.Reset()
-	cs.termToString(c.O, &sbb, false)
-	O = sbb.String()
-	
-
-	return [5]string{A0, A1, O, M, k}
+	return 
 }
 
 

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -245,6 +245,9 @@ func (cs *SparseR1CS) IsSolved(witness *witness.Witness, opts ...backend.ProverO
 	return err
 }
 
+// GetConstraints return a list of constraint formatted as in the paper
+// https://eprint.iacr.org/2019/953.pdf section 6
+// qL⋅xa + qR⋅xb + qO⋅xc + qM⋅(xaxb) + qC == 0
 func (cs *SparseR1CS) GetConstraints() [][]string {
 	var r [][]string 
 	for _, c := range cs.Constraints {
@@ -254,15 +257,6 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 	return r
 }
 
-// formatConstraint return a human readable representation of a constraint
-// in the form A + M + k == O
-// where
-// A = c1 * v1 + c2 *v2
-// M = c1 * v1 * v2
-// k = c1
-// If A is set, then M == 0 . If M is set, A == 0 .
-// k can be set for both A and M
-// cX are constants
 func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	isZeroM :=  (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
@@ -270,62 +264,57 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [5]string {
 	var sbb strings.Builder
 	
 	sbb.Reset()
-	cs.termToString(c.L, &sbb, false)
+	cs.termToString(c.L, &sbb)
 	A0 = sbb.String()
 	sbb.Reset()
-	cs.termToString(c.R, &sbb, false)
+	cs.termToString(c.R, &sbb)
 	A1 = sbb.String()
 
 	if isZeroM {
 		M = "0"
 	} else {
 		sbb.Reset()
-		cs.termToString(c.M[0], &sbb, false)
-		sbb.WriteString(" * ")
-		cs.termToString(c.M[1], &sbb, false)
+		cm0 := c.M[0]
+		addParenthesis := cm0.CoeffID() != compiled.CoeffIdOne
+		if addParenthesis {
+			sbb.WriteString(cs.Coefficients[cm0.CoeffID()].String())
+			sbb.WriteString("⋅")
+			sbb.WriteByte('(')
+		}
+		cm0.SetCoeffID(compiled.CoeffIdOne)
+		cs.termToString(cm0, &sbb)
+		sbb.WriteString(" × ")
+		cs.termToString(c.M[1], &sbb)
+		if addParenthesis {
+			sbb.WriteByte(')')
+		}
 		M = sbb.String()
 	}
 
 	k = cs.Coefficients[c.K].String()
 
-	// we need to negate O
 	sbb.Reset()
-	cs.termToString(c.O, &sbb, false)
+	cs.termToString(c.O, &sbb)
 	O = sbb.String()
 	
 
-	return [5]string{A0, A1, M,O, k}
+	return [5]string{A0, A1, O, M, k}
 }
 
 
-func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder, negate bool)   {
+func (cs *SparseR1CS) termToString(t compiled.Term, sbb *strings.Builder)   {
 	tID := t.CoeffID()
 	if tID == compiled.CoeffIdOne {
-		if negate {
-			sbb.WriteByte('-')	
-		} else {
-			// do nothing, just print the variable
-		}
+		// do nothing, just print the variable
 	} else if tID == compiled.CoeffIdMinusOne {
-		if negate {
-			// do nothing, just print the variable
-		} else {
-			// print neg sign
-			sbb.WriteByte('-')
-		}
+		// print neg sign
+		sbb.WriteByte('-')
 	} else if tID == compiled.CoeffIdZero {
 		sbb.WriteByte('0')
 		return
 	} else {
-		if negate {
-			var cNeg fr.Element 
-			cNeg.Neg(&cs.Coefficients[tID])
-			sbb.WriteString(cNeg.String())
-		} else {
-			sbb.WriteString(cs.Coefficients[tID].String())
-		}
-		
-		sbb.WriteByte('*')
+		sbb.WriteString(cs.Coefficients[tID].String())
+		sbb.WriteString("⋅")
 	}
 	vID := t.WireID()
 	visibility := t.VariableVisibility()

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -263,32 +263,31 @@ func (cs *SparseR1CS) GetConstraints() [][]string {
 // If A is set, then M == 0 . If M is set, A == 0 .
 // k can be set for both A and M
 // cX are constants
-func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
+func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [3]string {
 	isZeroA :=  (c.L.CoeffID() == compiled.CoeffIdZero) && (c.R.CoeffID() == compiled.CoeffIdZero)
 	isZeroM :=  (c.M[0].CoeffID() == compiled.CoeffIdZero) && (c.M[1].CoeffID() == compiled.CoeffIdZero)
 
-	var A, M, k, O string 
+	var AM, k, O string 
 	var sbb strings.Builder
-	
-	if isZeroA {
-		A = "0"
-	} else {
-		sbb.Reset()
-		cs.termToString(c.L, &sbb, false)
-		sbb.WriteString(" + ")
-		cs.termToString(c.R, &sbb, false)
-		A = sbb.String()
-	}
 
-	if isZeroM {
-		M = "0"
+	if isZeroA && isZeroM {
+		AM = "0"
 	} else {
-		sbb.Reset()
+		if isZeroA {
+			sbb.Reset()
 		cs.termToString(c.M[0], &sbb, false)
 		sbb.WriteString(" * ")
 		cs.termToString(c.M[1], &sbb, false)
-		M = sbb.String()
+		AM = sbb.String()
+		} else {
+			sbb.Reset()
+		cs.termToString(c.L, &sbb, false)
+		sbb.WriteString(" + ")
+		cs.termToString(c.R, &sbb, false)
+		AM = sbb.String()
+		}
 	}
+	
 
 	k = cs.Coefficients[c.K].String()
 
@@ -298,7 +297,7 @@ func (cs *SparseR1CS) formatConstraint(c compiled.SparseR1C) [4]string {
 	O = sbb.String()
 	
 
-	return [4]string{A, M, k, O}
+	return [3]string{AM, k, O}
 }
 
 

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -14,11 +14,6 @@ import (
 	{{ template "import_curve" . }}
 )
 
-// errUnsatisfiedConstraint can be generated when solving a R1CS
-func errUnsatisfiedConstraint(i int) error {
-	return fmt.Errorf("constraint #%d is not satisfied", i)
-}
-
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -14,8 +14,10 @@ import (
 	{{ template "import_curve" . }}
 )
 
-// ErrUnsatisfiedConstraint can be generated when solving a R1CS
-var ErrUnsatisfiedConstraint = errors.New("constraint is not satisfied")
+// errUnsatisfiedConstraint can be generated when solving a R1CS
+func errUnsatisfiedConstraint(i int) error {
+	return fmt.Errorf("constraint #%d is not satisfied", i)
+}
 
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS


### PR DESCRIPTION
This PR removes the `ccs.ToHTML` deadcode. It's not `gnark` job to produce HTML, the constraint system returns a list of formatted constraints in a `[][]string` and a user (like play.gnark.io ) can then render it. 

`ccs.GetConstraints` returns for PlonK the constraints in the form `qL⋅xa + qR⋅xb + qO⋅xc + qM⋅(xaxb) + qC == 0` (as in the paper) and for Groth16 `L⋅R == O` . 

Additionally, this PR adds a constraint ID number in the message for a unsatisfied constraint at solving time. 
