### PR TITLE
perf: replace big int pool in hint solver by tmp slice

### DIFF
--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -70,6 +70,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -84,6 +84,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -157,6 +157,8 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	inputs := s.tmpHintsIO[:nbInputs]
 	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
 
+	q := fr.Modulus()
+
 	for i := 0; i < nbInputs; i++ {
 
 		switch t := h.Inputs[i].(type) {
@@ -172,6 +174,9 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		default:
 			v := utils.FromInterface(t)
 			inputs[i] = &v
+
+			// here we have no guarantee that v < q, so we mod reduce
+			inputs[i].Mod(inputs[i], q)
 		}
 	}
 

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -70,6 +70,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -84,6 +84,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -157,6 +157,8 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	inputs := s.tmpHintsIO[:nbInputs]
 	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
 
+	q := fr.Modulus()
+
 	for i := 0; i < nbInputs; i++ {
 
 		switch t := h.Inputs[i].(type) {
@@ -172,6 +174,9 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		default:
 			v := utils.FromInterface(t)
 			inputs[i] = &v
+
+			// here we have no guarantee that v < q, so we mod reduce
+			inputs[i].Mod(inputs[i], q)
 		}
 	}
 

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -70,6 +70,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -84,6 +84,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -157,6 +157,8 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	inputs := s.tmpHintsIO[:nbInputs]
 	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
 
+	q := fr.Modulus()
+
 	for i := 0; i < nbInputs; i++ {
 
 		switch t := h.Inputs[i].(type) {
@@ -172,6 +174,9 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		default:
 			v := utils.FromInterface(t)
 			inputs[i] = &v
+
+			// here we have no guarantee that v < q, so we mod reduce
+			inputs[i].Mod(inputs[i], q)
 		}
 	}
 

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -70,6 +70,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -84,6 +84,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -157,6 +157,8 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	inputs := s.tmpHintsIO[:nbInputs]
 	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
 
+	q := fr.Modulus()
+
 	for i := 0; i < nbInputs; i++ {
 
 		switch t := h.Inputs[i].(type) {
@@ -172,6 +174,9 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		default:
 			v := utils.FromInterface(t)
 			inputs[i] = &v
+
+			// here we have no guarantee that v < q, so we mod reduce
+			inputs[i].Mod(inputs[i], q)
 		}
 	}
 

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -70,6 +70,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -84,6 +84,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {

--- a/internal/backend/bw6-633/cs/solution.go
+++ b/internal/backend/bw6-633/cs/solution.go
@@ -157,6 +157,8 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	inputs := s.tmpHintsIO[:nbInputs]
 	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
 
+	q := fr.Modulus()
+
 	for i := 0; i < nbInputs; i++ {
 
 		switch t := h.Inputs[i].(type) {
@@ -172,6 +174,9 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		default:
 			v := utils.FromInterface(t)
 			inputs[i] = &v
+
+			// here we have no guarantee that v < q, so we mod reduce
+			inputs[i].Mod(inputs[i], q)
 		}
 	}
 

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -70,6 +70,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -84,6 +84,11 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -157,6 +157,8 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	inputs := s.tmpHintsIO[:nbInputs]
 	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
 
+	q := fr.Modulus()
+
 	for i := 0; i < nbInputs; i++ {
 
 		switch t := h.Inputs[i].(type) {
@@ -172,6 +174,9 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		default:
 			v := utils.FromInterface(t)
 			inputs[i] = &v
+
+			// here we have no guarantee that v < q, so we mod reduce
+			inputs[i].Mod(inputs[i], q)
 		}
 	}
 

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -51,6 +51,11 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	if err != nil {
 		return make([]fr.Element, nbWires), err
 	}
+	
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
 
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -70,6 +70,12 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
+
+	defer func() {
+		// release memory
+		solution.tmpHintsIO = nil
+	}()
+
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -138,6 +138,8 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	inputs := s.tmpHintsIO[:nbInputs]
 	outputs := s.tmpHintsIO[nbInputs:nbInputs+nbOutputs]
 
+	q := fr.Modulus()
+
 	for i := 0; i < nbInputs; i++ {
 
 		switch t := h.Inputs[i].(type) {
@@ -153,6 +155,9 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		default:
 			v := utils.FromInterface(t)
 			inputs[i] = &v
+			
+			// here we have no guarantee that v < q, so we mod reduce
+			inputs[i].Mod(inputs[i], q)
 		}
 	}
 

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -3,7 +3,6 @@ import (
 	"errors"
     "fmt"
 	"math/big"
-	"sync"
 
     "github.com/consensys/gnark/backend/hint"
     "github.com/consensys/gnark/internal/backend/compiled"
@@ -21,6 +20,7 @@ type solution struct {
 	solved               []bool
 	nbSolved             int
 	mHintsFunctions      map[hint.ID]hint.Function
+	tmpHintsIO 			[]*big.Int
 }
 
 func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
@@ -30,6 +30,7 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		coefficients: coefficients,
 		solved: make([]bool, nbWires),
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
+		tmpHintsIO: make([]*big.Int, 0),
   }
 	
 	for _, h := range hintFunctions {
@@ -124,14 +125,20 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		return errors.New("missing hint function")
 	}
 
-	// compute values for all inputs.
-	inputs := make([]*big.Int, len(h.Inputs))
-	for i := 0; i < len(inputs); i++ {
-		inputs[i] = bigIntPool.Get().(*big.Int)
-		inputs[i].SetUint64(0)
+	// tmp IO big int memory
+	nbInputs := len(h.Inputs)
+	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
+	m := len(s.tmpHintsIO) 
+	if m < (nbInputs + nbOutputs) {
+		s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)
+		for i := m; i < len(s.tmpHintsIO); i++ {
+			s.tmpHintsIO[i] = big.NewInt(0)
+		}
 	}
+	inputs := s.tmpHintsIO[:nbInputs]
+	outputs := s.tmpHintsIO[nbInputs:nbInputs+nbOutputs]
 
-	for i := 0; i < len(h.Inputs); i++ {
+	for i := 0; i < nbInputs; i++ {
 
 		switch t := h.Inputs[i].(type) {
 		case compiled.Variable:
@@ -149,18 +156,6 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		}
 	}
 
-	outputs := make([]*big.Int, f.NbOutputs(curve.ID, len(inputs)))
-	for i := 0; i < len(outputs); i++ {
-		outputs[i] = bigIntPool.Get().(*big.Int)
-	}
-
-	// ensure our inputs are mod q
-	q := fr.Modulus()
-	for i := 0; i < len(inputs); i++ {
-		// note since we're only doing additions up there, we may want to avoid the use of Mod
-		// here in favor of Cmp & Sub
-		inputs[i].Mod(inputs[i], q)
-	}
 
 	err := f.Call(curve.ID, inputs, outputs)
 
@@ -170,20 +165,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 		s.set(h.Wires[i], v)
 	}
 
-	// release objects into pool
-	for i := 0; i < len(inputs); i++ {
-		bigIntPool.Put(inputs[i])
-	}
-
-	for i := 0; i < len(outputs); i++ {
-		bigIntPool.Put(outputs[i])
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err 
 }
 
 func (s *solution) printLogs(w io.Writer, logs []compiled.LogEntry) {
@@ -261,10 +243,4 @@ func (s *solution) logValue(log compiled.LogEntry) string {
 		}
 	}
 	return fmt.Sprintf(log.Format, toResolve...)
-}
-
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
 }


### PR DESCRIPTION
--> solveWithHint was doing useless mod reduce on the big int inputs (already mod reduce when computing linear expression with fr.Element)
--> solveWithHint was leaking a big.Int from the pool; anyway, seems for hint heavy workflows, better to just allocate a big.Int slice 👍  