### PR TITLE
refactor: revert Builder -> Compiler internal name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ func (circuit *CubicCircuit) Define(api frontend.API) error {
 
 // compiles our circuit into a R1CS
 var circuit CubicCircuit
-ccs, err := frontend.Compile(ecc.BN254, r1cs.NewCompiler, &circuit)
+ccs, err := frontend.Compile(ecc.BN254, r1cs.NewBuilder, &circuit)
 
 // groth16 zkSNARK: Setup
 pk, vk, err := groth16.Setup(ccs)

--- a/circuitstats_test.go
+++ b/circuitstats_test.go
@@ -33,13 +33,13 @@ func TestCircuitStatistics(t *testing.T) {
 				// copy the circuit now in case assert calls t.Parallel()
 				tData := circuits.Circuits[k]
 				assert.Run(func(assert *test.Assert) {
-					var newCompiler frontend.NewCompiler
+					var newCompiler frontend.NewBuilder
 
 					switch backendID {
 					case backend.GROTH16:
-						newCompiler = r1cs.NewCompiler
+						newCompiler = r1cs.NewBuilder
 					case backend.PLONK:
-						newCompiler = scs.NewCompiler
+						newCompiler = scs.NewBuilder
 					default:
 						panic("not implemented")
 					}

--- a/debug_test.go
+++ b/debug_test.go
@@ -174,7 +174,7 @@ func TestTraceNotBoolean(t *testing.T) {
 }
 
 func getPlonkTrace(circuit, w frontend.Circuit) (string, error) {
-	ccs, err := frontend.Compile(ecc.BN254, scs.NewCompiler, circuit)
+	ccs, err := frontend.Compile(ecc.BN254, scs.NewBuilder, circuit)
 	if err != nil {
 		return "", err
 	}
@@ -198,7 +198,7 @@ func getPlonkTrace(circuit, w frontend.Circuit) (string, error) {
 }
 
 func getGroth16Trace(circuit, w frontend.Circuit) (string, error) {
-	ccs, err := frontend.Compile(ecc.BN254, r1cs.NewCompiler, circuit)
+	ccs, err := frontend.Compile(ecc.BN254, r1cs.NewBuilder, circuit)
 	if err != nil {
 		return "", err
 	}

--- a/examples/plonk/main.go
+++ b/examples/plonk/main.go
@@ -73,7 +73,7 @@ func main() {
 	var circuit Circuit
 
 	// // building the circuit...
-	ccs, err := frontend.Compile(ecc.BN254, scs.NewCompiler, &circuit)
+	ccs, err := frontend.Compile(ecc.BN254, scs.NewBuilder, &circuit)
 	if err != nil {
 		fmt.Println("circuit compilation error")
 	}

--- a/examples/serialization/main.go
+++ b/examples/serialization/main.go
@@ -17,7 +17,7 @@ func main() {
 	var circuit cubic.Circuit
 
 	// compile a circuit
-	_r1cs, _ := frontend.Compile(ecc.BN254, r1cs.NewCompiler, &circuit)
+	_r1cs, _ := frontend.Compile(ecc.BN254, r1cs.NewBuilder, &circuit)
 
 	// R1CS implements io.WriterTo and io.ReaderFrom
 	var buf bytes.Buffer

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -9,7 +9,7 @@ import (
 	"github.com/consensys/gnark/frontend/schema"
 )
 
-type NewCompiler func(ecc.ID, CompileConfig) (Builder, error)
+type NewBuilder func(ecc.ID, CompileConfig) (Builder, error)
 
 // Compiler represents a constraint system compiler
 type Compiler interface {

--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -28,7 +28,7 @@ import (
 //
 // initialCapacity is an optional parameter that reserves memory in slices
 // it should be set to the estimated number of constraints in the circuit, if known.
-func Compile(curveID ecc.ID, newCompiler NewCompiler, circuit Circuit, opts ...CompileOption) (CompiledConstraintSystem, error) {
+func Compile(curveID ecc.ID, newCompiler NewBuilder, circuit Circuit, opts ...CompileOption) (CompiledConstraintSystem, error) {
 	// parse options
 	opt := CompileConfig{}
 	for _, o := range opts {

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 ConsenSys Software Inc.
+Copyright © 2020 ConsenSys
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scs
+package r1cs
 
 import (
 	"errors"
@@ -43,101 +43,97 @@ import (
 	"github.com/consensys/gnark/internal/utils"
 )
 
-func NewCompiler(curve ecc.ID, config frontend.CompileConfig) (frontend.Builder, error) {
-	return newCompiler(curve, config), nil
+// NewBuilder returns a new R1CS compiler
+func NewBuilder(curve ecc.ID, config frontend.CompileConfig) (frontend.Builder, error) {
+	return newBuilder(curve, config), nil
 }
 
-type scs struct {
+type r1cs struct {
 	compiled.ConstraintSystem
-	Constraints []compiled.SparseR1C
+	Constraints []compiled.R1C
 
 	st     cs.CoeffTable
 	config frontend.CompileConfig
 
 	// map for recording boolean constrained variables (to not constrain them twice)
-	mtBooleans map[int]struct{}
+	mtBooleans map[uint64][]compiled.LinearExpression
 }
 
 // initialCapacity has quite some impact on frontend performance, especially on large circuits size
 // we may want to add build tags to tune that
-func newCompiler(curveID ecc.ID, config frontend.CompileConfig) *scs {
-	system := scs{
+func newBuilder(curveID ecc.ID, config frontend.CompileConfig) *r1cs {
+	system := r1cs{
 		ConstraintSystem: compiled.ConstraintSystem{
 
 			MDebug: make(map[int]int),
 			MHints: make(map[int]*compiled.Hint),
 		},
-		mtBooleans:  make(map[int]struct{}),
-		Constraints: make([]compiled.SparseR1C, 0, config.Capacity),
+		Constraints: make([]compiled.R1C, 0, config.Capacity),
 		st:          cs.NewCoeffTable(),
+		mtBooleans:  make(map[uint64][]compiled.LinearExpression),
 		config:      config,
 	}
 
-	system.Public = make([]string, 0)
+	system.Public = make([]string, 1)
 	system.Secret = make([]string, 0)
+
+	// by default the circuit is given a public wire equal to 1
+	system.Public[0] = "one"
 
 	system.CurveID = curveID
 
 	return &system
 }
 
-// addPlonkConstraint creates a constraint of the for al+br+clr+k=0
-//func (system *SparseR1CS) addPlonkConstraint(l, r, o frontend.Variable, cidl, cidr, cidm1, cidm2, cido, k int, debugID ...int) {
-func (system *scs) addPlonkConstraint(l, r, o compiled.Term, cidl, cidr, cidm1, cidm2, cido, k int, debugID ...int) {
-
-	if len(debugID) > 0 {
-		system.MDebug[len(system.Constraints)] = debugID[0]
-	}
-
-	l.SetCoeffID(cidl)
-	r.SetCoeffID(cidr)
-	o.SetCoeffID(cido)
-
-	u := l
-	v := r
-	u.SetCoeffID(cidm1)
-	v.SetCoeffID(cidm2)
-
-	//system.Constraints = append(system.Constraints, compiled.SparseR1C{L: _l, R: _r, O: _o, M: [2]compiled.Term{u, v}, K: k})
-	system.Constraints = append(system.Constraints, compiled.SparseR1C{L: l, R: r, O: o, M: [2]compiled.Term{u, v}, K: k})
-}
-
 // newInternalVariable creates a new wire, appends it on the list of wires of the circuit, sets
 // the wire's id to the number of wires, and returns it
-func (system *scs) newInternalVariable() compiled.Term {
+func (system *r1cs) newInternalVariable() compiled.LinearExpression {
 	idx := system.NbInternalVariables
 	system.NbInternalVariables++
-	return compiled.Pack(idx, compiled.CoeffIdOne, schema.Internal)
+	return compiled.LinearExpression{
+		compiled.Pack(idx, compiled.CoeffIdOne, schema.Internal),
+	}
 }
 
-// AddPublicVariable creates a new Public Variable
-func (system *scs) AddPublicVariable(name string) frontend.Variable {
+// AddPublicVariable creates a new public Variable
+func (system *r1cs) AddPublicVariable(name string) frontend.Variable {
 	if system.Schema != nil {
 		panic("do not call AddPublicVariable in circuit.Define()")
 	}
 	idx := len(system.Public)
 	system.Public = append(system.Public, name)
-	return compiled.Pack(idx, compiled.CoeffIdOne, schema.Public)
+	return compiled.LinearExpression{
+		compiled.Pack(idx, compiled.CoeffIdOne, schema.Public),
+	}
 }
 
-// AddSecretVariable creates a new Secret Variable
-func (system *scs) AddSecretVariable(name string) frontend.Variable {
+// AddSecretVariable creates a new secret Variable
+func (system *r1cs) AddSecretVariable(name string) frontend.Variable {
 	if system.Schema != nil {
 		panic("do not call AddSecretVariable in circuit.Define()")
 	}
 	idx := len(system.Secret)
 	system.Secret = append(system.Secret, name)
-	return compiled.Pack(idx, compiled.CoeffIdOne, schema.Secret)
+	return compiled.LinearExpression{
+		compiled.Pack(idx, compiled.CoeffIdOne, schema.Secret),
+	}
+}
+
+func (system *r1cs) one() compiled.LinearExpression {
+	return compiled.LinearExpression{
+		compiled.Pack(0, compiled.CoeffIdOne, schema.Public),
+	}
 }
 
 // reduces redundancy in linear expression
 // It factorizes Variable that appears multiple times with != coeff Ids
 // To ensure the determinism in the compile process, Variables are stored as public∥secret∥internal∥unset
 // for each visibility, the Variables are sorted from lowest ID to highest ID
-func (system *scs) reduce(l compiled.LinearExpression) compiled.LinearExpression {
-
+func (system *r1cs) reduce(l compiled.LinearExpression) compiled.LinearExpression {
 	// ensure our linear expression is sorted, by visibility and by Variable ID
-	sort.Sort(l)
+	if !sort.IsSorted(l) { // may not help
+		sort.Sort(l)
+	}
 
 	mod := system.CurveID.Info().Fr.Modulus()
 	c := new(big.Int)
@@ -156,40 +152,94 @@ func (system *scs) reduce(l compiled.LinearExpression) compiled.LinearExpression
 	return l
 }
 
-// to handle wires that don't exist (=coef 0) in a sparse constraint
-func (system *scs) zero() compiled.Term {
-	var a compiled.Term
-	return a
+// newR1C clones the linear expression associated with the Variables (to avoid offseting the ID multiple time)
+// and return a R1C
+func newR1C(_l, _r, _o frontend.Variable) compiled.R1C {
+	l := _l.(compiled.LinearExpression)
+	r := _r.(compiled.LinearExpression)
+	o := _o.(compiled.LinearExpression)
+
+	// interestingly, this is key to groth16 performance.
+	// l * r == r * l == o
+	// but the "l" linear expression is going to end up in the A matrix
+	// the "r" linear expression is going to end up in the B matrix
+	// the less Variable we have appearing in the B matrix, the more likely groth16.Setup
+	// is going to produce infinity points in pk.G1.B and pk.G2.B, which will speed up proving time
+	if len(l) > len(r) {
+		l, r = r, l
+	}
+
+	return compiled.R1C{L: l.Clone(), R: r.Clone(), O: o.Clone()}
+}
+
+func (system *r1cs) addConstraint(r1c compiled.R1C, debugID ...int) {
+	system.Constraints = append(system.Constraints, r1c)
+	if len(debugID) > 0 {
+		system.MDebug[len(system.Constraints)-1] = debugID[0]
+	}
+}
+
+// Term packs a Variable and a coeff in a Term and returns it.
+// func (system *R1CSRefactor) setCoeff(v Variable, coeff *big.Int) Term {
+func (system *r1cs) setCoeff(v compiled.Term, coeff *big.Int) compiled.Term {
+	_, vID, vVis := v.Unpack()
+	return compiled.Pack(vID, system.st.CoeffID(coeff), vVis)
+}
+
+// MarkBoolean sets (but do not **constraint**!) v to be boolean
+// This is useful in scenarios where a variable is known to be boolean through a constraint
+// that is not api.AssertIsBoolean. If v is a constant, this is a no-op.
+func (system *r1cs) MarkBoolean(v frontend.Variable) {
+	if b, ok := system.ConstantValue(v); ok {
+		if !(b.IsUint64() && b.Uint64() <= 1) {
+			panic("MarkBoolean called a non-boolean constant")
+		}
+		return
+	}
+	// v is a linear expression
+	l := v.(compiled.LinearExpression)
+	if !sort.IsSorted(l) {
+		sort.Sort(l)
+	}
+
+	key := l.HashCode()
+	list := system.mtBooleans[key]
+	list = append(list, l)
+	system.mtBooleans[key] = list
 }
 
 // IsBoolean returns true if given variable was marked as boolean in the compiler (see MarkBoolean)
 // Use with care; variable may not have been **constrained** to be boolean
 // This returns true if the v is a constant and v == 0 || v == 1.
-func (system *scs) IsBoolean(v frontend.Variable) bool {
+func (system *r1cs) IsBoolean(v frontend.Variable) bool {
 	if b, ok := system.ConstantValue(v); ok {
 		return b.IsUint64() && b.Uint64() <= 1
 	}
-	_, ok := system.mtBooleans[int(v.(compiled.Term))]
-	return ok
-}
+	// v is a linear expression
+	l := v.(compiled.LinearExpression)
+	if !sort.IsSorted(l) {
+		sort.Sort(l)
+	}
 
-// MarkBoolean sets (but do not constraint!) v to be boolean
-// This is useful in scenarios where a variable is known to be boolean through a constraint
-// that is not api.AssertIsBoolean. If v is a constant, this is a no-op.
-func (system *scs) MarkBoolean(v frontend.Variable) {
-	if b, ok := system.ConstantValue(v); ok {
-		if !(b.IsUint64() && b.Uint64() <= 1) {
-			panic("MarkBoolean called a non-boolean constant")
+	key := l.HashCode()
+	list, ok := system.mtBooleans[key]
+	if !ok {
+		return false
+	}
+
+	for _, v := range list {
+		if v.Equal(l) {
+			return true
 		}
 	}
-	system.mtBooleans[int(v.(compiled.Term))] = struct{}{}
+	return false
 }
 
 // checkVariables perform post compilation checks on the Variables
 //
 // 1. checks that all user inputs are referenced in at least one constraint
 // 2. checks that all hints are constrained
-func (system *scs) checkVariables() error {
+func (system *r1cs) checkVariables() error {
 
 	// TODO @gbotrel add unit test for that.
 
@@ -197,28 +247,28 @@ func (system *scs) checkVariables() error {
 	cptPublic := len(system.Public)
 	cptHints := len(system.MHints)
 
-	// compared to R1CS, we may have a circuit which does not have any inputs
-	// (R1CS always has a constant ONE wire). Check the edge case and omit any
-	// processing if so.
-	if cptSecret+cptPublic+cptHints == 0 {
-		return nil
-	}
-
 	secretConstrained := make([]bool, cptSecret)
 	publicConstrained := make([]bool, cptPublic)
+	// one wire does not need to be constrained
+	publicConstrained[0] = true
+	cptPublic--
 
 	mHintsConstrained := make(map[int]bool)
 
-	// for each constraint, we check the terms and mark our inputs / hints as constrained
-	processTerm := func(t compiled.Term) {
+	// for each constraint, we check the linear expressions and mark our inputs / hints as constrained
+	processLinearExpression := func(l compiled.LinearExpression) {
+		for _, t := range l {
+			if t.CoeffID() == compiled.CoeffIdZero {
+				// ignore zero coefficient, as it does not constraint the Variable
+				// though, we may want to flag that IF the Variable doesn't appear else where
+				continue
+			}
+			visibility := t.VariableVisibility()
+			vID := t.WireID()
 
-		// L and M[0] handles the same wire but with a different coeff
-		visibility := t.VariableVisibility()
-		vID := t.WireID()
-		if t.CoeffID() != compiled.CoeffIdZero {
 			switch visibility {
 			case schema.Public:
-				if !publicConstrained[vID] {
+				if vID != 0 && !publicConstrained[vID] {
 					publicConstrained[vID] = true
 					cptPublic--
 				}
@@ -234,14 +284,12 @@ func (system *scs) checkVariables() error {
 				}
 			}
 		}
-
 	}
-	for _, c := range system.Constraints {
-		processTerm(c.L)
-		processTerm(c.R)
-		processTerm(c.M[0])
-		processTerm(c.M[1])
-		processTerm(c.O)
+	for _, r1c := range system.Constraints {
+		processLinearExpression(r1c.L)
+		processLinearExpression(r1c.R)
+		processLinearExpression(r1c.O)
+
 		if cptHints|cptSecret|cptPublic == 0 {
 			return nil // we can stop.
 		}
@@ -294,7 +342,8 @@ func init() {
 	tVariable = reflect.ValueOf(struct{ A frontend.Variable }{}).FieldByName("A").Type()
 }
 
-func (cs *scs) Compile() (frontend.CompiledConstraintSystem, error) {
+// Compile constructs a rank-1 constraint sytem
+func (cs *r1cs) Compile() (frontend.CompiledConstraintSystem, error) {
 
 	// ensure all inputs and hints are constrained
 	if !cs.config.IgnoreUnconstrainedInputs {
@@ -303,19 +352,21 @@ func (cs *scs) Compile() (frontend.CompiledConstraintSystem, error) {
 		}
 	}
 
-	res := compiled.SparseR1CS{
+	// wires = public wires  | secret wires | internal wires
+
+	// setting up the result
+	res := compiled.R1CS{
 		ConstraintSystem: cs.ConstraintSystem,
 		Constraints:      cs.Constraints,
 	}
 	res.NbPublicVariables = len(cs.Public)
 	res.NbSecretVariables = len(cs.Secret)
 
-	// Logs, DebugInfo and hints are copied, the only thing that will change
+	// for Logs, DebugInfo and hints the only thing that will change
 	// is that ID of the wires will be offseted to take into account the final wire vector ordering
 	// that is: public wires  | secret wires | internal wires
 
-	// shift variable ID
-	// we want publicWires | privateWires | internalWires
+	// offset variable ID depeneding on visibility
 	shiftVID := func(oldID int, visibility schema.Visibility) int {
 		switch visibility {
 		case schema.Internal:
@@ -324,41 +375,28 @@ func (cs *scs) Compile() (frontend.CompiledConstraintSystem, error) {
 			return oldID
 		case schema.Secret:
 			return oldID + res.NbPublicVariables
-		default:
-			return oldID
+		}
+		return oldID
+	}
+
+	// we just need to offset our ids, such that wires = [ public wires  | secret wires | internal wires ]
+	offsetIDs := func(l compiled.LinearExpression) {
+		for j := 0; j < len(l); j++ {
+			_, vID, visibility := l[j].Unpack()
+			l[j].SetWireID(shiftVID(vID, visibility))
 		}
 	}
 
-	offsetTermID := func(t *compiled.Term) {
-		_, VID, visibility := t.Unpack()
-		t.SetWireID(shiftVID(VID, visibility))
-	}
-
-	// offset the IDs of all constraints so that the variables are
-	// numbered like this: [publicVariables | secretVariables | internalVariables ]
 	for i := 0; i < len(res.Constraints); i++ {
-		r1c := &res.Constraints[i]
-		offsetTermID(&r1c.L)
-		offsetTermID(&r1c.R)
-		offsetTermID(&r1c.O)
-		offsetTermID(&r1c.M[0])
-		offsetTermID(&r1c.M[1])
-	}
-
-	// we need to offset the ids in Logs & DebugInfo
-	for i := 0; i < len(cs.Logs); i++ {
-		for j := 0; j < len(res.Logs[i].ToResolve); j++ {
-			offsetTermID(&res.Logs[i].ToResolve[j])
-		}
-	}
-	for i := 0; i < len(cs.DebugInfo); i++ {
-		for j := 0; j < len(res.DebugInfo[i].ToResolve); j++ {
-			offsetTermID(&res.DebugInfo[i].ToResolve[j])
-		}
+		offsetIDs(res.Constraints[i].L)
+		offsetIDs(res.Constraints[i].R)
+		offsetIDs(res.Constraints[i].O)
 	}
 
 	// we need to offset the ids in the hints
 	shiftedMap := make(map[int]*compiled.Hint)
+
+	// we need to offset the ids in the hints
 HINTLOOP:
 	for _, hint := range cs.MHints {
 		ws := make([]int, len(hint.Wires))
@@ -374,9 +412,11 @@ HINTLOOP:
 		copy(inputs, hint.Inputs)
 		for j := 0; j < len(inputs); j++ {
 			switch t := inputs[j].(type) {
-			case compiled.Term:
-				offsetTermID(&t)
-				inputs[j] = t // TODO check if we can remove it
+			case compiled.LinearExpression:
+				tmp := make(compiled.LinearExpression, len(t))
+				copy(tmp, t)
+				offsetIDs(tmp)
+				inputs[j] = tmp
 			default:
 				inputs[j] = t
 			}
@@ -388,36 +428,50 @@ HINTLOOP:
 	}
 	res.MHints = shiftedMap
 
+	// we need to offset the ids in Logs & DebugInfo
+	for i := 0; i < len(cs.Logs); i++ {
+
+		for j := 0; j < len(res.Logs[i].ToResolve); j++ {
+			_, vID, visibility := res.Logs[i].ToResolve[j].Unpack()
+			res.Logs[i].ToResolve[j].SetWireID(shiftVID(vID, visibility))
+		}
+	}
+	for i := 0; i < len(cs.DebugInfo); i++ {
+		for j := 0; j < len(res.DebugInfo[i].ToResolve); j++ {
+			_, vID, visibility := res.DebugInfo[i].ToResolve[j].Unpack()
+			res.DebugInfo[i].ToResolve[j].SetWireID(shiftVID(vID, visibility))
+		}
+	}
+
 	// build levels
 	res.Levels = buildLevels(res)
 
 	switch cs.CurveID {
 	case ecc.BLS12_377:
-		return bls12377r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
+		return bls12377r1cs.NewR1CS(res, cs.st.Coeffs), nil
 	case ecc.BLS12_381:
-		return bls12381r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
+		return bls12381r1cs.NewR1CS(res, cs.st.Coeffs), nil
 	case ecc.BN254:
-		return bn254r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
+		return bn254r1cs.NewR1CS(res, cs.st.Coeffs), nil
 	case ecc.BW6_761:
-		return bw6761r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
-	case ecc.BLS24_315:
-		return bls24315r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
+		return bw6761r1cs.NewR1CS(res, cs.st.Coeffs), nil
 	case ecc.BW6_633:
-		return bw6633r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
+		return bw6633r1cs.NewR1CS(res, cs.st.Coeffs), nil
+	case ecc.BLS24_315:
+		return bls24315r1cs.NewR1CS(res, cs.st.Coeffs), nil
 	default:
-		panic("unknown curveID")
+		panic("not implemtented")
 	}
-
 }
 
-func (cs *scs) SetSchema(s *schema.Schema) {
+func (cs *r1cs) SetSchema(s *schema.Schema) {
 	if cs.Schema != nil {
 		panic("SetSchema called multiple times")
 	}
 	cs.Schema = s
 }
 
-func buildLevels(ccs compiled.SparseR1CS) [][]int {
+func buildLevels(ccs compiled.R1CS) [][]int {
 
 	b := levelBuilder{
 		mWireToNode: make(map[int]int, ccs.NbInternalVariables), // at which node we resolved which wire
@@ -435,10 +489,9 @@ func buildLevels(ccs compiled.SparseR1CS) [][]int {
 
 		b.nodeLevel = 0
 
-		b.processTerm(c.L, cID)
-		b.processTerm(c.R, cID)
-		b.processTerm(c.O, cID)
-
+		b.processLE(c.L, cID)
+		b.processLE(c.R, cID)
+		b.processLE(c.O, cID)
 		b.nodeLevels[cID] = b.nodeLevel
 		b.mLevels[b.nodeLevel]++
 
@@ -458,7 +511,7 @@ func buildLevels(ccs compiled.SparseR1CS) [][]int {
 }
 
 type levelBuilder struct {
-	ccs      compiled.SparseR1CS
+	ccs      compiled.R1CS
 	nbInputs int
 
 	mWireToNode map[int]int // at which node we resolved which wire
@@ -468,70 +521,114 @@ type levelBuilder struct {
 	nodeLevel int // current level
 }
 
-func (b *levelBuilder) processTerm(t compiled.Term, cID int) {
-	wID := t.WireID()
-	if wID < b.nbInputs {
-		// it's a input, we ignore it
-		return
-	}
+func (b *levelBuilder) processLE(l compiled.LinearExpression, cID int) {
 
-	// if we know a which constraint solves this wire, then it's a dependency
-	n, ok := b.mWireToNode[wID]
-	if ok {
-		if n != cID { // can happen with hints...
-			// we add a dependency, check if we need to increment our current level
-			if b.nodeLevels[n] >= b.nodeLevel {
-				b.nodeLevel = b.nodeLevels[n] + 1 // we are at the next level at least since we depend on it
-			}
+	for _, t := range l {
+		wID := t.WireID()
+		if wID < b.nbInputs {
+			// it's a input, we ignore it
+			continue
 		}
-		return
-	}
 
-	// check if it's a hint and mark all the output wires
-	if h, ok := b.ccs.MHints[wID]; ok {
-
-		for _, in := range h.Inputs {
-			switch t := in.(type) {
-			case compiled.LinearExpression:
-				for _, tt := range t {
-					b.processTerm(tt, cID)
+		// if we know a which constraint solves this wire, then it's a dependency
+		n, ok := b.mWireToNode[wID]
+		if ok {
+			if n != cID { // can happen with hints...
+				// we add a dependency, check if we need to increment our current level
+				if b.nodeLevels[n] >= b.nodeLevel {
+					b.nodeLevel = b.nodeLevels[n] + 1 // we are at the next level at least since we depend on it
 				}
-			case compiled.Term:
-				b.processTerm(t, cID)
 			}
+			continue
 		}
 
-		for _, hwid := range h.Wires {
-			b.mWireToNode[hwid] = cID
+		// check if it's a hint and mark all the output wires
+		if h, ok := b.ccs.MHints[wID]; ok {
+
+			for _, in := range h.Inputs {
+				switch t := in.(type) {
+				case compiled.LinearExpression:
+					b.processLE(t, cID)
+				case compiled.Term:
+					b.processLE(compiled.LinearExpression{t}, cID)
+				}
+			}
+
+			for _, hwid := range h.Wires {
+				b.mWireToNode[hwid] = cID
+			}
+			continue
 		}
 
-		return
+		// mark this wire solved by current node
+		b.mWireToNode[wID] = cID
 	}
-
-	// mark this wire solved by current node
-	b.mWireToNode[wID] = cID
-
 }
 
-// ConstantValue returns the big.Int value of v. It
-// panics if v.IsConstant() == false
-func (system *scs) ConstantValue(v frontend.Variable) (*big.Int, bool) {
-	switch t := v.(type) {
-	case compiled.Term:
-		return nil, false
+// ConstantValue returns the big.Int value of v.
+// Will panic if v.IsConstant() == false
+func (system *r1cs) ConstantValue(v frontend.Variable) (*big.Int, bool) {
+	if _v, ok := v.(compiled.LinearExpression); ok {
+		assertIsSet(_v)
+
+		if len(_v) != 1 {
+			return nil, false
+		}
+		cID, vID, visibility := _v[0].Unpack()
+		if !(vID == 0 && visibility == schema.Public) {
+			return nil, false
+		}
+		return new(big.Int).Set(&system.st.Coeffs[cID]), true
+	}
+	r := utils.FromInterface(v)
+	return &r, true
+}
+
+func (system *r1cs) Backend() backend.ID {
+	return backend.GROTH16
+}
+
+// toVariable will return (and allocate if neccesary) a compiled.LinearExpression from given value
+//
+// if input is already a compiled.LinearExpression, does nothing
+// else, attempts to convert input to a big.Int (see utils.FromInterface) and returns a toVariable compiled.LinearExpression
+func (system *r1cs) toVariable(input interface{}) frontend.Variable {
+
+	switch t := input.(type) {
+	case compiled.LinearExpression:
+		assertIsSet(t)
+		return t
 	default:
-		res := utils.FromInterface(t)
-		return &res, true
+		n := utils.FromInterface(t)
+		if n.IsUint64() && n.Uint64() == 1 {
+			return system.one()
+		}
+		r := system.one()
+		r[0] = system.setCoeff(r[0], &n)
+		return r
 	}
 }
 
-func (system *scs) Backend() backend.ID {
-	return backend.PLONK
+// toVariables return frontend.Variable corresponding to inputs and the total size of the linear expressions
+func (system *r1cs) toVariables(in ...frontend.Variable) ([]compiled.LinearExpression, int) {
+	r := make([]compiled.LinearExpression, 0, len(in))
+	s := 0
+	e := func(i frontend.Variable) {
+		v := system.toVariable(i).(compiled.LinearExpression)
+		r = append(r, v)
+		s += len(v)
+	}
+	// e(i1)
+	// e(i2)
+	for i := 0; i < len(in); i++ {
+		e(in[i])
+	}
+	return r, s
 }
 
 // Tag creates a tag at a given place in a circuit. The state of the tag may contain informations needed to
 // measure constraints, variables and coefficients creations through AddCounter
-func (system *scs) Tag(name string) frontend.Tag {
+func (system *r1cs) Tag(name string) frontend.Tag {
 	_, file, line, _ := runtime.Caller(1)
 
 	return frontend.Tag{
@@ -542,16 +639,14 @@ func (system *scs) Tag(name string) frontend.Tag {
 }
 
 // AddCounter measures the number of constraints, variables and coefficients created between two tags
-// note that the PlonK statistics are contextual since there is a post-compile phase where linear expressions
-// are factorized. That is, measuring 2 times the "repeating" piece of circuit may give less constraints the second time
-func (system *scs) AddCounter(from, to frontend.Tag) {
+func (system *r1cs) AddCounter(from, to frontend.Tag) {
 	system.Counters = append(system.Counters, compiled.Counter{
 		From:          from.Name,
 		To:            to.Name,
 		NbVariables:   to.VID - from.VID,
 		NbConstraints: to.CID - from.CID,
 		CurveID:       system.CurveID,
-		BackendID:     backend.PLONK,
+		BackendID:     backend.GROTH16,
 	})
 }
 
@@ -567,21 +662,23 @@ func (system *scs) AddCounter(from, to frontend.Tag) {
 //
 // No new constraints are added to the newly created wire and must be added
 // manually in the circuit. Failing to do so leads to solver failure.
-func (system *scs) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.Variable) ([]frontend.Variable, error) {
+func (system *r1cs) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.Variable) ([]frontend.Variable, error) {
 
 	if nbOutputs <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}
-
 	hintInputs := make([]interface{}, len(inputs))
 
 	// ensure inputs are set and pack them in a []uint64
 	for i, in := range inputs {
 		switch t := in.(type) {
-		case compiled.Term:
-			hintInputs[i] = t
+		case compiled.LinearExpression:
+			assertIsSet(t)
+			tmp := make(compiled.LinearExpression, len(t))
+			copy(tmp, t)
+			hintInputs[i] = tmp
 		default:
-			hintInputs[i] = utils.FromInterface(in)
+			hintInputs[i] = utils.FromInterface(t)
 		}
 	}
 
@@ -590,7 +687,7 @@ func (system *scs) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.Va
 	res := make([]frontend.Variable, len(varIDs))
 	for i := range varIDs {
 		r := system.newInternalVariable()
-		_, vID, _ := r.Unpack()
+		_, vID, _ := r[0].Unpack()
 		varIDs[i] = vID
 		res[i] = r
 	}
@@ -603,63 +700,17 @@ func (system *scs) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.Va
 	return res, nil
 }
 
-// returns in split into a slice of compiledTerm and the sum of all constants in in as a bigInt
-func (system *scs) filterConstantSum(in []frontend.Variable) (compiled.LinearExpression, big.Int) {
-	res := make(compiled.LinearExpression, 0, len(in))
-	var b big.Int
-	for i := 0; i < len(in); i++ {
-		switch t := in[i].(type) {
-		case compiled.Term:
-			res = append(res, t)
-		default:
-			n := utils.FromInterface(t)
-			b.Add(&b, &n)
-		}
-	}
-	return res, b
-}
-
-// returns in split into a slice of compiledTerm and the product of all constants in in as a bigInt
-func (system *scs) filterConstantProd(in []frontend.Variable) (compiled.LinearExpression, big.Int) {
-	res := make(compiled.LinearExpression, 0, len(in))
-	var b big.Int
-	b.SetInt64(1)
-	for i := 0; i < len(in); i++ {
-		switch t := in[i].(type) {
-		case compiled.Term:
-			res = append(res, t)
-		default:
-			n := utils.FromInterface(t)
-			b.Mul(&b, &n).Mod(&b, system.CurveID.Info().Fr.Modulus())
-		}
-	}
-	return res, b
-}
-
-func (system *scs) splitSum(acc compiled.Term, r compiled.LinearExpression) compiled.Term {
-
-	// floor case
-	if len(r) == 0 {
-		return acc
+// assertIsSet panics if the variable is unset
+// this may happen if inside a Define we have
+// var a variable
+// cs.Mul(a, 1)
+// since a was not in the circuit struct it is not a secret variable
+func assertIsSet(l compiled.LinearExpression) {
+	// TODO PlonK scs doesn't have a similar check with compiled.Term == 0
+	if len(l) == 0 {
+		// errNoValue triggered when trying to access a variable that was not allocated
+		errNoValue := errors.New("can't determine API input value")
+		panic(errNoValue)
 	}
 
-	cl, _, _ := acc.Unpack()
-	cr, _, _ := r[0].Unpack()
-	o := system.newInternalVariable()
-	system.addPlonkConstraint(acc, r[0], o, cl, cr, compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdMinusOne, compiled.CoeffIdZero)
-	return system.splitSum(o, r[1:])
-}
-
-func (system *scs) splitProd(acc compiled.Term, r compiled.LinearExpression) compiled.Term {
-
-	// floor case
-	if len(r) == 0 {
-		return acc
-	}
-
-	cl, _, _ := acc.Unpack()
-	cr, _, _ := r[0].Unpack()
-	o := system.newInternalVariable()
-	system.addPlonkConstraint(acc, r[0], o, compiled.CoeffIdZero, compiled.CoeffIdZero, cl, cr, compiled.CoeffIdMinusOne, compiled.CoeffIdZero)
-	return system.splitProd(o, r[1:])
 }

--- a/frontend/cs/r1cs/r1cs_test.go
+++ b/frontend/cs/r1cs/r1cs_test.go
@@ -51,7 +51,7 @@ func TestQuickSort(t *testing.T) {
 
 func TestReduce(t *testing.T) {
 
-	cs := newCompiler(ecc.BN254, frontend.CompileConfig{})
+	cs := newBuilder(ecc.BN254, frontend.CompileConfig{})
 	x := cs.newInternalVariable()
 	y := cs.newInternalVariable()
 	z := cs.newInternalVariable()

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 ConsenSys
+Copyright © 2021 ConsenSys Software Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package r1cs
+package scs
 
 import (
 	"errors"
@@ -43,97 +43,101 @@ import (
 	"github.com/consensys/gnark/internal/utils"
 )
 
-// NewCompiler returns a new R1CS compiler
-func NewCompiler(curve ecc.ID, config frontend.CompileConfig) (frontend.Builder, error) {
-	return newCompiler(curve, config), nil
+func NewBuilder(curve ecc.ID, config frontend.CompileConfig) (frontend.Builder, error) {
+	return newBuilder(curve, config), nil
 }
 
-type r1cs struct {
+type scs struct {
 	compiled.ConstraintSystem
-	Constraints []compiled.R1C
+	Constraints []compiled.SparseR1C
 
 	st     cs.CoeffTable
 	config frontend.CompileConfig
 
 	// map for recording boolean constrained variables (to not constrain them twice)
-	mtBooleans map[uint64][]compiled.LinearExpression
+	mtBooleans map[int]struct{}
 }
 
 // initialCapacity has quite some impact on frontend performance, especially on large circuits size
 // we may want to add build tags to tune that
-func newCompiler(curveID ecc.ID, config frontend.CompileConfig) *r1cs {
-	system := r1cs{
+func newBuilder(curveID ecc.ID, config frontend.CompileConfig) *scs {
+	system := scs{
 		ConstraintSystem: compiled.ConstraintSystem{
 
 			MDebug: make(map[int]int),
 			MHints: make(map[int]*compiled.Hint),
 		},
-		Constraints: make([]compiled.R1C, 0, config.Capacity),
+		mtBooleans:  make(map[int]struct{}),
+		Constraints: make([]compiled.SparseR1C, 0, config.Capacity),
 		st:          cs.NewCoeffTable(),
-		mtBooleans:  make(map[uint64][]compiled.LinearExpression),
 		config:      config,
 	}
 
-	system.Public = make([]string, 1)
+	system.Public = make([]string, 0)
 	system.Secret = make([]string, 0)
-
-	// by default the circuit is given a public wire equal to 1
-	system.Public[0] = "one"
 
 	system.CurveID = curveID
 
 	return &system
 }
 
-// newInternalVariable creates a new wire, appends it on the list of wires of the circuit, sets
-// the wire's id to the number of wires, and returns it
-func (system *r1cs) newInternalVariable() compiled.LinearExpression {
-	idx := system.NbInternalVariables
-	system.NbInternalVariables++
-	return compiled.LinearExpression{
-		compiled.Pack(idx, compiled.CoeffIdOne, schema.Internal),
+// addPlonkConstraint creates a constraint of the for al+br+clr+k=0
+//func (system *SparseR1CS) addPlonkConstraint(l, r, o frontend.Variable, cidl, cidr, cidm1, cidm2, cido, k int, debugID ...int) {
+func (system *scs) addPlonkConstraint(l, r, o compiled.Term, cidl, cidr, cidm1, cidm2, cido, k int, debugID ...int) {
+
+	if len(debugID) > 0 {
+		system.MDebug[len(system.Constraints)] = debugID[0]
 	}
+
+	l.SetCoeffID(cidl)
+	r.SetCoeffID(cidr)
+	o.SetCoeffID(cido)
+
+	u := l
+	v := r
+	u.SetCoeffID(cidm1)
+	v.SetCoeffID(cidm2)
+
+	//system.Constraints = append(system.Constraints, compiled.SparseR1C{L: _l, R: _r, O: _o, M: [2]compiled.Term{u, v}, K: k})
+	system.Constraints = append(system.Constraints, compiled.SparseR1C{L: l, R: r, O: o, M: [2]compiled.Term{u, v}, K: k})
 }
 
-// AddPublicVariable creates a new public Variable
-func (system *r1cs) AddPublicVariable(name string) frontend.Variable {
+// newInternalVariable creates a new wire, appends it on the list of wires of the circuit, sets
+// the wire's id to the number of wires, and returns it
+func (system *scs) newInternalVariable() compiled.Term {
+	idx := system.NbInternalVariables
+	system.NbInternalVariables++
+	return compiled.Pack(idx, compiled.CoeffIdOne, schema.Internal)
+}
+
+// AddPublicVariable creates a new Public Variable
+func (system *scs) AddPublicVariable(name string) frontend.Variable {
 	if system.Schema != nil {
 		panic("do not call AddPublicVariable in circuit.Define()")
 	}
 	idx := len(system.Public)
 	system.Public = append(system.Public, name)
-	return compiled.LinearExpression{
-		compiled.Pack(idx, compiled.CoeffIdOne, schema.Public),
-	}
+	return compiled.Pack(idx, compiled.CoeffIdOne, schema.Public)
 }
 
-// AddSecretVariable creates a new secret Variable
-func (system *r1cs) AddSecretVariable(name string) frontend.Variable {
+// AddSecretVariable creates a new Secret Variable
+func (system *scs) AddSecretVariable(name string) frontend.Variable {
 	if system.Schema != nil {
 		panic("do not call AddSecretVariable in circuit.Define()")
 	}
 	idx := len(system.Secret)
 	system.Secret = append(system.Secret, name)
-	return compiled.LinearExpression{
-		compiled.Pack(idx, compiled.CoeffIdOne, schema.Secret),
-	}
-}
-
-func (system *r1cs) one() compiled.LinearExpression {
-	return compiled.LinearExpression{
-		compiled.Pack(0, compiled.CoeffIdOne, schema.Public),
-	}
+	return compiled.Pack(idx, compiled.CoeffIdOne, schema.Secret)
 }
 
 // reduces redundancy in linear expression
 // It factorizes Variable that appears multiple times with != coeff Ids
 // To ensure the determinism in the compile process, Variables are stored as public∥secret∥internal∥unset
 // for each visibility, the Variables are sorted from lowest ID to highest ID
-func (system *r1cs) reduce(l compiled.LinearExpression) compiled.LinearExpression {
+func (system *scs) reduce(l compiled.LinearExpression) compiled.LinearExpression {
+
 	// ensure our linear expression is sorted, by visibility and by Variable ID
-	if !sort.IsSorted(l) { // may not help
-		sort.Sort(l)
-	}
+	sort.Sort(l)
 
 	mod := system.CurveID.Info().Fr.Modulus()
 	c := new(big.Int)
@@ -152,94 +156,40 @@ func (system *r1cs) reduce(l compiled.LinearExpression) compiled.LinearExpressio
 	return l
 }
 
-// newR1C clones the linear expression associated with the Variables (to avoid offseting the ID multiple time)
-// and return a R1C
-func newR1C(_l, _r, _o frontend.Variable) compiled.R1C {
-	l := _l.(compiled.LinearExpression)
-	r := _r.(compiled.LinearExpression)
-	o := _o.(compiled.LinearExpression)
-
-	// interestingly, this is key to groth16 performance.
-	// l * r == r * l == o
-	// but the "l" linear expression is going to end up in the A matrix
-	// the "r" linear expression is going to end up in the B matrix
-	// the less Variable we have appearing in the B matrix, the more likely groth16.Setup
-	// is going to produce infinity points in pk.G1.B and pk.G2.B, which will speed up proving time
-	if len(l) > len(r) {
-		l, r = r, l
-	}
-
-	return compiled.R1C{L: l.Clone(), R: r.Clone(), O: o.Clone()}
-}
-
-func (system *r1cs) addConstraint(r1c compiled.R1C, debugID ...int) {
-	system.Constraints = append(system.Constraints, r1c)
-	if len(debugID) > 0 {
-		system.MDebug[len(system.Constraints)-1] = debugID[0]
-	}
-}
-
-// Term packs a Variable and a coeff in a Term and returns it.
-// func (system *R1CSRefactor) setCoeff(v Variable, coeff *big.Int) Term {
-func (system *r1cs) setCoeff(v compiled.Term, coeff *big.Int) compiled.Term {
-	_, vID, vVis := v.Unpack()
-	return compiled.Pack(vID, system.st.CoeffID(coeff), vVis)
-}
-
-// MarkBoolean sets (but do not **constraint**!) v to be boolean
-// This is useful in scenarios where a variable is known to be boolean through a constraint
-// that is not api.AssertIsBoolean. If v is a constant, this is a no-op.
-func (system *r1cs) MarkBoolean(v frontend.Variable) {
-	if b, ok := system.ConstantValue(v); ok {
-		if !(b.IsUint64() && b.Uint64() <= 1) {
-			panic("MarkBoolean called a non-boolean constant")
-		}
-		return
-	}
-	// v is a linear expression
-	l := v.(compiled.LinearExpression)
-	if !sort.IsSorted(l) {
-		sort.Sort(l)
-	}
-
-	key := l.HashCode()
-	list := system.mtBooleans[key]
-	list = append(list, l)
-	system.mtBooleans[key] = list
+// to handle wires that don't exist (=coef 0) in a sparse constraint
+func (system *scs) zero() compiled.Term {
+	var a compiled.Term
+	return a
 }
 
 // IsBoolean returns true if given variable was marked as boolean in the compiler (see MarkBoolean)
 // Use with care; variable may not have been **constrained** to be boolean
 // This returns true if the v is a constant and v == 0 || v == 1.
-func (system *r1cs) IsBoolean(v frontend.Variable) bool {
+func (system *scs) IsBoolean(v frontend.Variable) bool {
 	if b, ok := system.ConstantValue(v); ok {
 		return b.IsUint64() && b.Uint64() <= 1
 	}
-	// v is a linear expression
-	l := v.(compiled.LinearExpression)
-	if !sort.IsSorted(l) {
-		sort.Sort(l)
-	}
+	_, ok := system.mtBooleans[int(v.(compiled.Term))]
+	return ok
+}
 
-	key := l.HashCode()
-	list, ok := system.mtBooleans[key]
-	if !ok {
-		return false
-	}
-
-	for _, v := range list {
-		if v.Equal(l) {
-			return true
+// MarkBoolean sets (but do not constraint!) v to be boolean
+// This is useful in scenarios where a variable is known to be boolean through a constraint
+// that is not api.AssertIsBoolean. If v is a constant, this is a no-op.
+func (system *scs) MarkBoolean(v frontend.Variable) {
+	if b, ok := system.ConstantValue(v); ok {
+		if !(b.IsUint64() && b.Uint64() <= 1) {
+			panic("MarkBoolean called a non-boolean constant")
 		}
 	}
-	return false
+	system.mtBooleans[int(v.(compiled.Term))] = struct{}{}
 }
 
 // checkVariables perform post compilation checks on the Variables
 //
 // 1. checks that all user inputs are referenced in at least one constraint
 // 2. checks that all hints are constrained
-func (system *r1cs) checkVariables() error {
+func (system *scs) checkVariables() error {
 
 	// TODO @gbotrel add unit test for that.
 
@@ -247,28 +197,28 @@ func (system *r1cs) checkVariables() error {
 	cptPublic := len(system.Public)
 	cptHints := len(system.MHints)
 
+	// compared to R1CS, we may have a circuit which does not have any inputs
+	// (R1CS always has a constant ONE wire). Check the edge case and omit any
+	// processing if so.
+	if cptSecret+cptPublic+cptHints == 0 {
+		return nil
+	}
+
 	secretConstrained := make([]bool, cptSecret)
 	publicConstrained := make([]bool, cptPublic)
-	// one wire does not need to be constrained
-	publicConstrained[0] = true
-	cptPublic--
 
 	mHintsConstrained := make(map[int]bool)
 
-	// for each constraint, we check the linear expressions and mark our inputs / hints as constrained
-	processLinearExpression := func(l compiled.LinearExpression) {
-		for _, t := range l {
-			if t.CoeffID() == compiled.CoeffIdZero {
-				// ignore zero coefficient, as it does not constraint the Variable
-				// though, we may want to flag that IF the Variable doesn't appear else where
-				continue
-			}
-			visibility := t.VariableVisibility()
-			vID := t.WireID()
+	// for each constraint, we check the terms and mark our inputs / hints as constrained
+	processTerm := func(t compiled.Term) {
 
+		// L and M[0] handles the same wire but with a different coeff
+		visibility := t.VariableVisibility()
+		vID := t.WireID()
+		if t.CoeffID() != compiled.CoeffIdZero {
 			switch visibility {
 			case schema.Public:
-				if vID != 0 && !publicConstrained[vID] {
+				if !publicConstrained[vID] {
 					publicConstrained[vID] = true
 					cptPublic--
 				}
@@ -284,12 +234,14 @@ func (system *r1cs) checkVariables() error {
 				}
 			}
 		}
-	}
-	for _, r1c := range system.Constraints {
-		processLinearExpression(r1c.L)
-		processLinearExpression(r1c.R)
-		processLinearExpression(r1c.O)
 
+	}
+	for _, c := range system.Constraints {
+		processTerm(c.L)
+		processTerm(c.R)
+		processTerm(c.M[0])
+		processTerm(c.M[1])
+		processTerm(c.O)
 		if cptHints|cptSecret|cptPublic == 0 {
 			return nil // we can stop.
 		}
@@ -342,8 +294,7 @@ func init() {
 	tVariable = reflect.ValueOf(struct{ A frontend.Variable }{}).FieldByName("A").Type()
 }
 
-// Compile constructs a rank-1 constraint sytem
-func (cs *r1cs) Compile() (frontend.CompiledConstraintSystem, error) {
+func (cs *scs) Compile() (frontend.CompiledConstraintSystem, error) {
 
 	// ensure all inputs and hints are constrained
 	if !cs.config.IgnoreUnconstrainedInputs {
@@ -352,21 +303,19 @@ func (cs *r1cs) Compile() (frontend.CompiledConstraintSystem, error) {
 		}
 	}
 
-	// wires = public wires  | secret wires | internal wires
-
-	// setting up the result
-	res := compiled.R1CS{
+	res := compiled.SparseR1CS{
 		ConstraintSystem: cs.ConstraintSystem,
 		Constraints:      cs.Constraints,
 	}
 	res.NbPublicVariables = len(cs.Public)
 	res.NbSecretVariables = len(cs.Secret)
 
-	// for Logs, DebugInfo and hints the only thing that will change
+	// Logs, DebugInfo and hints are copied, the only thing that will change
 	// is that ID of the wires will be offseted to take into account the final wire vector ordering
 	// that is: public wires  | secret wires | internal wires
 
-	// offset variable ID depeneding on visibility
+	// shift variable ID
+	// we want publicWires | privateWires | internalWires
 	shiftVID := func(oldID int, visibility schema.Visibility) int {
 		switch visibility {
 		case schema.Internal:
@@ -375,28 +324,41 @@ func (cs *r1cs) Compile() (frontend.CompiledConstraintSystem, error) {
 			return oldID
 		case schema.Secret:
 			return oldID + res.NbPublicVariables
-		}
-		return oldID
-	}
-
-	// we just need to offset our ids, such that wires = [ public wires  | secret wires | internal wires ]
-	offsetIDs := func(l compiled.LinearExpression) {
-		for j := 0; j < len(l); j++ {
-			_, vID, visibility := l[j].Unpack()
-			l[j].SetWireID(shiftVID(vID, visibility))
+		default:
+			return oldID
 		}
 	}
 
+	offsetTermID := func(t *compiled.Term) {
+		_, VID, visibility := t.Unpack()
+		t.SetWireID(shiftVID(VID, visibility))
+	}
+
+	// offset the IDs of all constraints so that the variables are
+	// numbered like this: [publicVariables | secretVariables | internalVariables ]
 	for i := 0; i < len(res.Constraints); i++ {
-		offsetIDs(res.Constraints[i].L)
-		offsetIDs(res.Constraints[i].R)
-		offsetIDs(res.Constraints[i].O)
+		r1c := &res.Constraints[i]
+		offsetTermID(&r1c.L)
+		offsetTermID(&r1c.R)
+		offsetTermID(&r1c.O)
+		offsetTermID(&r1c.M[0])
+		offsetTermID(&r1c.M[1])
+	}
+
+	// we need to offset the ids in Logs & DebugInfo
+	for i := 0; i < len(cs.Logs); i++ {
+		for j := 0; j < len(res.Logs[i].ToResolve); j++ {
+			offsetTermID(&res.Logs[i].ToResolve[j])
+		}
+	}
+	for i := 0; i < len(cs.DebugInfo); i++ {
+		for j := 0; j < len(res.DebugInfo[i].ToResolve); j++ {
+			offsetTermID(&res.DebugInfo[i].ToResolve[j])
+		}
 	}
 
 	// we need to offset the ids in the hints
 	shiftedMap := make(map[int]*compiled.Hint)
-
-	// we need to offset the ids in the hints
 HINTLOOP:
 	for _, hint := range cs.MHints {
 		ws := make([]int, len(hint.Wires))
@@ -412,11 +374,9 @@ HINTLOOP:
 		copy(inputs, hint.Inputs)
 		for j := 0; j < len(inputs); j++ {
 			switch t := inputs[j].(type) {
-			case compiled.LinearExpression:
-				tmp := make(compiled.LinearExpression, len(t))
-				copy(tmp, t)
-				offsetIDs(tmp)
-				inputs[j] = tmp
+			case compiled.Term:
+				offsetTermID(&t)
+				inputs[j] = t // TODO check if we can remove it
 			default:
 				inputs[j] = t
 			}
@@ -428,50 +388,36 @@ HINTLOOP:
 	}
 	res.MHints = shiftedMap
 
-	// we need to offset the ids in Logs & DebugInfo
-	for i := 0; i < len(cs.Logs); i++ {
-
-		for j := 0; j < len(res.Logs[i].ToResolve); j++ {
-			_, vID, visibility := res.Logs[i].ToResolve[j].Unpack()
-			res.Logs[i].ToResolve[j].SetWireID(shiftVID(vID, visibility))
-		}
-	}
-	for i := 0; i < len(cs.DebugInfo); i++ {
-		for j := 0; j < len(res.DebugInfo[i].ToResolve); j++ {
-			_, vID, visibility := res.DebugInfo[i].ToResolve[j].Unpack()
-			res.DebugInfo[i].ToResolve[j].SetWireID(shiftVID(vID, visibility))
-		}
-	}
-
 	// build levels
 	res.Levels = buildLevels(res)
 
 	switch cs.CurveID {
 	case ecc.BLS12_377:
-		return bls12377r1cs.NewR1CS(res, cs.st.Coeffs), nil
+		return bls12377r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
 	case ecc.BLS12_381:
-		return bls12381r1cs.NewR1CS(res, cs.st.Coeffs), nil
+		return bls12381r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
 	case ecc.BN254:
-		return bn254r1cs.NewR1CS(res, cs.st.Coeffs), nil
+		return bn254r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
 	case ecc.BW6_761:
-		return bw6761r1cs.NewR1CS(res, cs.st.Coeffs), nil
-	case ecc.BW6_633:
-		return bw6633r1cs.NewR1CS(res, cs.st.Coeffs), nil
+		return bw6761r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
 	case ecc.BLS24_315:
-		return bls24315r1cs.NewR1CS(res, cs.st.Coeffs), nil
+		return bls24315r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
+	case ecc.BW6_633:
+		return bw6633r1cs.NewSparseR1CS(res, cs.st.Coeffs), nil
 	default:
-		panic("not implemtented")
+		panic("unknown curveID")
 	}
+
 }
 
-func (cs *r1cs) SetSchema(s *schema.Schema) {
+func (cs *scs) SetSchema(s *schema.Schema) {
 	if cs.Schema != nil {
 		panic("SetSchema called multiple times")
 	}
 	cs.Schema = s
 }
 
-func buildLevels(ccs compiled.R1CS) [][]int {
+func buildLevels(ccs compiled.SparseR1CS) [][]int {
 
 	b := levelBuilder{
 		mWireToNode: make(map[int]int, ccs.NbInternalVariables), // at which node we resolved which wire
@@ -489,9 +435,10 @@ func buildLevels(ccs compiled.R1CS) [][]int {
 
 		b.nodeLevel = 0
 
-		b.processLE(c.L, cID)
-		b.processLE(c.R, cID)
-		b.processLE(c.O, cID)
+		b.processTerm(c.L, cID)
+		b.processTerm(c.R, cID)
+		b.processTerm(c.O, cID)
+
 		b.nodeLevels[cID] = b.nodeLevel
 		b.mLevels[b.nodeLevel]++
 
@@ -511,7 +458,7 @@ func buildLevels(ccs compiled.R1CS) [][]int {
 }
 
 type levelBuilder struct {
-	ccs      compiled.R1CS
+	ccs      compiled.SparseR1CS
 	nbInputs int
 
 	mWireToNode map[int]int // at which node we resolved which wire
@@ -521,114 +468,70 @@ type levelBuilder struct {
 	nodeLevel int // current level
 }
 
-func (b *levelBuilder) processLE(l compiled.LinearExpression, cID int) {
-
-	for _, t := range l {
-		wID := t.WireID()
-		if wID < b.nbInputs {
-			// it's a input, we ignore it
-			continue
-		}
-
-		// if we know a which constraint solves this wire, then it's a dependency
-		n, ok := b.mWireToNode[wID]
-		if ok {
-			if n != cID { // can happen with hints...
-				// we add a dependency, check if we need to increment our current level
-				if b.nodeLevels[n] >= b.nodeLevel {
-					b.nodeLevel = b.nodeLevels[n] + 1 // we are at the next level at least since we depend on it
-				}
-			}
-			continue
-		}
-
-		// check if it's a hint and mark all the output wires
-		if h, ok := b.ccs.MHints[wID]; ok {
-
-			for _, in := range h.Inputs {
-				switch t := in.(type) {
-				case compiled.LinearExpression:
-					b.processLE(t, cID)
-				case compiled.Term:
-					b.processLE(compiled.LinearExpression{t}, cID)
-				}
-			}
-
-			for _, hwid := range h.Wires {
-				b.mWireToNode[hwid] = cID
-			}
-			continue
-		}
-
-		// mark this wire solved by current node
-		b.mWireToNode[wID] = cID
+func (b *levelBuilder) processTerm(t compiled.Term, cID int) {
+	wID := t.WireID()
+	if wID < b.nbInputs {
+		// it's a input, we ignore it
+		return
 	}
-}
 
-// ConstantValue returns the big.Int value of v.
-// Will panic if v.IsConstant() == false
-func (system *r1cs) ConstantValue(v frontend.Variable) (*big.Int, bool) {
-	if _v, ok := v.(compiled.LinearExpression); ok {
-		assertIsSet(_v)
-
-		if len(_v) != 1 {
-			return nil, false
+	// if we know a which constraint solves this wire, then it's a dependency
+	n, ok := b.mWireToNode[wID]
+	if ok {
+		if n != cID { // can happen with hints...
+			// we add a dependency, check if we need to increment our current level
+			if b.nodeLevels[n] >= b.nodeLevel {
+				b.nodeLevel = b.nodeLevels[n] + 1 // we are at the next level at least since we depend on it
+			}
 		}
-		cID, vID, visibility := _v[0].Unpack()
-		if !(vID == 0 && visibility == schema.Public) {
-			return nil, false
-		}
-		return new(big.Int).Set(&system.st.Coeffs[cID]), true
+		return
 	}
-	r := utils.FromInterface(v)
-	return &r, true
+
+	// check if it's a hint and mark all the output wires
+	if h, ok := b.ccs.MHints[wID]; ok {
+
+		for _, in := range h.Inputs {
+			switch t := in.(type) {
+			case compiled.LinearExpression:
+				for _, tt := range t {
+					b.processTerm(tt, cID)
+				}
+			case compiled.Term:
+				b.processTerm(t, cID)
+			}
+		}
+
+		for _, hwid := range h.Wires {
+			b.mWireToNode[hwid] = cID
+		}
+
+		return
+	}
+
+	// mark this wire solved by current node
+	b.mWireToNode[wID] = cID
+
 }
 
-func (system *r1cs) Backend() backend.ID {
-	return backend.GROTH16
-}
-
-// toVariable will return (and allocate if neccesary) a compiled.LinearExpression from given value
-//
-// if input is already a compiled.LinearExpression, does nothing
-// else, attempts to convert input to a big.Int (see utils.FromInterface) and returns a toVariable compiled.LinearExpression
-func (system *r1cs) toVariable(input interface{}) frontend.Variable {
-
-	switch t := input.(type) {
-	case compiled.LinearExpression:
-		assertIsSet(t)
-		return t
+// ConstantValue returns the big.Int value of v. It
+// panics if v.IsConstant() == false
+func (system *scs) ConstantValue(v frontend.Variable) (*big.Int, bool) {
+	switch t := v.(type) {
+	case compiled.Term:
+		return nil, false
 	default:
-		n := utils.FromInterface(t)
-		if n.IsUint64() && n.Uint64() == 1 {
-			return system.one()
-		}
-		r := system.one()
-		r[0] = system.setCoeff(r[0], &n)
-		return r
+		res := utils.FromInterface(t)
+		return &res, true
 	}
 }
 
-// toVariables return frontend.Variable corresponding to inputs and the total size of the linear expressions
-func (system *r1cs) toVariables(in ...frontend.Variable) ([]compiled.LinearExpression, int) {
-	r := make([]compiled.LinearExpression, 0, len(in))
-	s := 0
-	e := func(i frontend.Variable) {
-		v := system.toVariable(i).(compiled.LinearExpression)
-		r = append(r, v)
-		s += len(v)
-	}
-	// e(i1)
-	// e(i2)
-	for i := 0; i < len(in); i++ {
-		e(in[i])
-	}
-	return r, s
+func (system *scs) Backend() backend.ID {
+	return backend.PLONK
 }
 
 // Tag creates a tag at a given place in a circuit. The state of the tag may contain informations needed to
 // measure constraints, variables and coefficients creations through AddCounter
-func (system *r1cs) Tag(name string) frontend.Tag {
+func (system *scs) Tag(name string) frontend.Tag {
 	_, file, line, _ := runtime.Caller(1)
 
 	return frontend.Tag{
@@ -639,14 +542,16 @@ func (system *r1cs) Tag(name string) frontend.Tag {
 }
 
 // AddCounter measures the number of constraints, variables and coefficients created between two tags
-func (system *r1cs) AddCounter(from, to frontend.Tag) {
+// note that the PlonK statistics are contextual since there is a post-compile phase where linear expressions
+// are factorized. That is, measuring 2 times the "repeating" piece of circuit may give less constraints the second time
+func (system *scs) AddCounter(from, to frontend.Tag) {
 	system.Counters = append(system.Counters, compiled.Counter{
 		From:          from.Name,
 		To:            to.Name,
 		NbVariables:   to.VID - from.VID,
 		NbConstraints: to.CID - from.CID,
 		CurveID:       system.CurveID,
-		BackendID:     backend.GROTH16,
+		BackendID:     backend.PLONK,
 	})
 }
 
@@ -662,23 +567,21 @@ func (system *r1cs) AddCounter(from, to frontend.Tag) {
 //
 // No new constraints are added to the newly created wire and must be added
 // manually in the circuit. Failing to do so leads to solver failure.
-func (system *r1cs) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.Variable) ([]frontend.Variable, error) {
+func (system *scs) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.Variable) ([]frontend.Variable, error) {
 
 	if nbOutputs <= 0 {
 		return nil, fmt.Errorf("hint function must return at least one output")
 	}
+
 	hintInputs := make([]interface{}, len(inputs))
 
 	// ensure inputs are set and pack them in a []uint64
 	for i, in := range inputs {
 		switch t := in.(type) {
-		case compiled.LinearExpression:
-			assertIsSet(t)
-			tmp := make(compiled.LinearExpression, len(t))
-			copy(tmp, t)
-			hintInputs[i] = tmp
+		case compiled.Term:
+			hintInputs[i] = t
 		default:
-			hintInputs[i] = utils.FromInterface(t)
+			hintInputs[i] = utils.FromInterface(in)
 		}
 	}
 
@@ -687,7 +590,7 @@ func (system *r1cs) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.V
 	res := make([]frontend.Variable, len(varIDs))
 	for i := range varIDs {
 		r := system.newInternalVariable()
-		_, vID, _ := r[0].Unpack()
+		_, vID, _ := r.Unpack()
 		varIDs[i] = vID
 		res[i] = r
 	}
@@ -700,17 +603,63 @@ func (system *r1cs) NewHint(f hint.Function, nbOutputs int, inputs ...frontend.V
 	return res, nil
 }
 
-// assertIsSet panics if the variable is unset
-// this may happen if inside a Define we have
-// var a variable
-// cs.Mul(a, 1)
-// since a was not in the circuit struct it is not a secret variable
-func assertIsSet(l compiled.LinearExpression) {
-	// TODO PlonK scs doesn't have a similar check with compiled.Term == 0
-	if len(l) == 0 {
-		// errNoValue triggered when trying to access a variable that was not allocated
-		errNoValue := errors.New("can't determine API input value")
-		panic(errNoValue)
+// returns in split into a slice of compiledTerm and the sum of all constants in in as a bigInt
+func (system *scs) filterConstantSum(in []frontend.Variable) (compiled.LinearExpression, big.Int) {
+	res := make(compiled.LinearExpression, 0, len(in))
+	var b big.Int
+	for i := 0; i < len(in); i++ {
+		switch t := in[i].(type) {
+		case compiled.Term:
+			res = append(res, t)
+		default:
+			n := utils.FromInterface(t)
+			b.Add(&b, &n)
+		}
+	}
+	return res, b
+}
+
+// returns in split into a slice of compiledTerm and the product of all constants in in as a bigInt
+func (system *scs) filterConstantProd(in []frontend.Variable) (compiled.LinearExpression, big.Int) {
+	res := make(compiled.LinearExpression, 0, len(in))
+	var b big.Int
+	b.SetInt64(1)
+	for i := 0; i < len(in); i++ {
+		switch t := in[i].(type) {
+		case compiled.Term:
+			res = append(res, t)
+		default:
+			n := utils.FromInterface(t)
+			b.Mul(&b, &n).Mod(&b, system.CurveID.Info().Fr.Modulus())
+		}
+	}
+	return res, b
+}
+
+func (system *scs) splitSum(acc compiled.Term, r compiled.LinearExpression) compiled.Term {
+
+	// floor case
+	if len(r) == 0 {
+		return acc
 	}
 
+	cl, _, _ := acc.Unpack()
+	cr, _, _ := r[0].Unpack()
+	o := system.newInternalVariable()
+	system.addPlonkConstraint(acc, r[0], o, cl, cr, compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdMinusOne, compiled.CoeffIdZero)
+	return system.splitSum(o, r[1:])
+}
+
+func (system *scs) splitProd(acc compiled.Term, r compiled.LinearExpression) compiled.Term {
+
+	// floor case
+	if len(r) == 0 {
+		return acc
+	}
+
+	cl, _, _ := acc.Unpack()
+	cr, _, _ := r[0].Unpack()
+	o := system.newInternalVariable()
+	system.addPlonkConstraint(acc, r[0], o, compiled.CoeffIdZero, compiled.CoeffIdZero, cl, cr, compiled.CoeffIdMinusOne, compiled.CoeffIdZero)
+	return system.splitProd(o, r[1:])
 }

--- a/internal/backend/bls12-377/cs/r1cs_test.go
+++ b/internal/backend/bls12-377/cs/r1cs_test.go
@@ -36,7 +36,7 @@ func TestSerialization(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tc := circuits.Circuits[name]
 
-			r1cs1, err := frontend.Compile(ecc.BLS12_377, r1cs.NewCompiler, tc.Circuit)
+			r1cs1, err := frontend.Compile(ecc.BLS12_377, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -45,7 +45,7 @@ func TestSerialization(t *testing.T) {
 			}
 
 			// copmpile a second time to ensure determinism
-			r1cs2, err := frontend.Compile(ecc.BLS12_377, r1cs.NewCompiler, tc.Circuit)
+			r1cs2, err := frontend.Compile(ecc.BLS12_377, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -134,7 +134,7 @@ func (circuit *circuit) Define(api frontend.API) error {
 func BenchmarkSolve(b *testing.B) {
 
 	var c circuit
-	ccs, err := frontend.Compile(ecc.BLS12_377, r1cs.NewCompiler, &c)
+	ccs, err := frontend.Compile(ecc.BLS12_377, r1cs.NewBuilder, &c)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bls12-377/groth16/groth16_test.go
+++ b/internal/backend/bls12-377/groth16/groth16_test.go
@@ -58,7 +58,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	r1cs, err := frontend.Compile(curve.ID, r1cs.NewCompiler, &circuit)
+	r1cs, err := frontend.Compile(curve.ID, r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bls12-377/plonk/plonk_test.go
+++ b/internal/backend/bls12-377/plonk/plonk_test.go
@@ -62,7 +62,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	ccs, err := frontend.Compile(curve.ID, scs.NewCompiler, &circuit)
+	ccs, err := frontend.Compile(curve.ID, scs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bls12-381/cs/r1cs_test.go
+++ b/internal/backend/bls12-381/cs/r1cs_test.go
@@ -36,7 +36,7 @@ func TestSerialization(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tc := circuits.Circuits[name]
 
-			r1cs1, err := frontend.Compile(ecc.BLS12_381, r1cs.NewCompiler, tc.Circuit)
+			r1cs1, err := frontend.Compile(ecc.BLS12_381, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -45,7 +45,7 @@ func TestSerialization(t *testing.T) {
 			}
 
 			// copmpile a second time to ensure determinism
-			r1cs2, err := frontend.Compile(ecc.BLS12_381, r1cs.NewCompiler, tc.Circuit)
+			r1cs2, err := frontend.Compile(ecc.BLS12_381, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -134,7 +134,7 @@ func (circuit *circuit) Define(api frontend.API) error {
 func BenchmarkSolve(b *testing.B) {
 
 	var c circuit
-	ccs, err := frontend.Compile(ecc.BLS12_381, r1cs.NewCompiler, &c)
+	ccs, err := frontend.Compile(ecc.BLS12_381, r1cs.NewBuilder, &c)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bls12-381/groth16/groth16_test.go
+++ b/internal/backend/bls12-381/groth16/groth16_test.go
@@ -58,7 +58,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	r1cs, err := frontend.Compile(curve.ID, r1cs.NewCompiler, &circuit)
+	r1cs, err := frontend.Compile(curve.ID, r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bls12-381/plonk/plonk_test.go
+++ b/internal/backend/bls12-381/plonk/plonk_test.go
@@ -62,7 +62,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	ccs, err := frontend.Compile(curve.ID, scs.NewCompiler, &circuit)
+	ccs, err := frontend.Compile(curve.ID, scs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bls24-315/cs/r1cs_test.go
+++ b/internal/backend/bls24-315/cs/r1cs_test.go
@@ -36,7 +36,7 @@ func TestSerialization(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tc := circuits.Circuits[name]
 
-			r1cs1, err := frontend.Compile(ecc.BLS24_315, r1cs.NewCompiler, tc.Circuit)
+			r1cs1, err := frontend.Compile(ecc.BLS24_315, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -45,7 +45,7 @@ func TestSerialization(t *testing.T) {
 			}
 
 			// copmpile a second time to ensure determinism
-			r1cs2, err := frontend.Compile(ecc.BLS24_315, r1cs.NewCompiler, tc.Circuit)
+			r1cs2, err := frontend.Compile(ecc.BLS24_315, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -134,7 +134,7 @@ func (circuit *circuit) Define(api frontend.API) error {
 func BenchmarkSolve(b *testing.B) {
 
 	var c circuit
-	ccs, err := frontend.Compile(ecc.BLS24_315, r1cs.NewCompiler, &c)
+	ccs, err := frontend.Compile(ecc.BLS24_315, r1cs.NewBuilder, &c)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bls24-315/groth16/groth16_test.go
+++ b/internal/backend/bls24-315/groth16/groth16_test.go
@@ -58,7 +58,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	r1cs, err := frontend.Compile(curve.ID, r1cs.NewCompiler, &circuit)
+	r1cs, err := frontend.Compile(curve.ID, r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bls24-315/plonk/plonk_test.go
+++ b/internal/backend/bls24-315/plonk/plonk_test.go
@@ -62,7 +62,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	ccs, err := frontend.Compile(curve.ID, scs.NewCompiler, &circuit)
+	ccs, err := frontend.Compile(curve.ID, scs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bn254/cs/r1cs_test.go
+++ b/internal/backend/bn254/cs/r1cs_test.go
@@ -36,7 +36,7 @@ func TestSerialization(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tc := circuits.Circuits[name]
 
-			r1cs1, err := frontend.Compile(ecc.BN254, r1cs.NewCompiler, tc.Circuit)
+			r1cs1, err := frontend.Compile(ecc.BN254, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -45,7 +45,7 @@ func TestSerialization(t *testing.T) {
 			}
 
 			// copmpile a second time to ensure determinism
-			r1cs2, err := frontend.Compile(ecc.BN254, r1cs.NewCompiler, tc.Circuit)
+			r1cs2, err := frontend.Compile(ecc.BN254, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -134,7 +134,7 @@ func (circuit *circuit) Define(api frontend.API) error {
 func BenchmarkSolve(b *testing.B) {
 
 	var c circuit
-	ccs, err := frontend.Compile(ecc.BN254, r1cs.NewCompiler, &c)
+	ccs, err := frontend.Compile(ecc.BN254, r1cs.NewBuilder, &c)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bn254/groth16/groth16_test.go
+++ b/internal/backend/bn254/groth16/groth16_test.go
@@ -58,7 +58,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	r1cs, err := frontend.Compile(curve.ID, r1cs.NewCompiler, &circuit)
+	r1cs, err := frontend.Compile(curve.ID, r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bn254/plonk/plonk_test.go
+++ b/internal/backend/bn254/plonk/plonk_test.go
@@ -62,7 +62,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	ccs, err := frontend.Compile(curve.ID, scs.NewCompiler, &circuit)
+	ccs, err := frontend.Compile(curve.ID, scs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bw6-633/cs/r1cs_test.go
+++ b/internal/backend/bw6-633/cs/r1cs_test.go
@@ -36,7 +36,7 @@ func TestSerialization(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tc := circuits.Circuits[name]
 
-			r1cs1, err := frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, tc.Circuit)
+			r1cs1, err := frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -45,7 +45,7 @@ func TestSerialization(t *testing.T) {
 			}
 
 			// copmpile a second time to ensure determinism
-			r1cs2, err := frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, tc.Circuit)
+			r1cs2, err := frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -134,7 +134,7 @@ func (circuit *circuit) Define(api frontend.API) error {
 func BenchmarkSolve(b *testing.B) {
 
 	var c circuit
-	ccs, err := frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+	ccs, err := frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bw6-633/groth16/groth16_test.go
+++ b/internal/backend/bw6-633/groth16/groth16_test.go
@@ -58,7 +58,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	r1cs, err := frontend.Compile(curve.ID, r1cs.NewCompiler, &circuit)
+	r1cs, err := frontend.Compile(curve.ID, r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bw6-633/plonk/plonk_test.go
+++ b/internal/backend/bw6-633/plonk/plonk_test.go
@@ -62,7 +62,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	ccs, err := frontend.Compile(curve.ID, scs.NewCompiler, &circuit)
+	ccs, err := frontend.Compile(curve.ID, scs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bw6-761/cs/r1cs_test.go
+++ b/internal/backend/bw6-761/cs/r1cs_test.go
@@ -40,7 +40,7 @@ func TestSerialization(t *testing.T) {
 				return
 			}
 
-			r1cs1, err := frontend.Compile(ecc.BW6_761, r1cs.NewCompiler, tc.Circuit)
+			r1cs1, err := frontend.Compile(ecc.BW6_761, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -49,7 +49,7 @@ func TestSerialization(t *testing.T) {
 			}
 
 			// copmpile a second time to ensure determinism
-			r1cs2, err := frontend.Compile(ecc.BW6_761, r1cs.NewCompiler, tc.Circuit)
+			r1cs2, err := frontend.Compile(ecc.BW6_761, r1cs.NewBuilder, tc.Circuit)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -138,7 +138,7 @@ func (circuit *circuit) Define(api frontend.API) error {
 func BenchmarkSolve(b *testing.B) {
 
 	var c circuit
-	ccs, err := frontend.Compile(ecc.BW6_761, r1cs.NewCompiler, &c)
+	ccs, err := frontend.Compile(ecc.BW6_761, r1cs.NewBuilder, &c)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/backend/bw6-761/groth16/groth16_test.go
+++ b/internal/backend/bw6-761/groth16/groth16_test.go
@@ -58,7 +58,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	r1cs, err := frontend.Compile(curve.ID, r1cs.NewCompiler, &circuit)
+	r1cs, err := frontend.Compile(curve.ID, r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/bw6-761/plonk/plonk_test.go
+++ b/internal/backend/bw6-761/plonk/plonk_test.go
@@ -62,7 +62,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	ccs, err := frontend.Compile(curve.ID, scs.NewCompiler, &circuit)
+	ccs, err := frontend.Compile(curve.ID, scs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
@@ -24,7 +24,7 @@ func TestSerialization(t *testing.T) {
 			}
 		{{end}}
 
-		r1cs1, err := frontend.Compile(ecc.{{ .CurveID }}, r1cs.NewCompiler,	tc.Circuit)
+		r1cs1, err := frontend.Compile(ecc.{{ .CurveID }}, r1cs.NewBuilder,	tc.Circuit)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -33,7 +33,7 @@ func TestSerialization(t *testing.T) {
 		}
 
 		// copmpile a second time to ensure determinism
-		r1cs2, err := frontend.Compile(ecc.{{ .CurveID }},r1cs.NewCompiler, tc.Circuit)
+		r1cs2, err := frontend.Compile(ecc.{{ .CurveID }},r1cs.NewBuilder, tc.Circuit)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -123,7 +123,7 @@ func (circuit *circuit) Define(api frontend.API) error {
 func BenchmarkSolve(b *testing.B) {
 
 	var c circuit 
-	ccs, err := frontend.Compile(ecc.{{ .CurveID }},r1cs.NewCompiler, &c)
+	ccs, err := frontend.Compile(ecc.{{ .CurveID }},r1cs.NewBuilder, &c)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.go.tmpl
@@ -38,7 +38,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit) {
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	r1cs, err := frontend.Compile(curve.ID,r1cs.NewCompiler, &circuit)
+	r1cs, err := frontend.Compile(curve.ID,r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/generator/backend/template/zkpschemes/plonk/tests/plonk.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/tests/plonk.go.tmpl
@@ -43,7 +43,7 @@ func referenceCircuit() (frontend.CompiledConstraintSystem, frontend.Circuit, *k
 	circuit := refCircuit{
 		nbConstraints: nbConstraints,
 	}
-	ccs, err := frontend.Compile(curve.ID, scs.NewCompiler, &circuit)
+	ccs, err := frontend.Compile(curve.ID, scs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
 	}

--- a/std/algebra/fields_bls24315/e24_test.go
+++ b/std/algebra/fields_bls24315/e24_test.go
@@ -414,7 +414,7 @@ func BenchmarkMulE24(b *testing.B) {
 	var c fp24Mul
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -425,7 +425,7 @@ func BenchmarkSquareE24(b *testing.B) {
 	var c fp24Square
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -436,7 +436,7 @@ func BenchmarkInverseE24(b *testing.B) {
 	var c fp24Inverse
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -447,7 +447,7 @@ func BenchmarkConjugateE24(b *testing.B) {
 	var c fp24Conjugate
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -458,7 +458,7 @@ func BenchmarkMulBy034E24(b *testing.B) {
 	var c fp24MulBy034
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 		}
 
 	})

--- a/std/algebra/sw_bls12377/g1_test.go
+++ b/std/algebra/sw_bls12377/g1_test.go
@@ -392,7 +392,7 @@ func BenchmarkConstScalarMulG1(b *testing.B) {
 	c.R = r
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_761, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_761, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -400,7 +400,7 @@ func BenchmarkConstScalarMulG1(b *testing.B) {
 	b.Run("plonk", func(b *testing.B) {
 		var err error
 		for i := 0; i < b.N; i++ {
-			ccsBench, err = frontend.Compile(ecc.BW6_761, scs.NewCompiler, &c)
+			ccsBench, err = frontend.Compile(ecc.BW6_761, scs.NewBuilder, &c)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -421,7 +421,7 @@ func BenchmarkVarScalarMulG1(b *testing.B) {
 	c.R = r
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_761, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_761, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -429,7 +429,7 @@ func BenchmarkVarScalarMulG1(b *testing.B) {
 	b.Run("plonk", func(b *testing.B) {
 		var err error
 		for i := 0; i < b.N; i++ {
-			ccsBench, err = frontend.Compile(ecc.BW6_761, scs.NewCompiler, &c)
+			ccsBench, err = frontend.Compile(ecc.BW6_761, scs.NewBuilder, &c)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/std/algebra/sw_bls12377/g2_test.go
+++ b/std/algebra/sw_bls12377/g2_test.go
@@ -272,7 +272,7 @@ func BenchmarkDoubleAffineG2(b *testing.B) {
 	var c g2DoubleAffine
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_761, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_761, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -283,7 +283,7 @@ func BenchmarkAddAssignAffineG2(b *testing.B) {
 	var c g2AddAssignAffine
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_761, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_761, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -294,7 +294,7 @@ func BenchmarkDoubleAndAddAffineG2(b *testing.B) {
 	var c g2DoubleAndAddAffine
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_761, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_761, r1cs.NewBuilder, &c)
 		}
 
 	})

--- a/std/algebra/sw_bls12377/pairing_test.go
+++ b/std/algebra/sw_bls12377/pairing_test.go
@@ -200,7 +200,7 @@ func BenchmarkPairing(b *testing.B) {
 	var c pairingBLS377
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		frontend.Compile(ecc.BW6_761, scs.NewCompiler, &c)
+		frontend.Compile(ecc.BW6_761, scs.NewBuilder, &c)
 	}
 	// ccsBench, _ = compiler.Compile(ecc.BW6_761, backend.GROTH16, &c)
 	// b.Log("groth16", ccsBench.GetNbConstraints())

--- a/std/algebra/sw_bls24315/g1_test.go
+++ b/std/algebra/sw_bls24315/g1_test.go
@@ -392,7 +392,7 @@ func BenchmarkConstScalarMulG1(b *testing.B) {
 	c.R = r
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -400,7 +400,7 @@ func BenchmarkConstScalarMulG1(b *testing.B) {
 	b.Run("plonk", func(b *testing.B) {
 		var err error
 		for i := 0; i < b.N; i++ {
-			ccsBench, err = frontend.Compile(ecc.BW6_633, scs.NewCompiler, &c)
+			ccsBench, err = frontend.Compile(ecc.BW6_633, scs.NewBuilder, &c)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -421,7 +421,7 @@ func BenchmarkVarScalarMulG1(b *testing.B) {
 	c.R = r
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -429,7 +429,7 @@ func BenchmarkVarScalarMulG1(b *testing.B) {
 	b.Run("plonk", func(b *testing.B) {
 		var err error
 		for i := 0; i < b.N; i++ {
-			ccsBench, err = frontend.Compile(ecc.BW6_633, scs.NewCompiler, &c)
+			ccsBench, err = frontend.Compile(ecc.BW6_633, scs.NewBuilder, &c)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/std/algebra/sw_bls24315/g2_test.go
+++ b/std/algebra/sw_bls24315/g2_test.go
@@ -272,7 +272,7 @@ func BenchmarkDoubleAffineG2(b *testing.B) {
 	var c g2DoubleAffine
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -283,7 +283,7 @@ func BenchmarkAddAssignAffineG2(b *testing.B) {
 	var c g2AddAssignAffine
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 		}
 
 	})
@@ -294,7 +294,7 @@ func BenchmarkDoubleAndAddAffineG2(b *testing.B) {
 	var c g2DoubleAndAddAffine
 	b.Run("groth16", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+			ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 		}
 
 	})

--- a/std/algebra/sw_bls24315/pairing_test.go
+++ b/std/algebra/sw_bls24315/pairing_test.go
@@ -214,6 +214,6 @@ func TestTriplePairingBLS24315(t *testing.T) {
 
 func BenchmarkPairing(b *testing.B) {
 	var c pairingBLS24315
-	ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &c)
+	ccsBench, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &c)
 	b.Log("groth16", ccsBench.GetNbConstraints())
 }

--- a/std/algebra/twistededwards/bandersnatch/point_test.go
+++ b/std/algebra/twistededwards/bandersnatch/point_test.go
@@ -364,36 +364,36 @@ func TestNeg(t *testing.T) {
 // Bench
 func BenchmarkDouble(b *testing.B) {
 	var c double
-	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewCompiler, &c)
+	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewBuilder, &c)
 	b.Log("groth16", ccsBench.GetNbConstraints())
 }
 
 func BenchmarkAddGeneric(b *testing.B) {
 	var c addGeneric
-	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewCompiler, &c)
+	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewBuilder, &c)
 	b.Log("groth16", ccsBench.GetNbConstraints())
 }
 
 func BenchmarkAddFixedPoint(b *testing.B) {
 	var c add
-	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewCompiler, &c)
+	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewBuilder, &c)
 	b.Log("groth16", ccsBench.GetNbConstraints())
 }
 
 func BenchmarkMustBeOnCurve(b *testing.B) {
 	var c mustBeOnCurve
-	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewCompiler, &c)
+	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewBuilder, &c)
 	b.Log("groth16", ccsBench.GetNbConstraints())
 }
 
 func BenchmarkScalarMulGeneric(b *testing.B) {
 	var c scalarMulGeneric
-	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewCompiler, &c)
+	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewBuilder, &c)
 	b.Log("groth16", ccsBench.GetNbConstraints())
 }
 
 func BenchmarkScalarMulFixed(b *testing.B) {
 	var c scalarMulFixed
-	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewCompiler, &c)
+	ccsBench, _ := frontend.Compile(ecc.BLS12_381, r1cs.NewBuilder, &c)
 	b.Log("groth16", ccsBench.GetNbConstraints())
 }

--- a/std/fiat-shamir/transcript_test.go
+++ b/std/fiat-shamir/transcript_test.go
@@ -156,7 +156,7 @@ func BenchmarkCompile(b *testing.B) {
 	var ccs frontend.CompiledConstraintSystem
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ccs, _ = frontend.Compile(ecc.BN254, scs.NewCompiler, &circuit)
+		ccs, _ = frontend.Compile(ecc.BN254, scs.NewBuilder, &circuit)
 	}
 	b.Log(ccs.GetNbConstraints())
 }

--- a/std/groth16_bls12377/verifier_test.go
+++ b/std/groth16_bls12377/verifier_test.go
@@ -62,7 +62,7 @@ func generateBls12377InnerProof(t *testing.T, vk *groth16_bls12377.VerifyingKey,
 
 	// create a mock cs: knowing the preimage of a hash using mimc
 	var circuit, w mimcCircuit
-	r1cs, err := frontend.Compile(ecc.BLS12_377, r1cs.NewCompiler, &circuit)
+	r1cs, err := frontend.Compile(ecc.BLS12_377, r1cs.NewBuilder, &circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func BenchmarkCompile(b *testing.B) {
 	var ccs frontend.CompiledConstraintSystem
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ccs, _ = frontend.Compile(ecc.BW6_761, r1cs.NewCompiler, &circuit)
+		ccs, _ = frontend.Compile(ecc.BW6_761, r1cs.NewBuilder, &circuit)
 	}
 	b.Log(ccs.GetNbConstraints())
 }

--- a/std/groth16_bls24315/verifier_test.go
+++ b/std/groth16_bls24315/verifier_test.go
@@ -63,7 +63,7 @@ func generateBls24315InnerProof(t *testing.T, vk *groth16_bls24315.VerifyingKey,
 
 	// create a mock cs: knowing the preimage of a hash using mimc
 	var circuit, w mimcCircuit
-	r1cs, err := frontend.Compile(ecc.BLS24_315, r1cs.NewCompiler, &circuit)
+	r1cs, err := frontend.Compile(ecc.BLS24_315, r1cs.NewBuilder, &circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func BenchmarkCompile(b *testing.B) {
 	var ccs frontend.CompiledConstraintSystem
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ccs, _ = frontend.Compile(ecc.BW6_633, r1cs.NewCompiler, &circuit)
+		ccs, _ = frontend.Compile(ecc.BW6_633, r1cs.NewBuilder, &circuit)
 	}
 	b.Log(ccs.GetNbConstraints())
 }

--- a/test/assert.go
+++ b/test/assert.go
@@ -400,13 +400,13 @@ func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendI
 		return ccs, nil
 	}
 
-	var newBuilder frontend.NewCompiler
+	var newBuilder frontend.NewBuilder
 
 	switch backendID {
 	case backend.GROTH16:
-		newBuilder = r1cs.NewCompiler
+		newBuilder = r1cs.NewBuilder
 	case backend.PLONK:
-		newBuilder = scs.NewCompiler
+		newBuilder = scs.NewBuilder
 	default:
 		panic("not implemented")
 	}


### PR DESCRIPTION
This PR : #245   refactored an internal part of the frontend, and renamed the `Builder` to `Compiler`, reverting that change. 