### PR TITLE
Adds std/math/bits

### DIFF
--- a/backend/hint/builtin.go
+++ b/backend/hint/builtin.go
@@ -11,20 +11,10 @@ var (
 	// corresponds to checking if a == 0 (for which the function returns 1) or a
 	// != 0 (for which the function returns 0).
 	IsZero = NewStaticHint(isZero)
-
-	// IthBit returns the i-tb bit the input. The function expects exactly two
-	// integer inputs i and n, takes the little-endian bit representation of n and
-	// returns its i-th bit.
-	IthBit = NewStaticHint(ithBit)
-
-	// NBits returns the n first bits of the input. Expects one argument: n.
-	NBits = NewStaticHint(nBits)
 )
 
 func init() {
 	Register(IsZero)
-	Register(IthBit)
-	Register(NBits)
 }
 
 func isZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error {
@@ -45,24 +35,5 @@ func isZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error {
 	inputs[0].SetUint64(1)
 	result.Sub(inputs[0], result).Mod(result, q)
 
-	return nil
-}
-
-func ithBit(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
-	result := results[0]
-	if !inputs[1].IsUint64() {
-		result.SetUint64(0)
-		return nil
-	}
-
-	result.SetUint64(uint64(inputs[0].Bit(int(inputs[1].Uint64()))))
-	return nil
-}
-
-func nBits(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
-	n := inputs[0]
-	for i := 0; i < len(results); i++ {
-		results[i].SetUint64(uint64(n.Bit(i)))
-	}
 	return nil
 }

--- a/backend/hint/builtin.go
+++ b/backend/hint/builtin.go
@@ -19,16 +19,12 @@ var (
 
 	// NBits returns the n first bits of the input. Expects one argument: n.
 	NBits = NewStaticHint(nBits)
-
-	// NTrits returns the n first bits of the input. Expects one argument: n.
-	NTrits = NewStaticHint(nTrits)
 )
 
 func init() {
 	Register(IsZero)
 	Register(IthBit)
 	Register(NBits)
-	Register(NTrits)
 }
 
 func isZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error {
@@ -68,21 +64,5 @@ func nBits(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
 	for i := 0; i < len(results); i++ {
 		results[i].SetUint64(uint64(n.Bit(i)))
 	}
-	return nil
-}
-
-func nTrits(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
-	n := inputs[0]
-	// TODO using big.Int Text method is likely not cheap
-	base3 := n.Text(3)
-	i := 0
-	for j := len(base3) - 1; j >= 0 && i < len(results); j-- {
-		results[i].SetUint64(uint64(base3[j] - 48))
-		i++
-	}
-	for ; i < len(results); i++ {
-		results[i].SetUint64(0)
-	}
-
 	return nil
 }

--- a/backend/hint/builtin.go
+++ b/backend/hint/builtin.go
@@ -19,12 +19,16 @@ var (
 
 	// NBits returns the n first bits of the input. Expects one argument: n.
 	NBits = NewStaticHint(nBits)
+
+	// NTrits returns the n first bits of the input. Expects one argument: n.
+	NTrits = NewStaticHint(nTrits)
 )
 
 func init() {
 	Register(IsZero)
 	Register(IthBit)
 	Register(NBits)
+	Register(NTrits)
 }
 
 func isZero(curveID ecc.ID, inputs []*big.Int, results []*big.Int) error {
@@ -64,5 +68,21 @@ func nBits(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
 	for i := 0; i < len(results); i++ {
 		results[i].SetUint64(uint64(n.Bit(i)))
 	}
+	return nil
+}
+
+func nTrits(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
+	n := inputs[0]
+	// TODO using big.Int Text method is likely not cheap
+	base3 := n.Text(3)
+	i := 0
+	for j := len(base3) - 1; j >= 0 && i < len(results); j-- {
+		results[i].SetUint64(uint64(base3[j] - 48))
+		i++
+	}
+	for ; i < len(results); i++ {
+		results[i].SetUint64(0)
+	}
+
 	return nil
 }

--- a/examples/exponentiate/exponentiate.go
+++ b/examples/exponentiate/exponentiate.go
@@ -16,6 +16,7 @@ package exponentiate
 
 import (
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/bits"
 )
 
 // Circuit y == x**e
@@ -38,7 +39,7 @@ func (circuit *Circuit) Define(api frontend.API) error {
 
 	// specify constraints
 	output := frontend.Variable(1)
-	bits := api.ToBinary(circuit.E, bitSize)
+	bits := bits.ToBinary(api, circuit.E, bits.WithNbDigits(bitSize))
 
 	for i := 0; i < len(bits); i++ {
 		if i != 0 {

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -63,6 +63,7 @@ type API interface {
 	ToBinary(i1 Variable, n ...int) []Variable
 
 	// FromBinary packs b, seen as a fr.Element in little endian
+	// Deprecated: use std/math/bits instead
 	FromBinary(b ...Variable) Variable
 
 	// Xor returns a ^ b

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -59,11 +59,9 @@ type API interface {
 	// n default value is fr.Bits the number of bits needed to represent a field element
 	//
 	// The result in in little endian (first bit= lsb)
-	// Deprecated: use std/math/bits instead
 	ToBinary(i1 Variable, n ...int) []Variable
 
 	// FromBinary packs b, seen as a fr.Element in little endian
-	// Deprecated: use std/math/bits instead
 	FromBinary(b ...Variable) Variable
 
 	// Xor returns a ^ b

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -59,6 +59,7 @@ type API interface {
 	// n default value is fr.Bits the number of bits needed to represent a field element
 	//
 	// The result in in little endian (first bit= lsb)
+	// Deprecated: use std/math/bits instead
 	ToBinary(i1 Variable, n ...int) []Variable
 
 	// FromBinary packs b, seen as a fr.Element in little endian

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -268,7 +268,7 @@ func (system *r1cs) ToBinary(i1 frontend.Variable, n ...int) []frontend.Variable
 
 // FromBinary packs b, seen as a fr.Element in little endian
 func (system *r1cs) FromBinary(_b ...frontend.Variable) frontend.Variable {
-	return bits.FromBinary(system, _b...)
+	return bits.FromBinary(system, _b)
 }
 
 // Xor compute the XOR between two frontend.Variables

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -270,7 +270,7 @@ func (system *compiler) ToBinary(i1 frontend.Variable, n ...int) []frontend.Vari
 	if c, ok := system.ConstantValue(a); ok {
 		b := make([]frontend.Variable, nbBits)
 		for i := 0; i < len(b); i++ {
-			b[i] = system.toVariable(c.Bit(i))
+			b[i] = c.Bit(i) // system.toVariable(c.Bit(i))
 		}
 		return b
 	}

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/compiled"
 	"github.com/consensys/gnark/frontend/schema"
+	"github.com/consensys/gnark/std/math/bits"
 )
 
 // ---------------------------------------------------------------------------------------------
@@ -252,9 +253,7 @@ func (system *r1cs) Inverse(i1 frontend.Variable) frontend.Variable {
 // n default value is fr.Bits the number of bits needed to represent a field element
 //
 // The result in in little endian (first bit= lsb)
-// Deprecated: use std/math/bits instead
 func (system *r1cs) ToBinary(i1 frontend.Variable, n ...int) []frontend.Variable {
-
 	// nbBits
 	nbBits := system.BitLen()
 	if len(n) == 1 {
@@ -264,66 +263,12 @@ func (system *r1cs) ToBinary(i1 frontend.Variable, n ...int) []frontend.Variable
 		}
 	}
 
-	vars, _ := system.toVariables(i1)
-	a := vars[0]
-
-	// if a is a constant, work with the big int value.
-	if c, ok := system.ConstantValue(a); ok {
-		b := make([]frontend.Variable, nbBits)
-		for i := 0; i < len(b); i++ {
-			b[i] = c.Bit(i) // system.toVariable(c.Bit(i))
-		}
-		return b
-	}
-
-	return system.toBinary(a, nbBits, false)
-}
-
-// toBinary is equivalent to ToBinary, exept the returned bits are NOT boolean constrained.
-func (system *r1cs) toBinary(a compiled.LinearExpression, nbBits int, unsafe bool) []frontend.Variable {
-
-	if _, ok := system.ConstantValue(a); ok {
-		return system.ToBinary(a, nbBits)
-	}
-
-	// allocate the resulting frontend.Variables and bit-constraint them
-	sb := make([]frontend.Variable, nbBits)
-	var c big.Int
-	c.SetUint64(1)
-
-	bits, err := system.NewHint(hint.NBits, nbBits, a)
-	if err != nil {
-		panic(err)
-	}
-
-	for i := 0; i < nbBits; i++ {
-		sb[i] = system.Mul(bits[i], c)
-		c.Lsh(&c, 1)
-		if !unsafe {
-			system.AssertIsBoolean(bits[i])
-		}
-	}
-
-	//var Σbi compiled.LinearExpression
-	var Σbi frontend.Variable
-	if nbBits == 1 {
-		Σbi = sb[0]
-	} else if nbBits == 2 {
-		Σbi = system.Add(sb[0], sb[1])
-	} else {
-		Σbi = system.Add(sb[0], sb[1], sb[2:]...)
-	}
-	system.AssertIsEqual(Σbi, a)
-
-	// record the constraint Σ (2**i * b[i]) == a
-	return bits
-
+	return bits.ToBinary(system, i1, bits.WithNbDigits(nbBits))
 }
 
 // FromBinary packs b, seen as a fr.Element in little endian
-// Deprecated: use std/math/bits instead
 func (system *r1cs) FromBinary(_b ...frontend.Variable) frontend.Variable {
-	panic("Deprecated: use std/math/bits instead")
+	return bits.FromBinary(system, _b...)
 }
 
 // Xor compute the XOR between two frontend.Variables

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -323,25 +323,7 @@ func (system *r1cs) toBinary(a compiled.LinearExpression, nbBits int, unsafe boo
 // FromBinary packs b, seen as a fr.Element in little endian
 // Deprecated: use std/math/bits instead
 func (system *r1cs) FromBinary(_b ...frontend.Variable) frontend.Variable {
-	b, _ := system.toVariables(_b...)
-
-	// res = Σ (2**i * b[i])
-
-	var res, v frontend.Variable
-	res = system.toVariable(0) // no constraint is recorded
-
-	var c big.Int
-	c.SetUint64(1)
-
-	L := make(compiled.LinearExpression, len(b))
-	for i := 0; i < len(L); i++ {
-		v = system.Mul(c, b[i])      // no constraint is recorded
-		res = system.Add(v, res)     // no constraint is recorded
-		system.AssertIsBoolean(b[i]) // ensures the b[i]'s are boolean
-		c.Lsh(&c, 1)
-	}
-
-	return res
+	panic("Deprecated: use std/math/bits instead")
 }
 
 // Xor compute the XOR between two frontend.Variables

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -252,6 +252,7 @@ func (system *r1cs) Inverse(i1 frontend.Variable) frontend.Variable {
 // n default value is fr.Bits the number of bits needed to represent a field element
 //
 // The result in in little endian (first bit= lsb)
+// Deprecated: use std/math/bits instead
 func (system *r1cs) ToBinary(i1 frontend.Variable, n ...int) []frontend.Variable {
 
 	// nbBits

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -321,6 +321,7 @@ func (system *r1cs) toBinary(a compiled.LinearExpression, nbBits int, unsafe boo
 }
 
 // FromBinary packs b, seen as a fr.Element in little endian
+// Deprecated: use std/math/bits instead
 func (system *r1cs) FromBinary(_b ...frontend.Variable) frontend.Variable {
 	b, _ := system.toVariables(_b...)
 

--- a/frontend/cs/r1cs/api_assertions.go
+++ b/frontend/cs/r1cs/api_assertions.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/compiled"
 	"github.com/consensys/gnark/internal/utils"
+	"github.com/consensys/gnark/std/math/bits"
 )
 
 // AssertIsEqual adds an assertion in the constraint system (i1 == i2)
@@ -92,7 +93,7 @@ func (system *r1cs) mustBeLessOrEqVar(a, bound compiled.LinearExpression) {
 
 	nbBits := system.BitLen()
 
-	aBits := system.toBinary(a, nbBits, true)
+	aBits := bits.ToBinary(system, a, bits.WithNbDigits(nbBits), bits.WithUnconstrainedOutputs())
 	boundBits := system.ToBinary(bound, nbBits)
 
 	p := make([]frontend.Variable, nbBits+1)
@@ -145,7 +146,7 @@ func (system *r1cs) mustBeLessOrEqCst(a compiled.LinearExpression, bound big.Int
 
 	// note that at this stage, we didn't boolean-constraint these new variables yet
 	// (as opposed to ToBinary)
-	aBits := system.toBinary(a, nbBits, true)
+	aBits := bits.ToBinary(system, a, bits.WithNbDigits(nbBits), bits.WithUnconstrainedOutputs())
 
 	// t trailing bits in the bound
 	t := 0

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -173,6 +173,7 @@ func (system *scs) Inverse(i1 frontend.Variable) frontend.Variable {
 // n default value is fr.Bits the number of bits needed to represent a field element
 //
 // The result in in little endian (first bit= lsb)
+// Deprecated: use std/math/bits instead
 func (system *scs) ToBinary(i1 frontend.Variable, n ...int) []frontend.Variable {
 
 	// nbBits

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -238,20 +238,7 @@ func (system *scs) toBinary(a compiled.Term, nbBits int, unsafe bool) []frontend
 // FromBinary packs b, seen as a fr.Element in little endian
 // Deprecated: use std/math/bits instead
 func (system *scs) FromBinary(b ...frontend.Variable) frontend.Variable {
-	_b := make([]frontend.Variable, len(b))
-	var c big.Int
-	c.SetUint64(1)
-	for i := 0; i < len(b); i++ {
-		_b[i] = system.Mul(b[i], c)
-		c.Lsh(&c, 1)
-	}
-	if len(b) == 1 {
-		return b[0]
-	}
-	if len(b) == 1 {
-		return system.Add(_b[0], _b[1])
-	}
-	return system.Add(_b[0], _b[1], _b[2:]...)
+	panic("Deprecated: use std/math/bits instead")
 }
 
 // Xor returns a ^ b

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -189,7 +189,7 @@ func (system *scs) ToBinary(i1 frontend.Variable, n ...int) []frontend.Variable 
 
 // FromBinary packs b, seen as a fr.Element in little endian
 func (system *scs) FromBinary(b ...frontend.Variable) frontend.Variable {
-	return bits.FromBinary(system, b...)
+	return bits.FromBinary(system, b)
 }
 
 // Xor returns a ^ b

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -236,6 +236,7 @@ func (system *scs) toBinary(a compiled.Term, nbBits int, unsafe bool) []frontend
 }
 
 // FromBinary packs b, seen as a fr.Element in little endian
+// Deprecated: use std/math/bits instead
 func (system *scs) FromBinary(b ...frontend.Variable) frontend.Variable {
 	_b := make([]frontend.Variable, len(b))
 	var c big.Int

--- a/frontend/cs/scs/api_assertions.go
+++ b/frontend/cs/scs/api_assertions.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/compiled"
 	"github.com/consensys/gnark/internal/utils"
+	"github.com/consensys/gnark/std/math/bits"
 )
 
 // AssertIsEqual fails if i1 != i2
@@ -104,7 +105,7 @@ func (system *scs) mustBeLessOrEqVar(a compiled.Term, bound compiled.Term) {
 
 	nbBits := system.BitLen()
 
-	aBits := system.toBinary(a, nbBits, true)
+	aBits := bits.ToBinary(system, a, bits.WithNbDigits(nbBits), bits.WithUnconstrainedOutputs())
 	boundBits := system.ToBinary(bound, nbBits)
 
 	p := make([]frontend.Variable, nbBits+1)
@@ -162,7 +163,7 @@ func (system *scs) mustBeLessOrEqCst(a compiled.Term, bound big.Int) {
 
 	// note that at this stage, we didn't boolean-constraint these new variables yet
 	// (as opposed to ToBinary)
-	aBits := system.toBinary(a, nbBits, true)
+	aBits := bits.ToBinary(system, a, bits.WithNbDigits(nbBits), bits.WithUnconstrainedOutputs())
 
 	// t trailing bits in the bound
 	t := 0

--- a/std/hints.go
+++ b/std/hints.go
@@ -9,5 +9,5 @@ import (
 
 // GetHints return std hints that are always injected in gnark solvers
 func GetHints() []hint.Function {
-	return []hint.Function{sw_bls24315.DecomposeScalar, sw_bls12377.DecomposeScalar, bits.NTrits}
+	return []hint.Function{sw_bls24315.DecomposeScalar, sw_bls12377.DecomposeScalar, bits.NTrits, bits.NNAF}
 }

--- a/std/hints.go
+++ b/std/hints.go
@@ -4,9 +4,10 @@ import (
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/std/algebra/sw_bls12377"
 	"github.com/consensys/gnark/std/algebra/sw_bls24315"
+	"github.com/consensys/gnark/std/math/bits"
 )
 
 // GetHints return std hints that are always injected in gnark solvers
 func GetHints() []hint.Function {
-	return []hint.Function{sw_bls24315.DecomposeScalar, sw_bls12377.DecomposeScalar}
+	return []hint.Function{sw_bls24315.DecomposeScalar, sw_bls12377.DecomposeScalar, bits.NTrits}
 }

--- a/std/hints.go
+++ b/std/hints.go
@@ -9,5 +9,12 @@ import (
 
 // GetHints return std hints that are always injected in gnark solvers
 func GetHints() []hint.Function {
-	return []hint.Function{sw_bls24315.DecomposeScalar, sw_bls12377.DecomposeScalar, bits.NTrits, bits.NNAF}
+	return []hint.Function{
+		sw_bls24315.DecomposeScalar,
+		sw_bls12377.DecomposeScalar,
+		bits.NTrits,
+		bits.NNAF,
+		bits.IthBit,
+		bits.NBits,
+	}
 }

--- a/std/math/bits/conversion.go
+++ b/std/math/bits/conversion.go
@@ -1,0 +1,97 @@
+package bits
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/consensys/gnark/backend/hint"
+	"github.com/consensys/gnark/frontend"
+)
+
+type Base uint8
+
+const (
+	Binary  Base = 2
+	Ternary Base = 3
+	Quinary Base = 5
+)
+
+// ToBinary is an alias of ToBase(... Binary ...)
+func ToBinary(api frontend.API, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
+	return ToBase(api, v, Binary, opts...)
+}
+
+func ToBase(api frontend.API, v frontend.Variable, base Base, opts ...BaseConversionOption) []frontend.Variable {
+	// parse options
+	cfg := BaseConversionConfig{
+		NbDigits:      api.Compiler().Curve().Info().Fr.Bits,
+		Unconstrained: false,
+	}
+	switch base {
+	case Binary:
+		return toBinary(api, v, cfg)
+	default:
+		panic("not implemented")
+	}
+}
+
+func toBinary(api frontend.API, v frontend.Variable, cfg BaseConversionConfig) []frontend.Variable {
+	// if a is a constant, work with the big int value.
+	if c, ok := api.Compiler().ConstantValue(v); ok {
+		bits := make([]frontend.Variable, cfg.NbDigits)
+		for i := 0; i < len(bits); i++ {
+			bits[i] = c.Bit(i)
+		}
+		return bits
+	}
+
+	var c big.Int
+	c.SetUint64(1)
+
+	bits, err := api.Compiler().NewHint(hint.NBits, cfg.NbDigits, v)
+	if err != nil {
+		panic(err)
+	}
+
+	var Σbi frontend.Variable
+	Σbi = 0
+	for i := 0; i < cfg.NbDigits; i++ {
+		Σbi = api.Add(Σbi, api.Mul(bits[i], c))
+		c.Lsh(&c, 1)
+		if !cfg.Unconstrained {
+			api.AssertIsBoolean(bits[i])
+		}
+	}
+
+	// record the constraint Σ (2**i * b[i]) == a
+	api.AssertIsEqual(Σbi, v)
+
+	return bits
+}
+
+type BaseConversionOption func(opt *BaseConversionConfig) error
+
+type BaseConversionConfig struct {
+	NbDigits      int
+	Unconstrained bool
+}
+
+func WithNbDigits(nbDigits int) BaseConversionOption {
+	return func(opt *BaseConversionConfig) error {
+		if nbDigits <= 0 {
+			return errors.New("nbDigits <= 0")
+		}
+		opt.NbDigits = nbDigits
+		return nil
+	}
+}
+
+// WithUnconstrainedOutputs sets the bit conversion API to NOT constrain the output
+// This is UNSAFE but is useful when the outputs are already constrained by other circuit
+// constraints
+func WithUnconstrainedOutputs() BaseConversionOption {
+	return func(opt *BaseConversionConfig) error {
+		opt.Unconstrained = true
+		return nil
+	}
+}

--- a/std/math/bits/conversion.go
+++ b/std/math/bits/conversion.go
@@ -6,15 +6,19 @@ import (
 	"github.com/consensys/gnark/frontend"
 )
 
+// Base defines the base for decomposing the scalar into digits.
 type Base uint8
 
 const (
-	Binary  Base = 2
+	// Binary base decomposes scalar into bits (0-1)
+	Binary Base = 2
+
+	// Ternary base decomposes scalar into trits (0-1-2)
 	Ternary Base = 3
-	Quinary Base = 5
 )
 
-// ToBase converts b in given base
+// ToBase decomposes scalar v into digits in given base using options opts. The
+// decomposition is in little-endian order.
 func ToBase(api frontend.API, base Base, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
 	switch base {
 	case Binary:
@@ -26,33 +30,38 @@ func ToBase(api frontend.API, base Base, v frontend.Variable, opts ...BaseConver
 	}
 }
 
-// FromBase compute from a set of digits its canonical representation
-// For example for base 2, it returns Σbi = Σ (2**i * b[i])
-func FromBase(api frontend.API, base Base, digits ...frontend.Variable) frontend.Variable {
+// FromBase compute from a set of digits its canonical representation in
+// little-endian order.
+// For example for base 2, it returns Σbi = Σ (2**i * digits[i])
+func FromBase(api frontend.API, base Base, digits []frontend.Variable, opts ...BaseConversionOption) frontend.Variable {
 	if len(digits) == 0 {
 		panic("FromBase needs at least 1 digit")
 	}
 	switch base {
 	case Binary:
-		return fromBinary(api, digits)
+		return fromBinary(api, digits, opts...)
 	case Ternary:
-		return fromTernary(api, digits)
+		return fromTernary(api, digits, opts...)
 	default:
 		panic("not implemented")
 	}
 }
 
-type BaseConversionConfig struct {
-	NbDigits      int
-	Unconstrained bool
+type baseConversionConfig struct {
+	NbDigits             int
+	UnconstrainedOutputs bool
+	UnconstrainedInputs  bool
 }
 
-type BaseConversionOption func(opt *BaseConversionConfig) error
+// BaseConversionOption configures the behaviour of scalar decomposition.
+type BaseConversionOption func(opt *baseConversionConfig) error
 
-// WithNbDigits set the resulting number of digits to be used in the base conversion
-// nbDigits must be > 0
+// WithNbDigits set the resulting number of digits to be used in the base conversion.
+// nbDigits must be > 0. If nbDigits is lower than the length of full
+// decomposition, then nbDigits least significant digits are returned. If the
+// option is not set, then the full decomposition is returned.
 func WithNbDigits(nbDigits int) BaseConversionOption {
-	return func(opt *BaseConversionConfig) error {
+	return func(opt *baseConversionConfig) error {
 		if nbDigits <= 0 {
 			return errors.New("nbDigits <= 0")
 		}
@@ -61,12 +70,24 @@ func WithNbDigits(nbDigits int) BaseConversionOption {
 	}
 }
 
-// WithUnconstrainedOutputs sets the bit conversion API to NOT constrain the output
+// WithUnconstrainedOutputs sets the bit conversion API to NOT constrain the output bits.
 // This is UNSAFE but is useful when the outputs are already constrained by other circuit
-// constraints
+// constraints.
+// The sum of the digits will is constrained like so Σbi = Σ (base**i * digits[i])
+// But the individual digits are not constrained to be valid digits in base b.
 func WithUnconstrainedOutputs() BaseConversionOption {
-	return func(opt *BaseConversionConfig) error {
-		opt.Unconstrained = true
+	return func(opt *baseConversionConfig) error {
+		opt.UnconstrainedOutputs = true
+		return nil
+	}
+}
+
+// WithUnconstrainedInputs indicates to the FromBase apis to constrain its inputs (digits) to
+// ensure they are valid digits in base b. For example, FromBinary without this option will add
+// 1 constraint per bit to ensure it is either 0 or 1.
+func WithUnconstrainedInputs() BaseConversionOption {
+	return func(opt *baseConversionConfig) error {
+		opt.UnconstrainedInputs = true
 		return nil
 	}
 }

--- a/std/math/bits/conversion.go
+++ b/std/math/bits/conversion.go
@@ -2,9 +2,7 @@ package bits
 
 import (
 	"errors"
-	"math/big"
 
-	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -15,16 +13,6 @@ const (
 	Ternary Base = 3
 	Quinary Base = 5
 )
-
-// ToBinary is an alias of ToBase(... Binary ...)
-func ToBinary(api frontend.API, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
-	return ToBase(api, Binary, v, opts...)
-}
-
-// FromBinary is an alias of FromBase(... Binary ...)
-func FromBinary(api frontend.API, digits ...frontend.Variable) frontend.Variable {
-	return FromBase(api, Binary, digits...)
-}
 
 // ToBase converts b in given base
 func ToBase(api frontend.API, base Base, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
@@ -48,68 +36,6 @@ func FromBase(api frontend.API, base Base, digits ...frontend.Variable) frontend
 	default:
 		panic("not implemented")
 	}
-}
-
-func fromBinary(api frontend.API, digits []frontend.Variable) frontend.Variable {
-	// Σbi = Σ (2**i * b[i])
-	Σbi := frontend.Variable(0)
-
-	c := big.NewInt(1)
-
-	for i := 0; i < len(digits); i++ {
-		// TODO do we want to keep this AssertIsBoolean here?
-		api.AssertIsBoolean(digits[i])            // ensures the digits are actual bits
-		Σbi = api.Add(Σbi, api.Mul(c, digits[i])) // no constraint is recorded
-		c.Lsh(c, 1)
-	}
-
-	return Σbi
-}
-
-func toBinary(api frontend.API, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
-	// parse options
-	cfg := BaseConversionConfig{
-		NbDigits:      api.Compiler().Curve().Info().Fr.Bits,
-		Unconstrained: false,
-	}
-
-	for _, o := range opts {
-		if err := o(&cfg); err != nil {
-			panic(err)
-		}
-	}
-
-	// if a is a constant, work with the big int value.
-	if c, ok := api.Compiler().ConstantValue(v); ok {
-		bits := make([]frontend.Variable, cfg.NbDigits)
-		for i := 0; i < len(bits); i++ {
-			bits[i] = c.Bit(i)
-		}
-		return bits
-	}
-
-	var c big.Int
-	c.SetUint64(1)
-
-	bits, err := api.Compiler().NewHint(hint.NBits, cfg.NbDigits, v)
-	if err != nil {
-		panic(err)
-	}
-
-	var Σbi frontend.Variable
-	Σbi = 0
-	for i := 0; i < cfg.NbDigits; i++ {
-		Σbi = api.Add(Σbi, api.Mul(bits[i], c))
-		c.Lsh(&c, 1)
-		if !cfg.Unconstrained {
-			api.AssertIsBoolean(bits[i])
-		}
-	}
-
-	// record the constraint Σ (2**i * b[i]) == a
-	api.AssertIsEqual(Σbi, v)
-
-	return bits
 }
 
 type BaseConversionConfig struct {

--- a/std/math/bits/conversion.go
+++ b/std/math/bits/conversion.go
@@ -19,6 +19,8 @@ func ToBase(api frontend.API, base Base, v frontend.Variable, opts ...BaseConver
 	switch base {
 	case Binary:
 		return toBinary(api, v, opts...)
+	case Ternary:
+		return toTernary(api, v, opts...)
 	default:
 		panic("not implemented")
 	}
@@ -33,6 +35,8 @@ func FromBase(api frontend.API, base Base, digits ...frontend.Variable) frontend
 	switch base {
 	case Binary:
 		return fromBinary(api, digits)
+	case Ternary:
+		return fromTernary(api, digits)
 	default:
 		panic("not implemented")
 	}

--- a/std/math/bits/conversion_binary.go
+++ b/std/math/bits/conversion_binary.go
@@ -55,8 +55,7 @@ func toBinary(api frontend.API, v frontend.Variable, opts ...BaseConversionOptio
 		return bits
 	}
 
-	var c big.Int
-	c.SetUint64(1)
+	c := big.NewInt(1)
 
 	bits, err := api.Compiler().NewHint(hint.NBits, cfg.NbDigits, v)
 	if err != nil {
@@ -67,7 +66,7 @@ func toBinary(api frontend.API, v frontend.Variable, opts ...BaseConversionOptio
 	Σbi = 0
 	for i := 0; i < cfg.NbDigits; i++ {
 		Σbi = api.Add(Σbi, api.Mul(bits[i], c))
-		c.Lsh(&c, 1)
+		c.Lsh(c, 1)
 		if !cfg.Unconstrained {
 			api.AssertIsBoolean(bits[i])
 		}

--- a/std/math/bits/conversion_binary.go
+++ b/std/math/bits/conversion_binary.go
@@ -1,0 +1,80 @@
+package bits
+
+import (
+	"math/big"
+
+	"github.com/consensys/gnark/backend/hint"
+	"github.com/consensys/gnark/frontend"
+)
+
+// ToBinary is an alias of ToBase(... Binary ...)
+func ToBinary(api frontend.API, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
+	return ToBase(api, Binary, v, opts...)
+}
+
+// FromBinary is an alias of FromBase(... Binary ...)
+func FromBinary(api frontend.API, digits ...frontend.Variable) frontend.Variable {
+	return FromBase(api, Binary, digits...)
+}
+
+func fromBinary(api frontend.API, digits []frontend.Variable) frontend.Variable {
+	// Σbi = Σ (2**i * b[i])
+	Σbi := frontend.Variable(0)
+
+	c := big.NewInt(1)
+
+	for i := 0; i < len(digits); i++ {
+		// TODO do we want to keep this AssertIsBoolean here?
+		api.AssertIsBoolean(digits[i])            // ensures the digits are actual bits
+		Σbi = api.Add(Σbi, api.Mul(c, digits[i])) // no constraint is recorded
+		c.Lsh(c, 1)
+	}
+
+	return Σbi
+}
+
+func toBinary(api frontend.API, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
+	// parse options
+	cfg := BaseConversionConfig{
+		NbDigits:      api.Compiler().Curve().Info().Fr.Bits,
+		Unconstrained: false,
+	}
+
+	for _, o := range opts {
+		if err := o(&cfg); err != nil {
+			panic(err)
+		}
+	}
+
+	// if a is a constant, work with the big int value.
+	if c, ok := api.Compiler().ConstantValue(v); ok {
+		bits := make([]frontend.Variable, cfg.NbDigits)
+		for i := 0; i < len(bits); i++ {
+			bits[i] = c.Bit(i)
+		}
+		return bits
+	}
+
+	var c big.Int
+	c.SetUint64(1)
+
+	bits, err := api.Compiler().NewHint(hint.NBits, cfg.NbDigits, v)
+	if err != nil {
+		panic(err)
+	}
+
+	var Σbi frontend.Variable
+	Σbi = 0
+	for i := 0; i < cfg.NbDigits; i++ {
+		Σbi = api.Add(Σbi, api.Mul(bits[i], c))
+		c.Lsh(&c, 1)
+		if !cfg.Unconstrained {
+			api.AssertIsBoolean(bits[i])
+		}
+	}
+
+	// record the constraint Σ (2**i * b[i]) == a
+	api.AssertIsEqual(Σbi, v)
+
+	return bits
+}

--- a/std/math/bits/conversion_ternary.go
+++ b/std/math/bits/conversion_ternary.go
@@ -1,0 +1,1 @@
+package bits

--- a/std/math/bits/conversion_ternary.go
+++ b/std/math/bits/conversion_ternary.go
@@ -1,1 +1,91 @@
 package bits
+
+import (
+	"math"
+	"math/big"
+
+	"github.com/consensys/gnark/backend/hint"
+	"github.com/consensys/gnark/frontend"
+)
+
+// ToTernary is an alias of ToBase(... Ternary ...)
+func ToTernary(api frontend.API, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
+	return ToBase(api, Ternary, v, opts...)
+}
+
+// FromTernary is an alias of FromBase(... Ternary ...)
+func FromTernary(api frontend.API, digits ...frontend.Variable) frontend.Variable {
+	return FromBase(api, Ternary, digits...)
+}
+
+func fromTernary(api frontend.API, digits []frontend.Variable) frontend.Variable {
+	// Σti = Σ (3**i * b[i])
+	Σti := frontend.Variable(0)
+
+	c := big.NewInt(1)
+	base := big.NewInt(3)
+
+	for i := 0; i < len(digits); i++ {
+		// TODO ensures the digits are actual trits
+		Σti = api.Add(Σti, api.Mul(c, digits[i])) // no constraint is recorded
+		c.Mul(c, base)
+	}
+
+	return Σti
+}
+
+func toTernary(api frontend.API, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
+	// parse options
+	nbBits := api.Compiler().Curve().Info().Fr.Bits
+	nbTrits := int(float64(nbBits)/math.Log2(3.0)) + 1
+	cfg := BaseConversionConfig{
+		NbDigits:      nbTrits,
+		Unconstrained: false,
+	}
+
+	for _, o := range opts {
+		if err := o(&cfg); err != nil {
+			panic(err)
+		}
+	}
+
+	// if a is a constant, work with the big int value.
+	if c, ok := api.Compiler().ConstantValue(v); ok {
+		trits := make([]frontend.Variable, cfg.NbDigits)
+		// TODO using big.Int Text is likely not cheap
+		base3 := c.Text(3)
+		i := 0
+		for j := len(base3) - 1; j >= 0 && i < len(trits); j-- {
+			trits[i] = int(base3[j] - 48)
+			i++
+		}
+		for ; i < len(trits); i++ {
+			trits[i] = 0
+		}
+		return trits
+	}
+
+	c := big.NewInt(1)
+	b := big.NewInt(3)
+
+	trits, err := api.Compiler().NewHint(hint.NTrits, cfg.NbDigits, v)
+	if err != nil {
+		panic(err)
+	}
+
+	var Σti frontend.Variable
+	Σti = 0
+	for i := 0; i < cfg.NbDigits; i++ {
+		Σti = api.Add(Σti, api.Mul(trits[i], c))
+		c.Mul(c, b)
+		if !cfg.Unconstrained {
+			// TODO assert == 0, 1, 2
+			// api.AssertIsBoolean(trits[i])
+		}
+	}
+
+	// record the constraint Σ (3**i * t[i]) == a
+	api.AssertIsEqual(Σti, v)
+
+	return trits
+}

--- a/std/math/bits/conversion_test.go
+++ b/std/math/bits/conversion_test.go
@@ -15,7 +15,7 @@ type toBinaryCircuit struct {
 
 func (c *toBinaryCircuit) Define(api frontend.API) error {
 	// binary decomposition
-	nA := bits.FromBinary(api, c.B0, c.B1, c.B2)
+	nA := bits.FromBinary(api, []frontend.Variable{c.B0, c.B1, c.B2})
 
 	api.AssertIsEqual(nA, c.A)
 
@@ -40,7 +40,7 @@ type toTernaryCircuit struct {
 
 func (c *toTernaryCircuit) Define(api frontend.API) error {
 	// ternary decomposition
-	nA := bits.FromTernary(api, c.T0, c.T1, c.T2)
+	nA := bits.FromTernary(api, []frontend.Variable{c.T0, c.T1, c.T2})
 
 	api.AssertIsEqual(nA, c.A)
 

--- a/std/math/bits/conversion_test.go
+++ b/std/math/bits/conversion_test.go
@@ -15,9 +15,7 @@ type toBinaryCircuit struct {
 func (c *toBinaryCircuit) Define(api frontend.API) error {
 	// binary decomposition
 	nA := FromBinary(api, c.B0, c.B1, c.B2)
-	oA := api.FromBinary(c.B0, c.B1, c.B2)
 
-	api.AssertIsEqual(nA, oA)
 	api.AssertIsEqual(nA, c.A)
 
 	// to binary

--- a/std/math/bits/conversion_test.go
+++ b/std/math/bits/conversion_test.go
@@ -1,0 +1,18 @@
+package bits
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark/frontend"
+)
+
+type toBinaryCircuit struct {
+}
+
+func (c *toBinaryCircuit) Define(api frontend.API) error {
+	return nil
+}
+
+func TestToBinary(t *testing.T) {
+	// TODO
+}

--- a/std/math/bits/conversion_test.go
+++ b/std/math/bits/conversion_test.go
@@ -1,9 +1,10 @@
-package bits
+package bits_test
 
 import (
 	"testing"
 
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/bits"
 	"github.com/consensys/gnark/test"
 )
 
@@ -14,12 +15,12 @@ type toBinaryCircuit struct {
 
 func (c *toBinaryCircuit) Define(api frontend.API) error {
 	// binary decomposition
-	nA := FromBinary(api, c.B0, c.B1, c.B2)
+	nA := bits.FromBinary(api, c.B0, c.B1, c.B2)
 
 	api.AssertIsEqual(nA, c.A)
 
 	// to binary
-	b := ToBinary(api, c.A, WithNbDigits(3))
+	b := bits.ToBinary(api, c.A, bits.WithNbDigits(3))
 	api.AssertIsEqual(b[0], c.B0)
 	api.AssertIsEqual(b[1], c.B1)
 	api.AssertIsEqual(b[2], c.B2)
@@ -39,12 +40,12 @@ type toTernaryCircuit struct {
 
 func (c *toTernaryCircuit) Define(api frontend.API) error {
 	// ternary decomposition
-	nA := FromTernary(api, c.T0, c.T1, c.T2)
+	nA := bits.FromTernary(api, c.T0, c.T1, c.T2)
 
 	api.AssertIsEqual(nA, c.A)
 
 	// to ternary
-	t := ToTernary(api, c.A, WithNbDigits(3))
+	t := bits.ToTernary(api, c.A, bits.WithNbDigits(3))
 	api.AssertIsEqual(t[0], c.T0)
 	api.AssertIsEqual(t[1], c.T1)
 	api.AssertIsEqual(t[2], c.T2)

--- a/std/math/bits/conversion_test.go
+++ b/std/math/bits/conversion_test.go
@@ -28,9 +28,31 @@ func (c *toBinaryCircuit) Define(api frontend.API) error {
 }
 
 func TestToBinary(t *testing.T) {
-	// TODO
-
 	assert := test.NewAssert(t)
-
 	assert.ProverSucceeded(&toBinaryCircuit{}, &toBinaryCircuit{A: 5, B0: 1, B1: 0, B2: 1})
+}
+
+type toTernaryCircuit struct {
+	A          frontend.Variable
+	T0, T1, T2 frontend.Variable
+}
+
+func (c *toTernaryCircuit) Define(api frontend.API) error {
+	// ternary decomposition
+	nA := FromTernary(api, c.T0, c.T1, c.T2)
+
+	api.AssertIsEqual(nA, c.A)
+
+	// to ternary
+	t := ToTernary(api, c.A, WithNbDigits(3))
+	api.AssertIsEqual(t[0], c.T0)
+	api.AssertIsEqual(t[1], c.T1)
+	api.AssertIsEqual(t[2], c.T2)
+
+	return nil
+}
+
+func TestToTernary(t *testing.T) {
+	assert := test.NewAssert(t)
+	assert.ProverSucceeded(&toTernaryCircuit{}, &toTernaryCircuit{A: 5, T0: 2, T1: 1, T2: 0})
 }

--- a/std/math/bits/conversion_test.go
+++ b/std/math/bits/conversion_test.go
@@ -4,15 +4,35 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
 )
 
 type toBinaryCircuit struct {
+	A          frontend.Variable
+	B0, B1, B2 frontend.Variable
 }
 
 func (c *toBinaryCircuit) Define(api frontend.API) error {
+	// binary decomposition
+	nA := FromBinary(api, c.B0, c.B1, c.B2)
+	oA := api.FromBinary(c.B0, c.B1, c.B2)
+
+	api.AssertIsEqual(nA, oA)
+	api.AssertIsEqual(nA, c.A)
+
+	// to binary
+	b := ToBinary(api, c.A, WithNbDigits(3))
+	api.AssertIsEqual(b[0], c.B0)
+	api.AssertIsEqual(b[1], c.B1)
+	api.AssertIsEqual(b[2], c.B2)
+
 	return nil
 }
 
 func TestToBinary(t *testing.T) {
 	// TODO
+
+	assert := test.NewAssert(t)
+
+	assert.ProverSucceeded(&toBinaryCircuit{}, &toBinaryCircuit{A: 5, B0: 1, B1: 0, B2: 1})
 }

--- a/std/math/bits/naf.go
+++ b/std/math/bits/naf.go
@@ -1,0 +1,122 @@
+package bits
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/backend/hint"
+	"github.com/consensys/gnark/frontend"
+)
+
+var NNAF = hint.NewStaticHint(nNaf)
+
+func init() {
+	hint.Register(NNAF)
+}
+
+// ToNAF retuns the naf decomposition of given input
+func ToNAF(api frontend.API, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
+	// parse options
+	cfg := BaseConversionConfig{
+		NbDigits:      api.Compiler().Curve().Info().Fr.Bits,
+		Unconstrained: false,
+	}
+
+	for _, o := range opts {
+		if err := o(&cfg); err != nil {
+			panic(err)
+		}
+	}
+
+	// if v is a constant, work with the big int value.
+	if c, ok := api.Compiler().ConstantValue(v); ok {
+		bits := make([]*big.Int, cfg.NbDigits)
+		for i := 0; i < len(bits); i++ {
+			bits[i] = big.NewInt(0)
+		}
+		if err := nafDecomposition(c, bits); err != nil {
+			panic(err)
+		}
+		res := make([]frontend.Variable, len(bits))
+		for i := 0; i < len(bits); i++ {
+			res[i] = bits[i]
+		}
+		return res
+	}
+
+	c := big.NewInt(1)
+
+	bits, err := api.Compiler().NewHint(NNAF, cfg.NbDigits, v)
+	if err != nil {
+		panic(err)
+	}
+
+	var Σbi frontend.Variable
+	Σbi = 0
+	for i := 0; i < cfg.NbDigits; i++ {
+		Σbi = api.Add(Σbi, api.Mul(bits[i], c))
+		c.Lsh(c, 1)
+		if !cfg.Unconstrained {
+			// b * (1 - b) * (1 + b) == 0
+			// TODO this adds 3 constraint, not 2. Need api.Compiler().AddConstraint(...)
+			b := bits[i]
+			y := api.Mul(api.Sub(1, b), api.Add(1, b))
+			api.AssertIsEqual(api.Mul(b, y), 0)
+		}
+	}
+
+	// record the constraint Σ (2**i * b[i]) == v
+	api.AssertIsEqual(Σbi, v)
+
+	return bits
+}
+
+func nNaf(_ ecc.ID, inputs []*big.Int, results []*big.Int) error {
+	n := inputs[0]
+	return nafDecomposition(n, results)
+}
+
+// nafDecomposition gets the naf decomposition of a big number
+func nafDecomposition(a *big.Int, results []*big.Int) error {
+	if a == nil || a.Sign() == -1 {
+		return errors.New("invalid input to naf decomposition; negative (or nil) big.Int not supported")
+	}
+
+	var zero, one, three big.Int
+
+	one.SetUint64(1)
+	three.SetUint64(3)
+
+	n := 0
+
+	// some buffers
+	var buf, aCopy big.Int
+	aCopy.Set(a)
+
+	for aCopy.Cmp(&zero) != 0 && n < len(results) {
+
+		// if aCopy % 2 == 0
+		buf.And(&aCopy, &one)
+
+		// aCopy even
+		if buf.Cmp(&zero) == 0 {
+			results[n].SetUint64(0)
+		} else { // aCopy odd
+			buf.And(&aCopy, &three)
+			if buf.IsUint64() && buf.Uint64() == 3 {
+				results[n].SetInt64(-1)
+				aCopy.Add(&aCopy, &one)
+			} else {
+				results[n].SetUint64(1)
+			}
+		}
+		aCopy.Rsh(&aCopy, 1)
+		n++
+	}
+	for ; n < len(results); n++ {
+		results[n].SetUint64(0)
+	}
+
+	return nil
+}

--- a/std/math/bits/naf.go
+++ b/std/math/bits/naf.go
@@ -9,18 +9,22 @@ import (
 	"github.com/consensys/gnark/frontend"
 )
 
+// NNAF returns the NAF decomposition of the input. The number of digits is
+// defined by the number of elements in the results slice.
 var NNAF = hint.NewStaticHint(nNaf)
 
 func init() {
 	hint.Register(NNAF)
 }
 
-// ToNAF retuns the naf decomposition of given input
+// ToNAF returns the NAF decomposition of given input.
+// The non-adjacent form (NAF) of a number is a unique signed-digit representation,
+// in which non-zero values cannot be adjacent. For example, NAF(13) = [1, 0, -1, 0, 1].
 func ToNAF(api frontend.API, v frontend.Variable, opts ...BaseConversionOption) []frontend.Variable {
 	// parse options
-	cfg := BaseConversionConfig{
-		NbDigits:      api.Compiler().Curve().Info().Fr.Bits,
-		Unconstrained: false,
+	cfg := baseConversionConfig{
+		NbDigits:             api.Compiler().Curve().Info().Fr.Bits,
+		UnconstrainedOutputs: false,
 	}
 
 	for _, o := range opts {
@@ -57,7 +61,7 @@ func ToNAF(api frontend.API, v frontend.Variable, opts ...BaseConversionOption) 
 	for i := 0; i < cfg.NbDigits; i++ {
 		Σbi = api.Add(Σbi, api.Mul(bits[i], c))
 		c.Lsh(c, 1)
-		if !cfg.Unconstrained {
+		if !cfg.UnconstrainedOutputs {
 			// b * (1 - b) * (1 + b) == 0
 			// TODO this adds 3 constraint, not 2. Need api.Compiler().AddConstraint(...)
 			b := bits[i]

--- a/std/math/bits/naf_test.go
+++ b/std/math/bits/naf_test.go
@@ -1,0 +1,32 @@
+package bits_test
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/bits"
+	"github.com/consensys/gnark/test"
+)
+
+type toNAFCircuit struct {
+	A                  frontend.Variable
+	B0, B1, B2, B3, B4 frontend.Variable
+}
+
+func (c *toNAFCircuit) Define(api frontend.API) error {
+	// to binary
+	b := bits.ToNAF(api, c.A, bits.WithNbDigits(6))
+	api.AssertIsEqual(b[0], c.B0)
+	api.AssertIsEqual(b[1], c.B1)
+	api.AssertIsEqual(b[2], c.B2)
+	api.AssertIsEqual(b[3], c.B3)
+	api.AssertIsEqual(b[4], c.B4)
+	api.AssertIsEqual(b[5], 0)
+
+	return nil
+}
+
+func TestToNAF(t *testing.T) {
+	assert := test.NewAssert(t)
+	assert.ProverSucceeded(&toNAFCircuit{}, &toNAFCircuit{A: 13, B0: 1, B1: 0, B2: -1, B3: 0, B4: 1})
+}

--- a/test/assert.go
+++ b/test/assert.go
@@ -164,9 +164,9 @@ func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment 
 
 	// TODO may not be the right place, but ensures all our tests call these minimal tests
 	// (like filling a witness with zeroes, or binary values, ...)
-	// assert.Run(func(assert *Assert) {
-	// 	assert.Fuzz(circuit, 5, opts...)
-	// }, "fuzz")
+	assert.Run(func(assert *Assert) {
+		assert.Fuzz(circuit, 5, opts...)
+	}, "fuzz")
 }
 
 // ProverSucceeded fails the test if any of the following step errored:

--- a/test/assert.go
+++ b/test/assert.go
@@ -365,8 +365,6 @@ func (assert *Assert) Fuzz(circuit frontend.Circuit, fuzzCount int, opts ...Test
 					}
 				}
 
-				// fmt.Println(reflect.TypeOf(circuit).String(), valid)
-
 			}, curve.String(), b.String())
 
 		}
@@ -431,11 +429,6 @@ func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendI
 	// add the compiled circuit to the cache
 	assert.compiled[key] = ccs
 
-	// fmt.Println(key, ccs.GetNbConstraints())
-	// for _, c := range ccs.GetCounters() {
-	// 	fmt.Println(c.String())
-	// }
-
 	return ccs, nil
 }
 
@@ -457,7 +450,6 @@ func (assert *Assert) options(opts ...TestingOption) testingConfig {
 		if reflect.DeepEqual(opt.curves, ecc.Implemented()) {
 			opt.curves = []ecc.ID{ecc.BN254}
 		}
-		// opt.witnessSerialization = false
 	}
 	return opt
 }

--- a/test/assert.go
+++ b/test/assert.go
@@ -164,9 +164,9 @@ func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment 
 
 	// TODO may not be the right place, but ensures all our tests call these minimal tests
 	// (like filling a witness with zeroes, or binary values, ...)
-	assert.Run(func(assert *Assert) {
-		assert.Fuzz(circuit, 5, opts...)
-	}, "fuzz")
+	// assert.Run(func(assert *Assert) {
+	// 	assert.Fuzz(circuit, 5, opts...)
+	// }, "fuzz")
 }
 
 // ProverSucceeded fails the test if any of the following step errored:

--- a/test/assert.go
+++ b/test/assert.go
@@ -432,6 +432,9 @@ func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendI
 	assert.compiled[key] = ccs
 
 	// fmt.Println(key, ccs.GetNbConstraints())
+	// for _, c := range ccs.GetCounters() {
+	// 	fmt.Println(c.String())
+	// }
 
 	return ccs, nil
 }

--- a/test/engine_test.go
+++ b/test/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/bits"
 )
 
 type hintCircuit struct {
@@ -15,12 +16,12 @@ type hintCircuit struct {
 }
 
 func (circuit *hintCircuit) Define(api frontend.API) error {
-	res, err := api.Compiler().NewHint(hint.IthBit, 1, circuit.A, 3)
+	res, err := api.Compiler().NewHint(bits.IthBit, 1, circuit.A, 3)
 	if err != nil {
 		return fmt.Errorf("IthBit circuitA 3: %w", err)
 	}
 	a3b := res[0]
-	res, err = api.Compiler().NewHint(hint.IthBit, 1, circuit.A, 25)
+	res, err = api.Compiler().NewHint(bits.IthBit, 1, circuit.A, 25)
 	if err != nil {
 		return fmt.Errorf("IthBit circuitA 25: %w", err)
 	}


### PR DESCRIPTION
Closes #269 . 
This PR adds `std/math/bits` with `ToBase` `FromBase` (`ToBinary` `ToTernary`) and `ToNAF` circuit functions. 

`ToTernary` and `ToNAF` generates some unnecessary constraints but will be fixed with #243 . 

This PR keeps `api.ToBinary` (which calls `bits.ToBinary` ) since other part of `api` depends on binary decomposition (range checks). 