### PR TITLE
feat: added std.GetHints for convenience. fixes #264

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -48,18 +48,6 @@ func (id ID) String() string {
 	}
 }
 
-// NewProverConfig returns a default ProverConfig with given prover options opts
-// applied.
-func NewProverConfig(opts ...ProverOption) (ProverConfig, error) {
-	opt := ProverConfig{LoggerOut: os.Stdout, HintFunctions: hint.GetAll()}
-	for _, option := range opts {
-		if err := option(&opt); err != nil {
-			return ProverConfig{}, err
-		}
-	}
-	return opt, nil
-}
-
 // ProverOption defines option for altering the behaviour of the prover in
 // Prove, ReadAndProve and IsSolved methods. See the descriptions of functions
 // returning instances of this type for implemented options.
@@ -70,6 +58,18 @@ type ProverConfig struct {
 	Force         bool            // defaults to false
 	HintFunctions []hint.Function // defaults to all built-in hint functions
 	LoggerOut     io.Writer       // defaults to os.Stdout
+}
+
+// NewProverConfig returns a default ProverConfig with given prover options opts
+// applied.
+func NewProverConfig(opts ...ProverOption) (ProverConfig, error) {
+	opt := ProverConfig{LoggerOut: os.Stdout, HintFunctions: hint.GetAll()}
+	for _, option := range opts {
+		if err := option(&opt); err != nil {
+			return ProverConfig{}, err
+		}
+	}
+	return opt, nil
 }
 
 // IgnoreSolverError is a prover option that indicates that the Prove algorithm

--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -23,7 +23,6 @@ import (
 	"io"
 
 	"github.com/consensys/gnark-crypto/ecc"
-
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
 	"github.com/consensys/gnark/frontend"

--- a/backend/hint/builtin.go
+++ b/backend/hint/builtin.go
@@ -2,44 +2,32 @@ package hint
 
 import (
 	"math/big"
-	"sync"
 
 	"github.com/consensys/gnark-crypto/ecc"
 )
 
-var initBuiltinOnce sync.Once
-
-func init() {
-	initBuiltinOnce.Do(func() {
-		IsZero = NewStaticHint(builtinIsZero)
-		Register(IsZero)
-		IthBit = NewStaticHint(builtinIthBit)
-		Register(IthBit)
-		NBits = NewStaticHint(builtinNBits)
-		Register(NBits)
-	})
-}
-
-// TODO FIXME these may be redefined easily by an external package
-
-// The package provides the following built-in hint functions. All built-in hint
-// functions are registered in the registry.
 var (
 	// IsZero computes the value 1 - a^(modulus-1) for the single input a. This
 	// corresponds to checking if a == 0 (for which the function returns 1) or a
 	// != 0 (for which the function returns 0).
-	IsZero Function
+	IsZero = NewStaticHint(isZero)
 
 	// IthBit returns the i-tb bit the input. The function expects exactly two
 	// integer inputs i and n, takes the little-endian bit representation of n and
 	// returns its i-th bit.
-	IthBit Function
+	IthBit = NewStaticHint(ithBit)
 
 	// NBits returns the n first bits of the input. Expects one argument: n.
-	NBits Function
+	NBits = NewStaticHint(nBits)
 )
 
-func builtinIsZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error {
+func init() {
+	Register(IsZero)
+	Register(IthBit)
+	Register(NBits)
+}
+
+func isZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error {
 	result := results[0]
 
 	// get fr modulus
@@ -60,7 +48,7 @@ func builtinIsZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error 
 	return nil
 }
 
-func builtinIthBit(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
+func ithBit(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
 	result := results[0]
 	if !inputs[1].IsUint64() {
 		result.SetUint64(0)
@@ -71,7 +59,7 @@ func builtinIthBit(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
 	return nil
 }
 
-func builtinNBits(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
+func nBits(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
 	n := inputs[0]
 	for i := 0; i < len(results); i++ {
 		results[i].SetUint64(uint64(n.Bit(i)))

--- a/examples/plonk/main.go
+++ b/examples/plonk/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/plonk"
@@ -65,28 +64,6 @@ func (circuit *Circuit) Define(api frontend.API) error {
 	}
 
 	api.AssertIsEqual(circuit.Y, output)
-
-	return nil
-}
-
-func builtinIsZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error {
-	// fake one
-	result := results[0]
-
-	// get fr modulus
-	q := curveID.Info().Fr.Modulus()
-
-	// save input
-	result.Set(inputs[0])
-
-	// reuse input to compute q - 1
-	qMinusOne := inputs[0].SetUint64(1)
-	qMinusOne.Sub(q, qMinusOne)
-
-	// result =  1 - input**(q-1)
-	result.Exp(result, qMinusOne, q)
-	inputs[0].SetUint64(1)
-	result.Sub(inputs[0], result).Mod(result, q)
 
 	return nil
 }

--- a/examples/plonk/main.go
+++ b/examples/plonk/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/plonk"
@@ -64,6 +65,28 @@ func (circuit *Circuit) Define(api frontend.API) error {
 	}
 
 	api.AssertIsEqual(circuit.Y, output)
+
+	return nil
+}
+
+func builtinIsZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error {
+	// fake one
+	result := results[0]
+
+	// get fr modulus
+	q := curveID.Info().Fr.Modulus()
+
+	// save input
+	result.Set(inputs[0])
+
+	// reuse input to compute q - 1
+	qMinusOne := inputs[0].SetUint64(1)
+	qMinusOne.Sub(q, qMinusOne)
+
+	// result =  1 - input**(q-1)
+	result.Exp(result, qMinusOne, q)
+	inputs[0].SetUint64(1)
+	result.Sub(inputs[0], result).Mod(result, q)
 
 	return nil
 }

--- a/frontend/compiled/cs.go
+++ b/frontend/compiled/cs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/internal/utils"
@@ -38,9 +39,8 @@ type ConstraintSystem struct {
 
 	Counters []Counter // TODO @gbotrel no point in serializing these
 
-	// maps wire id to hint
-	// a wire may point to at most one hint
-	MHints map[int]*Hint
+	MHints             map[int]*Hint      // maps wireID to hint
+	MHintsDependencies map[hint.ID]string // maps hintID to hint string identifier
 
 	// each level contains independent constraints and can be parallelized
 	// it is guaranteed that all dependncies for constraints in a level l are solved

--- a/frontend/cs/r1cs/compiler.go
+++ b/frontend/cs/r1cs/compiler.go
@@ -64,9 +64,9 @@ type r1cs struct {
 func newCompiler(curveID ecc.ID, config frontend.CompileConfig) *r1cs {
 	system := r1cs{
 		ConstraintSystem: compiled.ConstraintSystem{
-
-			MDebug: make(map[int]int),
-			MHints: make(map[int]*compiled.Hint),
+			MDebug:             make(map[int]int),
+			MHints:             make(map[int]*compiled.Hint),
+			MHintsDependencies: make(map[hint.ID]string),
 		},
 		Constraints: make([]compiled.R1C, 0, config.Capacity),
 		st:          cs.NewCoeffTable(),
@@ -663,10 +663,21 @@ func (system *r1cs) AddCounter(from, to frontend.Tag) {
 // No new constraints are added to the newly created wire and must be added
 // manually in the circuit. Failing to do so leads to solver failure.
 func (system *r1cs) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.Variable) ([]frontend.Variable, error) {
-
 	if nbOutputs <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}
+
+	// register the hint as dependency
+	hintUUID, hintID := f.UUID(), f.String()
+	if id, ok := system.MHintsDependencies[hintUUID]; ok {
+		// hint already registered, let's ensure string id matches
+		if id != hintID {
+			return nil, fmt.Errorf("hint dependency registration failed; %s previously register with same UUID as %s", hintID, id)
+		}
+	} else {
+		system.MHintsDependencies[hintUUID] = hintID
+	}
+
 	hintInputs := make([]interface{}, len(inputs))
 
 	// ensure inputs are set and pack them in a []uint64

--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -67,7 +67,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
-	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbWires, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return make([]fr.Element, nbWires), err
 	}

--- a/internal/backend/bls12-377/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-377/cs/r1cs_sparse.go
@@ -82,7 +82,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 	}
 
 	// keep track of wire that have a value
-	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return solution.values, err
 	}

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -67,7 +67,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
-	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbWires, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return make([]fr.Element, nbWires), err
 	}

--- a/internal/backend/bls12-381/cs/r1cs_sparse.go
+++ b/internal/backend/bls12-381/cs/r1cs_sparse.go
@@ -82,7 +82,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 	}
 
 	// keep track of wire that have a value
-	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return solution.values, err
 	}

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -67,7 +67,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
-	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbWires, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return make([]fr.Element, nbWires), err
 	}

--- a/internal/backend/bls24-315/cs/r1cs_sparse.go
+++ b/internal/backend/bls24-315/cs/r1cs_sparse.go
@@ -82,7 +82,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 	}
 
 	// keep track of wire that have a value
-	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return solution.values, err
 	}

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -67,7 +67,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
-	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbWires, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return make([]fr.Element, nbWires), err
 	}

--- a/internal/backend/bn254/cs/r1cs_sparse.go
+++ b/internal/backend/bn254/cs/r1cs_sparse.go
@@ -82,7 +82,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 	}
 
 	// keep track of wire that have a value
-	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return solution.values, err
 	}

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -67,7 +67,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
-	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbWires, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return make([]fr.Element, nbWires), err
 	}

--- a/internal/backend/bw6-633/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-633/cs/r1cs_sparse.go
@@ -82,7 +82,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 	}
 
 	// keep track of wire that have a value
-	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return solution.values, err
 	}

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -67,7 +67,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
-	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbWires, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return make([]fr.Element, nbWires), err
 	}

--- a/internal/backend/bw6-761/cs/r1cs_sparse.go
+++ b/internal/backend/bw6-761/cs/r1cs_sparse.go
@@ -82,7 +82,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 	}
 
 	// keep track of wire that have a value
-	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbVariables, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return solution.values, err
 	}

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -12,6 +12,7 @@ import (
 	"github.com/consensys/gnark/frontend/compiled"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
 
 	"math"
@@ -50,7 +51,7 @@ func NewR1CS(cs compiled.R1CS, coefficients []big.Int) *R1CS {
 func (cs *R1CS) Solve(witness, a, b, c []fr.Element, opt backend.ProverConfig) ([]fr.Element, error) {
 
 	nbWires := cs.NbPublicVariables + cs.NbSecretVariables + cs.NbInternalVariables
-	solution, err := newSolution(nbWires, opt.HintFunctions, cs.Coefficients)
+	solution, err := newSolution(nbWires, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return make([]fr.Element, nbWires), err
 	}

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -12,7 +12,6 @@ import (
 	"github.com/consensys/gnark/frontend/compiled"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/backend"
-	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/witness"
 
 	"math"

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -13,6 +13,7 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/frontend/compiled"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/backend/witness"
 
@@ -68,7 +69,7 @@ func (cs *SparseR1CS) Solve(witness []fr.Element, opt backend.ProverConfig) ([]f
 
 
 	// keep track of wire that have a value
-	solution, err  := newSolution(nbVariables, opt.HintFunctions, cs.Coefficients)
+	solution, err  := newSolution(nbVariables, opt.HintFunctions, cs.MHintsDependencies, cs.Coefficients)
 	if err != nil {
 		return solution.values, err
 	}

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -13,7 +13,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/frontend/compiled"
 	"github.com/consensys/gnark/backend"
-	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/backend/witness"
 

--- a/internal/generator/backend/template/representations/solution.go.tmpl
+++ b/internal/generator/backend/template/representations/solution.go.tmpl
@@ -25,20 +25,32 @@ type solution struct {
 	mHintsFunctions      map[hint.ID]hint.Function
 }
 
-func newSolution(nbWires int, hintFunctions []hint.Function, coefficients []fr.Element) (solution, error) {
+func newSolution(nbWires int, hintFunctions []hint.Function, hintsDependencies map[hint.ID]string, coefficients []fr.Element) (solution, error) {
 
-  s := solution{
-		values: make([]fr.Element, nbWires),
-		coefficients: coefficients,
-		solved: make([]bool, nbWires),
-		mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
-  }
-	
+	s := solution{
+			values: make([]fr.Element, nbWires),
+			coefficients: coefficients,
+			solved: make([]bool, nbWires),
+			mHintsFunctions: make(map[hint.ID]hint.Function, len(hintFunctions)),
+	}
+
 	for _, h := range hintFunctions {
 		if _, ok := s.mHintsFunctions[h.UUID()]; ok {
-			return solution{}, fmt.Errorf("duplicate hint function %s", h)
+			return s, fmt.Errorf("duplicate hint function %s", h)
  		}
 		s.mHintsFunctions[h.UUID()] = h
+	}
+
+	// hintsDependencies is from compile time; it contains the list of hints the solver **needs**
+	var missing []string
+	for hintUUID, hintID := range hintsDependencies {
+		if _, ok := s.mHintsFunctions[hintUUID]; !ok {
+			missing = append(missing, hintID)
+		}
+	}
+
+	if len(missing) > 0 {
+		return s, fmt.Errorf("solver missing hint(s): %v", missing)
 	}
 
 	return s, nil

--- a/std/algebra/sw_bls12377/g1.go
+++ b/std/algebra/sw_bls12377/g1.go
@@ -206,7 +206,7 @@ func (P *G1Affine) ScalarMul(api frontend.API, Q G1Affine, s interface{}) *G1Aff
 	}
 }
 
-var scalarDecompositionHintBLS12377 = hint.NewStaticHint(func(curve ecc.ID, inputs []*big.Int, res []*big.Int) error {
+var DecomposeScalar = hint.NewStaticHint(func(curve ecc.ID, inputs []*big.Int, res []*big.Int) error {
 	cc := innerCurve(curve)
 	sp := ecc.SplitScalar(inputs[0], cc.glvBasis)
 	res[0].Set(&(sp[0]))
@@ -228,7 +228,7 @@ var scalarDecompositionHintBLS12377 = hint.NewStaticHint(func(curve ecc.ID, inpu
 })
 
 func init() {
-	hint.Register(scalarDecompositionHintBLS12377)
+	hint.Register(DecomposeScalar)
 }
 
 // varScalarMul sets P = [s] Q and returns P.
@@ -254,7 +254,7 @@ func (P *G1Affine) varScalarMul(api frontend.API, Q G1Affine, s frontend.Variabl
 	// the hints allow to decompose the scalar s into s1 and s2 such that
 	//     s1 + λ * s2 == s mod r,
 	// where λ is third root of one in 𝔽_r.
-	sd, err := api.Compiler().NewHint(scalarDecompositionHintBLS12377, 3, s)
+	sd, err := api.Compiler().NewHint(DecomposeScalar, 3, s)
 	if err != nil {
 		// err is non-nil only for invalid number of inputs
 		panic(err)

--- a/std/algebra/sw_bls24315/g1.go
+++ b/std/algebra/sw_bls24315/g1.go
@@ -206,7 +206,7 @@ func (P *G1Affine) ScalarMul(api frontend.API, Q G1Affine, s interface{}) *G1Aff
 	}
 }
 
-var scalarDecompositionHintBLS24315 = hint.NewStaticHint(func(curve ecc.ID, inputs []*big.Int, res []*big.Int) error {
+var DecomposeScalar = hint.NewStaticHint(func(curve ecc.ID, inputs []*big.Int, res []*big.Int) error {
 	cc := innerCurve(curve)
 	sp := ecc.SplitScalar(inputs[0], cc.glvBasis)
 	res[0].Set(&(sp[0]))
@@ -228,7 +228,7 @@ var scalarDecompositionHintBLS24315 = hint.NewStaticHint(func(curve ecc.ID, inpu
 })
 
 func init() {
-	hint.Register(scalarDecompositionHintBLS24315)
+	hint.Register(DecomposeScalar)
 }
 
 // varScalarMul sets P = [s] Q and returns P.
@@ -254,7 +254,7 @@ func (P *G1Affine) varScalarMul(api frontend.API, Q G1Affine, s frontend.Variabl
 	// the hints allow to decompose the scalar s into s1 and s2 such that
 	//     s1 + λ * s2 == s mod r,
 	// where λ is third root of one in 𝔽_r.
-	sd, err := api.Compiler().NewHint(scalarDecompositionHintBLS24315, 3, s)
+	sd, err := api.Compiler().NewHint(DecomposeScalar, 3, s)
 	if err != nil {
 		// err is non-nil only for invalid number of inputs
 		panic(err)

--- a/std/hints.go
+++ b/std/hints.go
@@ -1,0 +1,12 @@
+package std
+
+import (
+	"github.com/consensys/gnark/backend/hint"
+	"github.com/consensys/gnark/std/algebra/sw_bls12377"
+	"github.com/consensys/gnark/std/algebra/sw_bls24315"
+)
+
+// GetHints return std hints that are always injected in gnark solvers
+func GetHints() []hint.Function {
+	return []hint.Function{sw_bls24315.DecomposeScalar, sw_bls12377.DecomposeScalar}
+}


### PR DESCRIPTION
See #264. 


+ this PR adds a clear error message when a hint is missing for the solver; a compiled constraint system will be serialized with its hints dependencies; if any is missing at Solving time, the error message will contain the hint name. 