### PR TITLE
Fixes #283 : ensure test.Assert compile cache handles different objects of same type

### DIFF
--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -81,7 +81,6 @@ func parseCircuit(builder Builder, circuit Circuit) (err error) {
 	// leafs are Constraints that need to be initialized in the context of compiling a circuit
 	var handler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
 		if tInput.CanSet() {
-			// log.Trace().Str("name", name).Str("visibility", visibility.String()).Msg("init input wire")
 			switch visibility {
 			case schema.Secret:
 				tInput.Set(reflect.ValueOf(builder.AddSecretVariable(name)))

--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -81,6 +81,7 @@ func parseCircuit(builder Builder, circuit Circuit) (err error) {
 	// leafs are Constraints that need to be initialized in the context of compiling a circuit
 	var handler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
 		if tInput.CanSet() {
+			// log.Trace().Str("name", name).Str("visibility", visibility.String()).Msg("init input wire")
 			switch visibility {
 			case schema.Secret:
 				tInput.Set(reflect.ValueOf(builder.AddSecretVariable(name)))

--- a/test/assert.go
+++ b/test/assert.go
@@ -400,7 +400,7 @@ func (assert *Assert) getCircuitAddr(circuit frontend.Circuit) (uintptr, error) 
 	if vCircuit.Kind() != reflect.Ptr {
 		return 0, errors.New("frontend.Circuit methods must be defined on pointer receiver")
 	}
-	return vCircuit.UnsafeAddr(), nil
+	return vCircuit.Pointer(), nil
 }
 
 // compile the given circuit for given curve and backend, if not already present in cache

--- a/test/assert.go
+++ b/test/assert.go
@@ -55,7 +55,7 @@ type Assert struct {
 // the first call to assert.ProverSucceeded/Failed will compile the circuit for n curves, m backends
 // and subsequent calls will re-use the result of the compilation, if available.
 func NewAssert(t *testing.T) *Assert {
-	return &Assert{t, require.New(t), make(map[string]frontend.CompiledConstraintSystem)}
+	return &Assert{t: t, Assertions: require.New(t), compiled: make(map[string]frontend.CompiledConstraintSystem)}
 }
 
 // Run runs the test function fn as a subtest. The subtest is parametrized by
@@ -102,15 +102,19 @@ func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment 
 		if opt.witnessSerialization {
 			// do a round trip marshalling test
 			assert.Run(func(assert *Assert) {
+				assert.t.Parallel()
 				assert.marshalWitness(validWitness, curve, JSON)
 			}, curve.String(), "marshal/json")
 			assert.Run(func(assert *Assert) {
+				assert.t.Parallel()
 				assert.marshalWitness(validWitness, curve, Binary)
 			}, curve.String(), "marshal/binary")
 			assert.Run(func(assert *Assert) {
+				assert.t.Parallel()
 				assert.marshalWitness(validPublicWitness, curve, JSON, frontend.PublicOnly())
 			}, curve.String(), "marshal-public/json")
 			assert.Run(func(assert *Assert) {
+				assert.t.Parallel()
 				assert.marshalWitness(validPublicWitness, curve, Binary, frontend.PublicOnly())
 			}, curve.String(), "marshal-public/binary")
 		}
@@ -129,6 +133,8 @@ func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment 
 				// must not error with big int test engine (only the curveID is needed for this test)
 				err = IsSolved(circuit, validAssignment, curve, backend.UNKNOWN)
 				checkError(err)
+
+				assert.t.Parallel()
 
 				switch b {
 				case backend.GROTH16:
@@ -203,11 +209,12 @@ func (assert *Assert) ProverFailed(circuit frontend.Circuit, invalidAssignment f
 				ccs, err := assert.compile(circuit, curve, b, opt.compileOpts)
 				checkError(err)
 
-				err = ccs.IsSolved(invalidPublicWitness)
-				mustError(err)
-
 				// must error with big int test engine (only the curveID is needed here)
 				err = IsSolved(circuit, invalidAssignment, curve, backend.UNKNOWN)
+				mustError(err)
+
+				assert.t.Parallel()
+				err = ccs.IsSolved(invalidPublicWitness)
 				mustError(err)
 
 				switch b {
@@ -298,9 +305,6 @@ func (assert *Assert) solvingFailed(circuit frontend.Circuit, invalidAssignment 
 
 	// 1- compile the circuit
 	ccs, err := assert.compile(circuit, curve, b, opt.compileOpts)
-	if err != nil {
-		fmt.Println(reflect.TypeOf(circuit).String())
-	}
 	checkError(err)
 
 	// must error with big int test engine
@@ -391,13 +395,25 @@ func (assert *Assert) fuzzer(fuzzer filler, circuit, w frontend.Circuit, b backe
 	return 0
 }
 
+func (assert *Assert) getCircuitAddr(circuit frontend.Circuit) (uintptr, error) {
+	vCircuit := reflect.ValueOf(circuit)
+	if vCircuit.Kind() != reflect.Ptr {
+		return 0, errors.New("frontend.Circuit methods must be defined on pointer receiver")
+	}
+	return uintptr(vCircuit.UnsafePointer()), nil
+}
+
 // compile the given circuit for given curve and backend, if not already present in cache
 func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendID backend.ID, compileOpts []frontend.CompileOption) (frontend.CompiledConstraintSystem, error) {
-	key := curveID.String() + backendID.String() + reflect.TypeOf(circuit).String()
+	addr, err := assert.getCircuitAddr(circuit)
+	if err != nil {
+		return nil, err
+	}
+
+	key := fmt.Sprintf("%d%d%s%d", curveID, backendID, reflect.TypeOf(circuit).String(), addr)
 
 	// check if we already compiled it
 	if ccs, ok := assert.compiled[key]; ok {
-		// TODO we may want to check that it was compiled with the same compile options here
 		return ccs, nil
 	}
 
@@ -414,13 +430,11 @@ func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendI
 
 	// else compile it and ensure it is deterministic
 	ccs, err := frontend.Compile(curveID, newBuilder, circuit, compileOpts...)
-	// ccs, err := compiler.Compile(curveID, backendID, circuit, compileOpts...)
 	if err != nil {
 		return nil, err
 	}
 
 	_ccs, err := frontend.Compile(curveID, newBuilder, circuit, compileOpts...)
-	// _ccs, err := compiler.Compile(curveID, backendID, circuit, compileOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrCompilationNotDeterministic, err)
 	}
@@ -429,7 +443,7 @@ func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendI
 		return nil, ErrCompilationNotDeterministic
 	}
 
-	// add the compiled circuit to the cache
+	// // add the compiled circuit to the cache
 	assert.compiled[key] = ccs
 
 	return ccs, nil

--- a/test/assert.go
+++ b/test/assert.go
@@ -400,7 +400,7 @@ func (assert *Assert) getCircuitAddr(circuit frontend.Circuit) (uintptr, error) 
 	if vCircuit.Kind() != reflect.Ptr {
 		return 0, errors.New("frontend.Circuit methods must be defined on pointer receiver")
 	}
-	return uintptr(vCircuit.UnsafePointer()), nil
+	return vCircuit.UnsafeAddr(), nil
 }
 
 // compile the given circuit for given curve and backend, if not already present in cache

--- a/test/assert.go
+++ b/test/assert.go
@@ -443,7 +443,7 @@ func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendI
 		return nil, ErrCompilationNotDeterministic
 	}
 
-	// // add the compiled circuit to the cache
+	// add the compiled circuit to the cache
 	assert.compiled[key] = ccs
 
 	return ccs, nil

--- a/test/kzg_srs.go
+++ b/test/kzg_srs.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"crypto/rand"
+	"sync"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/kzg"
@@ -53,11 +54,15 @@ func NewKZGSRS(ccs frontend.CompiledConstraintSystem) (kzg.SRS, error) {
 }
 
 var srsCache map[ecc.ID]kzg.SRS
+var lock sync.Mutex
 
 func init() {
 	srsCache = make(map[ecc.ID]kzg.SRS)
 }
 func getCachedSRS(ccs frontend.CompiledConstraintSystem) (kzg.SRS, error) {
+	lock.Lock()
+	defer lock.Unlock()
+
 	if srs, ok := srsCache[ccs.CurveID()]; ok {
 		return srs, nil
 	}


### PR DESCRIPTION
additionally, adds a bit of parallelism in the Assert object, after the compile phase.
Not extremely efficient since most algorithms after the compile phase are already parallel. 