### PR TITLE
Perf parallel solver

### DIFF
--- a/debug_test.go
+++ b/debug_test.go
@@ -47,16 +47,16 @@ func TestPrintln(t *testing.T) {
 	expected.WriteString("debug_test.go:27 26 42\n")
 	expected.WriteString("debug_test.go:29 bits 1\n")
 	expected.WriteString("debug_test.go:30 circuit {A: 2, B: 11}\n")
-	expected.WriteString("debug_test.go:34 m <unsolved>\n")
+	expected.WriteString(`debug_test.go:34 m .*\n`)
 
 	{
 		trace, _ := getGroth16Trace(&circuit, &witness)
-		assert.Equal(expected.String(), trace)
+		assert.Regexp(expected.String(), trace)
 	}
 
 	{
 		trace, _ := getPlonkTrace(&circuit, &witness)
-		assert.Equal(expected.String(), trace)
+		assert.Regexp(expected.String(), trace)
 	}
 }
 

--- a/frontend/cs/plonk/conversion.go
+++ b/frontend/cs/plonk/conversion.go
@@ -116,6 +116,9 @@ HINTLOOP:
 	}
 	res.MHints = shiftedMap
 
+	// build levels
+	res.Levels = buildLevels(res)
+
 	switch cs.CurveID {
 	case ecc.BLS12_377:
 		return bls12377r1cs.NewSparseR1CS(res, cs.Coeffs), nil
@@ -137,4 +140,104 @@ HINTLOOP:
 
 func (cs *sparseR1CS) SetSchema(s *schema.Schema) {
 	cs.Schema = s
+}
+
+func buildLevels(ccs compiled.SparseR1CS) [][]int {
+
+	b := levelBuilder{
+		mWireToNode: make(map[int]int, ccs.NbInternalVariables), // at which node we resolved which wire
+		nodeLevels:  make([]int, len(ccs.Constraints)),          // level of a node
+		mLevels:     make(map[int]int),                          // level counts
+		ccs:         ccs,
+		nbInputs:    ccs.NbPublicVariables + ccs.NbSecretVariables,
+	}
+
+	// for each constraint, we're going to find its direct dependencies
+	// that is, wires (solved by previous constraints) on which it depends
+	// each of these dependencies is tagged with a level
+	// current constraint will be tagged with max(level) + 1
+	for cID, c := range ccs.Constraints {
+
+		b.nodeLevel = 0
+
+		b.processTerm(c.L, cID)
+		b.processTerm(c.R, cID)
+		b.processTerm(c.O, cID)
+
+		b.nodeLevels[cID] = b.nodeLevel
+		b.mLevels[b.nodeLevel]++
+
+	}
+
+	levels := make([][]int, len(b.mLevels))
+	for i := 0; i < len(levels); i++ {
+		// allocate memory
+		levels[i] = make([]int, 0, b.mLevels[i])
+	}
+
+	for n, l := range b.nodeLevels {
+		levels[l] = append(levels[l], n)
+	}
+
+	return levels
+}
+
+type levelBuilder struct {
+	ccs      compiled.SparseR1CS
+	nbInputs int
+
+	mWireToNode map[int]int // at which node we resolved which wire
+	nodeLevels  []int       // level per node
+	mLevels     map[int]int // number of constraint per level
+
+	nodeLevel int // current level
+}
+
+func (b *levelBuilder) processTerm(t compiled.Term, cID int) {
+	wID := t.WireID()
+	if wID < b.nbInputs {
+		// it's a input, we ignore it
+		return
+	}
+
+	// if we know a which constraint solves this wire, then it's a dependency
+	n, ok := b.mWireToNode[wID]
+	if ok {
+		if n != cID { // can happen with hints...
+			// we add a dependency, check if we need to increment our current level
+			if b.nodeLevels[n] >= b.nodeLevel {
+				b.nodeLevel = b.nodeLevels[n] + 1 // we are at the next level at least since we depend on it
+			}
+		}
+		return
+	}
+
+	// check if it's a hint and mark all the output wires
+	if h, ok := b.ccs.MHints[wID]; ok {
+
+		for _, in := range h.Inputs {
+			switch t := in.(type) {
+			case compiled.Variable:
+				for _, tt := range t.LinExp {
+					b.processTerm(tt, cID)
+				}
+			case compiled.LinearExpression:
+				for _, tt := range t {
+					b.processTerm(tt, cID)
+				}
+			case compiled.Term:
+				b.processTerm(t, cID)
+			}
+		}
+
+		for _, hwid := range h.Wires {
+			b.mWireToNode[hwid] = cID
+		}
+
+		return
+	}
+
+	// mark this wire solved by current node
+	b.mWireToNode[wID] = cID
+
 }

--- a/frontend/cs/plonk/conversion.go
+++ b/frontend/cs/plonk/conversion.go
@@ -148,7 +148,7 @@ func buildLevels(ccs compiled.SparseR1CS) [][]int {
 		mWireToNode: make(map[int]int, ccs.NbInternalVariables), // at which node we resolved which wire
 		nodeLevels:  make([]int, len(ccs.Constraints)),          // level of a node
 		mLevels:     make(map[int]int),                          // level counts
-		ccs:         ccs,
+		ccs:         ccs.CS,
 		nbInputs:    ccs.NbPublicVariables + ccs.NbSecretVariables,
 	}
 
@@ -183,7 +183,7 @@ func buildLevels(ccs compiled.SparseR1CS) [][]int {
 }
 
 type levelBuilder struct {
-	ccs      compiled.SparseR1CS
+	ccs      compiled.CS
 	nbInputs int
 
 	mWireToNode map[int]int // at which node we resolved which wire

--- a/frontend/cs/r1cs/conversion.go
+++ b/frontend/cs/r1cs/conversion.go
@@ -149,85 +149,102 @@ HINTLOOP:
 	}
 }
 
-func processLE(ccs compiled.R1CS, l compiled.LinearExpression, mWireToNode, mLevels map[int]int, nodeLevels []int, nodeLevel, cID int) int {
-	nbInputs := ccs.NbPublicVariables + ccs.NbSecretVariables
-
-	for _, t := range l {
-		wID := t.WireID()
-		if wID < nbInputs {
-			// it's a input, we ignore it
-			continue
-		}
-
-		// if we know a which constraint solves this wire, then it's a dependency
-		n, ok := mWireToNode[wID]
-		if ok {
-			if n != cID { // can happen with hints...
-				// we add a dependency, check if we need to increment our current level
-				if nodeLevels[n] >= nodeLevel {
-					nodeLevel = nodeLevels[n] + 1 // we are at the next level at least since we depend on it
-				}
-			}
-			continue
-		}
-
-		// check if it's a hint and mark all the output wires
-		if h, ok := ccs.MHints[wID]; ok {
-
-			for _, in := range h.Inputs {
-				switch t := in.(type) {
-				case compiled.Variable:
-					nodeLevel = processLE(ccs, t.LinExp, mWireToNode, mLevels, nodeLevels, nodeLevel, cID)
-				case compiled.LinearExpression:
-					nodeLevel = processLE(ccs, t, mWireToNode, mLevels, nodeLevels, nodeLevel, cID)
-				case compiled.Term:
-					nodeLevel = processLE(ccs, compiled.LinearExpression{t}, mWireToNode, mLevels, nodeLevels, nodeLevel, cID)
-				}
-			}
-
-			for _, hwid := range h.Wires {
-				mWireToNode[hwid] = cID
-			}
-			continue
-		}
-
-		// mark this wire solved by current node
-		mWireToNode[wID] = cID
-	}
-
-	return nodeLevel
+func (cs *r1CS) SetSchema(s *schema.Schema) {
+	cs.Schema = s
 }
 
 func buildLevels(ccs compiled.R1CS) [][]int {
 
-	mWireToNode := make(map[int]int, ccs.NbInternalVariables) // at which node we resolved which wire
-	nodeLevels := make([]int, len(ccs.Constraints))           // level of a node
-	mLevels := make(map[int]int)                              // level counts
+	b := levelBuilder{
+		mWireToNode: make(map[int]int, ccs.NbInternalVariables), // at which node we resolved which wire
+		nodeLevels:  make([]int, len(ccs.Constraints)),          // level of a node
+		mLevels:     make(map[int]int),                          // level counts
+		ccs:         ccs,
+		nbInputs:    ccs.NbPublicVariables + ccs.NbSecretVariables,
+	}
 
+	// for each constraint, we're going to find its direct dependencies
+	// that is, wires (solved by previous constraints) on which it depends
+	// each of these dependencies is tagged with a level
+	// current constraint will be tagged with max(level) + 1
 	for cID, c := range ccs.Constraints {
 
-		nodeLevel := 0
+		b.nodeLevel = 0
 
-		nodeLevel = processLE(ccs, c.L.LinExp, mWireToNode, mLevels, nodeLevels, nodeLevel, cID)
-		nodeLevel = processLE(ccs, c.R.LinExp, mWireToNode, mLevels, nodeLevels, nodeLevel, cID)
-		nodeLevel = processLE(ccs, c.O.LinExp, mWireToNode, mLevels, nodeLevels, nodeLevel, cID)
-		nodeLevels[cID] = nodeLevel
-		mLevels[nodeLevel]++
+		b.processLE(c.L.LinExp, cID)
+		b.processLE(c.R.LinExp, cID)
+		b.processLE(c.O.LinExp, cID)
+		b.nodeLevels[cID] = b.nodeLevel
+		b.mLevels[b.nodeLevel]++
 
 	}
 
-	levels := make([][]int, len(mLevels))
+	levels := make([][]int, len(b.mLevels))
 	for i := 0; i < len(levels); i++ {
-		levels[i] = make([]int, 0, mLevels[i])
+		// allocate memory
+		levels[i] = make([]int, 0, b.mLevels[i])
 	}
 
-	for n, l := range nodeLevels {
+	for n, l := range b.nodeLevels {
 		levels[l] = append(levels[l], n)
 	}
 
 	return levels
 }
 
-func (cs *r1CS) SetSchema(s *schema.Schema) {
-	cs.Schema = s
+type levelBuilder struct {
+	ccs      compiled.R1CS
+	nbInputs int
+
+	mWireToNode map[int]int // at which node we resolved which wire
+	nodeLevels  []int       // level per node
+	mLevels     map[int]int // number of constraint per level
+
+	nodeLevel int // current level
+}
+
+func (b *levelBuilder) processLE(l compiled.LinearExpression, cID int) {
+
+	for _, t := range l {
+		wID := t.WireID()
+		if wID < b.nbInputs {
+			// it's a input, we ignore it
+			continue
+		}
+
+		// if we know a which constraint solves this wire, then it's a dependency
+		n, ok := b.mWireToNode[wID]
+		if ok {
+			if n != cID { // can happen with hints...
+				// we add a dependency, check if we need to increment our current level
+				if b.nodeLevels[n] >= b.nodeLevel {
+					b.nodeLevel = b.nodeLevels[n] + 1 // we are at the next level at least since we depend on it
+				}
+			}
+			continue
+		}
+
+		// check if it's a hint and mark all the output wires
+		if h, ok := b.ccs.MHints[wID]; ok {
+
+			for _, in := range h.Inputs {
+				switch t := in.(type) {
+				case compiled.Variable:
+					b.processLE(t.LinExp, cID)
+				case compiled.LinearExpression:
+					b.processLE(t, cID)
+				case compiled.Term:
+					b.processLE(compiled.LinearExpression{t}, cID)
+				}
+			}
+
+			for _, hwid := range h.Wires {
+				b.mWireToNode[hwid] = cID
+			}
+			continue
+		}
+
+		// mark this wire solved by current node
+		b.mWireToNode[wID] = cID
+	}
 }

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -137,9 +137,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 						if dID, ok := cs.MDebug[i]; ok {
 							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							err = fmt.Errorf("%w - %s", err, debugInfoStr)
 						}
-						chError <- err
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 						wg.Done()
 						return
 					}
@@ -167,9 +167,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 					if dID, ok := cs.MDebug[int(i)]; ok {
 						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						err = fmt.Errorf("%w - %s", err, debugInfoStr)
 					}
-					return err
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 				}
 			}
 			continue

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -22,9 +22,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -33,7 +31,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 
@@ -96,7 +93,18 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	if err := cs.parallelSolve(a, b, c, &solution); err != nil {
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+			if dID, ok := cs.MDebug[i]; ok {
+				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+				err = fmt.Errorf("%w - %s", err, debugInfoStr)
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -106,117 +114,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	}
 
 	return solution.values, nil
-}
-
-func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-						if dID, ok := cs.MDebug[i]; ok {
-							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w - %s", err, debugInfoStr)
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-					if dID, ok := cs.MDebug[int(i)]; ok {
-						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w - %s", err, debugInfoStr)
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -19,11 +19,12 @@ package cs
 import (
 	"errors"
 	"fmt"
+	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
+	"runtime"
 	"strings"
-
-	"github.com/fxamacker/cbor/v2"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -32,6 +33,7 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 
@@ -70,11 +72,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}
@@ -93,45 +90,117 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness) + 1
+	solution.nbSolved += uint64(len(witness) + 1)
 
 	// now that we know all inputs are set, defer log printing once all solution.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	// check if there is an inconsistant constraint
-	var check fr.Element
-	var solved bool
+	if len(cs.Levels) != 0 {
 
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-	for i := 0; i < len(cs.Constraints); i++ {
-		// solve the constraint, this will compute the missing wire of the gate
-		solved, a[i], b[i], c[i], err = cs.solveConstraint(cs.Constraints[i], &solution)
-		if err != nil {
-			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
-			}
-			return solution.values, err
+		var wg sync.WaitGroup
+		chTasks := make(chan []int, runtime.NumCPU())
+		chError := make(chan error, runtime.NumCPU())
+
+		// start a pool
+		for i := 0; i < runtime.NumCPU(); i++ {
+			go func() {
+				for t := range chTasks {
+					for _, i := range t {
+						if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+							if dID, ok := cs.MDebug[i]; ok {
+								debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+								err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							}
+							chError <- err
+							wg.Done()
+							return
+						}
+					}
+					wg.Done()
+				}
+			}()
 		}
 
-		if solved {
-			// a[i] * b[i] == c[i], since we just computed it.
-			continue
-		}
+		// for each level, we push the tasks
+		for _, level := range cs.Levels {
 
-		// ensure a[i] * b[i] == c[i]
-		check.Mul(&a[i], &b[i])
-		if !check.Equal(&c[i]) {
-			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
+			const minWorkPerCPU = 50.0
+
+			// max CPU to use
+			maxCPU := float64(len(level)) / minWorkPerCPU
+			if maxCPU <= 1.0 {
+				// we do it sequentially
+				for _, n := range level {
+					i := n
+					if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+						if dID, ok := cs.MDebug[int(i)]; ok {
+							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						}
+
+						close(chTasks)
+						close(chError)
+						return solution.values, err
+					}
+				}
+				continue
 			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+
+			nbTasks := runtime.NumCPU()
+			mm := int(math.Ceil(maxCPU))
+			if nbTasks > mm {
+				nbTasks = mm
+			}
+			nbIterationsPerCpus := len(level) / nbTasks
+
+			// more CPUs than tasks: a CPU will work on exactly one iteration
+			if nbIterationsPerCpus < 1 {
+				nbIterationsPerCpus = 1
+				nbTasks = len(level)
+			}
+
+			extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+			extraTasksOffset := 0
+
+			for i := 0; i < nbTasks; i++ {
+				wg.Add(1)
+				_start := i*nbIterationsPerCpus + extraTasksOffset
+				_end := _start + nbIterationsPerCpus
+				if extraTasks > 0 {
+					_end++
+					extraTasks--
+					extraTasksOffset++
+				}
+				chTasks <- level[_start:_end]
+			}
+
+			wg.Wait()
+			if len(chError) > 0 {
+				close(chTasks)
+				close(chError)
+				return solution.values, <-chError
+			}
+		}
+		close(chTasks)
+		close(chError)
+
+	} else {
+
+		// for each constraint
+		// we are guaranteed that each R1C contains at most one unsolved wire
+		// first we solve the unsolved wire (if any)
+		// then we check that the constraint is valid
+		// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
+		for i := 0; i < len(cs.Constraints); i++ {
+			// solve the constraint, this will compute the missing wire of the gate
+			if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+				if dID, ok := cs.MDebug[i]; ok {
+					debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+					return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
+				}
+				return solution.values, err
+			}
 		}
 	}
 
@@ -183,7 +252,7 @@ func (cs *R1CS) divByCoeff(res *fr.Element, t compiled.Term) {
 // returns false, nil if there was no wire to solve
 // returns true, nil if exactly one wire was solved. In that case, it is redundant to check that
 // the constraint is satisfied later.
-func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool, a, b, c fr.Element, err error) {
+func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution, a, b, c *fr.Element) error {
 
 	// the index of the non zero entry shows if L, R or O has an uninstantiated wire
 	// the content is the ID of the wire non instantiated
@@ -220,28 +289,31 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 		return nil
 	}
 
-	if err = processLExp(r.L.LinExp, &a, 1); err != nil {
-		return
+	if err := processLExp(r.L.LinExp, a, 1); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.R.LinExp, &b, 2); err != nil {
-		return
+	if err := processLExp(r.R.LinExp, b, 2); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.O.LinExp, &c, 3); err != nil {
-		return
+	if err := processLExp(r.O.LinExp, c, 3); err != nil {
+		return err
 	}
 
 	if loc == 0 {
 		// there is nothing to solve, may happen if we have an assertion
 		// (ie a constraints that doesn't yield any output)
 		// or if we solved the unsolved wires with hint functions
-		return
+		var check fr.Element
+		if !check.Mul(a, b).Equal(c) {
+			return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+		}
+		return nil
 	}
 
 	// we compute the wire value and instantiate it
-	solved = true
-	vID := termToCompute.WireID()
+	wID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -249,36 +321,41 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 	switch loc {
 	case 1:
 		if !b.IsZero() {
-			wire.Div(&c, &b).
-				Sub(&wire, &a)
-			a.Add(&a, &wire)
+			wire.Div(c, b).
+				Sub(&wire, a)
+			a.Add(a, &wire)
 		} else {
 			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 2:
 		if !a.IsZero() {
-			wire.Div(&c, &a).
-				Sub(&wire, &b)
-			b.Add(&b, &wire)
+			wire.Div(c, a).
+				Sub(&wire, b)
+			b.Add(b, &wire)
 		} else {
-			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 3:
-		wire.Mul(&a, &b).
-			Sub(&wire, &c)
+		wire.Mul(a, b).
+			Sub(&wire, c)
 
-		c.Add(&c, &wire)
+		c.Add(c, &wire)
 	}
 
 	// wire is the term (coeff * value)
 	// but in the solution we want to store the value only
 	// note that in gnark frontend, coeff here is always 1 or -1
 	cs.divByCoeff(&wire, termToCompute)
-	solution.set(vID, wire)
+	solution.set(wID, wire)
 
-	return
+	return nil
 }
 
 // GetConstraints return a list of constraint formatted as L⋅R == O

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -84,11 +84,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {
@@ -97,7 +92,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness)
+	solution.nbSolved += uint64(len(witness))
 
 	// defer log printing once all solution.values are computed
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -21,9 +21,12 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"math"
 	"math/big"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -103,18 +106,8 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	// loop through the constraints to solve the variables
-	for i := 0; i < len(cs.Constraints); i++ {
-		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
-			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
-		}
-		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
-			errMsg := err.Error()
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
-			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-		}
+	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+		return solution.values, err
 	}
 
 	// sanity check; ensure all wires are marked as "instantiated"
@@ -124,6 +117,120 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
+}
+
+func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					// for each constraint in the task, solve it.
+					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+						wg.Done()
+						return
+					}
+					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+						errMsg := err.Error()
+						if dID, ok := cs.MDebug[i]; ok {
+							errMsg = solution.logValue(cs.DebugInfo[dID])
+						}
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range cs.Levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+				}
+				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+					errMsg := err.Error()
+					if dID, ok := cs.MDebug[i]; ok {
+						errMsg = solution.logValue(cs.DebugInfo[dID])
+					}
+					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -21,12 +21,9 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
-	"math"
 	"math/big"
 	"os"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -106,7 +103,23 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+	// solve the constraint in parallel
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
+			if dID, ok := cs.MDebug[i]; ok {
+				errMsg = solution.logValue(cs.DebugInfo[dID])
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -117,120 +130,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
-}
-
-func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-						errMsg := err.Error()
-						if dID, ok := cs.MDebug[i]; ok {
-							errMsg = solution.logValue(cs.DebugInfo[dID])
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-					errMsg := err.Error()
-					if dID, ok := cs.MDebug[i]; ok {
-						errMsg = solution.logValue(cs.DebugInfo[dID])
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend/schema"
@@ -37,9 +38,8 @@ import (
 type solution struct {
 	values, coefficients []fr.Element
 	solved               []bool
-	nbSolved             int
+	nbSolved             uint64
 	mHintsFunctions      map[hint.ID]hint.Function
-	tmpHintsIO           []*big.Int
 }
 
 func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
@@ -49,7 +49,6 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		coefficients:    coefficients,
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
-		tmpHintsIO:      make([]*big.Int, 0),
 	}
 
 	for _, h := range hintFunctions {
@@ -68,11 +67,12 @@ func (s *solution) set(id int, value fr.Element) {
 	}
 	s.values[id] = value
 	s.solved[id] = true
-	s.nbSolved++
+	atomic.AddUint64(&s.nbSolved, 1)
+	// s.nbSolved++
 }
 
 func (s *solution) isValid() bool {
-	return s.nbSolved == len(s.values)
+	return int(s.nbSolved) == len(s.values)
 }
 
 // computeTerm computes coef*variable
@@ -147,15 +147,21 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
 	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
-	m := len(s.tmpHintsIO)
-	if m < (nbInputs + nbOutputs) {
-		s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs+nbInputs)-m)...)
-		for i := m; i < len(s.tmpHintsIO); i++ {
-			s.tmpHintsIO[i] = big.NewInt(0)
-		}
+	// m := len(s.tmpHintsIO)
+	// if m < (nbInputs + nbOutputs) {
+	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)
+	// 	for i := m; i < len(s.tmpHintsIO); i++ {
+	// 		s.tmpHintsIO[i] = big.NewInt(0)
+	// 	}
+	// }
+	inputs := make([]*big.Int, nbInputs)
+	outputs := make([]*big.Int, nbOutputs)
+	for i := 0; i < nbInputs; i++ {
+		inputs[i] = big.NewInt(0)
 	}
-	inputs := s.tmpHintsIO[:nbInputs]
-	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
+	for i := 0; i < nbOutputs; i++ {
+		outputs[i] = big.NewInt(0)
+	}
 
 	q := fr.Modulus()
 

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
+	"runtime"
+	"sync"
 	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -272,4 +275,101 @@ func (s *solution) logValue(log compiled.LogEntry) string {
 		}
 	}
 	return fmt.Sprintf(log.Format, toResolve...)
+}
+
+func parallelSolve(levels [][]int, solveConstraint func(cID int) error) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					if err := solveConstraint(i); err != nil {
+						chError <- err
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := solveConstraint(i); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -36,6 +36,8 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-377"
 )
 
+var errUnsatisfiedConstraint = errors.New("unsatisfied constraint")
+
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -137,9 +137,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 						if dID, ok := cs.MDebug[i]; ok {
 							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							err = fmt.Errorf("%w - %s", err, debugInfoStr)
 						}
-						chError <- err
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 						wg.Done()
 						return
 					}
@@ -167,9 +167,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 					if dID, ok := cs.MDebug[int(i)]; ok {
 						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						err = fmt.Errorf("%w - %s", err, debugInfoStr)
 					}
-					return err
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 				}
 			}
 			continue

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -19,11 +19,12 @@ package cs
 import (
 	"errors"
 	"fmt"
+	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
+	"runtime"
 	"strings"
-
-	"github.com/fxamacker/cbor/v2"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -32,6 +33,7 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 
@@ -70,11 +72,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}
@@ -93,45 +90,117 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness) + 1
+	solution.nbSolved += uint64(len(witness) + 1)
 
 	// now that we know all inputs are set, defer log printing once all solution.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	// check if there is an inconsistant constraint
-	var check fr.Element
-	var solved bool
+	if len(cs.Levels) != 0 {
 
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-	for i := 0; i < len(cs.Constraints); i++ {
-		// solve the constraint, this will compute the missing wire of the gate
-		solved, a[i], b[i], c[i], err = cs.solveConstraint(cs.Constraints[i], &solution)
-		if err != nil {
-			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
-			}
-			return solution.values, err
+		var wg sync.WaitGroup
+		chTasks := make(chan []int, runtime.NumCPU())
+		chError := make(chan error, runtime.NumCPU())
+
+		// start a pool
+		for i := 0; i < runtime.NumCPU(); i++ {
+			go func() {
+				for t := range chTasks {
+					for _, i := range t {
+						if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+							if dID, ok := cs.MDebug[i]; ok {
+								debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+								err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							}
+							chError <- err
+							wg.Done()
+							return
+						}
+					}
+					wg.Done()
+				}
+			}()
 		}
 
-		if solved {
-			// a[i] * b[i] == c[i], since we just computed it.
-			continue
-		}
+		// for each level, we push the tasks
+		for _, level := range cs.Levels {
 
-		// ensure a[i] * b[i] == c[i]
-		check.Mul(&a[i], &b[i])
-		if !check.Equal(&c[i]) {
-			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
+			const minWorkPerCPU = 50.0
+
+			// max CPU to use
+			maxCPU := float64(len(level)) / minWorkPerCPU
+			if maxCPU <= 1.0 {
+				// we do it sequentially
+				for _, n := range level {
+					i := n
+					if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+						if dID, ok := cs.MDebug[int(i)]; ok {
+							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						}
+
+						close(chTasks)
+						close(chError)
+						return solution.values, err
+					}
+				}
+				continue
 			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+
+			nbTasks := runtime.NumCPU()
+			mm := int(math.Ceil(maxCPU))
+			if nbTasks > mm {
+				nbTasks = mm
+			}
+			nbIterationsPerCpus := len(level) / nbTasks
+
+			// more CPUs than tasks: a CPU will work on exactly one iteration
+			if nbIterationsPerCpus < 1 {
+				nbIterationsPerCpus = 1
+				nbTasks = len(level)
+			}
+
+			extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+			extraTasksOffset := 0
+
+			for i := 0; i < nbTasks; i++ {
+				wg.Add(1)
+				_start := i*nbIterationsPerCpus + extraTasksOffset
+				_end := _start + nbIterationsPerCpus
+				if extraTasks > 0 {
+					_end++
+					extraTasks--
+					extraTasksOffset++
+				}
+				chTasks <- level[_start:_end]
+			}
+
+			wg.Wait()
+			if len(chError) > 0 {
+				close(chTasks)
+				close(chError)
+				return solution.values, <-chError
+			}
+		}
+		close(chTasks)
+		close(chError)
+
+	} else {
+
+		// for each constraint
+		// we are guaranteed that each R1C contains at most one unsolved wire
+		// first we solve the unsolved wire (if any)
+		// then we check that the constraint is valid
+		// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
+		for i := 0; i < len(cs.Constraints); i++ {
+			// solve the constraint, this will compute the missing wire of the gate
+			if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+				if dID, ok := cs.MDebug[i]; ok {
+					debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+					return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
+				}
+				return solution.values, err
+			}
 		}
 	}
 
@@ -183,7 +252,7 @@ func (cs *R1CS) divByCoeff(res *fr.Element, t compiled.Term) {
 // returns false, nil if there was no wire to solve
 // returns true, nil if exactly one wire was solved. In that case, it is redundant to check that
 // the constraint is satisfied later.
-func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool, a, b, c fr.Element, err error) {
+func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution, a, b, c *fr.Element) error {
 
 	// the index of the non zero entry shows if L, R or O has an uninstantiated wire
 	// the content is the ID of the wire non instantiated
@@ -220,28 +289,31 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 		return nil
 	}
 
-	if err = processLExp(r.L.LinExp, &a, 1); err != nil {
-		return
+	if err := processLExp(r.L.LinExp, a, 1); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.R.LinExp, &b, 2); err != nil {
-		return
+	if err := processLExp(r.R.LinExp, b, 2); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.O.LinExp, &c, 3); err != nil {
-		return
+	if err := processLExp(r.O.LinExp, c, 3); err != nil {
+		return err
 	}
 
 	if loc == 0 {
 		// there is nothing to solve, may happen if we have an assertion
 		// (ie a constraints that doesn't yield any output)
 		// or if we solved the unsolved wires with hint functions
-		return
+		var check fr.Element
+		if !check.Mul(a, b).Equal(c) {
+			return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+		}
+		return nil
 	}
 
 	// we compute the wire value and instantiate it
-	solved = true
-	vID := termToCompute.WireID()
+	wID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -249,36 +321,41 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 	switch loc {
 	case 1:
 		if !b.IsZero() {
-			wire.Div(&c, &b).
-				Sub(&wire, &a)
-			a.Add(&a, &wire)
+			wire.Div(c, b).
+				Sub(&wire, a)
+			a.Add(a, &wire)
 		} else {
 			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 2:
 		if !a.IsZero() {
-			wire.Div(&c, &a).
-				Sub(&wire, &b)
-			b.Add(&b, &wire)
+			wire.Div(c, a).
+				Sub(&wire, b)
+			b.Add(b, &wire)
 		} else {
-			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 3:
-		wire.Mul(&a, &b).
-			Sub(&wire, &c)
+		wire.Mul(a, b).
+			Sub(&wire, c)
 
-		c.Add(&c, &wire)
+		c.Add(c, &wire)
 	}
 
 	// wire is the term (coeff * value)
 	// but in the solution we want to store the value only
 	// note that in gnark frontend, coeff here is always 1 or -1
 	cs.divByCoeff(&wire, termToCompute)
-	solution.set(vID, wire)
+	solution.set(wID, wire)
 
-	return
+	return nil
 }
 
 // GetConstraints return a list of constraint formatted as L⋅R == O

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -22,9 +22,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -33,7 +31,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 
@@ -96,7 +93,18 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	if err := cs.parallelSolve(a, b, c, &solution); err != nil {
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+			if dID, ok := cs.MDebug[i]; ok {
+				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+				err = fmt.Errorf("%w - %s", err, debugInfoStr)
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -106,117 +114,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	}
 
 	return solution.values, nil
-}
-
-func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-						if dID, ok := cs.MDebug[i]; ok {
-							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w - %s", err, debugInfoStr)
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-					if dID, ok := cs.MDebug[int(i)]; ok {
-						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w - %s", err, debugInfoStr)
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -84,11 +84,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {
@@ -97,7 +92,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness)
+	solution.nbSolved += uint64(len(witness))
 
 	// defer log printing once all solution.values are computed
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -21,9 +21,12 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"math"
 	"math/big"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -103,18 +106,8 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	// loop through the constraints to solve the variables
-	for i := 0; i < len(cs.Constraints); i++ {
-		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
-			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
-		}
-		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
-			errMsg := err.Error()
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
-			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-		}
+	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+		return solution.values, err
 	}
 
 	// sanity check; ensure all wires are marked as "instantiated"
@@ -124,6 +117,120 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
+}
+
+func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					// for each constraint in the task, solve it.
+					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+						wg.Done()
+						return
+					}
+					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+						errMsg := err.Error()
+						if dID, ok := cs.MDebug[i]; ok {
+							errMsg = solution.logValue(cs.DebugInfo[dID])
+						}
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range cs.Levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+				}
+				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+					errMsg := err.Error()
+					if dID, ok := cs.MDebug[i]; ok {
+						errMsg = solution.logValue(cs.DebugInfo[dID])
+					}
+					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -21,12 +21,9 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
-	"math"
 	"math/big"
 	"os"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -106,7 +103,23 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+	// solve the constraint in parallel
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
+			if dID, ok := cs.MDebug[i]; ok {
+				errMsg = solution.logValue(cs.DebugInfo[dID])
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -117,120 +130,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
-}
-
-func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-						errMsg := err.Error()
-						if dID, ok := cs.MDebug[i]; ok {
-							errMsg = solution.logValue(cs.DebugInfo[dID])
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-					errMsg := err.Error()
-					if dID, ok := cs.MDebug[i]; ok {
-						errMsg = solution.logValue(cs.DebugInfo[dID])
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -36,6 +36,8 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-381"
 )
 
+var errUnsatisfiedConstraint = errors.New("unsatisfied constraint")
+
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend/schema"
@@ -37,9 +38,8 @@ import (
 type solution struct {
 	values, coefficients []fr.Element
 	solved               []bool
-	nbSolved             int
+	nbSolved             uint64
 	mHintsFunctions      map[hint.ID]hint.Function
-	tmpHintsIO           []*big.Int
 }
 
 func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
@@ -49,7 +49,6 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		coefficients:    coefficients,
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
-		tmpHintsIO:      make([]*big.Int, 0),
 	}
 
 	for _, h := range hintFunctions {
@@ -68,11 +67,12 @@ func (s *solution) set(id int, value fr.Element) {
 	}
 	s.values[id] = value
 	s.solved[id] = true
-	s.nbSolved++
+	atomic.AddUint64(&s.nbSolved, 1)
+	// s.nbSolved++
 }
 
 func (s *solution) isValid() bool {
-	return s.nbSolved == len(s.values)
+	return int(s.nbSolved) == len(s.values)
 }
 
 // computeTerm computes coef*variable
@@ -147,15 +147,21 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
 	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
-	m := len(s.tmpHintsIO)
-	if m < (nbInputs + nbOutputs) {
-		s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs+nbInputs)-m)...)
-		for i := m; i < len(s.tmpHintsIO); i++ {
-			s.tmpHintsIO[i] = big.NewInt(0)
-		}
+	// m := len(s.tmpHintsIO)
+	// if m < (nbInputs + nbOutputs) {
+	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)
+	// 	for i := m; i < len(s.tmpHintsIO); i++ {
+	// 		s.tmpHintsIO[i] = big.NewInt(0)
+	// 	}
+	// }
+	inputs := make([]*big.Int, nbInputs)
+	outputs := make([]*big.Int, nbOutputs)
+	for i := 0; i < nbInputs; i++ {
+		inputs[i] = big.NewInt(0)
 	}
-	inputs := s.tmpHintsIO[:nbInputs]
-	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
+	for i := 0; i < nbOutputs; i++ {
+		outputs[i] = big.NewInt(0)
+	}
 
 	q := fr.Modulus()
 

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
+	"runtime"
+	"sync"
 	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -272,4 +275,101 @@ func (s *solution) logValue(log compiled.LogEntry) string {
 		}
 	}
 	return fmt.Sprintf(log.Format, toResolve...)
+}
+
+func parallelSolve(levels [][]int, solveConstraint func(cID int) error) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					if err := solveConstraint(i); err != nil {
+						chError <- err
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := solveConstraint(i); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -137,9 +137,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 						if dID, ok := cs.MDebug[i]; ok {
 							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							err = fmt.Errorf("%w - %s", err, debugInfoStr)
 						}
-						chError <- err
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 						wg.Done()
 						return
 					}
@@ -167,9 +167,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 					if dID, ok := cs.MDebug[int(i)]; ok {
 						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						err = fmt.Errorf("%w - %s", err, debugInfoStr)
 					}
-					return err
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 				}
 			}
 			continue

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -19,11 +19,12 @@ package cs
 import (
 	"errors"
 	"fmt"
+	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
+	"runtime"
 	"strings"
-
-	"github.com/fxamacker/cbor/v2"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -32,6 +33,7 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 
@@ -70,11 +72,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}
@@ -93,45 +90,117 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness) + 1
+	solution.nbSolved += uint64(len(witness) + 1)
 
 	// now that we know all inputs are set, defer log printing once all solution.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	// check if there is an inconsistant constraint
-	var check fr.Element
-	var solved bool
+	if len(cs.Levels) != 0 {
 
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-	for i := 0; i < len(cs.Constraints); i++ {
-		// solve the constraint, this will compute the missing wire of the gate
-		solved, a[i], b[i], c[i], err = cs.solveConstraint(cs.Constraints[i], &solution)
-		if err != nil {
-			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
-			}
-			return solution.values, err
+		var wg sync.WaitGroup
+		chTasks := make(chan []int, runtime.NumCPU())
+		chError := make(chan error, runtime.NumCPU())
+
+		// start a pool
+		for i := 0; i < runtime.NumCPU(); i++ {
+			go func() {
+				for t := range chTasks {
+					for _, i := range t {
+						if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+							if dID, ok := cs.MDebug[i]; ok {
+								debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+								err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							}
+							chError <- err
+							wg.Done()
+							return
+						}
+					}
+					wg.Done()
+				}
+			}()
 		}
 
-		if solved {
-			// a[i] * b[i] == c[i], since we just computed it.
-			continue
-		}
+		// for each level, we push the tasks
+		for _, level := range cs.Levels {
 
-		// ensure a[i] * b[i] == c[i]
-		check.Mul(&a[i], &b[i])
-		if !check.Equal(&c[i]) {
-			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
+			const minWorkPerCPU = 50.0
+
+			// max CPU to use
+			maxCPU := float64(len(level)) / minWorkPerCPU
+			if maxCPU <= 1.0 {
+				// we do it sequentially
+				for _, n := range level {
+					i := n
+					if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+						if dID, ok := cs.MDebug[int(i)]; ok {
+							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						}
+
+						close(chTasks)
+						close(chError)
+						return solution.values, err
+					}
+				}
+				continue
 			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+
+			nbTasks := runtime.NumCPU()
+			mm := int(math.Ceil(maxCPU))
+			if nbTasks > mm {
+				nbTasks = mm
+			}
+			nbIterationsPerCpus := len(level) / nbTasks
+
+			// more CPUs than tasks: a CPU will work on exactly one iteration
+			if nbIterationsPerCpus < 1 {
+				nbIterationsPerCpus = 1
+				nbTasks = len(level)
+			}
+
+			extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+			extraTasksOffset := 0
+
+			for i := 0; i < nbTasks; i++ {
+				wg.Add(1)
+				_start := i*nbIterationsPerCpus + extraTasksOffset
+				_end := _start + nbIterationsPerCpus
+				if extraTasks > 0 {
+					_end++
+					extraTasks--
+					extraTasksOffset++
+				}
+				chTasks <- level[_start:_end]
+			}
+
+			wg.Wait()
+			if len(chError) > 0 {
+				close(chTasks)
+				close(chError)
+				return solution.values, <-chError
+			}
+		}
+		close(chTasks)
+		close(chError)
+
+	} else {
+
+		// for each constraint
+		// we are guaranteed that each R1C contains at most one unsolved wire
+		// first we solve the unsolved wire (if any)
+		// then we check that the constraint is valid
+		// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
+		for i := 0; i < len(cs.Constraints); i++ {
+			// solve the constraint, this will compute the missing wire of the gate
+			if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+				if dID, ok := cs.MDebug[i]; ok {
+					debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+					return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
+				}
+				return solution.values, err
+			}
 		}
 	}
 
@@ -183,7 +252,7 @@ func (cs *R1CS) divByCoeff(res *fr.Element, t compiled.Term) {
 // returns false, nil if there was no wire to solve
 // returns true, nil if exactly one wire was solved. In that case, it is redundant to check that
 // the constraint is satisfied later.
-func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool, a, b, c fr.Element, err error) {
+func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution, a, b, c *fr.Element) error {
 
 	// the index of the non zero entry shows if L, R or O has an uninstantiated wire
 	// the content is the ID of the wire non instantiated
@@ -220,28 +289,31 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 		return nil
 	}
 
-	if err = processLExp(r.L.LinExp, &a, 1); err != nil {
-		return
+	if err := processLExp(r.L.LinExp, a, 1); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.R.LinExp, &b, 2); err != nil {
-		return
+	if err := processLExp(r.R.LinExp, b, 2); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.O.LinExp, &c, 3); err != nil {
-		return
+	if err := processLExp(r.O.LinExp, c, 3); err != nil {
+		return err
 	}
 
 	if loc == 0 {
 		// there is nothing to solve, may happen if we have an assertion
 		// (ie a constraints that doesn't yield any output)
 		// or if we solved the unsolved wires with hint functions
-		return
+		var check fr.Element
+		if !check.Mul(a, b).Equal(c) {
+			return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+		}
+		return nil
 	}
 
 	// we compute the wire value and instantiate it
-	solved = true
-	vID := termToCompute.WireID()
+	wID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -249,36 +321,41 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 	switch loc {
 	case 1:
 		if !b.IsZero() {
-			wire.Div(&c, &b).
-				Sub(&wire, &a)
-			a.Add(&a, &wire)
+			wire.Div(c, b).
+				Sub(&wire, a)
+			a.Add(a, &wire)
 		} else {
 			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 2:
 		if !a.IsZero() {
-			wire.Div(&c, &a).
-				Sub(&wire, &b)
-			b.Add(&b, &wire)
+			wire.Div(c, a).
+				Sub(&wire, b)
+			b.Add(b, &wire)
 		} else {
-			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 3:
-		wire.Mul(&a, &b).
-			Sub(&wire, &c)
+		wire.Mul(a, b).
+			Sub(&wire, c)
 
-		c.Add(&c, &wire)
+		c.Add(c, &wire)
 	}
 
 	// wire is the term (coeff * value)
 	// but in the solution we want to store the value only
 	// note that in gnark frontend, coeff here is always 1 or -1
 	cs.divByCoeff(&wire, termToCompute)
-	solution.set(vID, wire)
+	solution.set(wID, wire)
 
-	return
+	return nil
 }
 
 // GetConstraints return a list of constraint formatted as L⋅R == O

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -22,9 +22,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -33,7 +31,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 
@@ -96,7 +93,18 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	if err := cs.parallelSolve(a, b, c, &solution); err != nil {
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+			if dID, ok := cs.MDebug[i]; ok {
+				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+				err = fmt.Errorf("%w - %s", err, debugInfoStr)
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -106,117 +114,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	}
 
 	return solution.values, nil
-}
-
-func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-						if dID, ok := cs.MDebug[i]; ok {
-							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w - %s", err, debugInfoStr)
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-					if dID, ok := cs.MDebug[int(i)]; ok {
-						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w - %s", err, debugInfoStr)
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -84,11 +84,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {
@@ -97,7 +92,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness)
+	solution.nbSolved += uint64(len(witness))
 
 	// defer log printing once all solution.values are computed
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -21,9 +21,12 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"math"
 	"math/big"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -103,18 +106,8 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	// loop through the constraints to solve the variables
-	for i := 0; i < len(cs.Constraints); i++ {
-		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
-			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
-		}
-		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
-			errMsg := err.Error()
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
-			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-		}
+	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+		return solution.values, err
 	}
 
 	// sanity check; ensure all wires are marked as "instantiated"
@@ -124,6 +117,120 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
+}
+
+func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					// for each constraint in the task, solve it.
+					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+						wg.Done()
+						return
+					}
+					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+						errMsg := err.Error()
+						if dID, ok := cs.MDebug[i]; ok {
+							errMsg = solution.logValue(cs.DebugInfo[dID])
+						}
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range cs.Levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+				}
+				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+					errMsg := err.Error()
+					if dID, ok := cs.MDebug[i]; ok {
+						errMsg = solution.logValue(cs.DebugInfo[dID])
+					}
+					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -21,12 +21,9 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
-	"math"
 	"math/big"
 	"os"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -106,7 +103,23 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+	// solve the constraint in parallel
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
+			if dID, ok := cs.MDebug[i]; ok {
+				errMsg = solution.logValue(cs.DebugInfo[dID])
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -117,120 +130,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
-}
-
-func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-						errMsg := err.Error()
-						if dID, ok := cs.MDebug[i]; ok {
-							errMsg = solution.logValue(cs.DebugInfo[dID])
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-					errMsg := err.Error()
-					if dID, ok := cs.MDebug[i]; ok {
-						errMsg = solution.logValue(cs.DebugInfo[dID])
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -36,6 +36,8 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-315"
 )
 
+var errUnsatisfiedConstraint = errors.New("unsatisfied constraint")
+
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend/schema"
@@ -37,9 +38,8 @@ import (
 type solution struct {
 	values, coefficients []fr.Element
 	solved               []bool
-	nbSolved             int
+	nbSolved             uint64
 	mHintsFunctions      map[hint.ID]hint.Function
-	tmpHintsIO           []*big.Int
 }
 
 func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
@@ -49,7 +49,6 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		coefficients:    coefficients,
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
-		tmpHintsIO:      make([]*big.Int, 0),
 	}
 
 	for _, h := range hintFunctions {
@@ -68,11 +67,12 @@ func (s *solution) set(id int, value fr.Element) {
 	}
 	s.values[id] = value
 	s.solved[id] = true
-	s.nbSolved++
+	atomic.AddUint64(&s.nbSolved, 1)
+	// s.nbSolved++
 }
 
 func (s *solution) isValid() bool {
-	return s.nbSolved == len(s.values)
+	return int(s.nbSolved) == len(s.values)
 }
 
 // computeTerm computes coef*variable
@@ -147,15 +147,21 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
 	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
-	m := len(s.tmpHintsIO)
-	if m < (nbInputs + nbOutputs) {
-		s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs+nbInputs)-m)...)
-		for i := m; i < len(s.tmpHintsIO); i++ {
-			s.tmpHintsIO[i] = big.NewInt(0)
-		}
+	// m := len(s.tmpHintsIO)
+	// if m < (nbInputs + nbOutputs) {
+	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)
+	// 	for i := m; i < len(s.tmpHintsIO); i++ {
+	// 		s.tmpHintsIO[i] = big.NewInt(0)
+	// 	}
+	// }
+	inputs := make([]*big.Int, nbInputs)
+	outputs := make([]*big.Int, nbOutputs)
+	for i := 0; i < nbInputs; i++ {
+		inputs[i] = big.NewInt(0)
 	}
-	inputs := s.tmpHintsIO[:nbInputs]
-	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
+	for i := 0; i < nbOutputs; i++ {
+		outputs[i] = big.NewInt(0)
+	}
 
 	q := fr.Modulus()
 

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
+	"runtime"
+	"sync"
 	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -272,4 +275,101 @@ func (s *solution) logValue(log compiled.LogEntry) string {
 		}
 	}
 	return fmt.Sprintf(log.Format, toResolve...)
+}
+
+func parallelSolve(levels [][]int, solveConstraint func(cID int) error) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					if err := solveConstraint(i); err != nil {
+						chError <- err
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := solveConstraint(i); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -137,9 +137,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 						if dID, ok := cs.MDebug[i]; ok {
 							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							err = fmt.Errorf("%w - %s", err, debugInfoStr)
 						}
-						chError <- err
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 						wg.Done()
 						return
 					}
@@ -167,9 +167,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 					if dID, ok := cs.MDebug[int(i)]; ok {
 						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						err = fmt.Errorf("%w - %s", err, debugInfoStr)
 					}
-					return err
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 				}
 			}
 			continue

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -19,11 +19,12 @@ package cs
 import (
 	"errors"
 	"fmt"
+	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
+	"runtime"
 	"strings"
-
-	"github.com/fxamacker/cbor/v2"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -32,6 +33,7 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 
@@ -70,11 +72,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}
@@ -93,45 +90,117 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness) + 1
+	solution.nbSolved += uint64(len(witness) + 1)
 
 	// now that we know all inputs are set, defer log printing once all solution.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	// check if there is an inconsistant constraint
-	var check fr.Element
-	var solved bool
+	if len(cs.Levels) != 0 {
 
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-	for i := 0; i < len(cs.Constraints); i++ {
-		// solve the constraint, this will compute the missing wire of the gate
-		solved, a[i], b[i], c[i], err = cs.solveConstraint(cs.Constraints[i], &solution)
-		if err != nil {
-			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
-			}
-			return solution.values, err
+		var wg sync.WaitGroup
+		chTasks := make(chan []int, runtime.NumCPU())
+		chError := make(chan error, runtime.NumCPU())
+
+		// start a pool
+		for i := 0; i < runtime.NumCPU(); i++ {
+			go func() {
+				for t := range chTasks {
+					for _, i := range t {
+						if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+							if dID, ok := cs.MDebug[i]; ok {
+								debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+								err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							}
+							chError <- err
+							wg.Done()
+							return
+						}
+					}
+					wg.Done()
+				}
+			}()
 		}
 
-		if solved {
-			// a[i] * b[i] == c[i], since we just computed it.
-			continue
-		}
+		// for each level, we push the tasks
+		for _, level := range cs.Levels {
 
-		// ensure a[i] * b[i] == c[i]
-		check.Mul(&a[i], &b[i])
-		if !check.Equal(&c[i]) {
-			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
+			const minWorkPerCPU = 50.0
+
+			// max CPU to use
+			maxCPU := float64(len(level)) / minWorkPerCPU
+			if maxCPU <= 1.0 {
+				// we do it sequentially
+				for _, n := range level {
+					i := n
+					if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+						if dID, ok := cs.MDebug[int(i)]; ok {
+							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						}
+
+						close(chTasks)
+						close(chError)
+						return solution.values, err
+					}
+				}
+				continue
 			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+
+			nbTasks := runtime.NumCPU()
+			mm := int(math.Ceil(maxCPU))
+			if nbTasks > mm {
+				nbTasks = mm
+			}
+			nbIterationsPerCpus := len(level) / nbTasks
+
+			// more CPUs than tasks: a CPU will work on exactly one iteration
+			if nbIterationsPerCpus < 1 {
+				nbIterationsPerCpus = 1
+				nbTasks = len(level)
+			}
+
+			extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+			extraTasksOffset := 0
+
+			for i := 0; i < nbTasks; i++ {
+				wg.Add(1)
+				_start := i*nbIterationsPerCpus + extraTasksOffset
+				_end := _start + nbIterationsPerCpus
+				if extraTasks > 0 {
+					_end++
+					extraTasks--
+					extraTasksOffset++
+				}
+				chTasks <- level[_start:_end]
+			}
+
+			wg.Wait()
+			if len(chError) > 0 {
+				close(chTasks)
+				close(chError)
+				return solution.values, <-chError
+			}
+		}
+		close(chTasks)
+		close(chError)
+
+	} else {
+
+		// for each constraint
+		// we are guaranteed that each R1C contains at most one unsolved wire
+		// first we solve the unsolved wire (if any)
+		// then we check that the constraint is valid
+		// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
+		for i := 0; i < len(cs.Constraints); i++ {
+			// solve the constraint, this will compute the missing wire of the gate
+			if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+				if dID, ok := cs.MDebug[i]; ok {
+					debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+					return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
+				}
+				return solution.values, err
+			}
 		}
 	}
 
@@ -183,7 +252,7 @@ func (cs *R1CS) divByCoeff(res *fr.Element, t compiled.Term) {
 // returns false, nil if there was no wire to solve
 // returns true, nil if exactly one wire was solved. In that case, it is redundant to check that
 // the constraint is satisfied later.
-func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool, a, b, c fr.Element, err error) {
+func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution, a, b, c *fr.Element) error {
 
 	// the index of the non zero entry shows if L, R or O has an uninstantiated wire
 	// the content is the ID of the wire non instantiated
@@ -220,28 +289,31 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 		return nil
 	}
 
-	if err = processLExp(r.L.LinExp, &a, 1); err != nil {
-		return
+	if err := processLExp(r.L.LinExp, a, 1); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.R.LinExp, &b, 2); err != nil {
-		return
+	if err := processLExp(r.R.LinExp, b, 2); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.O.LinExp, &c, 3); err != nil {
-		return
+	if err := processLExp(r.O.LinExp, c, 3); err != nil {
+		return err
 	}
 
 	if loc == 0 {
 		// there is nothing to solve, may happen if we have an assertion
 		// (ie a constraints that doesn't yield any output)
 		// or if we solved the unsolved wires with hint functions
-		return
+		var check fr.Element
+		if !check.Mul(a, b).Equal(c) {
+			return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+		}
+		return nil
 	}
 
 	// we compute the wire value and instantiate it
-	solved = true
-	vID := termToCompute.WireID()
+	wID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -249,36 +321,41 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 	switch loc {
 	case 1:
 		if !b.IsZero() {
-			wire.Div(&c, &b).
-				Sub(&wire, &a)
-			a.Add(&a, &wire)
+			wire.Div(c, b).
+				Sub(&wire, a)
+			a.Add(a, &wire)
 		} else {
 			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 2:
 		if !a.IsZero() {
-			wire.Div(&c, &a).
-				Sub(&wire, &b)
-			b.Add(&b, &wire)
+			wire.Div(c, a).
+				Sub(&wire, b)
+			b.Add(b, &wire)
 		} else {
-			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 3:
-		wire.Mul(&a, &b).
-			Sub(&wire, &c)
+		wire.Mul(a, b).
+			Sub(&wire, c)
 
-		c.Add(&c, &wire)
+		c.Add(c, &wire)
 	}
 
 	// wire is the term (coeff * value)
 	// but in the solution we want to store the value only
 	// note that in gnark frontend, coeff here is always 1 or -1
 	cs.divByCoeff(&wire, termToCompute)
-	solution.set(vID, wire)
+	solution.set(wID, wire)
 
-	return
+	return nil
 }
 
 // GetConstraints return a list of constraint formatted as L⋅R == O

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -22,9 +22,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -33,7 +31,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 
@@ -96,7 +93,18 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	if err := cs.parallelSolve(a, b, c, &solution); err != nil {
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+			if dID, ok := cs.MDebug[i]; ok {
+				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+				err = fmt.Errorf("%w - %s", err, debugInfoStr)
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -106,117 +114,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	}
 
 	return solution.values, nil
-}
-
-func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-						if dID, ok := cs.MDebug[i]; ok {
-							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w - %s", err, debugInfoStr)
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-					if dID, ok := cs.MDebug[int(i)]; ok {
-						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w - %s", err, debugInfoStr)
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -84,11 +84,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {
@@ -97,7 +92,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness)
+	solution.nbSolved += uint64(len(witness))
 
 	// defer log printing once all solution.values are computed
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -21,9 +21,12 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"math"
 	"math/big"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -103,18 +106,8 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	// loop through the constraints to solve the variables
-	for i := 0; i < len(cs.Constraints); i++ {
-		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
-			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
-		}
-		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
-			errMsg := err.Error()
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
-			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-		}
+	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+		return solution.values, err
 	}
 
 	// sanity check; ensure all wires are marked as "instantiated"
@@ -124,6 +117,120 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
+}
+
+func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					// for each constraint in the task, solve it.
+					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+						wg.Done()
+						return
+					}
+					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+						errMsg := err.Error()
+						if dID, ok := cs.MDebug[i]; ok {
+							errMsg = solution.logValue(cs.DebugInfo[dID])
+						}
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range cs.Levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+				}
+				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+					errMsg := err.Error()
+					if dID, ok := cs.MDebug[i]; ok {
+						errMsg = solution.logValue(cs.DebugInfo[dID])
+					}
+					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -21,12 +21,9 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
-	"math"
 	"math/big"
 	"os"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -106,7 +103,23 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+	// solve the constraint in parallel
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
+			if dID, ok := cs.MDebug[i]; ok {
+				errMsg = solution.logValue(cs.DebugInfo[dID])
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -117,120 +130,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
-}
-
-func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-						errMsg := err.Error()
-						if dID, ok := cs.MDebug[i]; ok {
-							errMsg = solution.logValue(cs.DebugInfo[dID])
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-					errMsg := err.Error()
-					if dID, ok := cs.MDebug[i]; ok {
-						errMsg = solution.logValue(cs.DebugInfo[dID])
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend/schema"
@@ -37,9 +38,8 @@ import (
 type solution struct {
 	values, coefficients []fr.Element
 	solved               []bool
-	nbSolved             int
+	nbSolved             uint64
 	mHintsFunctions      map[hint.ID]hint.Function
-	tmpHintsIO           []*big.Int
 }
 
 func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
@@ -49,7 +49,6 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		coefficients:    coefficients,
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
-		tmpHintsIO:      make([]*big.Int, 0),
 	}
 
 	for _, h := range hintFunctions {
@@ -68,11 +67,12 @@ func (s *solution) set(id int, value fr.Element) {
 	}
 	s.values[id] = value
 	s.solved[id] = true
-	s.nbSolved++
+	atomic.AddUint64(&s.nbSolved, 1)
+	// s.nbSolved++
 }
 
 func (s *solution) isValid() bool {
-	return s.nbSolved == len(s.values)
+	return int(s.nbSolved) == len(s.values)
 }
 
 // computeTerm computes coef*variable
@@ -147,15 +147,21 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
 	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
-	m := len(s.tmpHintsIO)
-	if m < (nbInputs + nbOutputs) {
-		s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs+nbInputs)-m)...)
-		for i := m; i < len(s.tmpHintsIO); i++ {
-			s.tmpHintsIO[i] = big.NewInt(0)
-		}
+	// m := len(s.tmpHintsIO)
+	// if m < (nbInputs + nbOutputs) {
+	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)
+	// 	for i := m; i < len(s.tmpHintsIO); i++ {
+	// 		s.tmpHintsIO[i] = big.NewInt(0)
+	// 	}
+	// }
+	inputs := make([]*big.Int, nbInputs)
+	outputs := make([]*big.Int, nbOutputs)
+	for i := 0; i < nbInputs; i++ {
+		inputs[i] = big.NewInt(0)
 	}
-	inputs := s.tmpHintsIO[:nbInputs]
-	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
+	for i := 0; i < nbOutputs; i++ {
+		outputs[i] = big.NewInt(0)
+	}
 
 	q := fr.Modulus()
 

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -36,6 +36,8 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
 )
 
+var errUnsatisfiedConstraint = errors.New("unsatisfied constraint")
+
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
+	"runtime"
+	"sync"
 	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -272,4 +275,101 @@ func (s *solution) logValue(log compiled.LogEntry) string {
 		}
 	}
 	return fmt.Sprintf(log.Format, toResolve...)
+}
+
+func parallelSolve(levels [][]int, solveConstraint func(cID int) error) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					if err := solveConstraint(i); err != nil {
+						chError <- err
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := solveConstraint(i); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -137,9 +137,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 						if dID, ok := cs.MDebug[i]; ok {
 							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							err = fmt.Errorf("%w - %s", err, debugInfoStr)
 						}
-						chError <- err
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 						wg.Done()
 						return
 					}
@@ -167,9 +167,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 					if dID, ok := cs.MDebug[int(i)]; ok {
 						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						err = fmt.Errorf("%w - %s", err, debugInfoStr)
 					}
-					return err
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 				}
 			}
 			continue

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -22,9 +22,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -33,7 +31,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 
@@ -96,7 +93,18 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	if err := cs.parallelSolve(a, b, c, &solution); err != nil {
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+			if dID, ok := cs.MDebug[i]; ok {
+				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+				err = fmt.Errorf("%w - %s", err, debugInfoStr)
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -106,117 +114,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	}
 
 	return solution.values, nil
-}
-
-func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-						if dID, ok := cs.MDebug[i]; ok {
-							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w - %s", err, debugInfoStr)
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-					if dID, ok := cs.MDebug[int(i)]; ok {
-						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w - %s", err, debugInfoStr)
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -19,11 +19,12 @@ package cs
 import (
 	"errors"
 	"fmt"
+	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
+	"runtime"
 	"strings"
-
-	"github.com/fxamacker/cbor/v2"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -32,6 +33,7 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 
@@ -70,11 +72,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}
@@ -93,45 +90,117 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness) + 1
+	solution.nbSolved += uint64(len(witness) + 1)
 
 	// now that we know all inputs are set, defer log printing once all solution.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	// check if there is an inconsistant constraint
-	var check fr.Element
-	var solved bool
+	if len(cs.Levels) != 0 {
 
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-	for i := 0; i < len(cs.Constraints); i++ {
-		// solve the constraint, this will compute the missing wire of the gate
-		solved, a[i], b[i], c[i], err = cs.solveConstraint(cs.Constraints[i], &solution)
-		if err != nil {
-			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
-			}
-			return solution.values, err
+		var wg sync.WaitGroup
+		chTasks := make(chan []int, runtime.NumCPU())
+		chError := make(chan error, runtime.NumCPU())
+
+		// start a pool
+		for i := 0; i < runtime.NumCPU(); i++ {
+			go func() {
+				for t := range chTasks {
+					for _, i := range t {
+						if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+							if dID, ok := cs.MDebug[i]; ok {
+								debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+								err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							}
+							chError <- err
+							wg.Done()
+							return
+						}
+					}
+					wg.Done()
+				}
+			}()
 		}
 
-		if solved {
-			// a[i] * b[i] == c[i], since we just computed it.
-			continue
-		}
+		// for each level, we push the tasks
+		for _, level := range cs.Levels {
 
-		// ensure a[i] * b[i] == c[i]
-		check.Mul(&a[i], &b[i])
-		if !check.Equal(&c[i]) {
-			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
+			const minWorkPerCPU = 50.0
+
+			// max CPU to use
+			maxCPU := float64(len(level)) / minWorkPerCPU
+			if maxCPU <= 1.0 {
+				// we do it sequentially
+				for _, n := range level {
+					i := n
+					if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+						if dID, ok := cs.MDebug[int(i)]; ok {
+							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						}
+
+						close(chTasks)
+						close(chError)
+						return solution.values, err
+					}
+				}
+				continue
 			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+
+			nbTasks := runtime.NumCPU()
+			mm := int(math.Ceil(maxCPU))
+			if nbTasks > mm {
+				nbTasks = mm
+			}
+			nbIterationsPerCpus := len(level) / nbTasks
+
+			// more CPUs than tasks: a CPU will work on exactly one iteration
+			if nbIterationsPerCpus < 1 {
+				nbIterationsPerCpus = 1
+				nbTasks = len(level)
+			}
+
+			extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+			extraTasksOffset := 0
+
+			for i := 0; i < nbTasks; i++ {
+				wg.Add(1)
+				_start := i*nbIterationsPerCpus + extraTasksOffset
+				_end := _start + nbIterationsPerCpus
+				if extraTasks > 0 {
+					_end++
+					extraTasks--
+					extraTasksOffset++
+				}
+				chTasks <- level[_start:_end]
+			}
+
+			wg.Wait()
+			if len(chError) > 0 {
+				close(chTasks)
+				close(chError)
+				return solution.values, <-chError
+			}
+		}
+		close(chTasks)
+		close(chError)
+
+	} else {
+
+		// for each constraint
+		// we are guaranteed that each R1C contains at most one unsolved wire
+		// first we solve the unsolved wire (if any)
+		// then we check that the constraint is valid
+		// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
+		for i := 0; i < len(cs.Constraints); i++ {
+			// solve the constraint, this will compute the missing wire of the gate
+			if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+				if dID, ok := cs.MDebug[i]; ok {
+					debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+					return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
+				}
+				return solution.values, err
+			}
 		}
 	}
 
@@ -183,7 +252,7 @@ func (cs *R1CS) divByCoeff(res *fr.Element, t compiled.Term) {
 // returns false, nil if there was no wire to solve
 // returns true, nil if exactly one wire was solved. In that case, it is redundant to check that
 // the constraint is satisfied later.
-func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool, a, b, c fr.Element, err error) {
+func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution, a, b, c *fr.Element) error {
 
 	// the index of the non zero entry shows if L, R or O has an uninstantiated wire
 	// the content is the ID of the wire non instantiated
@@ -220,28 +289,31 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 		return nil
 	}
 
-	if err = processLExp(r.L.LinExp, &a, 1); err != nil {
-		return
+	if err := processLExp(r.L.LinExp, a, 1); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.R.LinExp, &b, 2); err != nil {
-		return
+	if err := processLExp(r.R.LinExp, b, 2); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.O.LinExp, &c, 3); err != nil {
-		return
+	if err := processLExp(r.O.LinExp, c, 3); err != nil {
+		return err
 	}
 
 	if loc == 0 {
 		// there is nothing to solve, may happen if we have an assertion
 		// (ie a constraints that doesn't yield any output)
 		// or if we solved the unsolved wires with hint functions
-		return
+		var check fr.Element
+		if !check.Mul(a, b).Equal(c) {
+			return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+		}
+		return nil
 	}
 
 	// we compute the wire value and instantiate it
-	solved = true
-	vID := termToCompute.WireID()
+	wID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -249,36 +321,41 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 	switch loc {
 	case 1:
 		if !b.IsZero() {
-			wire.Div(&c, &b).
-				Sub(&wire, &a)
-			a.Add(&a, &wire)
+			wire.Div(c, b).
+				Sub(&wire, a)
+			a.Add(a, &wire)
 		} else {
 			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 2:
 		if !a.IsZero() {
-			wire.Div(&c, &a).
-				Sub(&wire, &b)
-			b.Add(&b, &wire)
+			wire.Div(c, a).
+				Sub(&wire, b)
+			b.Add(b, &wire)
 		} else {
-			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 3:
-		wire.Mul(&a, &b).
-			Sub(&wire, &c)
+		wire.Mul(a, b).
+			Sub(&wire, c)
 
-		c.Add(&c, &wire)
+		c.Add(c, &wire)
 	}
 
 	// wire is the term (coeff * value)
 	// but in the solution we want to store the value only
 	// note that in gnark frontend, coeff here is always 1 or -1
 	cs.divByCoeff(&wire, termToCompute)
-	solution.set(vID, wire)
+	solution.set(wID, wire)
 
-	return
+	return nil
 }
 
 // GetConstraints return a list of constraint formatted as L⋅R == O

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -84,11 +84,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {
@@ -97,7 +92,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness)
+	solution.nbSolved += uint64(len(witness))
 
 	// defer log printing once all solution.values are computed
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -21,9 +21,12 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"math"
 	"math/big"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -103,18 +106,8 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	// loop through the constraints to solve the variables
-	for i := 0; i < len(cs.Constraints); i++ {
-		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
-			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
-		}
-		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
-			errMsg := err.Error()
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
-			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-		}
+	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+		return solution.values, err
 	}
 
 	// sanity check; ensure all wires are marked as "instantiated"
@@ -124,6 +117,120 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
+}
+
+func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					// for each constraint in the task, solve it.
+					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+						wg.Done()
+						return
+					}
+					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+						errMsg := err.Error()
+						if dID, ok := cs.MDebug[i]; ok {
+							errMsg = solution.logValue(cs.DebugInfo[dID])
+						}
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range cs.Levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+				}
+				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+					errMsg := err.Error()
+					if dID, ok := cs.MDebug[i]; ok {
+						errMsg = solution.logValue(cs.DebugInfo[dID])
+					}
+					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -21,12 +21,9 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
-	"math"
 	"math/big"
 	"os"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -106,7 +103,23 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+	// solve the constraint in parallel
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
+			if dID, ok := cs.MDebug[i]; ok {
+				errMsg = solution.logValue(cs.DebugInfo[dID])
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -117,120 +130,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
-}
-
-func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-						errMsg := err.Error()
-						if dID, ok := cs.MDebug[i]; ok {
-							errMsg = solution.logValue(cs.DebugInfo[dID])
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-					errMsg := err.Error()
-					if dID, ok := cs.MDebug[i]; ok {
-						errMsg = solution.logValue(cs.DebugInfo[dID])
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bw6-633/cs/solution.go
+++ b/internal/backend/bw6-633/cs/solution.go
@@ -36,6 +36,8 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-633"
 )
 
+var errUnsatisfiedConstraint = errors.New("unsatisfied constraint")
+
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bw6-633/cs/solution.go
+++ b/internal/backend/bw6-633/cs/solution.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend/schema"
@@ -37,9 +38,8 @@ import (
 type solution struct {
 	values, coefficients []fr.Element
 	solved               []bool
-	nbSolved             int
+	nbSolved             uint64
 	mHintsFunctions      map[hint.ID]hint.Function
-	tmpHintsIO           []*big.Int
 }
 
 func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
@@ -49,7 +49,6 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		coefficients:    coefficients,
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
-		tmpHintsIO:      make([]*big.Int, 0),
 	}
 
 	for _, h := range hintFunctions {
@@ -68,11 +67,12 @@ func (s *solution) set(id int, value fr.Element) {
 	}
 	s.values[id] = value
 	s.solved[id] = true
-	s.nbSolved++
+	atomic.AddUint64(&s.nbSolved, 1)
+	// s.nbSolved++
 }
 
 func (s *solution) isValid() bool {
-	return s.nbSolved == len(s.values)
+	return int(s.nbSolved) == len(s.values)
 }
 
 // computeTerm computes coef*variable
@@ -147,15 +147,21 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
 	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
-	m := len(s.tmpHintsIO)
-	if m < (nbInputs + nbOutputs) {
-		s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs+nbInputs)-m)...)
-		for i := m; i < len(s.tmpHintsIO); i++ {
-			s.tmpHintsIO[i] = big.NewInt(0)
-		}
+	// m := len(s.tmpHintsIO)
+	// if m < (nbInputs + nbOutputs) {
+	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)
+	// 	for i := m; i < len(s.tmpHintsIO); i++ {
+	// 		s.tmpHintsIO[i] = big.NewInt(0)
+	// 	}
+	// }
+	inputs := make([]*big.Int, nbInputs)
+	outputs := make([]*big.Int, nbOutputs)
+	for i := 0; i < nbInputs; i++ {
+		inputs[i] = big.NewInt(0)
 	}
-	inputs := s.tmpHintsIO[:nbInputs]
-	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
+	for i := 0; i < nbOutputs; i++ {
+		outputs[i] = big.NewInt(0)
+	}
 
 	q := fr.Modulus()
 

--- a/internal/backend/bw6-633/cs/solution.go
+++ b/internal/backend/bw6-633/cs/solution.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
+	"runtime"
+	"sync"
 	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -272,4 +275,101 @@ func (s *solution) logValue(log compiled.LogEntry) string {
 		}
 	}
 	return fmt.Sprintf(log.Format, toResolve...)
+}
+
+func parallelSolve(levels [][]int, solveConstraint func(cID int) error) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					if err := solveConstraint(i); err != nil {
+						chError <- err
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := solveConstraint(i); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -137,9 +137,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 						if dID, ok := cs.MDebug[i]; ok {
 							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							err = fmt.Errorf("%w - %s", err, debugInfoStr)
 						}
-						chError <- err
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 						wg.Done()
 						return
 					}
@@ -167,9 +167,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 					if dID, ok := cs.MDebug[int(i)]; ok {
 						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						err = fmt.Errorf("%w - %s", err, debugInfoStr)
 					}
-					return err
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
 				}
 			}
 			continue

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -19,11 +19,12 @@ package cs
 import (
 	"errors"
 	"fmt"
+	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
+	"runtime"
 	"strings"
-
-	"github.com/fxamacker/cbor/v2"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -32,6 +33,7 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 
@@ -70,11 +72,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
 	}
@@ -93,45 +90,117 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness) + 1
+	solution.nbSolved += uint64(len(witness) + 1)
 
 	// now that we know all inputs are set, defer log printing once all solution.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	// check if there is an inconsistant constraint
-	var check fr.Element
-	var solved bool
+	if len(cs.Levels) != 0 {
 
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-	for i := 0; i < len(cs.Constraints); i++ {
-		// solve the constraint, this will compute the missing wire of the gate
-		solved, a[i], b[i], c[i], err = cs.solveConstraint(cs.Constraints[i], &solution)
-		if err != nil {
-			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
-			}
-			return solution.values, err
+		var wg sync.WaitGroup
+		chTasks := make(chan []int, runtime.NumCPU())
+		chError := make(chan error, runtime.NumCPU())
+
+		// start a pool
+		for i := 0; i < runtime.NumCPU(); i++ {
+			go func() {
+				for t := range chTasks {
+					for _, i := range t {
+						if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+							if dID, ok := cs.MDebug[i]; ok {
+								debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+								err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							}
+							chError <- err
+							wg.Done()
+							return
+						}
+					}
+					wg.Done()
+				}
+			}()
 		}
 
-		if solved {
-			// a[i] * b[i] == c[i], since we just computed it.
-			continue
-		}
+		// for each level, we push the tasks
+		for _, level := range cs.Levels {
 
-		// ensure a[i] * b[i] == c[i]
-		check.Mul(&a[i], &b[i])
-		if !check.Equal(&c[i]) {
-			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
+			const minWorkPerCPU = 50.0
+
+			// max CPU to use
+			maxCPU := float64(len(level)) / minWorkPerCPU
+			if maxCPU <= 1.0 {
+				// we do it sequentially
+				for _, n := range level {
+					i := n
+					if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+						if dID, ok := cs.MDebug[int(i)]; ok {
+							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						}
+
+						close(chTasks)
+						close(chError)
+						return solution.values, err
+					}
+				}
+				continue
 			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+
+			nbTasks := runtime.NumCPU()
+			mm := int(math.Ceil(maxCPU))
+			if nbTasks > mm {
+				nbTasks = mm
+			}
+			nbIterationsPerCpus := len(level) / nbTasks
+
+			// more CPUs than tasks: a CPU will work on exactly one iteration
+			if nbIterationsPerCpus < 1 {
+				nbIterationsPerCpus = 1
+				nbTasks = len(level)
+			}
+
+			extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+			extraTasksOffset := 0
+
+			for i := 0; i < nbTasks; i++ {
+				wg.Add(1)
+				_start := i*nbIterationsPerCpus + extraTasksOffset
+				_end := _start + nbIterationsPerCpus
+				if extraTasks > 0 {
+					_end++
+					extraTasks--
+					extraTasksOffset++
+				}
+				chTasks <- level[_start:_end]
+			}
+
+			wg.Wait()
+			if len(chError) > 0 {
+				close(chTasks)
+				close(chError)
+				return solution.values, <-chError
+			}
+		}
+		close(chTasks)
+		close(chError)
+
+	} else {
+
+		// for each constraint
+		// we are guaranteed that each R1C contains at most one unsolved wire
+		// first we solve the unsolved wire (if any)
+		// then we check that the constraint is valid
+		// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
+		for i := 0; i < len(cs.Constraints); i++ {
+			// solve the constraint, this will compute the missing wire of the gate
+			if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+				if dID, ok := cs.MDebug[i]; ok {
+					debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+					return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
+				}
+				return solution.values, err
+			}
 		}
 	}
 
@@ -183,7 +252,7 @@ func (cs *R1CS) divByCoeff(res *fr.Element, t compiled.Term) {
 // returns false, nil if there was no wire to solve
 // returns true, nil if exactly one wire was solved. In that case, it is redundant to check that
 // the constraint is satisfied later.
-func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool, a, b, c fr.Element, err error) {
+func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution, a, b, c *fr.Element) error {
 
 	// the index of the non zero entry shows if L, R or O has an uninstantiated wire
 	// the content is the ID of the wire non instantiated
@@ -220,28 +289,31 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 		return nil
 	}
 
-	if err = processLExp(r.L.LinExp, &a, 1); err != nil {
-		return
+	if err := processLExp(r.L.LinExp, a, 1); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.R.LinExp, &b, 2); err != nil {
-		return
+	if err := processLExp(r.R.LinExp, b, 2); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.O.LinExp, &c, 3); err != nil {
-		return
+	if err := processLExp(r.O.LinExp, c, 3); err != nil {
+		return err
 	}
 
 	if loc == 0 {
 		// there is nothing to solve, may happen if we have an assertion
 		// (ie a constraints that doesn't yield any output)
 		// or if we solved the unsolved wires with hint functions
-		return
+		var check fr.Element
+		if !check.Mul(a, b).Equal(c) {
+			return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+		}
+		return nil
 	}
 
 	// we compute the wire value and instantiate it
-	solved = true
-	vID := termToCompute.WireID()
+	wID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -249,36 +321,41 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 	switch loc {
 	case 1:
 		if !b.IsZero() {
-			wire.Div(&c, &b).
-				Sub(&wire, &a)
-			a.Add(&a, &wire)
+			wire.Div(c, b).
+				Sub(&wire, a)
+			a.Add(a, &wire)
 		} else {
 			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 2:
 		if !a.IsZero() {
-			wire.Div(&c, &a).
-				Sub(&wire, &b)
-			b.Add(&b, &wire)
+			wire.Div(c, a).
+				Sub(&wire, b)
+			b.Add(b, &wire)
 		} else {
-			// we didn't actually ensure that a * b == c
-			solved = false
+			var check fr.Element
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 3:
-		wire.Mul(&a, &b).
-			Sub(&wire, &c)
+		wire.Mul(a, b).
+			Sub(&wire, c)
 
-		c.Add(&c, &wire)
+		c.Add(c, &wire)
 	}
 
 	// wire is the term (coeff * value)
 	// but in the solution we want to store the value only
 	// note that in gnark frontend, coeff here is always 1 or -1
 	cs.divByCoeff(&wire, termToCompute)
-	solution.set(vID, wire)
+	solution.set(wID, wire)
 
-	return
+	return nil
 }
 
 // GetConstraints return a list of constraint formatted as L⋅R == O

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -22,9 +22,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math/big"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -33,7 +31,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"math"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 
@@ -96,7 +93,18 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	if err := cs.parallelSolve(a, b, c, &solution); err != nil {
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+			if dID, ok := cs.MDebug[i]; ok {
+				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+				err = fmt.Errorf("%w - %s", err, debugInfoStr)
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -106,117 +114,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	}
 
 	return solution.values, nil
-}
-
-func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-						if dID, ok := cs.MDebug[i]; ok {
-							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w - %s", err, debugInfoStr)
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-					if dID, ok := cs.MDebug[int(i)]; ok {
-						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w - %s", err, debugInfoStr)
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -84,11 +84,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		return solution.values, err
 	}
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {
@@ -97,7 +92,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness)
+	solution.nbSolved += uint64(len(witness))
 
 	// defer log printing once all solution.values are computed
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -21,9 +21,12 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"math"
 	"math/big"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -103,18 +106,8 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	// loop through the constraints to solve the variables
-	for i := 0; i < len(cs.Constraints); i++ {
-		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
-			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
-		}
-		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
-			errMsg := err.Error()
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
-			}
-			return solution.values, fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-		}
+	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+		return solution.values, err
 	}
 
 	// sanity check; ensure all wires are marked as "instantiated"
@@ -124,6 +117,120 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
+}
+
+func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					// for each constraint in the task, solve it.
+					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+						wg.Done()
+						return
+					}
+					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+						errMsg := err.Error()
+						if dID, ok := cs.MDebug[i]; ok {
+							errMsg = solution.logValue(cs.DebugInfo[dID])
+						}
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range cs.Levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+				}
+				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+					errMsg := err.Error()
+					if dID, ok := cs.MDebug[i]; ok {
+						errMsg = solution.logValue(cs.DebugInfo[dID])
+					}
+					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -21,12 +21,9 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/fxamacker/cbor/v2"
 	"io"
-	"math"
 	"math/big"
 	"os"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
@@ -106,7 +103,23 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+	// solve the constraint in parallel
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
+			if dID, ok := cs.MDebug[i]; ok {
+				errMsg = solution.logValue(cs.DebugInfo[dID])
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -117,120 +130,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
-}
-
-func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-
-	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return
-					}
-					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-						errMsg := err.Error()
-						if dID, ok := cs.MDebug[i]; ok {
-							errMsg = solution.logValue(cs.DebugInfo[dID])
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-						wg.Done()
-						return
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-					errMsg := err.Error()
-					if dID, ok := cs.MDebug[i]; ok {
-						errMsg = solution.logValue(cs.DebugInfo[dID])
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-				}
-			}
-			continue
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower.
-		nbTasks := runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-
-		// wait for the level to be done
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
 }
 
 // computeHints computes wires associated with a hint function, if any

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -36,6 +36,8 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-761"
 )
 
+var errUnsatisfiedConstraint = errors.New("unsatisfied constraint")
+
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend/schema"
@@ -37,9 +38,8 @@ import (
 type solution struct {
 	values, coefficients []fr.Element
 	solved               []bool
-	nbSolved             int
+	nbSolved             uint64
 	mHintsFunctions      map[hint.ID]hint.Function
-	tmpHintsIO           []*big.Int
 }
 
 func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
@@ -49,7 +49,6 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		coefficients:    coefficients,
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
-		tmpHintsIO:      make([]*big.Int, 0),
 	}
 
 	for _, h := range hintFunctions {
@@ -68,11 +67,12 @@ func (s *solution) set(id int, value fr.Element) {
 	}
 	s.values[id] = value
 	s.solved[id] = true
-	s.nbSolved++
+	atomic.AddUint64(&s.nbSolved, 1)
+	// s.nbSolved++
 }
 
 func (s *solution) isValid() bool {
-	return s.nbSolved == len(s.values)
+	return int(s.nbSolved) == len(s.values)
 }
 
 // computeTerm computes coef*variable
@@ -147,15 +147,21 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
 	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
-	m := len(s.tmpHintsIO)
-	if m < (nbInputs + nbOutputs) {
-		s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs+nbInputs)-m)...)
-		for i := m; i < len(s.tmpHintsIO); i++ {
-			s.tmpHintsIO[i] = big.NewInt(0)
-		}
+	// m := len(s.tmpHintsIO)
+	// if m < (nbInputs + nbOutputs) {
+	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)
+	// 	for i := m; i < len(s.tmpHintsIO); i++ {
+	// 		s.tmpHintsIO[i] = big.NewInt(0)
+	// 	}
+	// }
+	inputs := make([]*big.Int, nbInputs)
+	outputs := make([]*big.Int, nbOutputs)
+	for i := 0; i < nbInputs; i++ {
+		inputs[i] = big.NewInt(0)
 	}
-	inputs := s.tmpHintsIO[:nbInputs]
-	outputs := s.tmpHintsIO[nbInputs : nbInputs+nbOutputs]
+	for i := 0; i < nbOutputs; i++ {
+		outputs[i] = big.NewInt(0)
+	}
 
 	q := fr.Modulus()
 

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
+	"runtime"
+	"sync"
 	"sync/atomic"
 
 	"github.com/consensys/gnark/backend/hint"
@@ -272,4 +275,101 @@ func (s *solution) logValue(log compiled.LogEntry) string {
 		}
 	}
 	return fmt.Sprintf(log.Format, toResolve...)
+}
+
+func parallelSolve(levels [][]int, solveConstraint func(cID int) error) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					if err := solveConstraint(i); err != nil {
+						chError <- err
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range levels {
+
+		// max CPU to use
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially
+			for _, i := range level {
+				if err := solveConstraint(i); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower.
+		nbTasks := runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+
+		// wait for the level to be done
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }

--- a/internal/backend/compiled/cs.go
+++ b/internal/backend/compiled/cs.go
@@ -38,6 +38,11 @@ type CS struct {
 	MHints map[int]*Hint
 
 	Schema *schema.Schema
+
+	// each level contains independent constraints and can be parallelized
+	// it is guaranteed that all dependncies for constraints in a level l are solved
+	// in previous levels
+	Levels [][]int
 }
 
 // Hint represents a solver hint

--- a/internal/backend/compiled/r1cs.go
+++ b/internal/backend/compiled/r1cs.go
@@ -18,6 +18,11 @@ package compiled
 type R1CS struct {
 	CS
 	Constraints []R1C
+
+	// each level contains independent constraints and can be parallelized
+	// it is guaranteed that all dependncies for constraints in a level l are solved
+	// in previous levels
+	Levels [][]int
 }
 
 // GetNbConstraints returns the number of constraints

--- a/internal/backend/compiled/r1cs.go
+++ b/internal/backend/compiled/r1cs.go
@@ -18,11 +18,6 @@ package compiled
 type R1CS struct {
 	CS
 	Constraints []R1C
-
-	// each level contains independent constraints and can be parallelized
-	// it is guaranteed that all dependncies for constraints in a level l are solved
-	// in previous levels
-	Levels [][]int
 }
 
 // GetNbConstraints returns the number of constraints

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -79,9 +79,15 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 
 	err = parallelSolve(cs.Levels, func(i int) error {
 		if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
-			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				err = fmt.Errorf("%w - %s", err, debugInfoStr)
+			// error can be from the hint functions, or because the constraint is not satisfied
+			// if the constraint is not satisfied, format the error either with debug info or with
+			// the inequality
+			if err == errUnsatisfiedConstraint {
+				if dID, ok := cs.MDebug[i]; ok {
+					err = errors.New(solution.logValue(cs.DebugInfo[dID]))
+				} else {
+					err = fmt.Errorf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
+				}
 			}
 			return fmt.Errorf("constraint #%d is not satisfied: %w",i, err) 
 		}
@@ -199,7 +205,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution, a,b,c *fr.El
 		// or if we solved the unsolved wires with hint functions
 		var check fr.Element 
 		if !check.Mul(a, b).Equal(c) {
-			return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			return errUnsatisfiedConstraint
 		}
 		return nil
 	}
@@ -221,7 +227,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution, a,b,c *fr.El
 			// we didn't actually ensure that a * b == c 
 			var check fr.Element 
 			if !check.Mul(a, b).Equal(c) {
-				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+				return errUnsatisfiedConstraint
 			}
 		}
 	case 2:
@@ -232,7 +238,7 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution, a,b,c *fr.El
 		} else {
 			var check fr.Element 
 			if !check.Mul(a, b).Equal(c) {
-				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+				return errUnsatisfiedConstraint
 			}
 		}
 	case 3:

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -3,9 +3,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"runtime"
 	"strings"
-	"sync"
 	"github.com/fxamacker/cbor/v2"
 
 	"github.com/consensys/gnark/internal/backend/ioutils"
@@ -14,7 +12,6 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
 
-	"math"
 	"github.com/consensys/gnark-crypto/ecc"
 
 	{{ template "import_fr" . }}
@@ -80,7 +77,18 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	if err := cs.parallelSolve(a, b, c, &solution); err != nil {
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+			if dID, ok := cs.MDebug[i]; ok {
+				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+				err = fmt.Errorf("%w - %s", err, debugInfoStr)
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %w",i, err) 
+		}
+		return nil 
+	})
+	
+	if err != nil {
 		return solution.values, err
 	}
 
@@ -93,119 +101,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 }
 
 
-
-func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.  
-	const minWorkPerCPU = 50.0
-
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-
-
-	var wg sync.WaitGroup 
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-						if dID, ok := cs.MDebug[i]; ok {
-							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w - %s", err, debugInfoStr)
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w",i, err)
-						wg.Done()
-						return 
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines 
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use 
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially 
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
-					if dID, ok := cs.MDebug[int(i)]; ok {
-						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w - %s", err, debugInfoStr)
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %w",i, err) 
-				}
-			}
-			continue 
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower. 
-		nbTasks :=  runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-	
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-	
-	
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-	
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-	
-		// wait for the level to be done 
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
-}
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise
 // this method wraps cs.Solve() and allocates cs.Solve() inputs

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -3,8 +3,9 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"runtime"
 	"strings"
-
+	"sync"
 	"github.com/fxamacker/cbor/v2"
 
 	"github.com/consensys/gnark/internal/backend/ioutils"
@@ -13,6 +14,7 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
 
+	"math"
 	"github.com/consensys/gnark-crypto/ecc"
 
 	{{ template "import_fr" . }}
@@ -52,10 +54,6 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 		return make([]fr.Element, nbWires), err
 	}
 	
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
 
 	if len(witness) != int(cs.NbPublicVariables-1+cs.NbSecretVariables) { // - 1 for ONE_WIRE
 		return solution.values, fmt.Errorf("invalid witness size, got %d, expected %d = %d (public - ONE_WIRE) + %d (secret)", len(witness), int(cs.NbPublicVariables-1+cs.NbSecretVariables), cs.NbPublicVariables-1, cs.NbSecretVariables)
@@ -75,15 +73,104 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness) + 1
+	solution.nbSolved += uint64(len(witness) + 1)
 
 	// now that we know all inputs are set, defer log printing once all solution.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	// check if there is an inconsistant constraint
-	var check fr.Element
-	var solved bool 
+	if len(cs.Levels) != 0 {
+
+		var wg sync.WaitGroup 
+		chTasks := make(chan []int, runtime.NumCPU())
+		chError := make(chan error, runtime.NumCPU())
+
+		// start a pool 
+		for i := 0; i < runtime.NumCPU(); i++ {
+			go func() {
+				for t := range chTasks {
+					for _, i := range t {
+						if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+							if dID, ok := cs.MDebug[i]; ok {
+								debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+								err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							}
+							chError <- err
+							wg.Done()
+							return 
+						}
+					}
+					wg.Done()
+				}
+			}()
+		}
+
+		// for each level, we push the tasks
+		for _, level := range cs.Levels {
+
+			const minWorkPerCPU = 50.0
+			
+			// max CPU to use 
+			maxCPU := float64(len(level)) / minWorkPerCPU 
+			if maxCPU <= 1.0 {
+				// we do it sequentially 
+				for _, n := range level {
+					i := n
+					if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
+						if dID, ok := cs.MDebug[int(i)]; ok {
+							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						}
+
+						close(chTasks)
+						close(chError)
+						return solution.values, err 
+					}
+				}
+				continue 
+			}
+
+			nbTasks :=  runtime.NumCPU()
+			mm := int(math.Ceil(maxCPU))
+			if nbTasks > mm {
+				nbTasks = mm
+			}
+			nbIterationsPerCpus := len(level) / nbTasks
+		
+			// more CPUs than tasks: a CPU will work on exactly one iteration
+			if nbIterationsPerCpus < 1 {
+				nbIterationsPerCpus = 1
+				nbTasks = len(level)
+			}
+		
+		
+			extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+			extraTasksOffset := 0
+		
+			for i := 0; i < nbTasks; i++ {
+				wg.Add(1)
+				_start := i*nbIterationsPerCpus + extraTasksOffset
+				_end := _start + nbIterationsPerCpus
+				if extraTasks > 0 {
+					_end++
+					extraTasks--
+					extraTasksOffset++
+				}
+				chTasks <- level[_start:_end]
+			}
+		
+			
+			wg.Wait()
+			if len(chError) > 0 {
+				close(chTasks)
+				close(chError)
+				return solution.values, <-chError
+			}
+		}
+		close(chTasks)
+		close(chError)
+		
+ 	} else {
 
 	// for each constraint
 	// we are guaranteed that each R1C contains at most one unsolved wire
@@ -92,30 +179,15 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	for i := 0; i < len(cs.Constraints); i++ {
 		// solve the constraint, this will compute the missing wire of the gate
-		solved, a[i], b[i], c[i], err = cs.solveConstraint(cs.Constraints[i], &solution)
-		if err != nil {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
 			if dID, ok := cs.MDebug[i]; ok {
 				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
 				return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
 			}
 			return solution.values, err
 		}
-
-		if solved {
-			// a[i] * b[i] == c[i], since we just computed it. 
-			continue
-		}
-
-		// ensure a[i] * b[i] == c[i]
-		check.Mul(&a[i], &b[i])
-		if !check.Equal(&c[i]) {
-			errMsg := fmt.Sprintf("%s ⋅ %s != %s", a[i].String(), b[i].String(), c[i].String())
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
-			}
-			return solution.values,  fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-		}
 	}
+}
 
 	// sanity check; ensure all wires are marked as "instantiated"
 	if !solution.isValid() {
@@ -167,7 +239,7 @@ func (cs *R1CS) divByCoeff(res *fr.Element, t compiled.Term) {
 // returns false, nil if there was no wire to solve 
 // returns true, nil if exactly one wire was solved. In that case, it is redundant to check that 
 // the constraint is satisfied later.
-func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool, a,b,c fr.Element, err error) {
+func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution, a,b,c *fr.Element) error {
 
 	// the index of the non zero entry shows if L, R or O has an uninstantiated wire
 	// the content is the ID of the wire non instantiated
@@ -204,28 +276,31 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 		return nil
 	}
 
-	if err = processLExp(r.L.LinExp, &a, 1); err != nil {
-		return
+	if err := processLExp(r.L.LinExp, a, 1); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.R.LinExp, &b, 2); err != nil {
-		return
+	if err := processLExp(r.R.LinExp, b, 2); err != nil {
+		return err
 	}
 
-	if err = processLExp(r.O.LinExp, &c, 3); err != nil {
-		return
+	if err := processLExp(r.O.LinExp, c, 3); err != nil {
+		return err
 	}
 
 	if loc == 0 {
 		// there is nothing to solve, may happen if we have an assertion
 		// (ie a constraints that doesn't yield any output)
 		// or if we solved the unsolved wires with hint functions
-		return
+		var check fr.Element 
+		if !check.Mul(a, b).Equal(c) {
+			return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+		}
+		return nil
 	}
 
 	// we compute the wire value and instantiate it
-	solved = true 
-	vID := termToCompute.WireID()
+	wID := termToCompute.WireID()
 
 	// solver result
 	var wire fr.Element
@@ -234,36 +309,42 @@ func (cs *R1CS) solveConstraint(r compiled.R1C, solution *solution) (solved bool
 	switch loc {
 	case 1:
 		if !b.IsZero() {
-			wire.Div(&c, &b).
-				Sub(&wire, &a)
-			a.Add(&a, &wire)
+			wire.Div(c, b).
+				Sub(&wire, a)
+			a.Add(a, &wire)
 		} else {
 			// we didn't actually ensure that a * b == c 
-			solved = false 
+			var check fr.Element 
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 2:
 		if !a.IsZero() {
-			wire.Div(&c, &a).
-				Sub(&wire, &b)
-			b.Add(&b, &wire)
+			wire.Div(c, a).
+				Sub(&wire, b)
+			b.Add(b, &wire)
 		} else {
-			// we didn't actually ensure that a * b == c 
-			solved = false 
+			var check fr.Element 
+			if !check.Mul(a, b).Equal(c) {
+				return fmt.Errorf("%s ⋅ %s != %s", a.String(), b.String(), c.String())
+			}
 		}
 	case 3:
-		wire.Mul(&a, &b).
-			Sub(&wire, &c)
+		wire.Mul(a, b).
+			Sub(&wire, c)
 		
-		c.Add(&c, &wire)
+		c.Add(c, &wire)
 	}
 
 	// wire is the term (coeff * value)
 	// but in the solution we want to store the value only
 	// note that in gnark frontend, coeff here is always 1 or -1
 	cs.divByCoeff(&wire, termToCompute)
-	solution.set(vID, wire)
+	solution.set(wID, wire)
 
-	return
+
+	return nil 
 }
 
 // GetConstraints return a list of constraint formatted as L⋅R == O

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -124,9 +124,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 						if dID, ok := cs.MDebug[i]; ok {
 							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+							err = fmt.Errorf("%w - %s", err, debugInfoStr)
 						}
-						chError <- err
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w",i, err)
 						wg.Done()
 						return 
 					}
@@ -154,9 +154,9 @@ func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
 				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
 					if dID, ok := cs.MDebug[int(i)]; ok {
 						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-						err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						err = fmt.Errorf("%w - %s", err, debugInfoStr)
 					}
-					return err 
+					return fmt.Errorf("constraint #%d is not satisfied: %w",i, err) 
 				}
 			}
 			continue 

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -41,6 +41,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 	return &r
 }
 
+
 // Solve sets all the wires and returns the a, b, c vectors.
 // the cs system should have been compiled before. The entries in a, b, c are in Montgomery form.
 // a, b, c vectors: ab-c = hz
@@ -66,7 +67,7 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 
 	solution.solved[0] = true // ONE_WIRE
 	solution.values[0].SetOne()
-	copy(solution.values[1:], witness) // TODO factorize
+	copy(solution.values[1:], witness) 
 	for i := 0; i < len(witness); i++ {
 		solution.solved[i+1] = true
 	}
@@ -79,115 +80,9 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	// (or sooner, if a constraint is not satisfied)
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)
 
-	if len(cs.Levels) != 0 {
-
-		var wg sync.WaitGroup 
-		chTasks := make(chan []int, runtime.NumCPU())
-		chError := make(chan error, runtime.NumCPU())
-
-		// start a pool 
-		for i := 0; i < runtime.NumCPU(); i++ {
-			go func() {
-				for t := range chTasks {
-					for _, i := range t {
-						if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
-							if dID, ok := cs.MDebug[i]; ok {
-								debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-								err = fmt.Errorf("%w: %s", err, debugInfoStr)
-							}
-							chError <- err
-							wg.Done()
-							return 
-						}
-					}
-					wg.Done()
-				}
-			}()
-		}
-
-		// for each level, we push the tasks
-		for _, level := range cs.Levels {
-
-			const minWorkPerCPU = 50.0
-			
-			// max CPU to use 
-			maxCPU := float64(len(level)) / minWorkPerCPU 
-			if maxCPU <= 1.0 {
-				// we do it sequentially 
-				for _, n := range level {
-					i := n
-					if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
-						if dID, ok := cs.MDebug[int(i)]; ok {
-							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-							err = fmt.Errorf("%w: %s", err, debugInfoStr)
-						}
-
-						close(chTasks)
-						close(chError)
-						return solution.values, err 
-					}
-				}
-				continue 
-			}
-
-			nbTasks :=  runtime.NumCPU()
-			mm := int(math.Ceil(maxCPU))
-			if nbTasks > mm {
-				nbTasks = mm
-			}
-			nbIterationsPerCpus := len(level) / nbTasks
-		
-			// more CPUs than tasks: a CPU will work on exactly one iteration
-			if nbIterationsPerCpus < 1 {
-				nbIterationsPerCpus = 1
-				nbTasks = len(level)
-			}
-		
-		
-			extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-			extraTasksOffset := 0
-		
-			for i := 0; i < nbTasks; i++ {
-				wg.Add(1)
-				_start := i*nbIterationsPerCpus + extraTasksOffset
-				_end := _start + nbIterationsPerCpus
-				if extraTasks > 0 {
-					_end++
-					extraTasks--
-					extraTasksOffset++
-				}
-				chTasks <- level[_start:_end]
-			}
-		
-			
-			wg.Wait()
-			if len(chError) > 0 {
-				close(chTasks)
-				close(chError)
-				return solution.values, <-chError
-			}
-		}
-		close(chTasks)
-		close(chError)
-		
- 	} else {
-
-	// for each constraint
-	// we are guaranteed that each R1C contains at most one unsolved wire
-	// first we solve the unsolved wire (if any)
-	// then we check that the constraint is valid
-	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
-	for i := 0; i < len(cs.Constraints); i++ {
-		// solve the constraint, this will compute the missing wire of the gate
-		if err := cs.solveConstraint(cs.Constraints[i], &solution, &a[i], &b[i], &c[i]); err != nil {
-			if dID, ok := cs.MDebug[i]; ok {
-				debugInfoStr := solution.logValue(cs.DebugInfo[dID])
-				return solution.values, fmt.Errorf("%w: %s", err, debugInfoStr)
-			}
-			return solution.values, err
-		}
+	if err := cs.parallelSolve(a, b, c, &solution); err != nil {
+		return solution.values, err
 	}
-}
 
 	// sanity check; ensure all wires are marked as "instantiated"
 	if !solution.isValid() {
@@ -195,6 +90,121 @@ func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) (
 	}
 
 	return solution.values, nil
+}
+
+
+
+func (cs *R1CS) parallelSolve(a, b, c []fr.Element, solution *solution) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.  
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+	// for each constraint
+	// we are guaranteed that each R1C contains at most one unsolved wire
+	// first we solve the unsolved wire (if any)
+	// then we check that the constraint is valid
+	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
+
+
+	var wg sync.WaitGroup 
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					// for each constraint in the task, solve it.
+					if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
+						if dID, ok := cs.MDebug[i]; ok {
+							debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+							err = fmt.Errorf("%w: %s", err, debugInfoStr)
+						}
+						chError <- err
+						wg.Done()
+						return 
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines 
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range cs.Levels {
+
+		// max CPU to use 
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially 
+			for _, i := range level {
+				if err := cs.solveConstraint(cs.Constraints[i], solution, &a[i], &b[i], &c[i]); err != nil {
+					if dID, ok := cs.MDebug[int(i)]; ok {
+						debugInfoStr := solution.logValue(cs.DebugInfo[dID])
+						err = fmt.Errorf("%w: %s", err, debugInfoStr)
+					}
+					return err 
+				}
+			}
+			continue 
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower. 
+		nbTasks :=  runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+	
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+	
+	
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+	
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+	
+		// wait for the level to be done 
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }
 
 // IsSolved returns nil if given witness solves the R1CS and error otherwise

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -6,6 +6,9 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"strings"
 	"os"
+	"sync"
+	"runtime"
+	"math"
 	
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/internal/backend/compiled"
@@ -90,19 +93,8 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-
-	// loop through the constraints to solve the variables
-	for i := 0; i < len(cs.Constraints); i++ {
-		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
-			return solution.values, fmt.Errorf("constraint %d: %w", i, err)
-		}
-		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
-			errMsg := err.Error()
-			if dID, ok := cs.MDebug[i]; ok {
-				errMsg = solution.logValue(cs.DebugInfo[dID])
-			}
-			return solution.values,  fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-		}
+	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+		return solution.values, err
 	}
 
 	// sanity check; ensure all wires are marked as "instantiated"
@@ -112,6 +104,122 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	return solution.values, nil
 
+}
+
+
+func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.  
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup 
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					// for each constraint in the task, solve it.
+					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+						wg.Done()
+						return 
+					}
+					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+						errMsg := err.Error()
+						if dID, ok := cs.MDebug[i]; ok {
+							errMsg = solution.logValue(cs.DebugInfo[dID])
+						}
+						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+						wg.Done()
+						return 
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines 
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range cs.Levels {
+
+		// max CPU to use 
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially 
+			for _, i := range level {
+				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
+					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+				}
+				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
+					errMsg := err.Error()
+					if dID, ok := cs.MDebug[i]; ok {
+						errMsg = solution.logValue(cs.DebugInfo[dID])
+					}
+					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+				}
+			}
+			continue 
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower. 
+		nbTasks :=  runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+	
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+	
+	
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+	
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+	
+		// wait for the level to be done 
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
 }
 
 

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -6,9 +6,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"strings"
 	"os"
-	"sync"
-	"runtime"
-	"math"
 	
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/internal/backend/compiled"
@@ -93,9 +90,26 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 		coefficientsNegInv[i].Neg(&coefficientsNegInv[i])
 	}
 
-	if err := cs.parallelSolve(&solution, coefficientsNegInv); err != nil {
+	// solve the constraint in parallel
+	err = parallelSolve(cs.Levels, func(i int) error {
+		if err := cs.solveConstraint(cs.Constraints[i], &solution, coefficientsNegInv); err != nil {
+			return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
+		}
+		if err := cs.checkConstraint(cs.Constraints[i], &solution); err != nil {
+			errMsg := err.Error()
+			if dID, ok := cs.MDebug[i]; ok {
+				errMsg = solution.logValue(cs.DebugInfo[dID])
+			}
+			return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
+		}
+
+		return nil 
+	})
+	
+	if err != nil {
 		return solution.values, err
 	}
+
 
 	// sanity check; ensure all wires are marked as "instantiated"
 	if !solution.isValid() {
@@ -107,120 +121,8 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 }
 
 
-func (cs *SparseR1CS) parallelSolve(solution *solution, coefficientsNegInv []fr.Element) error {
-	// minWorkPerCPU is the minimum target number of constraint a task should hold
-	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
-	// sequentially without sync.  
-	const minWorkPerCPU = 50.0
 
-	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
-	// and may only have dependencies on previous levels
 
-	var wg sync.WaitGroup 
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
-
-	// start a worker pool
-	// each worker wait on chTasks
-	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() {
-			for t := range chTasks {
-				for _, i := range t {
-					// for each constraint in the task, solve it.
-					if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-						wg.Done()
-						return 
-					}
-					if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-						errMsg := err.Error()
-						if dID, ok := cs.MDebug[i]; ok {
-							errMsg = solution.logValue(cs.DebugInfo[dID])
-						}
-						chError <- fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-						wg.Done()
-						return 
-					}
-				}
-				wg.Done()
-			}
-		}()
-	}
-
-	// clean up pool go routines 
-	defer func() {
-		close(chTasks)
-		close(chError)
-	}()
-
-	// for each level, we push the tasks
-	for _, level := range cs.Levels {
-
-		// max CPU to use 
-		maxCPU := float64(len(level)) / minWorkPerCPU
-
-		if maxCPU <= 1.0 {
-			// we do it sequentially 
-			for _, i := range level {
-				if err := cs.solveConstraint(cs.Constraints[i], solution, coefficientsNegInv); err != nil {
-					return fmt.Errorf("constraint #%d is not satisfied: %w", i, err)
-				}
-				if err := cs.checkConstraint(cs.Constraints[i], solution); err != nil {
-					errMsg := err.Error()
-					if dID, ok := cs.MDebug[i]; ok {
-						errMsg = solution.logValue(cs.DebugInfo[dID])
-					}
-					return fmt.Errorf("constraint #%d is not satisfied: %s", i, errMsg)
-				}
-			}
-			continue 
-		}
-
-		// number of tasks for this level is set to num cpus
-		// but if we don't have enough work for all our CPUS, it can be lower. 
-		nbTasks :=  runtime.NumCPU()
-		maxTasks := int(math.Ceil(maxCPU))
-		if nbTasks > maxTasks {
-			nbTasks = maxTasks
-		}
-		nbIterationsPerCpus := len(level) / nbTasks
-	
-		// more CPUs than tasks: a CPU will work on exactly one iteration
-		// note: this depends on minWorkPerCPU constant
-		if nbIterationsPerCpus < 1 {
-			nbIterationsPerCpus = 1
-			nbTasks = len(level)
-		}
-	
-	
-		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
-		extraTasksOffset := 0
-	
-		for i := 0; i < nbTasks; i++ {
-			wg.Add(1)
-			_start := i*nbIterationsPerCpus + extraTasksOffset
-			_end := _start + nbIterationsPerCpus
-			if extraTasks > 0 {
-				_end++
-				extraTasks--
-				extraTasksOffset++
-			}
-			// since we're never pushing more than num CPU tasks
-			// we will never be blocked here
-			chTasks <- level[_start:_end]
-		}
-	
-		// wait for the level to be done 
-		wg.Wait()
-
-		if len(chError) > 0 {
-			return <-chError
-		}
-	}
-
-	return nil
-}
 
 
 

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -121,11 +121,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 }
 
 
-
-
-
-
-
 // computeHints computes wires associated with a hint function, if any
 // if there is no remaining wire to solve, returns -1
 // else returns the wire position (L -> 0, R -> 1, O -> 2)

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -71,11 +71,6 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 	}
 
 
-	defer func() {
-		// release memory
-		solution.tmpHintsIO = nil
-	}()
-
 	// solution.values = [publicInputs | secretInputs | internalVariables ] -> we fill publicInputs | secretInputs
 	copy(solution.values, witness)
 	for i := 0; i < len(witness); i++ {
@@ -84,7 +79,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 	// keep track of the number of wire instantiations we do, for a sanity check to ensure
 	// we instantiated all wires
-	solution.nbSolved += len(witness) 
+	solution.nbSolved += uint64(len(witness))
 
 	// defer log printing once all solution.values are computed
 	defer solution.printLogs(opt.LoggerOut, cs.Logs)

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -3,6 +3,7 @@ import (
 	"errors"
     "fmt"
 	"math/big"
+	"sync/atomic"
 
     "github.com/consensys/gnark/backend/hint"
     "github.com/consensys/gnark/internal/backend/compiled"
@@ -18,9 +19,8 @@ import (
 type solution struct {
 	values, coefficients []fr.Element
 	solved               []bool
-	nbSolved             int
+	nbSolved             uint64
 	mHintsFunctions      map[hint.ID]hint.Function
-	tmpHintsIO 			[]*big.Int
 }
 
 func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
@@ -30,7 +30,6 @@ func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.E
 		coefficients: coefficients,
 		solved: make([]bool, nbWires),
 		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
-		tmpHintsIO: make([]*big.Int, 0),
   }
 	
 	for _, h := range hintFunctions {
@@ -49,11 +48,12 @@ func (s *solution) set(id int, value fr.Element) {
 	}
 	s.values[id] = value
 	s.solved[id] = true
-	s.nbSolved++
+	atomic.AddUint64(&s.nbSolved, 1)
+	// s.nbSolved++
 }
 
 func (s *solution) isValid() bool {
-	return s.nbSolved == len(s.values)
+	return int(s.nbSolved) == len(s.values)
 }
 
 // computeTerm computes coef*variable
@@ -128,15 +128,21 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
 	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
-	m := len(s.tmpHintsIO) 
-	if m < (nbInputs + nbOutputs) {
-		s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)
-		for i := m; i < len(s.tmpHintsIO); i++ {
-			s.tmpHintsIO[i] = big.NewInt(0)
-		}
+	// m := len(s.tmpHintsIO) 
+	// if m < (nbInputs + nbOutputs) {
+	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)
+	// 	for i := m; i < len(s.tmpHintsIO); i++ {
+	// 		s.tmpHintsIO[i] = big.NewInt(0)
+	// 	}
+	// }
+	inputs := make([]*big.Int, nbInputs) 
+	outputs :=  make([]*big.Int, nbOutputs)
+	for i :=0; i < nbInputs; i++ {
+		inputs[i] = big.NewInt(0)
 	}
-	inputs := s.tmpHintsIO[:nbInputs]
-	outputs := s.tmpHintsIO[nbInputs:nbInputs+nbOutputs]
+	for i :=0; i < nbOutputs; i++ {
+		outputs[i] = big.NewInt(0)
+	}
 
 	q := fr.Modulus()
 

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -17,6 +17,8 @@ import (
 	{{ template "import_curve" . }}
 )
 
+var errUnsatisfiedConstraint = errors.New("unsatisfied constraint")
+
 // solution represents elements needed to compute
 // a solution to a R1CS or SparseR1CS
 type solution struct {

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -4,6 +4,9 @@ import (
     "fmt"
 	"math/big"
 	"sync/atomic"
+	"sync"
+	"runtime"
+	"math"
 
     "github.com/consensys/gnark/backend/hint"
     "github.com/consensys/gnark/internal/backend/compiled"
@@ -255,3 +258,105 @@ func (s *solution) logValue(log compiled.LogEntry) string {
 	}
 	return fmt.Sprintf(log.Format, toResolve...)
 }
+
+
+
+
+func parallelSolve(levels [][]int,  solveConstraint func(cID int) error) error {
+	// minWorkPerCPU is the minimum target number of constraint a task should hold
+	// in other words, if a level has less than minWorkPerCPU, it will not be parallelized and executed
+	// sequentially without sync.  
+	const minWorkPerCPU = 50.0
+
+	// cs.Levels has a list of levels, where all constraints in a level l(n) are independent
+	// and may only have dependencies on previous levels
+
+	var wg sync.WaitGroup 
+	chTasks := make(chan []int, runtime.NumCPU())
+	chError := make(chan error, runtime.NumCPU())
+
+	// start a worker pool
+	// each worker wait on chTasks
+	// a task is a slice of constraint indexes to be solved
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for t := range chTasks {
+				for _, i := range t {
+					if err := solveConstraint(i); err != nil {
+						chError <- err
+						wg.Done()
+						return
+					}
+				}
+				wg.Done()
+			}
+		}()
+	}
+
+	// clean up pool go routines 
+	defer func() {
+		close(chTasks)
+		close(chError)
+	}()
+
+	// for each level, we push the tasks
+	for _, level := range levels {
+
+		// max CPU to use 
+		maxCPU := float64(len(level)) / minWorkPerCPU
+
+		if maxCPU <= 1.0 {
+			// we do it sequentially 
+			for _, i := range level {
+				if err := solveConstraint(i); err != nil {
+					return err 
+				}
+			}
+			continue 
+		}
+
+		// number of tasks for this level is set to num cpus
+		// but if we don't have enough work for all our CPUS, it can be lower. 
+		nbTasks :=  runtime.NumCPU()
+		maxTasks := int(math.Ceil(maxCPU))
+		if nbTasks > maxTasks {
+			nbTasks = maxTasks
+		}
+		nbIterationsPerCpus := len(level) / nbTasks
+	
+		// more CPUs than tasks: a CPU will work on exactly one iteration
+		// note: this depends on minWorkPerCPU constant
+		if nbIterationsPerCpus < 1 {
+			nbIterationsPerCpus = 1
+			nbTasks = len(level)
+		}
+	
+	
+		extraTasks := len(level) - (nbTasks * nbIterationsPerCpus)
+		extraTasksOffset := 0
+	
+		for i := 0; i < nbTasks; i++ {
+			wg.Add(1)
+			_start := i*nbIterationsPerCpus + extraTasksOffset
+			_end := _start + nbIterationsPerCpus
+			if extraTasks > 0 {
+				_end++
+				extraTasks--
+				extraTasksOffset++
+			}
+			// since we're never pushing more than num CPU tasks
+			// we will never be blocked here
+			chTasks <- level[_start:_end]
+		}
+	
+		// wait for the level to be done 
+		wg.Wait()
+
+		if len(chError) > 0 {
+			return <-chError
+		}
+	}
+
+	return nil
+}
+


### PR DESCRIPTION
Fixes #251 . 

`R1CS` and `SparseR1CS` solver are now parallel. The scheduling is not optimal, but better strategies do not scale well with very large circuits and make compile time explode. 

Strategy used here is to build a list of independent constraints at compile time, which can be solved in parallel at solving time. 