### PR TITLE
Simplify hints declaration and make frontend responsible for number of outputs, not hint / backend

### DIFF
--- a/backend/hint/builtin.go
+++ b/backend/hint/builtin.go
@@ -11,11 +11,11 @@ var initBuiltinOnce sync.Once
 
 func init() {
 	initBuiltinOnce.Do(func() {
-		IsZero = NewStaticHint(builtinIsZero, 1)
+		IsZero = NewStaticHint(builtinIsZero)
 		Register(IsZero)
-		IthBit = NewStaticHint(builtinIthBit, 2)
+		IthBit = NewStaticHint(builtinIthBit)
 		Register(IthBit)
-		NBits = NewStaticHint(builtinNBits, 1)
+		NBits = NewStaticHint(builtinNBits)
 		Register(NBits)
 	})
 }

--- a/backend/hint/builtin.go
+++ b/backend/hint/builtin.go
@@ -11,10 +11,12 @@ var initBuiltinOnce sync.Once
 
 func init() {
 	initBuiltinOnce.Do(func() {
-		IsZero = NewStaticHint(builtinIsZero, 1, 1)
+		IsZero = NewStaticHint(builtinIsZero, 1)
 		Register(IsZero)
-		IthBit = NewStaticHint(builtinIthBit, 2, 1)
+		IthBit = NewStaticHint(builtinIthBit, 2)
 		Register(IthBit)
+		NBits = NewStaticHint(builtinNBits, 1)
+		Register(NBits)
 	})
 }
 
@@ -30,6 +32,9 @@ var (
 	// integer inputs i and n, takes the little-endian bit representation of n and
 	// returns its i-th bit.
 	IthBit Function
+
+	// NBits returns the n first bits of the input. Expects one argument: n.
+	NBits Function
 )
 
 func builtinIsZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error {
@@ -61,5 +66,13 @@ func builtinIthBit(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
 	}
 
 	result.SetUint64(uint64(inputs[0].Bit(int(inputs[1].Uint64()))))
+	return nil
+}
+
+func builtinNBits(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
+	n := inputs[0]
+	for i := 0; i < len(results); i++ {
+		results[i].SetUint64(uint64(n.Bit(i)))
+	}
 	return nil
 }

--- a/backend/hint/hint.go
+++ b/backend/hint/hint.go
@@ -96,10 +96,13 @@ type Function interface {
 	// obtained from cache). A returned non-nil error will be propagated.
 	Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error
 
-	// NbOutputs returns the total number of outputs by the function when
+	// NbOutputs returns the MAX total number of outputs by the function when
+	// TODO @gbotrel @ivokub --> this should be used at compile time only.
+	// at solving time, what makes law is the number of wires associated with the hints
+	// assuming they were correctly allocated in the compile phase.
 	// invoked on the curveID with nInputs number of inputs. The number of
 	// outputs must be at least one and the framework errors otherwise.
-	NbOutputs(curveID ecc.ID, nInputs int) (nOutputs int)
+	// NbOutputs(curveID ecc.ID, nInputs int) (nOutputs int)
 
 	// String returns a human-readable description of the function used in logs
 	// and debug messages.
@@ -157,9 +160,9 @@ func (h *staticArgumentsFunction) Call(curveID ecc.ID, inputs []*big.Int, res []
 	return h.fn(curveID, inputs, res)
 }
 
-func (h *staticArgumentsFunction) NbOutputs(_ ecc.ID, _ int) int {
-	return h.nOut
-}
+// func (h *staticArgumentsFunction) NbOutputs(_ ecc.ID, _ int) int {
+// 	return h.nOut
+// }
 
 func (h *staticArgumentsFunction) UUID() ID {
 	return UUID(h.fn, uint64(h.nIn), uint64(h.nOut))

--- a/backend/hint/hint.go
+++ b/backend/hint/hint.go
@@ -81,7 +81,7 @@ type ID uint32
 // StaticFunction is a function which takes a constant number of inputs and
 // returns a constant number of outputs. Use NewStaticHint() to construct an
 // instance compatible with Function interface.
-type StaticFunction func(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error
+type StaticFunction func(curveID ecc.ID, inputs []*big.Int, outputs []*big.Int) error
 
 // Function defines an annotated hint function. To initialize a hint function
 // with static number of inputs and outputs, use NewStaticHint().
@@ -94,19 +94,15 @@ type Function interface {
 	// The length of res is NbOutputs() and every element is
 	// already initialized (but not necessarily to zero as the elements may be
 	// obtained from cache). A returned non-nil error will be propagated.
-	Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error
-
-	// NbOutputs returns the MAX total number of outputs by the function when
-	// TODO @gbotrel @ivokub --> this should be used at compile time only.
-	// at solving time, what makes law is the number of wires associated with the hints
-	// assuming they were correctly allocated in the compile phase.
-	// invoked on the curveID with nInputs number of inputs. The number of
-	// outputs must be at least one and the framework errors otherwise.
-	// NbOutputs(curveID ecc.ID, nInputs int) (nOutputs int)
+	Call(curveID ecc.ID, inputs []*big.Int, outputs []*big.Int) error
 
 	// String returns a human-readable description of the function used in logs
 	// and debug messages.
 	String() string
+}
+
+func NewStaticHint(fn StaticFunction) Function {
+	return fn
 }
 
 // UUID is a reference function for computing the hint ID based on a function
@@ -130,41 +126,16 @@ func UUID(fn StaticFunction, ctx ...uint64) ID {
 	return ID(hf.Sum32())
 }
 
-// staticArgumentsFunction defines a function where the number of inputs and
-// outputs is constant.
-type staticArgumentsFunction struct {
-	fn  StaticFunction
-	nIn int
+func (h StaticFunction) Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error {
+	return h(curveID, inputs, res)
 }
 
-// NewStaticHint returns an Function where the number of inputs and outputs is
-// constant. UUID is computed by combining fn, nIn and nOut and thus it is legal
-// to defined multiple AnnotatedFunctions on the same fn with different nIn and
-// nOut.
-func NewStaticHint(fn StaticFunction, nIn int) Function {
-	return &staticArgumentsFunction{
-		fn:  fn,
-		nIn: nIn,
-	}
+func (h StaticFunction) UUID() ID {
+	return UUID(h)
 }
 
-func (h *staticArgumentsFunction) Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error {
-	if len(inputs) != h.nIn {
-		return fmt.Errorf("input has %d elements, expected %d", len(inputs), h.nIn)
-	}
-	return h.fn(curveID, inputs, res)
-}
-
-// func (h *staticArgumentsFunction) NbOutputs(_ ecc.ID, _ int) int {
-// 	return h.nOut
-// }
-
-func (h *staticArgumentsFunction) UUID() ID {
-	return UUID(h.fn, uint64(h.nIn))
-}
-
-func (h *staticArgumentsFunction) String() string {
-	fnptr := reflect.ValueOf(h.fn).Pointer()
+func (h StaticFunction) String() string {
+	fnptr := reflect.ValueOf(h).Pointer()
 	name := runtime.FuncForPC(fnptr).Name()
-	return fmt.Sprintf("%s([%d]*big.Int, [?]*big.Int) at (%x)", name, h.nIn, fnptr)
+	return fmt.Sprintf("%s([?]*big.Int, [?]*big.Int) at (%x)", name, fnptr)
 }

--- a/backend/hint/hint.go
+++ b/backend/hint/hint.go
@@ -133,29 +133,24 @@ func UUID(fn StaticFunction, ctx ...uint64) ID {
 // staticArgumentsFunction defines a function where the number of inputs and
 // outputs is constant.
 type staticArgumentsFunction struct {
-	fn   StaticFunction
-	nIn  int
-	nOut int
+	fn  StaticFunction
+	nIn int
 }
 
 // NewStaticHint returns an Function where the number of inputs and outputs is
 // constant. UUID is computed by combining fn, nIn and nOut and thus it is legal
 // to defined multiple AnnotatedFunctions on the same fn with different nIn and
 // nOut.
-func NewStaticHint(fn StaticFunction, nIn, nOut int) Function {
+func NewStaticHint(fn StaticFunction, nIn int) Function {
 	return &staticArgumentsFunction{
-		fn:   fn,
-		nIn:  nIn,
-		nOut: nOut,
+		fn:  fn,
+		nIn: nIn,
 	}
 }
 
 func (h *staticArgumentsFunction) Call(curveID ecc.ID, inputs []*big.Int, res []*big.Int) error {
 	if len(inputs) != h.nIn {
 		return fmt.Errorf("input has %d elements, expected %d", len(inputs), h.nIn)
-	}
-	if len(res) != h.nOut {
-		return fmt.Errorf("result has %d elements, expected %d", len(res), h.nOut)
 	}
 	return h.fn(curveID, inputs, res)
 }
@@ -165,11 +160,11 @@ func (h *staticArgumentsFunction) Call(curveID ecc.ID, inputs []*big.Int, res []
 // }
 
 func (h *staticArgumentsFunction) UUID() ID {
-	return UUID(h.fn, uint64(h.nIn), uint64(h.nOut))
+	return UUID(h.fn, uint64(h.nIn))
 }
 
 func (h *staticArgumentsFunction) String() string {
 	fnptr := reflect.ValueOf(h.fn).Pointer()
 	name := runtime.FuncForPC(fnptr).Name()
-	return fmt.Sprintf("%s([%d]*big.Int, [%d]*big.Int) at (%x)", name, h.nIn, h.nOut, fnptr)
+	return fmt.Sprintf("%s([%d]*big.Int, [?]*big.Int) at (%x)", name, h.nIn, fnptr)
 }

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -123,7 +123,9 @@ type API interface {
 	//
 	// No new constraints are added to the newly created wire and must be added
 	// manually in the circuit. Failing to do so leads to solver failure.
-	NewHint(f hint.Function, inputs ...Variable) ([]Variable, error)
+	//
+	// If nbOutputs is specified, it must be >= 1 and <= f.NbOutputs
+	NewHint(f hint.Function, nbOutputs int, inputs ...Variable) ([]Variable, error)
 
 	// Tag creates a tag at a given place in a circuit. The state of the tag may contain informations needed to
 	// measure constraints, variables and coefficients creations through AddCounter

--- a/frontend/cs/plonk/api.go
+++ b/frontend/cs/plonk/api.go
@@ -208,7 +208,7 @@ func (system *sparseR1CS) toBinary(a compiled.Term, nbBits int, unsafe bool) []f
 	var c big.Int
 	c.SetUint64(1)
 	for i := 0; i < nbBits; i++ {
-		res, err := system.NewHint(hint.IthBit, a, i)
+		res, err := system.NewHint(hint.IthBit, 1, a, i)
 		if err != nil {
 			panic(err)
 		}
@@ -413,7 +413,7 @@ func (system *sparseR1CS) IsZero(i1 frontend.Variable) frontend.Variable {
 	// a * m = 0            // constrain m to be 0 if a != 0
 	// _ = inverse(m + a) 	// constrain m to be 1 if a == 0
 	a := i1.(compiled.Term)
-	res, err := system.NewHint(hint.IsZero, a)
+	res, err := system.NewHint(hint.IsZero, 1, a)
 	if err != nil {
 		// the function errs only if the number of inputs is invalid.
 		panic(err)
@@ -573,9 +573,9 @@ func (system *sparseR1CS) AddCounter(from, to frontend.Tag) {
 //
 // No new constraints are added to the newly created wire and must be added
 // manually in the circuit. Failing to do so leads to solver failure.
-func (system *sparseR1CS) NewHint(f hint.Function, inputs ...frontend.Variable) ([]frontend.Variable, error) {
+func (system *sparseR1CS) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.Variable) ([]frontend.Variable, error) {
 
-	if f.NbOutputs(system.Curve(), len(inputs)) <= 0 {
+	if nbOutputs <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}
 
@@ -592,7 +592,7 @@ func (system *sparseR1CS) NewHint(f hint.Function, inputs ...frontend.Variable) 
 	}
 
 	// prepare wires
-	varIDs := make([]int, f.NbOutputs(system.Curve(), len(inputs)))
+	varIDs := make([]int, nbOutputs)
 	res := make([]frontend.Variable, len(varIDs))
 	for i := range varIDs {
 		r := system.newInternalVariable()

--- a/frontend/cs/plonk/api.go
+++ b/frontend/cs/plonk/api.go
@@ -203,20 +203,20 @@ func (system *sparseR1CS) ToBinary(i1 frontend.Variable, n ...int) []frontend.Va
 func (system *sparseR1CS) toBinary(a compiled.Term, nbBits int, unsafe bool) []frontend.Variable {
 
 	// allocate the resulting frontend.Variables and bit-constraint them
-	b := make([]frontend.Variable, nbBits)
 	sb := make([]frontend.Variable, nbBits)
 	var c big.Int
 	c.SetUint64(1)
+
+	bits, err := system.NewHint(hint.NBits, nbBits, a)
+	if err != nil {
+		panic(err)
+	}
+
 	for i := 0; i < nbBits; i++ {
-		res, err := system.NewHint(hint.IthBit, 1, a, i)
-		if err != nil {
-			panic(err)
-		}
-		b[i] = res[0]
-		sb[i] = system.Mul(b[i], c)
+		sb[i] = system.Mul(bits[i], c)
 		c.Lsh(&c, 1)
 		if !unsafe {
-			system.AssertIsBoolean(b[i])
+			system.AssertIsBoolean(bits[i])
 		}
 	}
 
@@ -233,7 +233,7 @@ func (system *sparseR1CS) toBinary(a compiled.Term, nbBits int, unsafe bool) []f
 	system.AssertIsEqual(Σbi, a)
 
 	// record the constraint Σ (2**i * b[i]) == a
-	return b
+	return bits
 
 }
 

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -301,20 +301,20 @@ func (system *r1CS) toBinary(a compiled.Variable, nbBits int, unsafe bool) []fro
 	a.AssertIsSet()
 
 	// allocate the resulting frontend.Variables and bit-constraint them
-	b := make([]frontend.Variable, nbBits)
 	sb := make([]frontend.Variable, nbBits)
 	var c big.Int
 	c.SetUint64(1)
+
+	bits, err := system.NewHint(hint.NBits, nbBits, a)
+	if err != nil {
+		panic(err)
+	}
+
 	for i := 0; i < nbBits; i++ {
-		res, err := system.NewHint(hint.IthBit, 1, a, i)
-		if err != nil {
-			panic(err)
-		}
-		b[i] = res[0]
-		sb[i] = system.Mul(b[i], c)
+		sb[i] = system.Mul(bits[i], c)
 		c.Lsh(&c, 1)
 		if !unsafe {
-			system.AssertIsBoolean(b[i])
+			system.AssertIsBoolean(bits[i])
 		}
 	}
 
@@ -330,7 +330,7 @@ func (system *r1CS) toBinary(a compiled.Variable, nbBits int, unsafe bool) []fro
 	system.AssertIsEqual(Σbi, a)
 
 	// record the constraint Σ (2**i * b[i]) == a
-	return b
+	return bits
 
 }
 

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -306,7 +306,7 @@ func (system *r1CS) toBinary(a compiled.Variable, nbBits int, unsafe bool) []fro
 	var c big.Int
 	c.SetUint64(1)
 	for i := 0; i < nbBits; i++ {
-		res, err := system.NewHint(hint.IthBit, a, i)
+		res, err := system.NewHint(hint.IthBit, 1, a, i)
 		if err != nil {
 			panic(err)
 		}
@@ -523,7 +523,7 @@ func (system *r1CS) IsZero(i1 frontend.Variable) frontend.Variable {
 	// _ = inverse(m + a) 	// constrain m to be 1 if a == 0
 
 	// m is computed by the solver such that m = 1 - a^(modulus - 1)
-	res, err := system.NewHint(hint.IsZero, a)
+	res, err := system.NewHint(hint.IsZero, 1, a)
 	if err != nil {
 		// the function errs only if the number of inputs is invalid.
 		panic(err)
@@ -709,9 +709,9 @@ func (system *r1CS) AddCounter(from, to frontend.Tag) {
 //
 // No new constraints are added to the newly created wire and must be added
 // manually in the circuit. Failing to do so leads to solver failure.
-func (system *r1CS) NewHint(f hint.Function, inputs ...frontend.Variable) ([]frontend.Variable, error) {
+func (system *r1CS) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.Variable) ([]frontend.Variable, error) {
 
-	if f.NbOutputs(system.Curve(), len(inputs)) <= 0 {
+	if nbOutputs <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}
 	hintInputs := make([]interface{}, len(inputs))
@@ -732,7 +732,7 @@ func (system *r1CS) NewHint(f hint.Function, inputs ...frontend.Variable) ([]fro
 	}
 
 	// prepare wires
-	varIDs := make([]int, f.NbOutputs(system.Curve(), len(inputs)))
+	varIDs := make([]int, nbOutputs)
 	res := make([]frontend.Variable, len(varIDs))
 	for i := range varIDs {
 		r := system.newInternalVariable()

--- a/internal/backend/bls12-377/cs/solution.go
+++ b/internal/backend/bls12-377/cs/solution.go
@@ -148,7 +148,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
-	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
+	nbOutputs := len(h.Wires)
 	// m := len(s.tmpHintsIO)
 	// if m < (nbInputs + nbOutputs) {
 	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)

--- a/internal/backend/bls12-381/cs/solution.go
+++ b/internal/backend/bls12-381/cs/solution.go
@@ -148,7 +148,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
-	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
+	nbOutputs := len(h.Wires)
 	// m := len(s.tmpHintsIO)
 	// if m < (nbInputs + nbOutputs) {
 	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)

--- a/internal/backend/bls24-315/cs/solution.go
+++ b/internal/backend/bls24-315/cs/solution.go
@@ -148,7 +148,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
-	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
+	nbOutputs := len(h.Wires)
 	// m := len(s.tmpHintsIO)
 	// if m < (nbInputs + nbOutputs) {
 	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)

--- a/internal/backend/bn254/cs/solution.go
+++ b/internal/backend/bn254/cs/solution.go
@@ -148,7 +148,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
-	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
+	nbOutputs := len(h.Wires)
 	// m := len(s.tmpHintsIO)
 	// if m < (nbInputs + nbOutputs) {
 	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)

--- a/internal/backend/bw6-633/cs/solution.go
+++ b/internal/backend/bw6-633/cs/solution.go
@@ -148,7 +148,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
-	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
+	nbOutputs := len(h.Wires)
 	// m := len(s.tmpHintsIO)
 	// if m < (nbInputs + nbOutputs) {
 	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)

--- a/internal/backend/bw6-761/cs/solution.go
+++ b/internal/backend/bw6-761/cs/solution.go
@@ -148,7 +148,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
-	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
+	nbOutputs := len(h.Wires)
 	// m := len(s.tmpHintsIO)
 	// if m < (nbInputs + nbOutputs) {
 	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)

--- a/internal/backend/circuits/hint.go
+++ b/internal/backend/circuits/hint.go
@@ -101,12 +101,12 @@ func init() {
 var mulBy7 = hint.NewStaticHint(func(curveID ecc.ID, inputs []*big.Int, result []*big.Int) error {
 	result[0].Mul(inputs[0], big.NewInt(7)).Mod(result[0], curveID.Info().Fr.Modulus())
 	return nil
-}, 1)
+})
 
 var make3 = hint.NewStaticHint(func(curveID ecc.ID, inputs []*big.Int, result []*big.Int) error {
 	result[0].SetUint64(3)
 	return nil
-}, 0)
+})
 
 var dvHint = &doubleVector{}
 

--- a/internal/backend/circuits/hint.go
+++ b/internal/backend/circuits/hint.go
@@ -101,12 +101,12 @@ func init() {
 var mulBy7 = hint.NewStaticHint(func(curveID ecc.ID, inputs []*big.Int, result []*big.Int) error {
 	result[0].Mul(inputs[0], big.NewInt(7)).Mod(result[0], curveID.Info().Fr.Modulus())
 	return nil
-}, 1, 1)
+}, 1)
 
 var make3 = hint.NewStaticHint(func(curveID ecc.ID, inputs []*big.Int, result []*big.Int) error {
 	result[0].SetUint64(3)
 	return nil
-}, 0, 1)
+}, 0)
 
 var dvHint = &doubleVector{}
 

--- a/internal/backend/circuits/hint.go
+++ b/internal/backend/circuits/hint.go
@@ -14,7 +14,7 @@ type hintCircuit struct {
 }
 
 func (circuit *hintCircuit) Define(api frontend.API) error {
-	res, err := api.NewHint(mulBy7, circuit.A)
+	res, err := api.NewHint(mulBy7, 1, circuit.A)
 	if err != nil {
 		return fmt.Errorf("mulBy7: %w", err)
 	}
@@ -23,7 +23,7 @@ func (circuit *hintCircuit) Define(api frontend.API) error {
 
 	api.AssertIsEqual(a7, _a7)
 	api.AssertIsEqual(a7, circuit.B)
-	res, err = api.NewHint(make3)
+	res, err = api.NewHint(make3, 1)
 	if err != nil {
 		return fmt.Errorf("make3: %w", err)
 	}
@@ -39,7 +39,7 @@ type vectorDoubleCircuit struct {
 }
 
 func (c *vectorDoubleCircuit) Define(api frontend.API) error {
-	res, err := api.NewHint(dvHint, c.A...)
+	res, err := api.NewHint(dvHint, len(c.B), c.A...)
 	if err != nil {
 		return fmt.Errorf("double newhint: %w", err)
 	}

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -129,7 +129,7 @@ func (s *solution) solveWithHint(vID int, h *compiled.Hint) error {
 
 	// tmp IO big int memory
 	nbInputs := len(h.Inputs)
-	nbOutputs := f.NbOutputs(curve.ID, len(h.Inputs))
+	nbOutputs := len(h.Wires)
 	// m := len(s.tmpHintsIO) 
 	// if m < (nbInputs + nbOutputs) {
 	// 	s.tmpHintsIO = append(s.tmpHintsIO, make([]*big.Int, (nbOutputs + nbInputs) - m)...)

--- a/std/algebra/sw_bls12377/g1.go
+++ b/std/algebra/sw_bls12377/g1.go
@@ -225,7 +225,7 @@ var scalarDecompositionHintBLS12377 = hint.NewStaticHint(func(curve ecc.ID, inpu
 	res[2].Div(res[2], cc.fr)
 
 	return nil
-}, 1, 3)
+}, 1)
 
 func init() {
 	hint.Register(scalarDecompositionHintBLS12377)

--- a/std/algebra/sw_bls12377/g1.go
+++ b/std/algebra/sw_bls12377/g1.go
@@ -254,7 +254,7 @@ func (P *G1Affine) varScalarMul(api frontend.API, Q G1Affine, s frontend.Variabl
 	// the hints allow to decompose the scalar s into s1 and s2 such that
 	//     s1 + λ * s2 == s mod r,
 	// where λ is third root of one in 𝔽_r.
-	sd, err := api.NewHint(scalarDecompositionHintBLS12377, s)
+	sd, err := api.NewHint(scalarDecompositionHintBLS12377, 3, s)
 	if err != nil {
 		// err is non-nil only for invalid number of inputs
 		panic(err)

--- a/std/algebra/sw_bls12377/g1.go
+++ b/std/algebra/sw_bls12377/g1.go
@@ -225,7 +225,7 @@ var scalarDecompositionHintBLS12377 = hint.NewStaticHint(func(curve ecc.ID, inpu
 	res[2].Div(res[2], cc.fr)
 
 	return nil
-}, 1)
+})
 
 func init() {
 	hint.Register(scalarDecompositionHintBLS12377)

--- a/std/algebra/sw_bls24315/g1.go
+++ b/std/algebra/sw_bls24315/g1.go
@@ -225,7 +225,7 @@ var scalarDecompositionHintBLS24315 = hint.NewStaticHint(func(curve ecc.ID, inpu
 	res[2].Div(res[2], cc.fr)
 
 	return nil
-}, 1)
+})
 
 func init() {
 	hint.Register(scalarDecompositionHintBLS24315)

--- a/std/algebra/sw_bls24315/g1.go
+++ b/std/algebra/sw_bls24315/g1.go
@@ -254,7 +254,7 @@ func (P *G1Affine) varScalarMul(api frontend.API, Q G1Affine, s frontend.Variabl
 	// the hints allow to decompose the scalar s into s1 and s2 such that
 	//     s1 + λ * s2 == s mod r,
 	// where λ is third root of one in 𝔽_r.
-	sd, err := api.NewHint(scalarDecompositionHintBLS24315, s)
+	sd, err := api.NewHint(scalarDecompositionHintBLS24315, 3, s)
 	if err != nil {
 		// err is non-nil only for invalid number of inputs
 		panic(err)

--- a/std/algebra/sw_bls24315/g1.go
+++ b/std/algebra/sw_bls24315/g1.go
@@ -225,7 +225,7 @@ var scalarDecompositionHintBLS24315 = hint.NewStaticHint(func(curve ecc.ID, inpu
 	res[2].Div(res[2], cc.fr)
 
 	return nil
-}, 1, 3)
+}, 1)
 
 func init() {
 	hint.Register(scalarDecompositionHintBLS24315)

--- a/test/engine.go
+++ b/test/engine.go
@@ -325,9 +325,9 @@ func (e *engine) Println(a ...frontend.Variable) {
 	fmt.Println(sbb.String())
 }
 
-func (e *engine) NewHint(f hint.Function, inputs ...frontend.Variable) ([]frontend.Variable, error) {
+func (e *engine) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.Variable) ([]frontend.Variable, error) {
 
-	if f.NbOutputs(e.Curve(), len(inputs)) <= 0 {
+	if nbOutputs <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}
 
@@ -337,7 +337,7 @@ func (e *engine) NewHint(f hint.Function, inputs ...frontend.Variable) ([]fronte
 		v := e.toBigInt(inputs[i])
 		in[i] = &v
 	}
-	res := make([]*big.Int, f.NbOutputs(e.Curve(), len(inputs)))
+	res := make([]*big.Int, nbOutputs)
 	for i := range res {
 		res[i] = new(big.Int)
 	}

--- a/test/engine_test.go
+++ b/test/engine_test.go
@@ -15,22 +15,22 @@ type hintCircuit struct {
 }
 
 func (circuit *hintCircuit) Define(api frontend.API) error {
-	res, err := api.NewHint(hint.IthBit, circuit.A, 3)
+	res, err := api.NewHint(hint.IthBit, 1, circuit.A, 3)
 	if err != nil {
 		return fmt.Errorf("IthBit circuitA 3: %w", err)
 	}
 	a3b := res[0]
-	res, err = api.NewHint(hint.IthBit, circuit.A, 25)
+	res, err = api.NewHint(hint.IthBit, 1, circuit.A, 25)
 	if err != nil {
 		return fmt.Errorf("IthBit circuitA 25: %w", err)
 	}
 	a25b := res[0]
-	res, err = api.NewHint(hint.IsZero, circuit.A)
+	res, err = api.NewHint(hint.IsZero, 1, circuit.A)
 	if err != nil {
 		return fmt.Errorf("IsZero CircuitA: %w", err)
 	}
 	aisZero := res[0]
-	res, err = api.NewHint(hint.IsZero, circuit.B)
+	res, err = api.NewHint(hint.IsZero, 1, circuit.B)
 	if err != nil {
 		return fmt.Errorf("IsZero, CircuitB")
 	}


### PR DESCRIPTION
Creating this one as draft before cleaning it as it opens a discussion. It reverts some changes introduced by #183  #175  (cc @ivokub ). 

Essentially, this PR proposes to remove `nbInputs` and `nbOutputs` set in `StaticHintFunction` and the `NbOutputs()` function in the `Hint` interface. 

Trying to implement multi-outputs (with variable length) hints for binary operation, this declarative way is really not helping;

1. The circuit developer will provide a list of inputs to the hint function (example; `api.NewHint(myHint, input0, input1, ...)`. IF (and I don't think we need to) we want to check that the number of inputs matches what the hints can process, it's up to the hint to perform the check (ie if len(inputs) > ... --> error). Currently this was encapsulated in a `Call` function. 

2. Similarly, the circuit developer knows how many outputs it expects from a hint. He should set it like so `bits := api.NewHint(BitsHint, 220, value)` would return the first 220 bits for example in `[]bits`. Previously this was done declaratively at hint definition, through `NbOutputs()` method, which was called both in the frontend and the backend at solving time. --> it makes no sense as the backend will not decide the number of outputs, the frontend did at compile time and created the exact number of wires needed. 


@ivokub did you have specific future scenario in mind when doing this pattern? 
