### PR TITLE
clean: remove PairingContext and Extension objects from api calls in std/.../pairing

### DIFF
--- a/internal/stats/snippet.go
+++ b/internal/stats/snippet.go
@@ -81,9 +81,6 @@ func initSnippets() {
 	})
 
 	registerSnippet("pairing_bls12377", func(api frontend.API, newVariable func() frontend.Variable) {
-		ateLoop := uint64(9586122913090633729)
-		ext := fields_bls12377.GetBLS12377ExtensionFp12(api)
-		pairingInfo := sw_bls12377.PairingContext{AteLoop: ateLoop, Extension: ext}
 
 		var dummyG1 sw_bls12377.G1Affine
 		var dummyG2 sw_bls12377.G2Affine
@@ -96,17 +93,14 @@ func initSnippets() {
 
 		var resMillerLoop fields_bls12377.E12
 		// e(psi0, -gamma)*e(-πC, -δ)*e(πA, πB)
-		sw_bls12377.MillerLoop(api, dummyG1, dummyG2, &resMillerLoop, pairingInfo)
+		sw_bls12377.MillerLoop(api, dummyG1, dummyG2, &resMillerLoop)
 
 		// performs the final expo
 		var resPairing fields_bls12377.E12
-		resPairing.FinalExponentiation(api, resMillerLoop, pairingInfo.AteLoop, pairingInfo.Extension)
+		resPairing.FinalExponentiation(api, resMillerLoop)
 	}, ecc.BW6_761)
 
 	registerSnippet("pairing_bls24315", func(api frontend.API, newVariable func() frontend.Variable) {
-		ateLoop := uint64(3218079743)
-		ext := fields_bls24315.GetBLS24315ExtensionFp24(api)
-		pairingInfo := sw_bls24315.PairingContext{AteLoop: ateLoop, Extension: ext}
 
 		var dummyG1 sw_bls24315.G1Affine
 		var dummyG2 sw_bls24315.G2Affine
@@ -123,11 +117,11 @@ func initSnippets() {
 
 		var resMillerLoop fields_bls24315.E24
 		// e(psi0, -gamma)*e(-πC, -δ)*e(πA, πB)
-		sw_bls24315.MillerLoop(api, dummyG1, dummyG2, &resMillerLoop, pairingInfo)
+		sw_bls24315.MillerLoop(api, dummyG1, dummyG2, &resMillerLoop)
 
 		// performs the final expo
 		var resPairing fields_bls24315.E24
-		resPairing.FinalExponentiation(api, resMillerLoop, pairingInfo.AteLoop, pairingInfo.Extension)
+		resPairing.FinalExponentiation(api, resMillerLoop)
 	}, ecc.BW6_633)
 
 }

--- a/std/algebra/fields_bls12377/e12.go
+++ b/std/algebra/fields_bls12377/e12.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fields_bls12377
 
 import (
+	"math/big"
+
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark/frontend"
 )
@@ -25,28 +27,28 @@ import (
 type Extension struct {
 
 	// generators of each sub field
-	uSquare interface{}
+	uSquare *big.Int
 
 	// frobenius applied to generators
-	frobv   interface{} // v**p  = (v**6)**(p-1/6)*v, frobv=(v**6)**(p-1/6), belongs to Fp)
-	frobv2  interface{} // frobv2 = (v**6)**(p-1/3)
-	frobw   interface{} // frobw = (w**12)**(p-1/12)
-	frobvw  interface{} // frobvw = (v**6)**(p-1/6)*(w*12)**(p-1/12)
-	frobv2w interface{} // frobv2w = (v**6)**(2*(p-1)/6)*(w*12)**(p-1/12)
+	frobv   *big.Int // v**p  = (v**6)**(p-1/6)*v, frobv=(v**6)**(p-1/6), belongs to Fp)
+	frobv2  *big.Int // frobv2 = (v**6)**(p-1/3)
+	frobw   *big.Int // frobw = (w**12)**(p-1/12)
+	frobvw  *big.Int // frobvw = (v**6)**(p-1/6)*(w*12)**(p-1/12)
+	frobv2w *big.Int // frobv2w = (v**6)**(2*(p-1)/6)*(w*12)**(p-1/12)
 
 	// frobenius square applied to generators
-	frob2v   interface{} // v**(p**2)  = (v**6)**(p**2-1/6)*v, frobv=(v**6)**(p**2-1/6), belongs to Fp)
-	frob2v2  interface{} // frobv2 = (v**6)**(2*(p**2-1)/6)
-	frob2w   interface{} // frobw = (w**12)**(p**2-1/12)
-	frob2vw  interface{} // frobvw = (v**6)**(p**2-1/6)*(w*12)**(p**2-1/12)
-	frob2v2w interface{} // frobv2w = (v**6)**(2*(p**2-1)/6)*(w*12)**(p**2-1/12)
+	frob2v   *big.Int // v**(p**2)  = (v**6)**(p**2-1/6)*v, frobv=(v**6)**(p**2-1/6), belongs to Fp)
+	frob2v2  *big.Int // frobv2 = (v**6)**(2*(p**2-1)/6)
+	frob2w   *big.Int // frobw = (w**12)**(p**2-1/12)
+	frob2vw  *big.Int // frobvw = (v**6)**(p**2-1/6)*(w*12)**(p**2-1/12)
+	frob2v2w *big.Int // frobv2w = (v**6)**(2*(p**2-1)/6)*(w*12)**(p**2-1/12)
 
 	// frobenius cube applied to generators
-	frob3v   interface{} // v**(p**3)  = (v**6)**(p**3-1/6)*v, frobv=(v**6)**(p**3-1/6), belongs to Fp)
-	frob3v2  interface{} // frobv2 = (v**6)**(2*(p**3-1)/6)
-	frob3w   interface{} // frobw = (w**12)**(p**3-1/12)
-	frob3vw  interface{} // frobvw = (v**6)**(p**3-1/6)*(w*12)**(p**3-1/12)
-	frob3v2w interface{} // frobv2w = (v**6)**(2*(p**3-1)/6)*(w*12)**(p**3-1/12)
+	frob3v   *big.Int // v**(p**3)  = (v**6)**(p**3-1/6)*v, frobv=(v**6)**(p**3-1/6), belongs to Fp)
+	frob3v2  *big.Int // frobv2 = (v**6)**(2*(p**3-1)/6)
+	frob3w   *big.Int // frobw = (w**12)**(p**3-1/12)
+	frob3vw  *big.Int // frobvw = (v**6)**(p**3-1/6)*(w*12)**(p**3-1/12)
+	frob3v2w *big.Int // frobv2w = (v**6)**(2*(p**3-1)/6)*(w*12)**(p**3-1/12)
 
 }
 
@@ -55,30 +57,42 @@ type E12 struct {
 	C0, C1 E6
 }
 
-// GetBLS12377ExtensionFp12 get extension field parameters for bls12377
-func GetBLS12377ExtensionFp12(api frontend.API) Extension {
+var ext = getBLS12377ExtensionFp12()
+
+// return big.Int from base10 input
+func newInt(in string) *big.Int {
+	r := new(big.Int)
+	_, ok := r.SetString(in, 10)
+	if !ok {
+		panic("invalid base10 big.Int: " + in)
+	}
+	return r
+}
+
+// getBLS12377ExtensionFp12 get extension field parameters for bls12377
+func getBLS12377ExtensionFp12() Extension {
 
 	res := Extension{}
 
-	res.uSquare = -5
+	res.uSquare = newInt("-5")
 
-	res.frobv = "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410946"
-	res.frobv2 = "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945"
-	res.frobw = "92949345220277864758624960506473182677953048909283248980960104381795901929519566951595905490535835115111760994353"
-	res.frobvw = "216465761340224619389371505802605247630151569547285782856803747159100223055385581585702401816380679166954762214499"
-	res.frobv2w = "123516416119946754630746545296132064952198520638002533875843642777304321125866014634106496325844844051843001220146"
+	res.frobv = newInt("80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410946")
+	res.frobv2 = newInt("80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945")
+	res.frobw = newInt("92949345220277864758624960506473182677953048909283248980960104381795901929519566951595905490535835115111760994353")
+	res.frobvw = newInt("216465761340224619389371505802605247630151569547285782856803747159100223055385581585702401816380679166954762214499")
+	res.frobv2w = newInt("123516416119946754630746545296132064952198520638002533875843642777304321125866014634106496325844844051843001220146")
 
-	res.frob2v = "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945"
-	res.frob2v2 = "258664426012969093929703085429980814127835149614277183275038967946009968870203535512256352201271898244626862047231"
-	res.frob2w = "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410946"
-	res.frob2vw = "258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458176"
-	res.frob2v2w = "258664426012969093929703085429980814127835149614277183275038967946009968870203535512256352201271898244626862047232"
+	res.frob2v = newInt("80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945")
+	res.frob2v2 = newInt("258664426012969093929703085429980814127835149614277183275038967946009968870203535512256352201271898244626862047231")
+	res.frob2w = newInt("80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410946")
+	res.frob2vw = newInt("258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458176")
+	res.frob2v2w = newInt("258664426012969093929703085429980814127835149614277183275038967946009968870203535512256352201271898244626862047232")
 
-	res.frob3v = "258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458176"
-	res.frob3v2 = "1"
-	res.frob3w = "216465761340224619389371505802605247630151569547285782856803747159100223055385581585702401816380679166954762214499"
-	res.frob3vw = "42198664672744474621281227892288285906241943207628877683080515507620245292955241189266486323192680957485559243678"
-	res.frob3v2w = "216465761340224619389371505802605247630151569547285782856803747159100223055385581585702401816380679166954762214499"
+	res.frob3v = newInt("258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458176")
+	res.frob3v2 = newInt("1")
+	res.frob3w = newInt("216465761340224619389371505802605247630151569547285782856803747159100223055385581585702401816380679166954762214499")
+	res.frob3vw = newInt("42198664672744474621281227892288285906241943207628877683080515507620245292955241189266486323192680957485559243678")
+	res.frob3v2w = newInt("216465761340224619389371505802605247630151569547285782856803747159100223055385581585702401816380679166954762214499")
 
 	return res
 }
@@ -122,35 +136,35 @@ func (e *E12) Neg(api frontend.API, e1 E12) *E12 {
 }
 
 // Mul multiplies 2 elmts in Fp12
-func (e *E12) Mul(api frontend.API, e1, e2 E12, ext Extension) *E12 {
+func (e *E12) Mul(api frontend.API, e1, e2 E12) *E12 {
 
 	var u, v, ac, bd E6
 	u.Add(api, e1.C0, e1.C1)
 	v.Add(api, e2.C0, e2.C1)
-	v.Mul(api, u, v, ext)
+	v.Mul(api, u, v)
 
-	ac.Mul(api, e1.C0, e2.C0, ext)
-	bd.Mul(api, e1.C1, e2.C1, ext)
+	ac.Mul(api, e1.C0, e2.C0)
+	bd.Mul(api, e1.C1, e2.C1)
 	e.C1.Sub(api, v, ac).Sub(api, e.C1, bd)
 
-	bd.MulByNonResidue(api, bd, ext)
+	bd.MulByNonResidue(api, bd)
 	e.C0.Add(api, ac, bd)
 
 	return e
 }
 
 // Square squares an element in Fp12
-func (e *E12) Square(api frontend.API, x E12, ext Extension) *E12 {
+func (e *E12) Square(api frontend.API, x E12) *E12 {
 
 	//Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
 	var c0, c2, c3 E6
 	c0.Sub(api, x.C0, x.C1)
-	c3.MulByNonResidue(api, x.C1, ext)
+	c3.MulByNonResidue(api, x.C1)
 	c3.Sub(api, x.C0, c3)
-	c2.Mul(api, x.C0, x.C1, ext)
-	c0.Mul(api, c0, c3, ext).Add(api, c0, c2)
+	c2.Mul(api, x.C0, x.C1)
+	c0.Mul(api, c0, c3).Add(api, c0, c2)
 	e.C1.Add(api, c2, c2)
-	c2.MulByNonResidue(api, c2, ext)
+	c2.MulByNonResidue(api, c2)
 	e.C0.Add(api, c0, c2)
 
 	return e
@@ -159,18 +173,18 @@ func (e *E12) Square(api frontend.API, x E12, ext Extension) *E12 {
 // Karabina's compressed cyclotomic square
 // https://eprint.iacr.org/2010/542.pdf
 // Th. 3.2 with minor modifications to fit our tower
-func (e *E12) CyclotomicSquareCompressed(api frontend.API, x E12, ext Extension) *E12 {
+func (e *E12) CyclotomicSquareCompressed(api frontend.API, x E12) *E12 {
 
 	var t [7]E2
 
 	// t0 = g1²
-	t[0].Square(api, x.C0.B1, ext)
+	t[0].Square(api, x.C0.B1)
 	// t1 = g5²
-	t[1].Square(api, x.C1.B2, ext)
+	t[1].Square(api, x.C1.B2)
 	// t5 = g1 + g5
 	t[5].Add(api, x.C0.B1, x.C1.B2)
 	// t2 = (g1 + g5)²
-	t[2].Square(api, t[5], ext)
+	t[2].Square(api, t[5])
 
 	// t3 = g1² + g5²
 	t[3].Add(api, t[0], t[1])
@@ -180,12 +194,12 @@ func (e *E12) CyclotomicSquareCompressed(api frontend.API, x E12, ext Extension)
 	// t6 = g3 + g2
 	t[6].Add(api, x.C1.B0, x.C0.B2)
 	// t3 = (g3 + g2)²
-	t[3].Square(api, t[6], ext)
+	t[3].Square(api, t[6])
 	// t2 = g3²
-	t[2].Square(api, x.C1.B0, ext)
+	t[2].Square(api, x.C1.B0)
 
 	// t6 = 2 * nr * g1 * g5
-	t[6].MulByNonResidue(api, t[5], ext)
+	t[6].MulByNonResidue(api, t[5])
 	// t5 = 4 * nr * g1 * g5 + 2 * g3
 	t[5].Add(api, t[6], x.C1.B0).
 		Double(api, t[5])
@@ -193,14 +207,14 @@ func (e *E12) CyclotomicSquareCompressed(api frontend.API, x E12, ext Extension)
 	e.C1.B0.Add(api, t[5], t[6])
 
 	// t4 = nr * g5²
-	t[4].MulByNonResidue(api, t[1], ext)
+	t[4].MulByNonResidue(api, t[1])
 	// t5 = nr * g5² + g1²
 	t[5].Add(api, t[0], t[4])
 	// t6 = nr * g5² + g1² - g2
 	t[6].Sub(api, t[5], x.C0.B2)
 
 	// t1 = g2²
-	t[1].Square(api, x.C0.B2, ext)
+	t[1].Square(api, x.C0.B2)
 
 	// t6 = 2 * nr * g5² + 2 * g1² - 2*g2
 	t[6].Double(api, t[6])
@@ -208,7 +222,7 @@ func (e *E12) CyclotomicSquareCompressed(api frontend.API, x E12, ext Extension)
 	e.C0.B2.Add(api, t[6], t[5])
 
 	// t4 = nr * g2²
-	t[4].MulByNonResidue(api, t[1], ext)
+	t[4].MulByNonResidue(api, t[1])
 	// t5 = g3² + nr * g2²
 	t[5].Add(api, t[2], t[4])
 	// t6 = g3² + nr * g2² - g1
@@ -233,41 +247,41 @@ func (e *E12) CyclotomicSquareCompressed(api frontend.API, x E12, ext Extension)
 }
 
 // Decompress Karabina's cyclotomic square result
-func (e *E12) Decompress(api frontend.API, x E12, ext Extension) *E12 {
+func (e *E12) Decompress(api frontend.API, x E12) *E12 {
 
 	var t [3]E2
 	var one E2
 	one.SetOne(api)
 
 	// t0 = g1²
-	t[0].Square(api, x.C0.B1, ext)
+	t[0].Square(api, x.C0.B1)
 	// t1 = 3 * g1² - 2 * g2
 	t[1].Sub(api, t[0], x.C0.B2).
 		Double(api, t[1]).
 		Add(api, t[1], t[0])
 		// t0 = E * g5² + t1
-	t[2].Square(api, x.C1.B2, ext)
-	t[0].MulByNonResidue(api, t[2], ext).
+	t[2].Square(api, x.C1.B2)
+	t[0].MulByNonResidue(api, t[2]).
 		Add(api, t[0], t[1])
 	// t1 = 1/(4 * g3)
 	t[1].Double(api, x.C1.B0).
 		Double(api, t[1]).
-		Inverse(api, t[1], ext)
+		Inverse(api, t[1])
 	// z4 = g4
-	e.C1.B1.Mul(api, t[0], t[1], ext)
+	e.C1.B1.Mul(api, t[0], t[1])
 
 	// t1 = g2 * g1
-	t[1].Mul(api, x.C0.B2, x.C0.B1, ext)
+	t[1].Mul(api, x.C0.B2, x.C0.B1)
 	// t2 = 2 * g4² - 3 * g2 * g1
-	t[2].Square(api, e.C1.B1, ext).
+	t[2].Square(api, e.C1.B1).
 		Sub(api, t[2], t[1]).
 		Double(api, t[2]).
 		Sub(api, t[2], t[1])
 	// t1 = g3 * g5
-	t[1].Mul(api, x.C1.B0, x.C1.B2, ext)
+	t[1].Mul(api, x.C1.B0, x.C1.B2)
 	// c₀ = E * (2 * g4² + g3 * g5 - 3 * g2 * g1) + 1
 	t[2].Add(api, t[2], t[1])
-	e.C0.B0.MulByNonResidue(api, t[2], ext).
+	e.C0.B0.MulByNonResidue(api, t[2]).
 		Add(api, e.C0.B0, one)
 
 	e.C0.B1 = x.C0.B1
@@ -281,24 +295,24 @@ func (e *E12) Decompress(api frontend.API, x E12, ext Extension) *E12 {
 // Granger-Scott's cyclotomic square
 // squares a Fp12 elt in the cyclotomic group
 // https://eprint.iacr.org/2009/565.pdf, 3.2
-func (e *E12) CyclotomicSquare(api frontend.API, x E12, ext Extension) *E12 {
+func (e *E12) CyclotomicSquare(api frontend.API, x E12) *E12 {
 
 	// https://eprint.iacr.org/2009/565.pdf, 3.2
 	var t [9]E2
 
-	t[0].Square(api, x.C1.B1, ext)
-	t[1].Square(api, x.C0.B0, ext)
-	t[6].Add(api, x.C1.B1, x.C0.B0).Square(api, t[6], ext).Sub(api, t[6], t[0]).Sub(api, t[6], t[1]) // 2*x4*x0
-	t[2].Square(api, x.C0.B2, ext)
-	t[3].Square(api, x.C1.B0, ext)
-	t[7].Add(api, x.C0.B2, x.C1.B0).Square(api, t[7], ext).Sub(api, t[7], t[2]).Sub(api, t[7], t[3]) // 2*x2*x3
-	t[4].Square(api, x.C1.B2, ext)
-	t[5].Square(api, x.C0.B1, ext)
-	t[8].Add(api, x.C1.B2, x.C0.B1).Square(api, t[8], ext).Sub(api, t[8], t[4]).Sub(api, t[8], t[5]).MulByNonResidue(api, t[8], ext) // 2*x5*x1*u
+	t[0].Square(api, x.C1.B1)
+	t[1].Square(api, x.C0.B0)
+	t[6].Add(api, x.C1.B1, x.C0.B0).Square(api, t[6]).Sub(api, t[6], t[0]).Sub(api, t[6], t[1]) // 2*x4*x0
+	t[2].Square(api, x.C0.B2)
+	t[3].Square(api, x.C1.B0)
+	t[7].Add(api, x.C0.B2, x.C1.B0).Square(api, t[7]).Sub(api, t[7], t[2]).Sub(api, t[7], t[3]) // 2*x2*x3
+	t[4].Square(api, x.C1.B2)
+	t[5].Square(api, x.C0.B1)
+	t[8].Add(api, x.C1.B2, x.C0.B1).Square(api, t[8]).Sub(api, t[8], t[4]).Sub(api, t[8], t[5]).MulByNonResidue(api, t[8]) // 2*x5*x1*u
 
-	t[0].MulByNonResidue(api, t[0], ext).Add(api, t[0], t[1]) // x4²*u + x0²
-	t[2].MulByNonResidue(api, t[2], ext).Add(api, t[2], t[3]) // x2²*u + x3²
-	t[4].MulByNonResidue(api, t[4], ext).Add(api, t[4], t[5]) // x5²*u + x1²
+	t[0].MulByNonResidue(api, t[0]).Add(api, t[0], t[1]) // x4²*u + x0²
+	t[2].MulByNonResidue(api, t[2]).Add(api, t[2], t[3]) // x2²*u + x3²
+	t[4].MulByNonResidue(api, t[4]).Add(api, t[4], t[5]) // x5²*u + x1²
 
 	e.C0.B0.Sub(api, t[0], x.C0.B0).Add(api, e.C0.B0, e.C0.B0).Add(api, e.C0.B0, t[0])
 	e.C0.B1.Sub(api, t[2], x.C0.B1).Add(api, e.C0.B1, e.C0.B1).Add(api, e.C0.B1, t[2])
@@ -319,27 +333,27 @@ func (e *E12) Conjugate(api frontend.API, e1 E12) *E12 {
 }
 
 // MulBy034 multiplication by sparse element
-func (e *E12) MulBy034(api frontend.API, c3, c4 E2, ext Extension) *E12 {
+func (e *E12) MulBy034(api frontend.API, c3, c4 E2) *E12 {
 
 	var d E6
 
 	a := e.C0
 	b := e.C1
 
-	b.MulBy01(api, c3, c4, ext)
+	b.MulBy01(api, c3, c4)
 
 	c3.Add(api, E2{A0: 1, A1: 0}, c3)
 	d.Add(api, e.C0, e.C1)
-	d.MulBy01(api, c3, c4, ext)
+	d.MulBy01(api, c3, c4)
 
 	e.C1.Add(api, a, b).Neg(api, e.C1).Add(api, e.C1, d)
-	e.C0.MulByNonResidue(api, b, ext).Add(api, e.C0, a)
+	e.C0.MulByNonResidue(api, b).Add(api, e.C0, a)
 
 	return e
 }
 
 // Frobenius applies frob to an fp12 elmt
-func (e *E12) Frobenius(api frontend.API, e1 E12, ext Extension) *E12 {
+func (e *E12) Frobenius(api frontend.API, e1 E12) *E12 {
 
 	e.C0.B0.Conjugate(api, e1.C0.B0)
 	e.C0.B1.Conjugate(api, e1.C0.B1).MulByFp(api, e.C0.B1, ext.frobv)
@@ -353,7 +367,7 @@ func (e *E12) Frobenius(api frontend.API, e1 E12, ext Extension) *E12 {
 }
 
 // FrobeniusSquare applies frob**2 to an fp12 elmt
-func (e *E12) FrobeniusSquare(api frontend.API, e1 E12, ext Extension) *E12 {
+func (e *E12) FrobeniusSquare(api frontend.API, e1 E12) *E12 {
 
 	e.C0.B0 = e1.C0.B0
 	e.C0.B1.MulByFp(api, e1.C0.B1, ext.frob2v)
@@ -366,7 +380,7 @@ func (e *E12) FrobeniusSquare(api frontend.API, e1 E12, ext Extension) *E12 {
 }
 
 // FrobeniusCube applies frob**2 to an fp12 elmt
-func (e *E12) FrobeniusCube(api frontend.API, e1 E12, ext Extension) *E12 {
+func (e *E12) FrobeniusCube(api frontend.API, e1 E12) *E12 {
 
 	e.C0.B0.Conjugate(api, e1.C0.B0)
 	e.C0.B1.Conjugate(api, e1.C0.B1).MulByFp(api, e.C0.B1, ext.frob3v)
@@ -379,20 +393,20 @@ func (e *E12) FrobeniusCube(api frontend.API, e1 E12, ext Extension) *E12 {
 }
 
 // Inverse inverse an elmt in Fp12
-func (e *E12) Inverse(api frontend.API, e1 E12, ext Extension) *E12 {
+func (e *E12) Inverse(api frontend.API, e1 E12) *E12 {
 
 	var t [2]E6
 	var buf E6
 
-	t[0].Square(api, e1.C0, ext)
-	t[1].Square(api, e1.C1, ext)
+	t[0].Square(api, e1.C0)
+	t[1].Square(api, e1.C1)
 
-	buf.MulByNonResidue(api, t[1], ext)
+	buf.MulByNonResidue(api, t[1])
 	t[0].Sub(api, t[0], buf)
 
-	t[1].Inverse(api, t[0], ext)
-	e.C0.Mul(api, e1.C0, t[1], ext)
-	e.C1.Mul(api, e1.C1, t[1], ext).Neg(api, e.C1)
+	t[1].Inverse(api, t[0])
+	e.C0.Mul(api, e1.C0, t[1])
+	e.C1.Mul(api, e1.C1, t[1]).Neg(api, e.C1)
 
 	return e
 }
@@ -417,36 +431,36 @@ func (e *E12) Select(api frontend.API, b frontend.Variable, r1, r2 E12) *E12 {
 }
 
 // nSquareCompressed repeated compressed cyclotmic square
-func (e *E12) nSquareCompressed(api frontend.API, n int, ext Extension) {
+func (e *E12) nSquareCompressed(api frontend.API, n int) {
 	for i := 0; i < n; i++ {
-		e.CyclotomicSquareCompressed(api, *e, ext)
+		e.CyclotomicSquareCompressed(api, *e)
 	}
 }
 
 // Expt compute e1**exponent, where the exponent is hardcoded
 // This function is only used for the final expo of the pairing for bls12377, so the exponent is supposed to be hardcoded
 // and on 64 bits.
-func (e *E12) Expt(api frontend.API, e1 E12, exponent uint64, ext Extension) *E12 {
+func (e *E12) Expt(api frontend.API, e1 E12, exponent uint64) *E12 {
 
 	res := E12{}
 	x33 := E12{}
 	res = e1
 
-	res.nSquareCompressed(api, 5, ext)
-	res.Decompress(api, res, ext)
-	res.Mul(api, res, e1, ext)
+	res.nSquareCompressed(api, 5)
+	res.Decompress(api, res)
+	res.Mul(api, res, e1)
 	x33 = res
-	res.nSquareCompressed(api, 7, ext)
-	res.Decompress(api, res, ext)
-	res.Mul(api, res, x33, ext)
-	res.nSquareCompressed(api, 4, ext)
-	res.Decompress(api, res, ext)
-	res.Mul(api, res, e1, ext)
-	res.CyclotomicSquare(api, res, ext)
-	res.Mul(api, res, e1, ext)
-	res.nSquareCompressed(api, 46, ext)
-	res.Decompress(api, res, ext)
-	res.Mul(api, res, e1, ext)
+	res.nSquareCompressed(api, 7)
+	res.Decompress(api, res)
+	res.Mul(api, res, x33)
+	res.nSquareCompressed(api, 4)
+	res.Decompress(api, res)
+	res.Mul(api, res, e1)
+	res.CyclotomicSquare(api, res)
+	res.Mul(api, res, e1)
+	res.nSquareCompressed(api, 46)
+	res.Decompress(api, res)
+	res.Mul(api, res, e1)
 
 	*e = res
 
@@ -455,7 +469,9 @@ func (e *E12) Expt(api frontend.API, e1 E12, exponent uint64, ext Extension) *E1
 }
 
 // FinalExponentiation computes the final expo x**(p**6-1)(p**2+1)(p**4 - p**2 +1)/r
-func (e *E12) FinalExponentiation(api frontend.API, e1 E12, genT uint64, ext Extension) *E12 {
+func (e *E12) FinalExponentiation(api frontend.API, e1 E12) *E12 {
+	const ateLoop = 9586122913090633729
+	const genT = ateLoop
 
 	result := e1
 
@@ -464,33 +480,33 @@ func (e *E12) FinalExponentiation(api frontend.API, e1 E12, genT uint64, ext Ext
 
 	// easy part
 	t[0].Conjugate(api, result)
-	result.Inverse(api, result, ext)
-	t[0].Mul(api, t[0], result, ext)
-	result.FrobeniusSquare(api, t[0], ext).
-		Mul(api, result, t[0], ext)
+	result.Inverse(api, result)
+	t[0].Mul(api, t[0], result)
+	result.FrobeniusSquare(api, t[0]).
+		Mul(api, result, t[0])
 
 	// hard part (up to permutation)
 	// Daiki Hayashida and Kenichiro Hayasaka
 	// and Tadanori Teruya
 	// https://eprint.iacr.org/2020/875.pdf
-	t[0].CyclotomicSquare(api, result, ext)
-	t[1].Expt(api, result, genT, ext)
+	t[0].CyclotomicSquare(api, result)
+	t[1].Expt(api, result, genT)
 	t[2].Conjugate(api, result)
-	t[1].Mul(api, t[1], t[2], ext)
-	t[2].Expt(api, t[1], genT, ext)
+	t[1].Mul(api, t[1], t[2])
+	t[2].Expt(api, t[1], genT)
 	t[1].Conjugate(api, t[1])
-	t[1].Mul(api, t[1], t[2], ext)
-	t[2].Expt(api, t[1], genT, ext)
-	t[1].Frobenius(api, t[1], ext)
-	t[1].Mul(api, t[1], t[2], ext)
-	result.Mul(api, result, t[0], ext)
-	t[0].Expt(api, t[1], genT, ext)
-	t[2].Expt(api, t[0], genT, ext)
-	t[0].FrobeniusSquare(api, t[1], ext)
+	t[1].Mul(api, t[1], t[2])
+	t[2].Expt(api, t[1], genT)
+	t[1].Frobenius(api, t[1])
+	t[1].Mul(api, t[1], t[2])
+	result.Mul(api, result, t[0])
+	t[0].Expt(api, t[1], genT)
+	t[2].Expt(api, t[0], genT)
+	t[0].FrobeniusSquare(api, t[1])
 	t[1].Conjugate(api, t[1])
-	t[1].Mul(api, t[1], t[2], ext)
-	t[1].Mul(api, t[1], t[0], ext)
-	result.Mul(api, result, t[1], ext)
+	t[1].Mul(api, t[1], t[2])
+	t[1].Mul(api, t[1], t[0])
+	result.Mul(api, result, t[1])
 
 	*e = result
 	return e

--- a/std/algebra/fields_bls12377/e12_test.go
+++ b/std/algebra/fields_bls12377/e12_test.go
@@ -98,8 +98,8 @@ type fp12Mul struct {
 
 func (circuit *fp12Mul) Define(api frontend.API) error {
 	expected := E12{}
-	ext := GetBLS12377ExtensionFp12(api)
-	expected.Mul(api, circuit.A, circuit.B, ext)
+
+	expected.Mul(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -129,8 +129,8 @@ type fp12Square struct {
 }
 
 func (circuit *fp12Square) Define(api frontend.API) error {
-	ext := GetBLS12377ExtensionFp12(api)
-	s := circuit.A.Square(api, circuit.A, ext)
+
+	s := circuit.A.Square(api, circuit.A)
 	s.MustBeEqual(api, circuit.B)
 	return nil
 }
@@ -159,10 +159,10 @@ type fp12CycloSquare struct {
 }
 
 func (circuit *fp12CycloSquare) Define(api frontend.API) error {
-	ext := GetBLS12377ExtensionFp12(api)
+
 	var u, v E12
-	u.Square(api, circuit.A, ext)
-	v.CyclotomicSquare(api, circuit.A, ext)
+	u.Square(api, circuit.A)
+	v.CyclotomicSquare(api, circuit.A)
 	u.MustBeEqual(api, v)
 	u.MustBeEqual(api, circuit.B)
 	return nil
@@ -199,11 +199,11 @@ type fp12CycloSquareCompressed struct {
 }
 
 func (circuit *fp12CycloSquareCompressed) Define(api frontend.API) error {
-	ext := GetBLS12377ExtensionFp12(api)
+
 	var u, v E12
-	u.Square(api, circuit.A, ext)
-	v.CyclotomicSquareCompressed(api, circuit.A, ext)
-	v.Decompress(api, v, ext)
+	u.Square(api, circuit.A)
+	v.CyclotomicSquareCompressed(api, circuit.A)
+	v.Decompress(api, v)
 	u.MustBeEqual(api, v)
 	u.MustBeEqual(api, circuit.B)
 	return nil
@@ -270,17 +270,17 @@ type fp12Frobenius struct {
 }
 
 func (circuit *fp12Frobenius) Define(api frontend.API) error {
-	ext := GetBLS12377ExtensionFp12(api)
+
 	fb := E12{}
-	fb.Frobenius(api, circuit.A, ext)
+	fb.Frobenius(api, circuit.A)
 	fb.MustBeEqual(api, circuit.C)
 
 	fbSquare := E12{}
-	fbSquare.FrobeniusSquare(api, circuit.A, ext)
+	fbSquare.FrobeniusSquare(api, circuit.A)
 	fbSquare.MustBeEqual(api, circuit.D)
 
 	fbCube := E12{}
-	fbCube.FrobeniusCube(api, circuit.A, ext)
+	fbCube.FrobeniusCube(api, circuit.A)
 	fbCube.MustBeEqual(api, circuit.E)
 	return nil
 }
@@ -313,8 +313,8 @@ type fp12Inverse struct {
 
 func (circuit *fp12Inverse) Define(api frontend.API) error {
 	expected := E12{}
-	ext := GetBLS12377ExtensionFp12(api)
-	expected.Inverse(api, circuit.A, ext)
+
+	expected.Inverse(api, circuit.A)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -343,9 +343,9 @@ type fp12FixedExpo struct {
 
 func (circuit *fp12FixedExpo) Define(api frontend.API) error {
 	expected := E12{}
-	ext := GetBLS12377ExtensionFp12(api)
+
 	expo := uint64(9586122913090633729)
-	expected.Expt(api, circuit.A, expo, ext)
+	expected.Expt(api, circuit.A, expo)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -381,9 +381,8 @@ type fp12FinalExpo struct {
 
 func (circuit *fp12FinalExpo) Define(api frontend.API) error {
 	expected := E12{}
-	ext := GetBLS12377ExtensionFp12(api)
-	expo := uint64(9586122913090633729)
-	expected.FinalExponentiation(api, circuit.A, expo, ext)
+
+	expected.FinalExponentiation(api, circuit.A)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -412,8 +411,8 @@ type fp12MulBy034 struct {
 }
 
 func (circuit *fp12MulBy034) Define(api frontend.API) error {
-	ext := GetBLS12377ExtensionFp12(api)
-	circuit.A.MulBy034(api, circuit.B, circuit.C, ext)
+
+	circuit.A.MulBy034(api, circuit.B, circuit.C)
 	circuit.A.MustBeEqual(api, circuit.W)
 	return nil
 }

--- a/std/algebra/fields_bls12377/e2.go
+++ b/std/algebra/fields_bls12377/e2.go
@@ -20,7 +20,6 @@ import (
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/internal/utils"
 )
 
 // E2 element in a quadratic extension
@@ -64,7 +63,7 @@ func (e *E2) Sub(api frontend.API, e1, e2 E2) *E2 {
 }
 
 // Mul e2 elmts: 5C
-func (e *E2) Mul(api frontend.API, e1, e2 E2, ext Extension) *E2 {
+func (e *E2) Mul(api frontend.API, e1, e2 E2) *E2 {
 
 	// 1C
 	l1 := api.Add(e1.A0, e1.A1)
@@ -81,19 +80,17 @@ func (e *E2) Mul(api frontend.API, e1, e2 E2, ext Extension) *E2 {
 	e.A1 = api.Sub(u, l31)
 
 	// 1C
-	buSquare := utils.FromInterface(ext.uSquare)
-	l41 := api.Mul(bd, buSquare)
+	l41 := api.Mul(bd, ext.uSquare)
 	e.A0 = api.Add(ac, l41)
 
 	return e
 }
 
 // Square e2 elt
-func (e *E2) Square(api frontend.API, x E2, ext Extension) *E2 {
+func (e *E2) Square(api frontend.API, x E2) *E2 {
 	//algo 22 https://eprint.iacr.org/2010/354.pdf
 	c0 := api.Add(x.A0, x.A1)
-	buSquare := utils.FromInterface(ext.uSquare)
-	c2 := api.Mul(x.A1, buSquare)
+	c2 := api.Mul(x.A1, ext.uSquare)
 	c2 = api.Add(c2, x.A0)
 
 	c0 = api.Mul(c0, c2) // (x1+x2)*(x1+(u**2)x2)
@@ -115,7 +112,7 @@ func (e *E2) MulByFp(api frontend.API, e1 E2, c interface{}) *E2 {
 
 // MulByNonResidue multiplies an fp2 elmt by the imaginary elmt
 // ext.uSquare is the square of the imaginary root
-func (e *E2) MulByNonResidue(api frontend.API, e1 E2, ext Extension) *E2 {
+func (e *E2) MulByNonResidue(api frontend.API, e1 E2) *E2 {
 	x := e1.A0
 	e.A0 = api.Mul(e1.A1, ext.uSquare)
 	e.A1 = x
@@ -130,7 +127,7 @@ func (e *E2) Conjugate(api frontend.API, e1 E2) *E2 {
 }
 
 // Inverse inverses an fp2elmt
-func (e *E2) Inverse(api frontend.API, e1 E2, ext Extension) *E2 {
+func (e *E2) Inverse(api frontend.API, e1 E2) *E2 {
 
 	var a0, a1, t0, t1, t1beta frontend.Variable
 

--- a/std/algebra/fields_bls12377/e2_test.go
+++ b/std/algebra/fields_bls12377/e2_test.go
@@ -91,8 +91,8 @@ type e2Mul struct {
 
 func (circuit *e2Mul) Define(api frontend.API) error {
 	var expected E2
-	ext := Extension{uSquare: -5}
-	expected.Mul(api, circuit.A, circuit.B, ext)
+
+	expected.Mul(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -186,9 +186,9 @@ type fp2Inverse struct {
 }
 
 func (circuit *fp2Inverse) Define(api frontend.API) error {
-	ext := Extension{uSquare: -5}
+
 	expected := E2{}
-	expected.Inverse(api, circuit.A, ext)
+	expected.Inverse(api, circuit.A)
 
 	expected.MustBeEqual(api, circuit.C)
 	return nil
@@ -232,7 +232,7 @@ func TestMulByNonResidueFp2(t *testing.T) {
 	// fp2a := NewFp2Elmt(&cs, api.SECRET_INPUT("a0"), api.SECRET_INPUT("a1"))
 
 	// fp2c := NewFp2Elmt(&cs, nil, nil)
-	// fp2c.MulByNonResidue(&cs, &fp2a, ext)
+	// fp2c.MulByNonResidue(&cs, &fp2a)
 
 	// api.Tag(fp2c.X, "c0")
 	// api.Tag(fp2c.Y, "c1")

--- a/std/algebra/fields_bls12377/e6.go
+++ b/std/algebra/fields_bls12377/e6.go
@@ -65,26 +65,26 @@ func (e *E6) Neg(api frontend.API, e1 E6) *E6 {
 
 // Mul creates a fp6elmt from fp elmts
 // icube is the imaginary elmt to the cube
-func (e *E6) Mul(api frontend.API, e1, e2 E6, ext Extension) *E6 {
+func (e *E6) Mul(api frontend.API, e1, e2 E6) *E6 {
 
 	// Algorithm 13 from https://eprint.iacr.org/2010/354.pdf
 	var t0, t1, t2, c0, c1, c2, tmp E2
-	t0.Mul(api, e1.B0, e2.B0, ext)
-	t1.Mul(api, e1.B1, e2.B1, ext)
-	t2.Mul(api, e1.B2, e2.B2, ext)
+	t0.Mul(api, e1.B0, e2.B0)
+	t1.Mul(api, e1.B1, e2.B1)
+	t2.Mul(api, e1.B2, e2.B2)
 
 	c0.Add(api, e1.B1, e1.B2)
 	tmp.Add(api, e2.B1, e2.B2)
-	c0.Mul(api, c0, tmp, ext).Sub(api, c0, t1).Sub(api, c0, t2).MulByNonResidue(api, c0, ext).Add(api, c0, t0)
+	c0.Mul(api, c0, tmp).Sub(api, c0, t1).Sub(api, c0, t2).MulByNonResidue(api, c0).Add(api, c0, t0)
 
 	c1.Add(api, e1.B0, e1.B1)
 	tmp.Add(api, e2.B0, e2.B1)
-	c1.Mul(api, c1, tmp, ext).Sub(api, c1, t0).Sub(api, c1, t1)
-	tmp.MulByNonResidue(api, t2, ext)
+	c1.Mul(api, c1, tmp).Sub(api, c1, t0).Sub(api, c1, t1)
+	tmp.MulByNonResidue(api, t2)
 	c1.Add(api, c1, tmp)
 
 	tmp.Add(api, e1.B0, e1.B2)
-	c2.Add(api, e2.B0, e2.B2).Mul(api, c2, tmp, ext).Sub(api, c2, t0).Sub(api, c2, t2).Add(api, c2, t1)
+	c2.Add(api, e2.B0, e2.B2).Mul(api, c2, tmp).Sub(api, c2, t0).Sub(api, c2, t2).Add(api, c2, t1)
 
 	e.B0 = c0
 	e.B1 = c1
@@ -95,12 +95,12 @@ func (e *E6) Mul(api frontend.API, e1, e2 E6, ext Extension) *E6 {
 
 // MulByFp2 creates a fp6elmt from fp elmts
 // icube is the imaginary elmt to the cube
-func (e *E6) MulByFp2(api frontend.API, e1 E6, e2 E2, ext Extension) *E6 {
+func (e *E6) MulByFp2(api frontend.API, e1 E6, e2 E2) *E6 {
 	res := E6{}
 
-	res.B0.Mul(api, e1.B0, e2, ext)
-	res.B1.Mul(api, e1.B1, e2, ext)
-	res.B2.Mul(api, e1.B2, e2, ext)
+	res.B0.Mul(api, e1.B0, e2)
+	res.B1.Mul(api, e1.B1, e2)
+	res.B2.Mul(api, e1.B2, e2)
 
 	e.B0 = res.B0
 	e.B1 = res.B1
@@ -110,9 +110,9 @@ func (e *E6) MulByFp2(api frontend.API, e1 E6, e2 E2, ext Extension) *E6 {
 }
 
 // MulByNonResidue multiplies e by the imaginary elmt of Fp6 (noted a+bV+cV where V**3 in F²)
-func (e *E6) MulByNonResidue(api frontend.API, e1 E6, ext Extension) *E6 {
+func (e *E6) MulByNonResidue(api frontend.API, e1 E6) *E6 {
 	res := E6{}
-	res.B0.MulByNonResidue(api, e1.B2, ext)
+	res.B0.MulByNonResidue(api, e1.B2)
 	e.B1 = e1.B0
 	e.B2 = e1.B1
 	e.B0 = res.B0
@@ -120,19 +120,19 @@ func (e *E6) MulByNonResidue(api frontend.API, e1 E6, ext Extension) *E6 {
 }
 
 // Square sets z to the E6 product of x,x, returns e
-func (e *E6) Square(api frontend.API, x E6, ext Extension) *E6 {
+func (e *E6) Square(api frontend.API, x E6) *E6 {
 
 	// Algorithm 16 from https://eprint.iacr.org/2010/354.pdf
 	var c4, c5, c1, c2, c3, c0 E2
-	c4.Mul(api, x.B0, x.B1, ext).Double(api, c4)
-	c5.Square(api, x.B2, ext)
-	c1.MulByNonResidue(api, c5, ext).Add(api, c1, c4)
+	c4.Mul(api, x.B0, x.B1).Double(api, c4)
+	c5.Square(api, x.B2)
+	c1.MulByNonResidue(api, c5).Add(api, c1, c4)
 	c2.Sub(api, c4, c5)
-	c3.Square(api, x.B0, ext)
+	c3.Square(api, x.B0)
 	c4.Sub(api, x.B0, x.B1).Add(api, c4, x.B2)
-	c5.Mul(api, x.B1, x.B2, ext).Double(api, c5)
-	c4.Square(api, c4, ext)
-	c0.MulByNonResidue(api, c5, ext).Add(api, c0, c3)
+	c5.Mul(api, x.B1, x.B2).Double(api, c5)
+	c4.Square(api, c4)
+	c0.MulByNonResidue(api, c5).Add(api, c0, c3)
 	e.B2.Add(api, c2, c4).Add(api, e.B2, c5).Sub(api, e.B2, c3)
 	e.B0 = c0
 	e.B1 = c1
@@ -141,40 +141,40 @@ func (e *E6) Square(api frontend.API, x E6, ext Extension) *E6 {
 }
 
 // Inverse inverses an Fp6 elmt
-func (e *E6) Inverse(api frontend.API, e1 E6, ext Extension) *E6 {
+func (e *E6) Inverse(api frontend.API, e1 E6) *E6 {
 
 	var t [7]E2
 	var c [3]E2
 	var buf E2
 
-	t[0].Square(api, e1.B0, ext)
-	t[1].Square(api, e1.B1, ext)
-	t[2].Square(api, e1.B2, ext)
-	t[3].Mul(api, e1.B0, e1.B1, ext)
-	t[4].Mul(api, e1.B0, e1.B2, ext)
-	t[5].Mul(api, e1.B1, e1.B2, ext)
+	t[0].Square(api, e1.B0)
+	t[1].Square(api, e1.B1)
+	t[2].Square(api, e1.B2)
+	t[3].Mul(api, e1.B0, e1.B1)
+	t[4].Mul(api, e1.B0, e1.B2)
+	t[5].Mul(api, e1.B1, e1.B2)
 
-	c[0].MulByNonResidue(api, t[5], ext)
+	c[0].MulByNonResidue(api, t[5])
 
 	c[0].Neg(api, c[0]).Add(api, c[0], t[0])
 
-	c[1].MulByNonResidue(api, t[2], ext)
+	c[1].MulByNonResidue(api, t[2])
 
 	c[1].Sub(api, c[1], t[3])
 	c[2].Sub(api, t[1], t[4])
-	t[6].Mul(api, e1.B2, c[1], ext)
-	buf.Mul(api, e1.B1, c[2], ext)
+	t[6].Mul(api, e1.B2, c[1])
+	buf.Mul(api, e1.B1, c[2])
 	t[6].Add(api, t[6], buf)
 
-	t[6].MulByNonResidue(api, t[6], ext)
+	t[6].MulByNonResidue(api, t[6])
 
-	buf.Mul(api, e1.B0, c[0], ext)
+	buf.Mul(api, e1.B0, c[0])
 	t[6].Add(api, t[6], buf)
 
-	t[6].Inverse(api, t[6], ext)
-	e.B0.Mul(api, c[0], t[6], ext)
-	e.B1.Mul(api, c[1], t[6], ext)
-	e.B2.Mul(api, c[2], t[6], ext)
+	t[6].Inverse(api, t[6])
+	e.B0.Mul(api, c[0], t[6])
+	e.B1.Mul(api, c[1], t[6])
+	e.B2.Mul(api, c[2], t[6])
 
 	return e
 
@@ -195,37 +195,37 @@ func (e *E6) MustBeEqual(api frontend.API, other E6) {
 }
 
 // MulByE2 multiplies an element in E6 by an element in E2
-func (e *E6) MulByE2(api frontend.API, e1 E6, e2 E2, ext Extension) *E6 {
+func (e *E6) MulByE2(api frontend.API, e1 E6, e2 E2) *E6 {
 	e2Copy := E2{}
 	e2Copy = e2
-	e.B0.Mul(api, e1.B0, e2Copy, ext)
-	e.B1.Mul(api, e1.B1, e2Copy, ext)
-	e.B2.Mul(api, e1.B2, e2Copy, ext)
+	e.B0.Mul(api, e1.B0, e2Copy)
+	e.B1.Mul(api, e1.B1, e2Copy)
+	e.B2.Mul(api, e1.B2, e2Copy)
 	return e
 }
 
 // MulBy01 multiplication by sparse element (c0,c1,0)
-func (e *E6) MulBy01(api frontend.API, c0, c1 E2, ext Extension) *E6 {
+func (e *E6) MulBy01(api frontend.API, c0, c1 E2) *E6 {
 
 	var a, b, tmp, t0, t1, t2 E2
 
-	a.Mul(api, e.B0, c0, ext)
-	b.Mul(api, e.B1, c1, ext)
+	a.Mul(api, e.B0, c0)
+	b.Mul(api, e.B1, c1)
 
 	tmp.Add(api, e.B1, e.B2)
-	t0.Mul(api, c1, tmp, ext)
+	t0.Mul(api, c1, tmp)
 	t0.Sub(api, t0, b)
-	t0.MulByNonResidue(api, t0, ext)
+	t0.MulByNonResidue(api, t0)
 	t0.Add(api, t0, a)
 
 	tmp.Add(api, e.B0, e.B2)
-	t2.Mul(api, c0, tmp, ext)
+	t2.Mul(api, c0, tmp)
 	t2.Sub(api, t2, a)
 	t2.Add(api, t2, b)
 
 	t1.Add(api, c0, c1)
 	tmp.Add(api, e.B0, e.B1)
-	t1.Mul(api, t1, tmp, ext)
+	t1.Mul(api, t1, tmp)
 	t1.Sub(api, t1, a)
 	t1.Sub(api, t1, b)
 

--- a/std/algebra/fields_bls12377/e6_test.go
+++ b/std/algebra/fields_bls12377/e6_test.go
@@ -25,12 +25,6 @@ import (
 	"github.com/consensys/gnark/test"
 )
 
-func getBLS377ExtensionFp6(api frontend.API) Extension {
-	res := Extension{}
-	res.uSquare = -5
-	return res
-}
-
 //--------------------------------------------------------------------
 // test
 
@@ -103,8 +97,8 @@ type fp6Mul struct {
 
 func (circuit *fp6Mul) Define(api frontend.API) error {
 	expected := E6{}
-	ext := getBLS377ExtensionFp6(api)
-	expected.Mul(api, circuit.A, circuit.B, ext)
+
+	expected.Mul(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -135,8 +129,8 @@ type fp6MulByNonResidue struct {
 
 func (circuit *fp6MulByNonResidue) Define(api frontend.API) error {
 	expected := E6{}
-	ext := getBLS377ExtensionFp6(api)
-	expected.MulByNonResidue(api, circuit.A, ext)
+
+	expected.MulByNonResidue(api, circuit.A)
 
 	expected.MustBeEqual(api, circuit.C)
 	return nil
@@ -167,8 +161,8 @@ type fp6Inverse struct {
 
 func (circuit *fp6Inverse) Define(api frontend.API) error {
 	expected := E6{}
-	ext := getBLS377ExtensionFp6(api)
-	expected.Inverse(api, circuit.A, ext)
+
+	expected.Inverse(api, circuit.A)
 
 	expected.MustBeEqual(api, circuit.C)
 	return nil
@@ -215,7 +209,7 @@ func TestMulByFp2Fp6(t *testing.T) {
 	// fp6a := newOperandFp6(&cs, "a")
 	// fp2b := newOperandFp2(&cs, "b")
 	// fp6c := NewFp6Elmt(&cs, nil, nil, nil, nil, nil, nil)
-	// fp6c.MulByFp2(&cs, &fp6a, &fp2b, ext)
+	// fp6c.MulByFp2(&cs, &fp6a, &fp2b)
 	// tagFp6Elmt(&cs, fp6c, "c")
 
 	// // assign the inputs

--- a/std/algebra/fields_bls24315/e12.go
+++ b/std/algebra/fields_bls24315/e12.go
@@ -65,26 +65,26 @@ func (e *E12) Neg(api frontend.API, e1 E12) *E12 {
 
 // Mul creates a fp12elmt from fp elmts
 // icube is the imaginary elmt to the cube
-func (e *E12) Mul(api frontend.API, e1, e2 E12, ext Extension) *E12 {
+func (e *E12) Mul(api frontend.API, e1, e2 E12) *E12 {
 
 	// Algorithm 13 from https://eprint.iacr.org/2010/354.pdf
 	var t0, t1, t2, c0, c1, c2, tmp E4
-	t0.Mul(api, e1.C0, e2.C0, ext)
-	t1.Mul(api, e1.C1, e2.C1, ext)
-	t2.Mul(api, e1.C2, e2.C2, ext)
+	t0.Mul(api, e1.C0, e2.C0)
+	t1.Mul(api, e1.C1, e2.C1)
+	t2.Mul(api, e1.C2, e2.C2)
 
 	c0.Add(api, e1.C1, e1.C2)
 	tmp.Add(api, e2.C1, e2.C2)
-	c0.Mul(api, c0, tmp, ext).Sub(api, c0, t1).Sub(api, c0, t2).MulByNonResidue(api, c0, ext).Add(api, c0, t0)
+	c0.Mul(api, c0, tmp).Sub(api, c0, t1).Sub(api, c0, t2).MulByNonResidue(api, c0).Add(api, c0, t0)
 
 	c1.Add(api, e1.C0, e1.C1)
 	tmp.Add(api, e2.C0, e2.C1)
-	c1.Mul(api, c1, tmp, ext).Sub(api, c1, t0).Sub(api, c1, t1)
-	tmp.MulByNonResidue(api, t2, ext)
+	c1.Mul(api, c1, tmp).Sub(api, c1, t0).Sub(api, c1, t1)
+	tmp.MulByNonResidue(api, t2)
 	c1.Add(api, c1, tmp)
 
 	tmp.Add(api, e1.C0, e1.C2)
-	c2.Add(api, e2.C0, e2.C2).Mul(api, c2, tmp, ext).Sub(api, c2, t0).Sub(api, c2, t2).Add(api, c2, t1)
+	c2.Add(api, e2.C0, e2.C2).Mul(api, c2, tmp).Sub(api, c2, t0).Sub(api, c2, t2).Add(api, c2, t1)
 
 	e.C0 = c0
 	e.C1 = c1
@@ -95,12 +95,12 @@ func (e *E12) Mul(api frontend.API, e1, e2 E12, ext Extension) *E12 {
 
 // MulByFp2 creates a fp12elmt from fp elmts
 // icube is the imaginary elmt to the cube
-func (e *E12) MulByFp2(api frontend.API, e1 E12, e2 E4, ext Extension) *E12 {
+func (e *E12) MulByFp2(api frontend.API, e1 E12, e2 E4) *E12 {
 	res := E12{}
 
-	res.C0.Mul(api, e1.C0, e2, ext)
-	res.C1.Mul(api, e1.C1, e2, ext)
-	res.C2.Mul(api, e1.C2, e2, ext)
+	res.C0.Mul(api, e1.C0, e2)
+	res.C1.Mul(api, e1.C1, e2)
+	res.C2.Mul(api, e1.C2, e2)
 
 	e.C0 = res.C0
 	e.C1 = res.C1
@@ -110,9 +110,9 @@ func (e *E12) MulByFp2(api frontend.API, e1 E12, e2 E4, ext Extension) *E12 {
 }
 
 // MulByNonResidue multiplies e by the imaginary elmt of Fp12 (noted a+bV+cV where V**3 in F²)
-func (e *E12) MulByNonResidue(api frontend.API, e1 E12, ext Extension) *E12 {
+func (e *E12) MulByNonResidue(api frontend.API, e1 E12) *E12 {
 	res := E12{}
-	res.C0.MulByNonResidue(api, e1.C2, ext)
+	res.C0.MulByNonResidue(api, e1.C2)
 	e.C1 = e1.C0
 	e.C2 = e1.C1
 	e.C0 = res.C0
@@ -120,19 +120,19 @@ func (e *E12) MulByNonResidue(api frontend.API, e1 E12, ext Extension) *E12 {
 }
 
 // Square sets z to the E12 product of x,x, returns e
-func (e *E12) Square(api frontend.API, x E12, ext Extension) *E12 {
+func (e *E12) Square(api frontend.API, x E12) *E12 {
 
 	// Algorithm 16 from https://eprint.iacr.org/2010/354.pdf
 	var c4, c5, c1, c2, c3, c0 E4
-	c4.Mul(api, x.C0, x.C1, ext).Double(api, c4)
-	c5.Square(api, x.C2, ext)
-	c1.MulByNonResidue(api, c5, ext).Add(api, c1, c4)
+	c4.Mul(api, x.C0, x.C1).Double(api, c4)
+	c5.Square(api, x.C2)
+	c1.MulByNonResidue(api, c5).Add(api, c1, c4)
 	c2.Sub(api, c4, c5)
-	c3.Square(api, x.C0, ext)
+	c3.Square(api, x.C0)
 	c4.Sub(api, x.C0, x.C1).Add(api, c4, x.C2)
-	c5.Mul(api, x.C1, x.C2, ext).Double(api, c5)
-	c4.Square(api, c4, ext)
-	c0.MulByNonResidue(api, c5, ext).Add(api, c0, c3)
+	c5.Mul(api, x.C1, x.C2).Double(api, c5)
+	c4.Square(api, c4)
+	c0.MulByNonResidue(api, c5).Add(api, c0, c3)
 	e.C2.Add(api, c2, c4).Add(api, e.C2, c5).Sub(api, e.C2, c3)
 	e.C0 = c0
 	e.C1 = c1
@@ -141,40 +141,40 @@ func (e *E12) Square(api frontend.API, x E12, ext Extension) *E12 {
 }
 
 // Inverse inverses an Fp12 elmt
-func (e *E12) Inverse(api frontend.API, e1 E12, ext Extension) *E12 {
+func (e *E12) Inverse(api frontend.API, e1 E12) *E12 {
 
 	var t [7]E4
 	var c [3]E4
 	var buf E4
 
-	t[0].Square(api, e1.C0, ext)
-	t[1].Square(api, e1.C1, ext)
-	t[2].Square(api, e1.C2, ext)
-	t[3].Mul(api, e1.C0, e1.C1, ext)
-	t[4].Mul(api, e1.C0, e1.C2, ext)
-	t[5].Mul(api, e1.C1, e1.C2, ext)
+	t[0].Square(api, e1.C0)
+	t[1].Square(api, e1.C1)
+	t[2].Square(api, e1.C2)
+	t[3].Mul(api, e1.C0, e1.C1)
+	t[4].Mul(api, e1.C0, e1.C2)
+	t[5].Mul(api, e1.C1, e1.C2)
 
-	c[0].MulByNonResidue(api, t[5], ext)
+	c[0].MulByNonResidue(api, t[5])
 
 	c[0].Neg(api, c[0]).Add(api, c[0], t[0])
 
-	c[1].MulByNonResidue(api, t[2], ext)
+	c[1].MulByNonResidue(api, t[2])
 
 	c[1].Sub(api, c[1], t[3])
 	c[2].Sub(api, t[1], t[4])
-	t[6].Mul(api, e1.C2, c[1], ext)
-	buf.Mul(api, e1.C1, c[2], ext)
+	t[6].Mul(api, e1.C2, c[1])
+	buf.Mul(api, e1.C1, c[2])
 	t[6].Add(api, t[6], buf)
 
-	t[6].MulByNonResidue(api, t[6], ext)
+	t[6].MulByNonResidue(api, t[6])
 
-	buf.Mul(api, e1.C0, c[0], ext)
+	buf.Mul(api, e1.C0, c[0])
 	t[6].Add(api, t[6], buf)
 
-	t[6].Inverse(api, t[6], ext)
-	e.C0.Mul(api, c[0], t[6], ext)
-	e.C1.Mul(api, c[1], t[6], ext)
-	e.C2.Mul(api, c[2], t[6], ext)
+	t[6].Inverse(api, t[6])
+	e.C0.Mul(api, c[0], t[6])
+	e.C1.Mul(api, c[1], t[6])
+	e.C2.Mul(api, c[2], t[6])
 
 	return e
 
@@ -188,37 +188,37 @@ func (e *E12) MustBeEqual(api frontend.API, other E12) {
 }
 
 // MulByE4 multiplies an element in E12 by an element in E4
-func (e *E12) MulByE4(api frontend.API, e1 E12, e2 E4, ext Extension) *E12 {
+func (e *E12) MulByE4(api frontend.API, e1 E12, e2 E4) *E12 {
 	e2Copy := E4{}
 	e2Copy = e2
-	e.C0.Mul(api, e1.C0, e2Copy, ext)
-	e.C1.Mul(api, e1.C1, e2Copy, ext)
-	e.C2.Mul(api, e1.C2, e2Copy, ext)
+	e.C0.Mul(api, e1.C0, e2Copy)
+	e.C1.Mul(api, e1.C1, e2Copy)
+	e.C2.Mul(api, e1.C2, e2Copy)
 	return e
 }
 
 // MulBy01 multiplication by sparse element (c0,c1,0)
-func (e *E12) MulBy01(api frontend.API, c0, c1 E4, ext Extension) *E12 {
+func (e *E12) MulBy01(api frontend.API, c0, c1 E4) *E12 {
 
 	var a, b, tmp, t0, t1, t2 E4
 
-	a.Mul(api, e.C0, c0, ext)
-	b.Mul(api, e.C1, c1, ext)
+	a.Mul(api, e.C0, c0)
+	b.Mul(api, e.C1, c1)
 
 	tmp.Add(api, e.C1, e.C2)
-	t0.Mul(api, c1, tmp, ext)
+	t0.Mul(api, c1, tmp)
 	t0.Sub(api, t0, b)
-	t0.MulByNonResidue(api, t0, ext)
+	t0.MulByNonResidue(api, t0)
 	t0.Add(api, t0, a)
 
 	tmp.Add(api, e.C0, e.C2)
-	t2.Mul(api, c0, tmp, ext)
+	t2.Mul(api, c0, tmp)
 	t2.Sub(api, t2, a)
 	t2.Add(api, t2, b)
 
 	t1.Add(api, c0, c1)
 	tmp.Add(api, e.C0, e.C1)
-	t1.Mul(api, t1, tmp, ext)
+	t1.Mul(api, t1, tmp)
 	t1.Sub(api, t1, a)
 	t1.Sub(api, t1, b)
 

--- a/std/algebra/fields_bls24315/e12_test.go
+++ b/std/algebra/fields_bls24315/e12_test.go
@@ -25,12 +25,6 @@ import (
 	"github.com/consensys/gnark/test"
 )
 
-func getBLS24315ExtensionFp12(api frontend.API) Extension {
-	res := Extension{}
-	res.uSquare = 13
-	return res
-}
-
 //--------------------------------------------------------------------
 // test
 
@@ -103,8 +97,8 @@ type fp12Mul struct {
 
 func (circuit *fp12Mul) Define(api frontend.API) error {
 	expected := E12{}
-	ext := getBLS24315ExtensionFp12(api)
-	expected.Mul(api, circuit.A, circuit.B, ext)
+
+	expected.Mul(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -135,8 +129,8 @@ type fp12MulByNonResidue struct {
 
 func (circuit *fp12MulByNonResidue) Define(api frontend.API) error {
 	expected := E12{}
-	ext := getBLS24315ExtensionFp12(api)
-	expected.MulByNonResidue(api, circuit.A, ext)
+
+	expected.MulByNonResidue(api, circuit.A)
 
 	expected.MustBeEqual(api, circuit.C)
 	return nil
@@ -167,8 +161,8 @@ type fp12Inverse struct {
 
 func (circuit *fp12Inverse) Define(api frontend.API) error {
 	expected := E12{}
-	ext := getBLS24315ExtensionFp12(api)
-	expected.Inverse(api, circuit.A, ext)
+
+	expected.Inverse(api, circuit.A)
 
 	expected.MustBeEqual(api, circuit.C)
 	return nil

--- a/std/algebra/fields_bls24315/e2.go
+++ b/std/algebra/fields_bls24315/e2.go
@@ -64,7 +64,7 @@ func (e *E2) Sub(api frontend.API, e1, e2 E2) *E2 {
 }
 
 // Mul e2 elmts: 5C
-func (e *E2) Mul(api frontend.API, e1, e2 E2, ext Extension) *E2 {
+func (e *E2) Mul(api frontend.API, e1, e2 E2) *E2 {
 
 	// 1C
 	l1 := api.Add(e1.A0, e1.A1)
@@ -89,7 +89,7 @@ func (e *E2) Mul(api frontend.API, e1, e2 E2, ext Extension) *E2 {
 }
 
 // Square e2 elt
-func (e *E2) Square(api frontend.API, x E2, ext Extension) *E2 {
+func (e *E2) Square(api frontend.API, x E2) *E2 {
 	//Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
 
 	c0 := api.Sub(x.A0, x.A1)
@@ -115,7 +115,7 @@ func (e *E2) MulByFp(api frontend.API, e1 E2, c interface{}) *E2 {
 
 // MulByNonResidue multiplies an fp2 elmt by the imaginary elmt
 // ext.uSquare is the square of the imaginary root
-func (e *E2) MulByNonResidue(api frontend.API, e1 E2, ext Extension) *E2 {
+func (e *E2) MulByNonResidue(api frontend.API, e1 E2) *E2 {
 	e.A0, e.A1 = e1.A1, e1.A0
 	e.A0 = api.Mul(e.A0, ext.uSquare)
 	return e
@@ -129,7 +129,7 @@ func (e *E2) Conjugate(api frontend.API, e1 E2) *E2 {
 }
 
 // Inverse inverses an fp2elmt
-func (e *E2) Inverse(api frontend.API, e1 E2, ext Extension) *E2 {
+func (e *E2) Inverse(api frontend.API, e1 E2) *E2 {
 
 	// Algorithm 23 from https://eprint.iacr.org/2010/354.pdf
 

--- a/std/algebra/fields_bls24315/e24.go
+++ b/std/algebra/fields_bls24315/e24.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fields_bls24315
 
 import (
+	"math/big"
+
 	bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315"
 	"github.com/consensys/gnark/frontend"
 )
@@ -25,22 +27,22 @@ import (
 type Extension struct {
 
 	// generators of each sub field
-	uSquare interface{}
+	uSquare *big.Int
 
 	// Frobenius coefficients
-	frobCoeff0  interface{}
-	frobCoeff1  interface{}
-	frobCoeff2  interface{}
-	frobCoeff3  interface{}
-	frobCoeff4  interface{}
-	frobCoeff5  interface{}
-	frobCoeff6  interface{}
-	frobCoeff7  interface{}
-	frobCoeff8  interface{}
-	frobCoeff9  interface{}
-	frobCoeff10 interface{}
-	frobCoeff11 interface{}
-	frobCoeff12 interface{}
+	frobCoeff0  *big.Int
+	frobCoeff1  *big.Int
+	frobCoeff2  *big.Int
+	frobCoeff3  *big.Int
+	frobCoeff4  *big.Int
+	frobCoeff5  *big.Int
+	frobCoeff6  *big.Int
+	frobCoeff7  *big.Int
+	frobCoeff8  *big.Int
+	frobCoeff9  *big.Int
+	frobCoeff10 *big.Int
+	frobCoeff11 *big.Int
+	frobCoeff12 *big.Int
 }
 
 // E24 element in a quadratic extension
@@ -48,26 +50,37 @@ type E24 struct {
 	D0, D1 E12
 }
 
-// GetBLS24315ExtensionFp24 get extension field parameters for bls24315
-func GetBLS24315ExtensionFp24(api frontend.API) Extension {
+var ext = getBLS24315ExtensionFp24()
+
+// return big.Int from base10 input
+func newInt(in string) *big.Int {
+	r := new(big.Int)
+	_, ok := r.SetString(in, 10)
+	if !ok {
+		panic("invalid base10 big.Int: " + in)
+	}
+	return r
+}
+
+// getBLS24315ExtensionFp24 get extension field parameters for bls24315
+func getBLS24315ExtensionFp24() Extension {
 
 	res := Extension{}
 
-	res.uSquare = 13
-
-	res.frobCoeff0 = "14265754707630841383590096931465005402246260064523506653409458152869013672931584279153351926943"
-	res.frobCoeff1 = "17432737665785421589107433512831558061649422754130449334965277047994983947893909429238815314776"
-	res.frobCoeff2 = "39705142672498995661671850106945620852186608752525090699191017895721506694646055668218723303426"
-	res.frobCoeff3 = "39705142672498995661671850106945620852186608752525090699191017895721506694646055668218723303427"
-	res.frobCoeff4 = "36538159751358858129508353309042417085530339727307806653508466610511913818164017196988153745736"
-	res.frobCoeff5 = "37719635718874797449167165011304104204868932892052995456614707782168504515295626008356825673023"
-	res.frobCoeff6 = "33342866563749162527758572927163102293238492708847648721152723115703639794013692274261201232097"
-	res.frobCoeff7 = "13266452002786802757645810648664867986567631927642464177452792960815113608167203350720036682455"
-	res.frobCoeff8 = "29019463919452620058839222695754364428302059305947724697987901631588253225470374568267230540725"
-	res.frobCoeff9 = "27033956928813979172980697816649498888237489781085970819538323908118873647639658229550439080179"
-	res.frobCoeff10 = "20076414560962359770112762278498234306670860781205184543699930154888526185846488923541164549642"
-	res.frobCoeff11 = "37014442673353839783463348892746893664389658635873267609916377398480286678854893830142"
-	res.frobCoeff12 = "37014442673353839783463348892746893664389658635873267609916377398480286678854893830143"
+	res.uSquare = newInt("13")
+	res.frobCoeff0 = newInt("14265754707630841383590096931465005402246260064523506653409458152869013672931584279153351926943")
+	res.frobCoeff1 = newInt("17432737665785421589107433512831558061649422754130449334965277047994983947893909429238815314776")
+	res.frobCoeff2 = newInt("39705142672498995661671850106945620852186608752525090699191017895721506694646055668218723303426")
+	res.frobCoeff3 = newInt("39705142672498995661671850106945620852186608752525090699191017895721506694646055668218723303427")
+	res.frobCoeff4 = newInt("36538159751358858129508353309042417085530339727307806653508466610511913818164017196988153745736")
+	res.frobCoeff5 = newInt("37719635718874797449167165011304104204868932892052995456614707782168504515295626008356825673023")
+	res.frobCoeff6 = newInt("33342866563749162527758572927163102293238492708847648721152723115703639794013692274261201232097")
+	res.frobCoeff7 = newInt("13266452002786802757645810648664867986567631927642464177452792960815113608167203350720036682455")
+	res.frobCoeff8 = newInt("29019463919452620058839222695754364428302059305947724697987901631588253225470374568267230540725")
+	res.frobCoeff9 = newInt("27033956928813979172980697816649498888237489781085970819538323908118873647639658229550439080179")
+	res.frobCoeff10 = newInt("20076414560962359770112762278498234306670860781205184543699930154888526185846488923541164549642")
+	res.frobCoeff11 = newInt("37014442673353839783463348892746893664389658635873267609916377398480286678854893830142")
+	res.frobCoeff12 = newInt("37014442673353839783463348892746893664389658635873267609916377398480286678854893830143")
 
 	return res
 }
@@ -124,35 +137,35 @@ func (e *E24) Neg(api frontend.API, e1 E24) *E24 {
 }
 
 // Mul multiplies 2 elmts in Fp24
-func (e *E24) Mul(api frontend.API, e1, e2 E24, ext Extension) *E24 {
+func (e *E24) Mul(api frontend.API, e1, e2 E24) *E24 {
 
 	var u, v, ac, bd E12
 	u.Add(api, e1.D0, e1.D1)
 	v.Add(api, e2.D0, e2.D1)
-	v.Mul(api, u, v, ext)
+	v.Mul(api, u, v)
 
-	ac.Mul(api, e1.D0, e2.D0, ext)
-	bd.Mul(api, e1.D1, e2.D1, ext)
+	ac.Mul(api, e1.D0, e2.D0)
+	bd.Mul(api, e1.D1, e2.D1)
 	e.D1.Sub(api, v, ac).Sub(api, e.D1, bd)
 
-	bd.MulByNonResidue(api, bd, ext)
+	bd.MulByNonResidue(api, bd)
 	e.D0.Add(api, ac, bd)
 
 	return e
 }
 
 // Square squares an element in Fp24
-func (e *E24) Square(api frontend.API, x E24, ext Extension) *E24 {
+func (e *E24) Square(api frontend.API, x E24) *E24 {
 
 	//Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
 	var c0, c2, c3 E12
 	c0.Sub(api, x.D0, x.D1)
-	c3.MulByNonResidue(api, x.D1, ext)
+	c3.MulByNonResidue(api, x.D1)
 	c3.Sub(api, x.D0, c3)
-	c2.Mul(api, x.D0, x.D1, ext)
-	c0.Mul(api, c0, c3, ext).Add(api, c0, c2)
+	c2.Mul(api, x.D0, x.D1)
+	c0.Mul(api, c0, c3).Add(api, c0, c2)
 	e.D1.Add(api, c2, c2)
-	c2.MulByNonResidue(api, c2, ext)
+	c2.MulByNonResidue(api, c2)
 	e.D0.Add(api, c0, c2)
 
 	return e
@@ -160,17 +173,17 @@ func (e *E24) Square(api frontend.API, x E24, ext Extension) *E24 {
 
 // Karabina's compressed cyclotomic square
 // https://eprint.iacr.org/2010/542.pdf
-func (e *E24) CyclotomicSquareCompressed(api frontend.API, x E24, ext Extension) *E24 {
+func (e *E24) CyclotomicSquareCompressed(api frontend.API, x E24) *E24 {
 	var t [7]E4
 
 	// t0 = g1²
-	t[0].Square(api, x.D0.C1, ext)
+	t[0].Square(api, x.D0.C1)
 	// t1 = g5²
-	t[1].Square(api, x.D1.C2, ext)
+	t[1].Square(api, x.D1.C2)
 	// t5 = g1 + g5
 	t[5].Add(api, x.D0.C1, x.D1.C2)
 	// t2 = (g1 + g5)²
-	t[2].Square(api, t[5], ext)
+	t[2].Square(api, t[5])
 
 	// t3 = g1² + g5²
 	t[3].Add(api, t[0], t[1])
@@ -180,12 +193,12 @@ func (e *E24) CyclotomicSquareCompressed(api frontend.API, x E24, ext Extension)
 	// t6 = g3 + g2
 	t[6].Add(api, x.D1.C0, x.D0.C2)
 	// t3 = (g3 + g2)²
-	t[3].Square(api, t[6], ext)
+	t[3].Square(api, t[6])
 	// t2 = g3²
-	t[2].Square(api, x.D1.C0, ext)
+	t[2].Square(api, x.D1.C0)
 
 	// t6 = 2 * nr * g1 * g5
-	t[6].MulByNonResidue(api, t[5], ext)
+	t[6].MulByNonResidue(api, t[5])
 	// t5 = 4 * nr * g1 * g5 + 2 * g3
 	t[5].Add(api, t[6], x.D1.C0).
 		Double(api, t[5])
@@ -193,14 +206,14 @@ func (e *E24) CyclotomicSquareCompressed(api frontend.API, x E24, ext Extension)
 	e.D1.C0.Add(api, t[5], t[6])
 
 	// t4 = nr * g5²
-	t[4].MulByNonResidue(api, t[1], ext)
+	t[4].MulByNonResidue(api, t[1])
 	// t5 = nr * g5² + g1²
 	t[5].Add(api, t[0], t[4])
 	// t6 = nr * g5² + g1² - g2
 	t[6].Sub(api, t[5], x.D0.C2)
 
 	// t1 = g2²
-	t[1].Square(api, x.D0.C2, ext)
+	t[1].Square(api, x.D0.C2)
 
 	// t6 = 2 * nr * g5² + 2 * g1² - 2*g2
 	t[6].Double(api, t[6])
@@ -208,7 +221,7 @@ func (e *E24) CyclotomicSquareCompressed(api frontend.API, x E24, ext Extension)
 	e.D0.C2.Add(api, t[6], t[5])
 
 	// t4 = nr * g2²
-	t[4].MulByNonResidue(api, t[1], ext)
+	t[4].MulByNonResidue(api, t[1])
 	// t5 = g3² + nr * g2²
 	t[5].Add(api, t[2], t[4])
 	// t6 = g3² + nr * g2² - g1
@@ -233,41 +246,41 @@ func (e *E24) CyclotomicSquareCompressed(api frontend.API, x E24, ext Extension)
 }
 
 // Decompress Karabina's cyclotomic square result
-func (e *E24) Decompress(api frontend.API, x E24, ext Extension) *E24 {
+func (e *E24) Decompress(api frontend.API, x E24) *E24 {
 
 	var t [3]E4
 	var one E4
 	one.SetOne(api)
 
 	// t0 = g1²
-	t[0].Square(api, x.D0.C1, ext)
+	t[0].Square(api, x.D0.C1)
 	// t1 = 3 * g1² - 2 * g2
 	t[1].Sub(api, t[0], x.D0.C2).
 		Double(api, t[1]).
 		Add(api, t[1], t[0])
 		// t0 = E * g5² + t1
-	t[2].Square(api, x.D1.C2, ext)
-	t[0].MulByNonResidue(api, t[2], ext).
+	t[2].Square(api, x.D1.C2)
+	t[0].MulByNonResidue(api, t[2]).
 		Add(api, t[0], t[1])
 	// t1 = 1/(4 * g3)
 	t[1].Double(api, x.D1.C0).
 		Double(api, t[1]).
-		Inverse(api, t[1], ext)
+		Inverse(api, t[1])
 	// z4 = g4
-	e.D1.C1.Mul(api, t[0], t[1], ext)
+	e.D1.C1.Mul(api, t[0], t[1])
 
 	// t1 = g2 * g1
-	t[1].Mul(api, x.D0.C2, x.D0.C1, ext)
+	t[1].Mul(api, x.D0.C2, x.D0.C1)
 	// t2 = 2 * g4² - 3 * g2 * g1
-	t[2].Square(api, e.D1.C1, ext).
+	t[2].Square(api, e.D1.C1).
 		Sub(api, t[2], t[1]).
 		Double(api, t[2]).
 		Sub(api, t[2], t[1])
 	// t1 = g3 * g5
-	t[1].Mul(api, x.D1.C0, x.D1.C2, ext)
+	t[1].Mul(api, x.D1.C0, x.D1.C2)
 	// c₀ = E * (2 * g4² + g3 * g5 - 3 * g2 * g1) + 1
 	t[2].Add(api, t[2], t[1])
-	e.D0.C0.MulByNonResidue(api, t[2], ext).
+	e.D0.C0.MulByNonResidue(api, t[2]).
 		Add(api, e.D0.C0, one)
 
 	e.D0.C1 = x.D0.C1
@@ -281,23 +294,23 @@ func (e *E24) Decompress(api frontend.API, x E24, ext Extension) *E24 {
 // Granger-Scott's cyclotomic square
 // squares a Fp24 elt in the cyclotomic group
 // https://eprint.iacr.org/2009/565.pdf, 3.2
-func (e *E24) CyclotomicSquare(api frontend.API, x E24, ext Extension) *E24 {
+func (e *E24) CyclotomicSquare(api frontend.API, x E24) *E24 {
 
 	var t [9]E4
 
-	t[0].Square(api, x.D1.C1, ext)
-	t[1].Square(api, x.D0.C0, ext)
-	t[6].Add(api, x.D1.C1, x.D0.C0).Square(api, t[6], ext).Sub(api, t[6], t[0]).Sub(api, t[6], t[1]) // 2*x4*x0
-	t[2].Square(api, x.D0.C2, ext)
-	t[3].Square(api, x.D1.C0, ext)
-	t[7].Add(api, x.D0.C2, x.D1.C0).Square(api, t[7], ext).Sub(api, t[7], t[2]).Sub(api, t[7], t[3]) // 2*x2*x3
-	t[4].Square(api, x.D1.C2, ext)
-	t[5].Square(api, x.D0.C1, ext)
-	t[8].Add(api, x.D1.C2, x.D0.C1).Square(api, t[8], ext).Sub(api, t[8], t[4]).Sub(api, t[8], t[5]).MulByNonResidue(api, t[8], ext)
+	t[0].Square(api, x.D1.C1)
+	t[1].Square(api, x.D0.C0)
+	t[6].Add(api, x.D1.C1, x.D0.C0).Square(api, t[6]).Sub(api, t[6], t[0]).Sub(api, t[6], t[1]) // 2*x4*x0
+	t[2].Square(api, x.D0.C2)
+	t[3].Square(api, x.D1.C0)
+	t[7].Add(api, x.D0.C2, x.D1.C0).Square(api, t[7]).Sub(api, t[7], t[2]).Sub(api, t[7], t[3]) // 2*x2*x3
+	t[4].Square(api, x.D1.C2)
+	t[5].Square(api, x.D0.C1)
+	t[8].Add(api, x.D1.C2, x.D0.C1).Square(api, t[8]).Sub(api, t[8], t[4]).Sub(api, t[8], t[5]).MulByNonResidue(api, t[8])
 
-	t[0].MulByNonResidue(api, t[0], ext).Add(api, t[0], t[1])
-	t[2].MulByNonResidue(api, t[2], ext).Add(api, t[2], t[3])
-	t[4].MulByNonResidue(api, t[4], ext).Add(api, t[4], t[5])
+	t[0].MulByNonResidue(api, t[0]).Add(api, t[0], t[1])
+	t[2].MulByNonResidue(api, t[2]).Add(api, t[2], t[3])
+	t[4].MulByNonResidue(api, t[4]).Add(api, t[4], t[5])
 
 	e.D0.C0.Sub(api, t[0], x.D0.C0).Add(api, e.D0.C0, e.D0.C0).Add(api, e.D0.C0, t[0])
 	e.D0.C1.Sub(api, t[2], x.D0.C1).Add(api, e.D0.C1, e.D0.C1).Add(api, e.D0.C1, t[2])
@@ -318,7 +331,7 @@ func (e *E24) Conjugate(api frontend.API, e1 E24) *E24 {
 }
 
 // MulBy034 multiplication by sparse element
-func (e *E24) MulBy034(api frontend.API, c3, c4 E4, ext Extension) *E24 {
+func (e *E24) MulBy034(api frontend.API, c3, c4 E4) *E24 {
 
 	var d E12
 	var one E4
@@ -327,70 +340,70 @@ func (e *E24) MulBy034(api frontend.API, c3, c4 E4, ext Extension) *E24 {
 	a := e.D0
 	b := e.D1
 
-	b.MulBy01(api, c3, c4, ext)
+	b.MulBy01(api, c3, c4)
 
 	c3.Add(api, one, c3)
 	d.Add(api, e.D0, e.D1)
-	d.MulBy01(api, c3, c4, ext)
+	d.MulBy01(api, c3, c4)
 
 	e.D1.Add(api, a, b).Neg(api, e.D1).Add(api, e.D1, d)
-	e.D0.MulByNonResidue(api, b, ext).Add(api, e.D0, a)
+	e.D0.MulByNonResidue(api, b).Add(api, e.D0, a)
 
 	return e
 }
 
 // Inverse inverse an elmt in Fp24
-func (e *E24) Inverse(api frontend.API, e1 E24, ext Extension) *E24 {
+func (e *E24) Inverse(api frontend.API, e1 E24) *E24 {
 
 	var t [2]E12
 	var buf E12
 
-	t[0].Square(api, e1.D0, ext)
-	t[1].Square(api, e1.D1, ext)
+	t[0].Square(api, e1.D0)
+	t[1].Square(api, e1.D1)
 
-	buf.MulByNonResidue(api, t[1], ext)
+	buf.MulByNonResidue(api, t[1])
 	t[0].Sub(api, t[0], buf)
 
-	t[1].Inverse(api, t[0], ext)
-	e.D0.Mul(api, e1.D0, t[1], ext)
-	e.D1.Mul(api, e1.D1, t[1], ext).Neg(api, e.D1)
+	t[1].Inverse(api, t[0])
+	e.D0.Mul(api, e1.D0, t[1])
+	e.D1.Mul(api, e1.D1, t[1]).Neg(api, e.D1)
 
 	return e
 }
 
 // nSquareCompressed repeated compressed cyclotmic square
-func (e *E24) nSquareCompressed(api frontend.API, n int, ext Extension) {
+func (e *E24) nSquareCompressed(api frontend.API, n int) {
 	for i := 0; i < n; i++ {
-		e.CyclotomicSquareCompressed(api, *e, ext)
+		e.CyclotomicSquareCompressed(api, *e)
 	}
 }
 
 // nSquare repeated compressed cyclotmic square
-func (e *E24) nSquare(api frontend.API, n int, ext Extension) {
+func (e *E24) nSquare(api frontend.API, n int) {
 	for i := 0; i < n; i++ {
-		e.CyclotomicSquare(api, *e, ext)
+		e.CyclotomicSquare(api, *e)
 	}
 }
 
 // Expt compute e1**exponent, where the exponent is hardcoded
 // This function is only used for the final expo of the pairing for bls24315, so the exponent is supposed to be hardcoded and on 32 bits.
-func (e *E24) Expt(api frontend.API, x E24, exponent uint64, ext Extension) *E24 {
+func (e *E24) Expt(api frontend.API, x E24, exponent uint64) *E24 {
 
 	res := E24{}
 	xInv := E24{}
 	res = x
 	xInv.Conjugate(api, x)
 
-	res.nSquare(api, 2, ext)
-	res.Mul(api, res, xInv, ext)
-	res.nSquareCompressed(api, 8, ext)
-	res.Decompress(api, res, ext)
-	res.Mul(api, res, xInv, ext)
-	res.nSquare(api, 2, ext)
-	res.Mul(api, res, x, ext)
-	res.nSquareCompressed(api, 20, ext)
-	res.Decompress(api, res, ext)
-	res.Mul(api, res, xInv, ext)
+	res.nSquare(api, 2)
+	res.Mul(api, res, xInv)
+	res.nSquareCompressed(api, 8)
+	res.Decompress(api, res)
+	res.Mul(api, res, xInv)
+	res.nSquare(api, 2)
+	res.Mul(api, res, x)
+	res.nSquareCompressed(api, 20)
+	res.Decompress(api, res)
+	res.Mul(api, res, xInv)
 	res.Conjugate(api, res)
 
 	*e = res
@@ -411,7 +424,7 @@ func (e *E24) Assign(a *bls24315.E24) {
 }
 
 // Frobenius applies frob to an fp24 elmt
-func (e *E24) Frobenius(api frontend.API, x E24, ext Extension) *E24 {
+func (e *E24) Frobenius(api frontend.API, x E24) *E24 {
 
 	e.D0.C0.B0.Conjugate(api, x.D0.C0.B0)
 	e.D0.C0.B1.Conjugate(api, x.D0.C0.B1).MulByFp(api, e.D0.C0.B1, ext.frobCoeff0)
@@ -430,7 +443,7 @@ func (e *E24) Frobenius(api frontend.API, x E24, ext Extension) *E24 {
 }
 
 // FrobeniusSquare applies frob**2 to an fp24 elmt
-func (e *E24) FrobeniusSquare(api frontend.API, x E24, ext Extension) *E24 {
+func (e *E24) FrobeniusSquare(api frontend.API, x E24) *E24 {
 
 	e.D0.C0.Conjugate(api, x.D0.C0)
 	e.D0.C1.Conjugate(api, x.D0.C1).MulByFp(api, e.D0.C1, ext.frobCoeff3)
@@ -443,7 +456,7 @@ func (e *E24) FrobeniusSquare(api frontend.API, x E24, ext Extension) *E24 {
 }
 
 // FrobeniusQuad applies frob**4 to an fp24 elmt
-func (e *E24) FrobeniusQuad(api frontend.API, x E24, ext Extension) *E24 {
+func (e *E24) FrobeniusQuad(api frontend.API, x E24) *E24 {
 
 	e.D0.C0 = x.D0.C0
 	e.D0.C1.MulByFp(api, x.D0.C1, ext.frobCoeff2)
@@ -456,8 +469,9 @@ func (e *E24) FrobeniusQuad(api frontend.API, x E24, ext Extension) *E24 {
 }
 
 // FinalExponentiation computes the final expo x**(p**12-1)(p**4+1)(p**8 - p**4 +1)/r
-func (e *E24) FinalExponentiation(api frontend.API, e1 E24, genT uint64, ext Extension) *E24 {
-
+func (e *E24) FinalExponentiation(api frontend.API, e1 E24) *E24 {
+	const ateLoop = 3218079743
+	const genT = ateLoop
 	result := e1
 
 	// https://eprint.iacr.org/2012/232.pdf, section 7
@@ -465,40 +479,40 @@ func (e *E24) FinalExponentiation(api frontend.API, e1 E24, genT uint64, ext Ext
 
 	// easy part
 	t[0].Conjugate(api, result)
-	result.Inverse(api, result, ext)
-	t[0].Mul(api, t[0], result, ext)
-	result.FrobeniusQuad(api, t[0], ext).
-		Mul(api, result, t[0], ext)
+	result.Inverse(api, result)
+	t[0].Mul(api, t[0], result)
+	result.FrobeniusQuad(api, t[0]).
+		Mul(api, result, t[0])
 
 	// hard part (api, up to permutation)
 	// Daiki Hayashida and Kenichiro Hayasaka
 	// and Tadanori Teruya
 	// https://eprint.iacr.org/2020/875.pdf
 	// 3*Phi_24(api, p)/r = (api, u-1)² * (api, u+p) * (api, u²+p²) * (api, u⁴+p⁴-1) + 3
-	t[0].CyclotomicSquare(api, result, ext)
-	t[1].Expt(api, result, genT, ext)
+	t[0].CyclotomicSquare(api, result)
+	t[1].Expt(api, result, genT)
 	t[2].Conjugate(api, result)
-	t[1].Mul(api, t[1], t[2], ext)
-	t[2].Expt(api, t[1], genT, ext)
+	t[1].Mul(api, t[1], t[2])
+	t[2].Expt(api, t[1], genT)
 	t[1].Conjugate(api, t[1])
-	t[1].Mul(api, t[1], t[2], ext)
-	t[2].Expt(api, t[1], genT, ext)
-	t[1].Frobenius(api, t[1], ext)
-	t[1].Mul(api, t[1], t[2], ext)
-	result.Mul(api, result, t[0], ext)
-	t[0].Expt(api, t[1], genT, ext)
-	t[2].Expt(api, t[0], genT, ext)
-	t[0].FrobeniusSquare(api, t[1], ext)
-	t[2].Mul(api, t[0], t[2], ext)
-	t[1].Expt(api, t[2], genT, ext)
-	t[1].Expt(api, t[1], genT, ext)
-	t[1].Expt(api, t[1], genT, ext)
-	t[1].Expt(api, t[1], genT, ext)
-	t[0].FrobeniusQuad(api, t[2], ext)
-	t[0].Mul(api, t[0], t[1], ext)
+	t[1].Mul(api, t[1], t[2])
+	t[2].Expt(api, t[1], genT)
+	t[1].Frobenius(api, t[1])
+	t[1].Mul(api, t[1], t[2])
+	result.Mul(api, result, t[0])
+	t[0].Expt(api, t[1], genT)
+	t[2].Expt(api, t[0], genT)
+	t[0].FrobeniusSquare(api, t[1])
+	t[2].Mul(api, t[0], t[2])
+	t[1].Expt(api, t[2], genT)
+	t[1].Expt(api, t[1], genT)
+	t[1].Expt(api, t[1], genT)
+	t[1].Expt(api, t[1], genT)
+	t[0].FrobeniusQuad(api, t[2])
+	t[0].Mul(api, t[0], t[1])
 	t[2].Conjugate(api, t[2])
-	t[0].Mul(api, t[0], t[2], ext)
-	result.Mul(api, result, t[0], ext)
+	t[0].Mul(api, t[0], t[2])
+	result.Mul(api, result, t[0])
 
 	*e = result
 

--- a/std/algebra/fields_bls24315/e24_test.go
+++ b/std/algebra/fields_bls24315/e24_test.go
@@ -98,8 +98,8 @@ type fp24Mul struct {
 
 func (circuit *fp24Mul) Define(api frontend.API) error {
 	expected := E24{}
-	ext := GetBLS24315ExtensionFp24(api)
-	expected.Mul(api, circuit.A, circuit.B, ext)
+
+	expected.Mul(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -129,8 +129,8 @@ type fp24Square struct {
 }
 
 func (circuit *fp24Square) Define(api frontend.API) error {
-	ext := GetBLS24315ExtensionFp24(api)
-	s := circuit.A.Square(api, circuit.A, ext)
+
+	s := circuit.A.Square(api, circuit.A)
 	s.MustBeEqual(api, circuit.B)
 	return nil
 }
@@ -159,10 +159,10 @@ type fp24CycloSquare struct {
 }
 
 func (circuit *fp24CycloSquare) Define(api frontend.API) error {
-	ext := GetBLS24315ExtensionFp24(api)
+
 	var u, v E24
-	u.Square(api, circuit.A, ext)
-	v.CyclotomicSquare(api, circuit.A, ext)
+	u.Square(api, circuit.A)
+	v.CyclotomicSquare(api, circuit.A)
 	u.MustBeEqual(api, v)
 	u.MustBeEqual(api, circuit.B)
 	return nil
@@ -199,11 +199,11 @@ type fp24CycloSquareCompressed struct {
 }
 
 func (circuit *fp24CycloSquareCompressed) Define(api frontend.API) error {
-	ext := GetBLS24315ExtensionFp24(api)
+
 	var u, v E24
-	u.Square(api, circuit.A, ext)
-	v.CyclotomicSquareCompressed(api, circuit.A, ext)
-	v.Decompress(api, v, ext)
+	u.Square(api, circuit.A)
+	v.CyclotomicSquareCompressed(api, circuit.A)
+	v.Decompress(api, v)
 	u.MustBeEqual(api, v)
 	u.MustBeEqual(api, circuit.B)
 	return nil
@@ -271,8 +271,8 @@ type fp24Inverse struct {
 
 func (circuit *fp24Inverse) Define(api frontend.API) error {
 	expected := E24{}
-	ext := GetBLS24315ExtensionFp24(api)
-	expected.Inverse(api, circuit.A, ext)
+
+	expected.Inverse(api, circuit.A)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -301,8 +301,8 @@ type fp24MulBy034 struct {
 }
 
 func (circuit *fp24MulBy034) Define(api frontend.API) error {
-	ext := GetBLS24315ExtensionFp24(api)
-	circuit.A.MulBy034(api, circuit.B, circuit.C, ext)
+
+	circuit.A.MulBy034(api, circuit.B, circuit.C)
 	circuit.A.MustBeEqual(api, circuit.W)
 	return nil
 }
@@ -338,18 +338,17 @@ type fp24Frobenius struct {
 }
 
 func (circuit *fp24Frobenius) Define(api frontend.API) error {
-	ext := GetBLS24315ExtensionFp24(api)
 
 	fb := E24{}
-	fb.Frobenius(api, circuit.A, ext)
+	fb.Frobenius(api, circuit.A)
 	fb.MustBeEqual(api, circuit.C)
 
 	fbSquare := E24{}
-	fbSquare.FrobeniusSquare(api, circuit.A, ext)
+	fbSquare.FrobeniusSquare(api, circuit.A)
 	fbSquare.MustBeEqual(api, circuit.D)
 
 	fbQuad := E24{}
-	fbQuad.FrobeniusQuad(api, circuit.A, ext)
+	fbQuad.FrobeniusQuad(api, circuit.A)
 	fbQuad.MustBeEqual(api, circuit.E)
 
 	return nil
@@ -383,9 +382,8 @@ type fp24FinalExpo struct {
 
 func (circuit *fp24FinalExpo) Define(api frontend.API) error {
 	expected := E24{}
-	ext := GetBLS24315ExtensionFp24(api)
-	expo := uint64(3218079743)
-	expected.FinalExponentiation(api, circuit.A, expo, ext)
+
+	expected.FinalExponentiation(api, circuit.A)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }

--- a/std/algebra/fields_bls24315/e2_test.go
+++ b/std/algebra/fields_bls24315/e2_test.go
@@ -91,8 +91,8 @@ type e2Square struct {
 
 func (circuit *e2Square) Define(api frontend.API) error {
 	var expected E2
-	ext := Extension{uSquare: 13}
-	expected.Square(api, circuit.A, ext)
+
+	expected.Square(api, circuit.A)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -119,8 +119,8 @@ type e2Mul struct {
 
 func (circuit *e2Mul) Define(api frontend.API) error {
 	var expected E2
-	ext := Extension{uSquare: 13}
-	expected.Mul(api, circuit.A, circuit.B, ext)
+
+	expected.Mul(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -214,9 +214,9 @@ type fp2Inverse struct {
 }
 
 func (circuit *fp2Inverse) Define(api frontend.API) error {
-	ext := Extension{uSquare: 13}
+
 	expected := E2{}
-	expected.Inverse(api, circuit.A, ext)
+	expected.Inverse(api, circuit.A)
 
 	expected.MustBeEqual(api, circuit.C)
 	return nil

--- a/std/algebra/fields_bls24315/e4.go
+++ b/std/algebra/fields_bls24315/e4.go
@@ -72,34 +72,34 @@ func (e *E4) Sub(api frontend.API, e1, e2 E4) *E4 {
 }
 
 // Mul e4 elmts: 5C
-func (e *E4) Mul(api frontend.API, e1, e2 E4, ext Extension) *E4 {
+func (e *E4) Mul(api frontend.API, e1, e2 E4) *E4 {
 
 	var a, b, c E2
 
 	a.Add(api, e1.B0, e1.B1)
 	b.Add(api, e2.B0, e2.B1)
-	a.Mul(api, a, b, ext)
-	b.Mul(api, e1.B0, e2.B0, ext)
-	c.Mul(api, e1.B1, e2.B1, ext)
+	a.Mul(api, a, b)
+	b.Mul(api, e1.B0, e2.B0)
+	c.Mul(api, e1.B1, e2.B1)
 	e.B1.Sub(api, a, b).Sub(api, e.B1, c)
-	e.B0.MulByNonResidue(api, c, ext).Add(api, e.B0, b)
+	e.B0.MulByNonResidue(api, c).Add(api, e.B0, b)
 
 	return e
 }
 
 // Square e4 elt
-func (e *E4) Square(api frontend.API, x E4, ext Extension) *E4 {
+func (e *E4) Square(api frontend.API, x E4) *E4 {
 
 	//Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
 
 	var c0, c2, c3 E2
 
 	c0.Sub(api, x.B0, x.B1)
-	c3.MulByNonResidue(api, x.B1, ext).Sub(api, x.B0, c3)
-	c2.Mul(api, x.B0, x.B1, ext)
-	c0.Mul(api, c0, c3, ext).Add(api, c0, c2)
+	c3.MulByNonResidue(api, x.B1).Sub(api, x.B0, c3)
+	c2.Mul(api, x.B0, x.B1)
+	c0.Mul(api, c0, c3).Add(api, c0, c2)
 	e.B1.Double(api, c2)
-	c2.MulByNonResidue(api, c2, ext)
+	c2.MulByNonResidue(api, c2)
 	e.B0.Add(api, c0, c2)
 
 	return e
@@ -114,9 +114,9 @@ func (e *E4) MulByFp(api frontend.API, e1 E4, c interface{}) *E4 {
 
 // MulByNonResidue multiplies an e4 elmt by the imaginary elmt
 // ext.uSquare is the square of the imaginary root
-func (e *E4) MulByNonResidue(api frontend.API, e1 E4, ext Extension) *E4 {
+func (e *E4) MulByNonResidue(api frontend.API, e1 E4) *E4 {
 	e.B1, e.B0 = e1.B0, e1.B1
-	e.B0.MulByNonResidue(api, e.B0, ext)
+	e.B0.MulByNonResidue(api, e.B0)
 	return e
 }
 
@@ -128,19 +128,19 @@ func (e *E4) Conjugate(api frontend.API, e1 E4) *E4 {
 }
 
 // Inverse inverses an e4 elmt
-func (e *E4) Inverse(api frontend.API, e1 E4, ext Extension) *E4 {
+func (e *E4) Inverse(api frontend.API, e1 E4) *E4 {
 
 	// Algorithm 23 from https://eprint.iacr.org/2010/354.pdf
 
 	var t0, t1, tmp E2
 
-	t0.Square(api, e1.B0, ext)
-	t1.Square(api, e1.B1, ext)
-	tmp.MulByNonResidue(api, t1, ext)
+	t0.Square(api, e1.B0)
+	t1.Square(api, e1.B1)
+	tmp.MulByNonResidue(api, t1)
 	t0.Sub(api, t0, tmp)
-	t1.Inverse(api, t0, ext)
-	e.B0.Mul(api, e1.B0, t1, ext)
-	e.B1.Mul(api, e1.B1, t1, ext).Neg(api, e.B1)
+	t1.Inverse(api, t0)
+	e.B0.Mul(api, e1.B0, t1)
+	e.B1.Mul(api, e1.B1, t1).Neg(api, e.B1)
 
 	return e
 }

--- a/std/algebra/fields_bls24315/e4_test.go
+++ b/std/algebra/fields_bls24315/e4_test.go
@@ -91,8 +91,8 @@ type e4Square struct {
 
 func (circuit *e4Square) Define(api frontend.API) error {
 	var expected E4
-	ext := Extension{uSquare: 13}
-	expected.Square(api, circuit.A, ext)
+
+	expected.Square(api, circuit.A)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -119,8 +119,8 @@ type e4Mul struct {
 
 func (circuit *e4Mul) Define(api frontend.API) error {
 	var expected E4
-	ext := Extension{uSquare: 13}
-	expected.Mul(api, circuit.A, circuit.B, ext)
+
+	expected.Mul(api, circuit.A, circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -215,8 +215,8 @@ type fp4Inverse struct {
 
 func (circuit *fp4Inverse) Define(api frontend.API) error {
 	var expected E4
-	ext := Extension{uSquare: 13}
-	expected.Inverse(api, circuit.A, ext)
+
+	expected.Inverse(api, circuit.A)
 
 	expected.MustBeEqual(api, circuit.C)
 	return nil

--- a/std/algebra/sw_bls12377/g2.go
+++ b/std/algebra/sw_bls12377/g2.go
@@ -37,12 +37,12 @@ type G2Affine struct {
 }
 
 // ToProj sets p to p1 in projective coords and return it
-func (p *G2Jac) ToProj(api frontend.API, p1 *G2Jac, ext fields_bls12377.Extension) *G2Jac {
-	p.X.Mul(api, p1.X, p1.Z, ext)
+func (p *G2Jac) ToProj(api frontend.API, p1 *G2Jac) *G2Jac {
+	p.X.Mul(api, p1.X, p1.Z)
 	p.Y = p1.Y
 	var t fields_bls12377.E2
-	t.Square(api, p1.Z, ext)
-	p.Z.Mul(api, p.Z, t, ext)
+	t.Square(api, p1.Z)
+	p.Z.Mul(api, p.Z, t)
 	return p
 }
 
@@ -63,76 +63,76 @@ func (p *G2Affine) Neg(api frontend.API, p1 *G2Affine) *G2Affine {
 
 // AddAssign adds 2 point in Jacobian coordinates
 // p=p, a=p1
-func (p *G2Jac) AddAssign(api frontend.API, p1 *G2Jac, ext fields_bls12377.Extension) *G2Jac {
+func (p *G2Jac) AddAssign(api frontend.API, p1 *G2Jac) *G2Jac {
 
 	var Z1Z1, Z2Z2, U1, U2, S1, S2, H, I, J, r, V fields_bls12377.E2
 
-	Z1Z1.Square(api, p1.Z, ext)
+	Z1Z1.Square(api, p1.Z)
 
-	Z2Z2.Square(api, p.Z, ext)
+	Z2Z2.Square(api, p.Z)
 
-	U1.Mul(api, p1.X, Z2Z2, ext)
+	U1.Mul(api, p1.X, Z2Z2)
 
-	U2.Mul(api, p.X, Z1Z1, ext)
+	U2.Mul(api, p.X, Z1Z1)
 
-	S1.Mul(api, p1.Y, p.Z, ext)
-	S1.Mul(api, S1, Z2Z2, ext)
+	S1.Mul(api, p1.Y, p.Z)
+	S1.Mul(api, S1, Z2Z2)
 
-	S2.Mul(api, p.Y, p1.Z, ext)
-	S2.Mul(api, S2, Z1Z1, ext)
+	S2.Mul(api, p.Y, p1.Z)
+	S2.Mul(api, S2, Z1Z1)
 
 	H.Sub(api, U2, U1)
 
 	I.Add(api, H, H)
-	I.Square(api, I, ext)
+	I.Square(api, I)
 
-	J.Mul(api, H, I, ext)
+	J.Mul(api, H, I)
 
 	r.Sub(api, S2, S1)
 	r.Add(api, r, r)
 
-	V.Mul(api, U1, I, ext)
+	V.Mul(api, U1, I)
 
-	p.X.Square(api, r, ext)
+	p.X.Square(api, r)
 	p.X.Sub(api, p.X, J)
 	p.X.Sub(api, p.X, V)
 	p.X.Sub(api, p.X, V)
 
 	p.Y.Sub(api, V, p.X)
-	p.Y.Mul(api, p.Y, r, ext)
+	p.Y.Mul(api, p.Y, r)
 
-	S1.Mul(api, J, S1, ext)
+	S1.Mul(api, J, S1)
 	S1.Add(api, S1, S1)
 
 	p.Y.Sub(api, p.Y, S1)
 
 	p.Z.Add(api, p.Z, p1.Z)
-	p.Z.Square(api, p.Z, ext)
+	p.Z.Square(api, p.Z)
 	p.Z.Sub(api, p.Z, Z1Z1)
 	p.Z.Sub(api, p.Z, Z2Z2)
-	p.Z.Mul(api, p.Z, H, ext)
+	p.Z.Mul(api, p.Z, H)
 
 	return p
 }
 
 // AddAssign add p1 to p and return p
-func (p *G2Affine) AddAssign(api frontend.API, p1 *G2Affine, ext fields_bls12377.Extension) *G2Affine {
+func (p *G2Affine) AddAssign(api frontend.API, p1 *G2Affine) *G2Affine {
 
 	var n, d, l, xr, yr fields_bls12377.E2
 
 	// compute lambda = (p1.y-p.y)/(p1.x-p.x)
 	n.Sub(api, p1.Y, p.Y)
 	d.Sub(api, p1.X, p.X)
-	l.Inverse(api, d, ext).Mul(api, l, n, ext)
+	l.Inverse(api, d).Mul(api, l, n)
 
 	// xr =lambda**2-p1.x-p.x
-	xr.Square(api, l, ext).
+	xr.Square(api, l).
 		Sub(api, xr, p1.X).
 		Sub(api, xr, p.X)
 
 	// yr = lambda(p.x - xr)-p.y
 	yr.Sub(api, p.X, xr).
-		Mul(api, l, yr, ext).
+		Mul(api, l, yr).
 		Sub(api, yr, p.Y)
 
 	p.X = xr
@@ -143,23 +143,23 @@ func (p *G2Affine) AddAssign(api frontend.API, p1 *G2Affine, ext fields_bls12377
 
 // Double compute 2*p1, assign the result to p and return it
 // Only for curve with j invariant 0 (a=0).
-func (p *G2Affine) Double(api frontend.API, p1 *G2Affine, ext fields_bls12377.Extension) *G2Affine {
+func (p *G2Affine) Double(api frontend.API, p1 *G2Affine) *G2Affine {
 
 	var n, d, l, xr, yr fields_bls12377.E2
 
 	// lambda = 3*p1.x**2/2*p.y
-	n.Square(api, p1.X, ext).MulByFp(api, n, 3)
+	n.Square(api, p1.X).MulByFp(api, n, 3)
 	d.MulByFp(api, p1.Y, 2)
-	l.Inverse(api, d, ext).Mul(api, l, n, ext)
+	l.Inverse(api, d).Mul(api, l, n)
 
 	// xr = lambda**2-2*p1.x
-	xr.Square(api, l, ext).
+	xr.Square(api, l).
 		Sub(api, xr, p1.X).
 		Sub(api, xr, p1.X)
 
 	// yr = lambda*(p.x-xr)-p.y
 	yr.Sub(api, p1.X, xr).
-		Mul(api, l, yr, ext).
+		Mul(api, l, yr).
 		Sub(api, yr, p1.Y)
 
 	p.X = xr
@@ -170,29 +170,29 @@ func (p *G2Affine) Double(api frontend.API, p1 *G2Affine, ext fields_bls12377.Ex
 }
 
 // Double doubles a point in jacobian coords
-func (p *G2Jac) Double(api frontend.API, p1 *G2Jac, ext fields_bls12377.Extension) *G2Jac {
+func (p *G2Jac) Double(api frontend.API, p1 *G2Jac) *G2Jac {
 
 	var XX, YY, YYYY, ZZ, S, M, T fields_bls12377.E2
 
-	XX.Square(api, p.X, ext)
-	YY.Square(api, p.Y, ext)
-	YYYY.Square(api, YY, ext)
-	ZZ.Square(api, p.Z, ext)
+	XX.Square(api, p.X)
+	YY.Square(api, p.Y)
+	YYYY.Square(api, YY)
+	ZZ.Square(api, p.Z)
 	S.Add(api, p.X, YY)
-	S.Square(api, S, ext)
+	S.Square(api, S)
 	S.Sub(api, S, XX)
 	S.Sub(api, S, YYYY)
 	S.Add(api, S, S)
 	M.MulByFp(api, XX, 3) // M = 3*XX+a*ZZ², here a=0 (we suppose sw has j invariant 0)
 	p.Z.Add(api, p.Z, p.Y)
-	p.Z.Square(api, p.Z, ext)
+	p.Z.Square(api, p.Z)
 	p.Z.Sub(api, p.Z, YY)
 	p.Z.Sub(api, p.Z, ZZ)
-	p.X.Square(api, M, ext)
+	p.X.Square(api, M)
 	T.Add(api, S, S)
 	p.X.Sub(api, p.X, T)
 	p.Y.Sub(api, S, p.X)
-	p.Y.Mul(api, p.Y, M, ext)
+	p.Y.Mul(api, p.Y, M)
 	YYYY.MulByFp(api, YYYY, 8)
 	p.Y.Sub(api, p.Y, YYYY)
 
@@ -226,17 +226,17 @@ func (p *G2Affine) MustBeEqual(api frontend.API, other G2Affine) {
 }
 
 // DoubleAndAdd computes 2*p1+p2 in affine coords
-func (p *G2Affine) DoubleAndAdd(api frontend.API, p1, p2 *G2Affine, ext fields_bls12377.Extension) *G2Affine {
+func (p *G2Affine) DoubleAndAdd(api frontend.API, p1, p2 *G2Affine) *G2Affine {
 
 	var n, d, l1, l2, x3, x4, y4 fields_bls12377.E2
 
 	// compute lambda1 = (y2-y1)/(x2-x1)
 	n.Sub(api, p1.Y, p2.Y)
 	d.Sub(api, p1.X, p2.X)
-	l1.Inverse(api, d, ext).Mul(api, l1, n, ext)
+	l1.Inverse(api, d).Mul(api, l1, n)
 
 	// compute x3 = lambda1**2-x1-x2
-	x3.Square(api, l1, ext).
+	x3.Square(api, l1).
 		Sub(api, x3, p1.X).
 		Sub(api, x3, p2.X)
 
@@ -244,17 +244,17 @@ func (p *G2Affine) DoubleAndAdd(api frontend.API, p1, p2 *G2Affine, ext fields_b
 	// compute lambda2 = -lambda1-2*y1/(x3-x1)
 	n.Double(api, p1.Y)
 	d.Sub(api, x3, p1.X)
-	l2.Inverse(api, d, ext).Mul(api, l2, n, ext)
+	l2.Inverse(api, d).Mul(api, l2, n)
 	l2.Add(api, l2, l1).Neg(api, l2)
 
 	// compute x4 =lambda2**2-x1-x3
-	x4.Square(api, l2, ext).
+	x4.Square(api, l2).
 		Sub(api, x4, p1.X).
 		Sub(api, x4, x3)
 
 	// compute y4 = lambda2*(x1 - x4)-y1
 	y4.Sub(api, p1.X, x4).
-		Mul(api, l2, y4, ext).
+		Mul(api, l2, y4).
 		Sub(api, y4, p1.Y)
 
 	p.X = x4

--- a/std/algebra/sw_bls12377/g2_test.go
+++ b/std/algebra/sw_bls12377/g2_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/std/algebra/fields_bls12377"
 	"github.com/consensys/gnark/test"
 
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
@@ -40,7 +39,7 @@ type g2AddAssign struct {
 
 func (circuit *g2AddAssign) Define(api frontend.API) error {
 	expected := circuit.A
-	expected.AddAssign(api, &circuit.B, fields_bls12377.GetBLS12377ExtensionFp12(api))
+	expected.AddAssign(api, &circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -77,7 +76,7 @@ type g2AddAssignAffine struct {
 
 func (circuit *g2AddAssignAffine) Define(api frontend.API) error {
 	expected := circuit.A
-	expected.AddAssign(api, &circuit.B, fields_bls12377.GetBLS12377ExtensionFp12(api))
+	expected.AddAssign(api, &circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -118,7 +117,7 @@ type g2DoubleAssign struct {
 
 func (circuit *g2DoubleAssign) Define(api frontend.API) error {
 	expected := circuit.A
-	expected.Double(api, &circuit.A, fields_bls12377.GetBLS12377ExtensionFp12(api))
+	expected.Double(api, &circuit.A)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -153,7 +152,7 @@ type g2DoubleAndAddAffine struct {
 
 func (circuit *g2DoubleAndAddAffine) Define(api frontend.API) error {
 	expected := circuit.A
-	expected.DoubleAndAdd(api, &circuit.A, &circuit.B, fields_bls12377.GetBLS12377ExtensionFp12(api))
+	expected.DoubleAndAdd(api, &circuit.A, &circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -194,7 +193,7 @@ type g2DoubleAffine struct {
 
 func (circuit *g2DoubleAffine) Define(api frontend.API) error {
 	expected := circuit.A
-	expected.Double(api, &circuit.A, fields_bls12377.GetBLS12377ExtensionFp12(api))
+	expected.Double(api, &circuit.A)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }

--- a/std/algebra/sw_bls12377/pairing.go
+++ b/std/algebra/sw_bls12377/pairing.go
@@ -25,9 +25,8 @@ import (
 
 // PairingContext contains useful info about the pairing
 type PairingContext struct {
-	AteLoop     uint64 // stores the ate loop
-	Extension   fields_bls12377.Extension
-	BTwistCoeff fields_bls12377.E2
+	AteLoop   uint64 // stores the ate loop
+	Extension fields_bls12377.Extension
 }
 
 // LineEvaluation represents a sparse Fp12 Elmt (result of the line evaluation)

--- a/std/algebra/sw_bls12377/pairing_test.go
+++ b/std/algebra/sw_bls12377/pairing_test.go
@@ -38,17 +38,13 @@ type pairingBLS377 struct {
 
 func (circuit *pairingBLS377) Define(api frontend.API) error {
 
-	ateLoop := uint64(9586122913090633729)
-	ext := fields_bls12377.GetBLS12377ExtensionFp12(api)
-	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-
 	milRes := fields_bls12377.E12{}
 	//MillerLoop(cs, circuit.P, circuit.Q, &milRes, pairingInfo)
 	//MillerLoopAffine(cs, circuit.P, circuit.Q, &milRes, pairingInfo)
-	MillerLoop(api, circuit.P, circuit.Q, &milRes, pairingInfo)
+	MillerLoop(api, circuit.P, circuit.Q, &milRes)
 
 	pairingRes := fields_bls12377.E12{}
-	pairingRes.FinalExponentiation(api, milRes, ateLoop, ext)
+	pairingRes.FinalExponentiation(api, milRes)
 
 	mustbeEq(api, pairingRes, &circuit.pairingRes)
 
@@ -80,11 +76,8 @@ type finalExp struct {
 
 func (circuit *finalExp) Define(api frontend.API) error {
 
-	ateLoop := uint64(9586122913090633729)
-	ext := fields_bls12377.GetBLS12377ExtensionFp12(api)
-
 	pairingRes := fields_bls12377.E12{}
-	pairingRes.FinalExponentiation(api, circuit.ML, ateLoop, ext)
+	pairingRes.FinalExponentiation(api, circuit.ML)
 
 	mustbeEq(api, pairingRes, &circuit.R)
 
@@ -152,15 +145,11 @@ type triplePairingBLS377 struct {
 
 func (circuit *triplePairingBLS377) Define(api frontend.API) error {
 
-	ateLoop := uint64(9586122913090633729)
-	ext := fields_bls12377.GetBLS12377ExtensionFp12(api)
-	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-
 	milRes := fields_bls12377.E12{}
-	TripleMillerLoop(api, [3]G1Affine{circuit.P1, circuit.P2, circuit.P3}, [3]G2Affine{circuit.Q1, circuit.Q2, circuit.Q3}, &milRes, pairingInfo)
+	TripleMillerLoop(api, [3]G1Affine{circuit.P1, circuit.P2, circuit.P3}, [3]G2Affine{circuit.Q1, circuit.Q2, circuit.Q3}, &milRes)
 
 	pairingRes := fields_bls12377.E12{}
-	pairingRes.FinalExponentiation(api, milRes, ateLoop, ext)
+	pairingRes.FinalExponentiation(api, milRes)
 
 	mustbeEq(api, pairingRes, &circuit.pairingRes)
 

--- a/std/algebra/sw_bls12377/pairing_test.go
+++ b/std/algebra/sw_bls12377/pairing_test.go
@@ -41,8 +41,6 @@ func (circuit *pairingBLS377) Define(api frontend.API) error {
 	ateLoop := uint64(9586122913090633729)
 	ext := fields_bls12377.GetBLS12377ExtensionFp12(api)
 	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.A0 = 0
-	pairingInfo.BTwistCoeff.A1 = "155198655607781456406391640216936120121836107652948796323930557600032281009004493664981332883744016074664192874906"
 
 	milRes := fields_bls12377.E12{}
 	//MillerLoop(cs, circuit.P, circuit.Q, &milRes, pairingInfo)
@@ -84,9 +82,6 @@ func (circuit *finalExp) Define(api frontend.API) error {
 
 	ateLoop := uint64(9586122913090633729)
 	ext := fields_bls12377.GetBLS12377ExtensionFp12(api)
-	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.A0 = 0
-	pairingInfo.BTwistCoeff.A1 = "155198655607781456406391640216936120121836107652948796323930557600032281009004493664981332883744016074664192874906"
 
 	pairingRes := fields_bls12377.E12{}
 	pairingRes.FinalExponentiation(api, circuit.ML, ateLoop, ext)
@@ -160,8 +155,6 @@ func (circuit *triplePairingBLS377) Define(api frontend.API) error {
 	ateLoop := uint64(9586122913090633729)
 	ext := fields_bls12377.GetBLS12377ExtensionFp12(api)
 	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.A0 = 0
-	pairingInfo.BTwistCoeff.A1 = "155198655607781456406391640216936120121836107652948796323930557600032281009004493664981332883744016074664192874906"
 
 	milRes := fields_bls12377.E12{}
 	TripleMillerLoop(api, [3]G1Affine{circuit.P1, circuit.P2, circuit.P3}, [3]G2Affine{circuit.Q1, circuit.Q2, circuit.Q3}, &milRes, pairingInfo)

--- a/std/algebra/sw_bls24315/g2.go
+++ b/std/algebra/sw_bls24315/g2.go
@@ -37,12 +37,12 @@ type G2Affine struct {
 }
 
 // ToProj sets p to p1 in projective coords and return it
-func (p *G2Jac) ToProj(api frontend.API, p1 *G2Jac, ext fields_bls24315.Extension) *G2Jac {
-	p.X.Mul(api, p1.X, p1.Z, ext)
+func (p *G2Jac) ToProj(api frontend.API, p1 *G2Jac) *G2Jac {
+	p.X.Mul(api, p1.X, p1.Z)
 	p.Y = p1.Y
 	var t fields_bls24315.E4
-	t.Square(api, p1.Z, ext)
-	p.Z.Mul(api, p.Z, t, ext)
+	t.Square(api, p1.Z)
+	p.Z.Mul(api, p.Z, t)
 	return p
 }
 
@@ -63,76 +63,76 @@ func (p *G2Affine) Neg(api frontend.API, p1 *G2Affine) *G2Affine {
 
 // AddAssign adds 2 point in Jacobian coordinates
 // p=p, a=p1
-func (p *G2Jac) AddAssign(api frontend.API, p1 *G2Jac, ext fields_bls24315.Extension) *G2Jac {
+func (p *G2Jac) AddAssign(api frontend.API, p1 *G2Jac) *G2Jac {
 
 	var Z1Z1, Z2Z2, U1, U2, S1, S2, H, I, J, r, V fields_bls24315.E4
 
-	Z1Z1.Square(api, p1.Z, ext)
+	Z1Z1.Square(api, p1.Z)
 
-	Z2Z2.Square(api, p.Z, ext)
+	Z2Z2.Square(api, p.Z)
 
-	U1.Mul(api, p1.X, Z2Z2, ext)
+	U1.Mul(api, p1.X, Z2Z2)
 
-	U2.Mul(api, p.X, Z1Z1, ext)
+	U2.Mul(api, p.X, Z1Z1)
 
-	S1.Mul(api, p1.Y, p.Z, ext)
-	S1.Mul(api, S1, Z2Z2, ext)
+	S1.Mul(api, p1.Y, p.Z)
+	S1.Mul(api, S1, Z2Z2)
 
-	S2.Mul(api, p.Y, p1.Z, ext)
-	S2.Mul(api, S2, Z1Z1, ext)
+	S2.Mul(api, p.Y, p1.Z)
+	S2.Mul(api, S2, Z1Z1)
 
 	H.Sub(api, U2, U1)
 
 	I.Add(api, H, H)
-	I.Square(api, I, ext)
+	I.Square(api, I)
 
-	J.Mul(api, H, I, ext)
+	J.Mul(api, H, I)
 
 	r.Sub(api, S2, S1)
 	r.Add(api, r, r)
 
-	V.Mul(api, U1, I, ext)
+	V.Mul(api, U1, I)
 
-	p.X.Square(api, r, ext)
+	p.X.Square(api, r)
 	p.X.Sub(api, p.X, J)
 	p.X.Sub(api, p.X, V)
 	p.X.Sub(api, p.X, V)
 
 	p.Y.Sub(api, V, p.X)
-	p.Y.Mul(api, p.Y, r, ext)
+	p.Y.Mul(api, p.Y, r)
 
-	S1.Mul(api, J, S1, ext)
+	S1.Mul(api, J, S1)
 	S1.Add(api, S1, S1)
 
 	p.Y.Sub(api, p.Y, S1)
 
 	p.Z.Add(api, p.Z, p1.Z)
-	p.Z.Square(api, p.Z, ext)
+	p.Z.Square(api, p.Z)
 	p.Z.Sub(api, p.Z, Z1Z1)
 	p.Z.Sub(api, p.Z, Z2Z2)
-	p.Z.Mul(api, p.Z, H, ext)
+	p.Z.Mul(api, p.Z, H)
 
 	return p
 }
 
 // AddAssign add p1 to p and return p
-func (p *G2Affine) AddAssign(api frontend.API, p1 *G2Affine, ext fields_bls24315.Extension) *G2Affine {
+func (p *G2Affine) AddAssign(api frontend.API, p1 *G2Affine) *G2Affine {
 
 	var n, d, l, xr, yr fields_bls24315.E4
 
 	// compute lambda = (p1.y-p.y)/(p1.x-p.x)
 	n.Sub(api, p1.Y, p.Y)
 	d.Sub(api, p1.X, p.X)
-	l.Inverse(api, d, ext).Mul(api, l, n, ext)
+	l.Inverse(api, d).Mul(api, l, n)
 
 	// xr =lambda**2-p1.x-p.x
-	xr.Square(api, l, ext).
+	xr.Square(api, l).
 		Sub(api, xr, p1.X).
 		Sub(api, xr, p.X)
 
 	// yr = lambda(p.x - xr)-p.y
 	yr.Sub(api, p.X, xr).
-		Mul(api, l, yr, ext).
+		Mul(api, l, yr).
 		Sub(api, yr, p.Y)
 
 	p.X = xr
@@ -143,23 +143,23 @@ func (p *G2Affine) AddAssign(api frontend.API, p1 *G2Affine, ext fields_bls24315
 
 // Double compute 2*p1, assign the result to p and return it
 // Only for curve with j invariant 0 (a=0).
-func (p *G2Affine) Double(api frontend.API, p1 *G2Affine, ext fields_bls24315.Extension) *G2Affine {
+func (p *G2Affine) Double(api frontend.API, p1 *G2Affine) *G2Affine {
 
 	var n, d, l, xr, yr fields_bls24315.E4
 
 	// lambda = 3*p1.x**2/2*p.y
-	n.Square(api, p1.X, ext).MulByFp(api, n, 3)
+	n.Square(api, p1.X).MulByFp(api, n, 3)
 	d.MulByFp(api, p1.Y, 2)
-	l.Inverse(api, d, ext).Mul(api, l, n, ext)
+	l.Inverse(api, d).Mul(api, l, n)
 
 	// xr = lambda**2-2*p1.x
-	xr.Square(api, l, ext).
+	xr.Square(api, l).
 		Sub(api, xr, p1.X).
 		Sub(api, xr, p1.X)
 
 	// yr = lambda*(p.x-xr)-p.y
 	yr.Sub(api, p1.X, xr).
-		Mul(api, l, yr, ext).
+		Mul(api, l, yr).
 		Sub(api, yr, p1.Y)
 
 	p.X = xr
@@ -170,29 +170,29 @@ func (p *G2Affine) Double(api frontend.API, p1 *G2Affine, ext fields_bls24315.Ex
 }
 
 // Double doubles a point in jacobian coords
-func (p *G2Jac) Double(api frontend.API, p1 *G2Jac, ext fields_bls24315.Extension) *G2Jac {
+func (p *G2Jac) Double(api frontend.API, p1 *G2Jac) *G2Jac {
 
 	var XX, YY, YYYY, ZZ, S, M, T fields_bls24315.E4
 
-	XX.Square(api, p.X, ext)
-	YY.Square(api, p.Y, ext)
-	YYYY.Square(api, YY, ext)
-	ZZ.Square(api, p.Z, ext)
+	XX.Square(api, p.X)
+	YY.Square(api, p.Y)
+	YYYY.Square(api, YY)
+	ZZ.Square(api, p.Z)
 	S.Add(api, p.X, YY)
-	S.Square(api, S, ext)
+	S.Square(api, S)
 	S.Sub(api, S, XX)
 	S.Sub(api, S, YYYY)
 	S.Add(api, S, S)
 	M.MulByFp(api, XX, 3) // M = 3*XX+a*ZZ², here a=0 (we suppose sw has j invariant 0)
 	p.Z.Add(api, p.Z, p.Y)
-	p.Z.Square(api, p.Z, ext)
+	p.Z.Square(api, p.Z)
 	p.Z.Sub(api, p.Z, YY)
 	p.Z.Sub(api, p.Z, ZZ)
-	p.X.Square(api, M, ext)
+	p.X.Square(api, M)
 	T.Add(api, S, S)
 	p.X.Sub(api, p.X, T)
 	p.Y.Sub(api, S, p.X)
-	p.Y.Mul(api, p.Y, M, ext)
+	p.Y.Mul(api, p.Y, M)
 	YYYY.MulByFp(api, YYYY, 8)
 	p.Y.Sub(api, p.Y, YYYY)
 
@@ -226,17 +226,17 @@ func (p *G2Affine) MustBeEqual(api frontend.API, other G2Affine) {
 }
 
 // DoubleAndAdd computes 2*p1+p2 in affine coords
-func (p *G2Affine) DoubleAndAdd(api frontend.API, p1, p2 *G2Affine, ext fields_bls24315.Extension) *G2Affine {
+func (p *G2Affine) DoubleAndAdd(api frontend.API, p1, p2 *G2Affine) *G2Affine {
 
 	var n, d, l1, l2, x3, x4, y4 fields_bls24315.E4
 
 	// compute lambda1 = (y2-y1)/(x2-x1)
 	n.Sub(api, p1.Y, p2.Y)
 	d.Sub(api, p1.X, p2.X)
-	l1.Inverse(api, d, ext).Mul(api, l1, n, ext)
+	l1.Inverse(api, d).Mul(api, l1, n)
 
 	// compute x3 = lambda1**2-x1-x2
-	x3.Square(api, l1, ext).
+	x3.Square(api, l1).
 		Sub(api, x3, p1.X).
 		Sub(api, x3, p2.X)
 
@@ -244,17 +244,17 @@ func (p *G2Affine) DoubleAndAdd(api frontend.API, p1, p2 *G2Affine, ext fields_b
 	// compute lambda2 = -lambda1-2*y1/(x3-x1)
 	n.Double(api, p1.Y)
 	d.Sub(api, x3, p1.X)
-	l2.Inverse(api, d, ext).Mul(api, l2, n, ext)
+	l2.Inverse(api, d).Mul(api, l2, n)
 	l2.Add(api, l2, l1).Neg(api, l2)
 
 	// compute x4 =lambda2**2-x1-x3
-	x4.Square(api, l2, ext).
+	x4.Square(api, l2).
 		Sub(api, x4, p1.X).
 		Sub(api, x4, x3)
 
 	// compute y4 = lambda2*(x1 - x4)-y1
 	y4.Sub(api, p1.X, x4).
-		Mul(api, l2, y4, ext).
+		Mul(api, l2, y4).
 		Sub(api, y4, p1.Y)
 
 	p.X = x4

--- a/std/algebra/sw_bls24315/g2_test.go
+++ b/std/algebra/sw_bls24315/g2_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	"github.com/consensys/gnark/std/algebra/fields_bls24315"
 	"github.com/consensys/gnark/test"
 
 	bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315"
@@ -40,7 +39,7 @@ type g2AddAssign struct {
 
 func (circuit *g2AddAssign) Define(api frontend.API) error {
 	expected := circuit.A
-	expected.AddAssign(api, &circuit.B, fields_bls24315.GetBLS24315ExtensionFp24(api))
+	expected.AddAssign(api, &circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -77,7 +76,7 @@ type g2AddAssignAffine struct {
 
 func (circuit *g2AddAssignAffine) Define(api frontend.API) error {
 	expected := circuit.A
-	expected.AddAssign(api, &circuit.B, fields_bls24315.GetBLS24315ExtensionFp24(api))
+	expected.AddAssign(api, &circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -118,7 +117,7 @@ type g2DoubleAssign struct {
 
 func (circuit *g2DoubleAssign) Define(api frontend.API) error {
 	expected := circuit.A
-	expected.Double(api, &circuit.A, fields_bls24315.GetBLS24315ExtensionFp24(api))
+	expected.Double(api, &circuit.A)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -153,7 +152,7 @@ type g2DoubleAndAddAffine struct {
 
 func (circuit *g2DoubleAndAddAffine) Define(api frontend.API) error {
 	expected := circuit.A
-	expected.DoubleAndAdd(api, &circuit.A, &circuit.B, fields_bls24315.GetBLS24315ExtensionFp24(api))
+	expected.DoubleAndAdd(api, &circuit.A, &circuit.B)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }
@@ -194,7 +193,7 @@ type g2DoubleAffine struct {
 
 func (circuit *g2DoubleAffine) Define(api frontend.API) error {
 	expected := circuit.A
-	expected.Double(api, &circuit.A, fields_bls24315.GetBLS24315ExtensionFp24(api))
+	expected.Double(api, &circuit.A)
 	expected.MustBeEqual(api, circuit.C)
 	return nil
 }

--- a/std/algebra/sw_bls24315/pairing.go
+++ b/std/algebra/sw_bls24315/pairing.go
@@ -24,19 +24,13 @@ import (
 	"github.com/consensys/gnark/std/algebra/fields_bls24315"
 )
 
-// PairingContext contains useful info about the pairing
-type PairingContext struct {
-	AteLoop   uint64 // stores the ate loop
-	Extension fields_bls24315.Extension
-}
-
 // LineEvaluation represents a sparse Fp12 Elmt (result of the line evaluation)
 type LineEvaluation struct {
 	R0, R1 fields_bls24315.E4
 }
 
 // MillerLoop computes the miller loop
-func MillerLoop(api frontend.API, P G1Affine, Q G2Affine, res *fields_bls24315.E24, pairingInfo PairingContext) *fields_bls24315.E24 {
+func MillerLoop(api frontend.API, P G1Affine, Q G2Affine, res *fields_bls24315.E24) *fields_bls24315.E24 {
 
 	var ateLoop2NAF [33]int8
 	optimaAteLoop, _ := new(big.Int).SetString("3218079743", 10)
@@ -52,29 +46,29 @@ func MillerLoop(api frontend.API, P G1Affine, Q G2Affine, res *fields_bls24315.E
 	xOverY := api.DivUnchecked(P.X, P.Y)
 
 	for i := len(ateLoop2NAF) - 2; i >= 0; i-- {
-		res.Square(api, *res, pairingInfo.Extension)
+		res.Square(api, *res)
 
 		if ateLoop2NAF[i] == 0 {
-			Qacc, l1 = DoubleStep(api, &Qacc, pairingInfo.Extension)
+			Qacc, l1 = DoubleStep(api, &Qacc)
 			l1.R0.MulByFp(api, l1.R0, xOverY)
 			l1.R1.MulByFp(api, l1.R1, yInv)
-			res.MulBy034(api, l1.R0, l1.R1, pairingInfo.Extension)
+			res.MulBy034(api, l1.R0, l1.R1)
 		} else if ateLoop2NAF[i] == 1 {
-			Qacc, l1, l2 = DoubleAndAddStep(api, &Qacc, &Q, pairingInfo.Extension)
+			Qacc, l1, l2 = DoubleAndAddStep(api, &Qacc, &Q)
 			l1.R0.MulByFp(api, l1.R0, xOverY)
 			l1.R1.MulByFp(api, l1.R1, yInv)
-			res.MulBy034(api, l1.R0, l1.R1, pairingInfo.Extension)
+			res.MulBy034(api, l1.R0, l1.R1)
 			l2.R0.MulByFp(api, l2.R0, xOverY)
 			l2.R1.MulByFp(api, l2.R1, yInv)
-			res.MulBy034(api, l2.R0, l2.R1, pairingInfo.Extension)
+			res.MulBy034(api, l2.R0, l2.R1)
 		} else {
-			Qacc, l1, l2 = DoubleAndAddStep(api, &Qacc, &Qneg, pairingInfo.Extension)
+			Qacc, l1, l2 = DoubleAndAddStep(api, &Qacc, &Qneg)
 			l1.R0.MulByFp(api, l1.R0, xOverY)
 			l1.R1.MulByFp(api, l1.R1, yInv)
-			res.MulBy034(api, l1.R0, l1.R1, pairingInfo.Extension)
+			res.MulBy034(api, l1.R0, l1.R1)
 			l2.R0.MulByFp(api, l2.R0, xOverY)
 			l2.R1.MulByFp(api, l2.R1, yInv)
-			res.MulBy034(api, l2.R0, l2.R1, pairingInfo.Extension)
+			res.MulBy034(api, l2.R0, l2.R1)
 		}
 	}
 
@@ -84,7 +78,7 @@ func MillerLoop(api frontend.API, P G1Affine, Q G2Affine, res *fields_bls24315.E
 }
 
 // DoubleAndAddStep
-func DoubleAndAddStep(api frontend.API, p1, p2 *G2Affine, ext fields_bls24315.Extension) (G2Affine, LineEvaluation, LineEvaluation) {
+func DoubleAndAddStep(api frontend.API, p1, p2 *G2Affine) (G2Affine, LineEvaluation, LineEvaluation) {
 
 	var n, d, l1, l2, x3, x4, y4 fields_bls24315.E4
 	var line1, line2 LineEvaluation
@@ -93,10 +87,10 @@ func DoubleAndAddStep(api frontend.API, p1, p2 *G2Affine, ext fields_bls24315.Ex
 	// compute lambda1 = (y2-y1)/(x2-x1)
 	n.Sub(api, p1.Y, p2.Y)
 	d.Sub(api, p1.X, p2.X)
-	l1.Inverse(api, d, ext).Mul(api, l1, n, ext)
+	l1.Inverse(api, d).Mul(api, l1, n)
 
 	// x3 =lambda1**2-p1.x-p2.x
-	x3.Square(api, l1, ext).
+	x3.Square(api, l1).
 		Sub(api, x3, p1.X).
 		Sub(api, x3, p2.X)
 
@@ -104,22 +98,22 @@ func DoubleAndAddStep(api frontend.API, p1, p2 *G2Affine, ext fields_bls24315.Ex
 
 		// compute line1
 	line1.R0.Neg(api, l1)
-	line1.R1.Mul(api, l1, p1.X, ext).Sub(api, line1.R1, p1.Y)
+	line1.R1.Mul(api, l1, p1.X).Sub(api, line1.R1, p1.Y)
 
 	// compute lambda2 = -lambda1-2*y1/(x3-x1)
 	n.Double(api, p1.Y)
 	d.Sub(api, x3, p1.X)
-	l2.Inverse(api, d, ext).Mul(api, l2, n, ext)
+	l2.Inverse(api, d).Mul(api, l2, n)
 	l2.Add(api, l2, l1).Neg(api, l2)
 
 	// compute x4 = lambda2**2-x1-x3
-	x4.Square(api, l2, ext).
+	x4.Square(api, l2).
 		Sub(api, x4, p1.X).
 		Sub(api, x4, x3)
 
 	// compute y4 = lambda2*(x1 - x4)-y1
 	y4.Sub(api, p1.X, x4).
-		Mul(api, l2, y4, ext).
+		Mul(api, l2, y4).
 		Sub(api, y4, p1.Y)
 
 	p.X = x4
@@ -127,44 +121,44 @@ func DoubleAndAddStep(api frontend.API, p1, p2 *G2Affine, ext fields_bls24315.Ex
 
 	// compute line2
 	line2.R0.Neg(api, l2)
-	line2.R1.Mul(api, l2, p1.X, ext).Sub(api, line2.R1, p1.Y)
+	line2.R1.Mul(api, l2, p1.X).Sub(api, line2.R1, p1.Y)
 
 	return p, line1, line2
 }
 
-func DoubleStep(api frontend.API, p1 *G2Affine, ext fields_bls24315.Extension) (G2Affine, LineEvaluation) {
+func DoubleStep(api frontend.API, p1 *G2Affine) (G2Affine, LineEvaluation) {
 
 	var n, d, l, xr, yr fields_bls24315.E4
 	var p G2Affine
 	var line LineEvaluation
 
 	// lambda = 3*p1.x**2/2*p.y
-	n.Square(api, p1.X, ext).MulByFp(api, n, 3)
+	n.Square(api, p1.X).MulByFp(api, n, 3)
 	d.MulByFp(api, p1.Y, 2)
-	l.Inverse(api, d, ext).Mul(api, l, n, ext)
+	l.Inverse(api, d).Mul(api, l, n)
 
 	// xr = lambda**2-2*p1.x
-	xr.Square(api, l, ext).
+	xr.Square(api, l).
 		Sub(api, xr, p1.X).
 		Sub(api, xr, p1.X)
 
 	// yr = lambda*(p.x-xr)-p.y
 	yr.Sub(api, p1.X, xr).
-		Mul(api, l, yr, ext).
+		Mul(api, l, yr).
 		Sub(api, yr, p1.Y)
 
 	p.X = xr
 	p.Y = yr
 
 	line.R0.Neg(api, l)
-	line.R1.Mul(api, l, p1.X, ext).Sub(api, line.R1, p1.Y)
+	line.R1.Mul(api, l, p1.X).Sub(api, line.R1, p1.Y)
 
 	return p, line
 
 }
 
 // TripleMillerLoop computes the product of three miller loops
-func TripleMillerLoop(api frontend.API, P [3]G1Affine, Q [3]G2Affine, res *fields_bls24315.E24, pairingInfo PairingContext) *fields_bls24315.E24 {
+func TripleMillerLoop(api frontend.API, P [3]G1Affine, Q [3]G2Affine, res *fields_bls24315.E24) *fields_bls24315.E24 {
 
 	var ateLoop2NAF [33]int8
 	optimaAteLoop, _ := new(big.Int).SetString("3218079743", 10)
@@ -185,34 +179,34 @@ func TripleMillerLoop(api frontend.API, P [3]G1Affine, Q [3]G2Affine, res *field
 	}
 
 	for i := len(ateLoop2NAF) - 2; i >= 0; i-- {
-		res.Square(api, *res, pairingInfo.Extension)
+		res.Square(api, *res)
 
 		if ateLoop2NAF[i] == 0 {
 			for k := 0; k < 3; k++ {
-				Qacc[k], l1 = DoubleStep(api, &Qacc[k], pairingInfo.Extension)
+				Qacc[k], l1 = DoubleStep(api, &Qacc[k])
 				l1.R0.MulByFp(api, l1.R0, xOverY[k])
 				l1.R1.MulByFp(api, l1.R1, yInv[k])
-				res.MulBy034(api, l1.R0, l1.R1, pairingInfo.Extension)
+				res.MulBy034(api, l1.R0, l1.R1)
 			}
 		} else if ateLoop2NAF[i] == 1 {
 			for k := 0; k < 3; k++ {
-				Qacc[k], l1, l2 = DoubleAndAddStep(api, &Qacc[k], &Q[k], pairingInfo.Extension)
+				Qacc[k], l1, l2 = DoubleAndAddStep(api, &Qacc[k], &Q[k])
 				l1.R0.MulByFp(api, l1.R0, xOverY[k])
 				l1.R1.MulByFp(api, l1.R1, yInv[k])
-				res.MulBy034(api, l1.R0, l1.R1, pairingInfo.Extension)
+				res.MulBy034(api, l1.R0, l1.R1)
 				l2.R0.MulByFp(api, l2.R0, xOverY[k])
 				l2.R1.MulByFp(api, l2.R1, yInv[k])
-				res.MulBy034(api, l2.R0, l2.R1, pairingInfo.Extension)
+				res.MulBy034(api, l2.R0, l2.R1)
 			}
 		} else {
 			for k := 0; k < 3; k++ {
-				Qacc[k], l1, l2 = DoubleAndAddStep(api, &Qacc[k], &Qneg[k], pairingInfo.Extension)
+				Qacc[k], l1, l2 = DoubleAndAddStep(api, &Qacc[k], &Qneg[k])
 				l1.R0.MulByFp(api, l1.R0, xOverY[k])
 				l1.R1.MulByFp(api, l1.R1, yInv[k])
-				res.MulBy034(api, l1.R0, l1.R1, pairingInfo.Extension)
+				res.MulBy034(api, l1.R0, l1.R1)
 				l2.R0.MulByFp(api, l2.R0, xOverY[k])
 				l2.R1.MulByFp(api, l2.R1, yInv[k])
-				res.MulBy034(api, l2.R0, l2.R1, pairingInfo.Extension)
+				res.MulBy034(api, l2.R0, l2.R1)
 			}
 		}
 	}

--- a/std/algebra/sw_bls24315/pairing.go
+++ b/std/algebra/sw_bls24315/pairing.go
@@ -26,9 +26,8 @@ import (
 
 // PairingContext contains useful info about the pairing
 type PairingContext struct {
-	AteLoop     uint64 // stores the ate loop
-	Extension   fields_bls24315.Extension
-	BTwistCoeff fields_bls24315.E4
+	AteLoop   uint64 // stores the ate loop
+	Extension fields_bls24315.Extension
 }
 
 // LineEvaluation represents a sparse Fp12 Elmt (result of the line evaluation)

--- a/std/algebra/sw_bls24315/pairing_test.go
+++ b/std/algebra/sw_bls24315/pairing_test.go
@@ -39,11 +39,6 @@ func (circuit *finalExp) Define(api frontend.API) error {
 
 	ateLoop := uint64(9586122913090633729)
 	ext := fields_bls24315.GetBLS24315ExtensionFp24(api)
-	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.B0.A0 = 0
-	pairingInfo.BTwistCoeff.B0.A1 = 0
-	pairingInfo.BTwistCoeff.B1.A0 = 0
-	pairingInfo.BTwistCoeff.B1.A1 = "6108483493771298205388567675447533806912846525679192205394505462405828322019437284165171866703"
 
 	pairingRes := fields_bls24315.E24{}
 	pairingRes.FinalExponentiation(api, circuit.ML, ateLoop, ext)
@@ -77,10 +72,6 @@ func (circuit *pairingBLS24315) Define(api frontend.API) error {
 	ateLoop := uint64(3218079743)
 	ext := fields_bls24315.GetBLS24315ExtensionFp24(api)
 	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.B0.A0 = 0
-	pairingInfo.BTwistCoeff.B0.A1 = 0
-	pairingInfo.BTwistCoeff.B1.A0 = 0
-	pairingInfo.BTwistCoeff.B1.A1 = "6108483493771298205388567675447533806912846525679192205394505462405828322019437284165171866703"
 
 	milRes := fields_bls24315.E24{}
 	MillerLoop(api, circuit.P, circuit.Q, &milRes, pairingInfo)
@@ -174,10 +165,6 @@ func (circuit *triplePairingBLS24315) Define(api frontend.API) error {
 	ateLoop := uint64(3218079743)
 	ext := fields_bls24315.GetBLS24315ExtensionFp24(api)
 	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.B0.A0 = 0
-	pairingInfo.BTwistCoeff.B0.A1 = 0
-	pairingInfo.BTwistCoeff.B1.A0 = 0
-	pairingInfo.BTwistCoeff.B1.A1 = "6108483493771298205388567675447533806912846525679192205394505462405828322019437284165171866703"
 
 	milRes := fields_bls24315.E24{}
 	TripleMillerLoop(api, [3]G1Affine{circuit.P1, circuit.P2, circuit.P3}, [3]G2Affine{circuit.Q1, circuit.Q2, circuit.Q3}, &milRes, pairingInfo)

--- a/std/algebra/sw_bls24315/pairing_test.go
+++ b/std/algebra/sw_bls24315/pairing_test.go
@@ -37,11 +37,8 @@ type finalExp struct {
 
 func (circuit *finalExp) Define(api frontend.API) error {
 
-	ateLoop := uint64(9586122913090633729)
-	ext := fields_bls24315.GetBLS24315ExtensionFp24(api)
-
 	pairingRes := fields_bls24315.E24{}
-	pairingRes.FinalExponentiation(api, circuit.ML, ateLoop, ext)
+	pairingRes.FinalExponentiation(api, circuit.ML)
 
 	mustbeEq(api, pairingRes, &circuit.R)
 
@@ -69,15 +66,11 @@ type pairingBLS24315 struct {
 
 func (circuit *pairingBLS24315) Define(api frontend.API) error {
 
-	ateLoop := uint64(3218079743)
-	ext := fields_bls24315.GetBLS24315ExtensionFp24(api)
-	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-
 	milRes := fields_bls24315.E24{}
-	MillerLoop(api, circuit.P, circuit.Q, &milRes, pairingInfo)
+	MillerLoop(api, circuit.P, circuit.Q, &milRes)
 
 	pairingRes := fields_bls24315.E24{}
-	pairingRes.FinalExponentiation(api, milRes, ateLoop, ext)
+	pairingRes.FinalExponentiation(api, milRes)
 
 	mustbeEq(api, pairingRes, &circuit.pairingRes)
 
@@ -162,15 +155,11 @@ type triplePairingBLS24315 struct {
 
 func (circuit *triplePairingBLS24315) Define(api frontend.API) error {
 
-	ateLoop := uint64(3218079743)
-	ext := fields_bls24315.GetBLS24315ExtensionFp24(api)
-	pairingInfo := PairingContext{AteLoop: ateLoop, Extension: ext}
-
 	milRes := fields_bls24315.E24{}
-	TripleMillerLoop(api, [3]G1Affine{circuit.P1, circuit.P2, circuit.P3}, [3]G2Affine{circuit.Q1, circuit.Q2, circuit.Q3}, &milRes, pairingInfo)
+	TripleMillerLoop(api, [3]G1Affine{circuit.P1, circuit.P2, circuit.P3}, [3]G2Affine{circuit.Q1, circuit.Q2, circuit.Q3}, &milRes)
 
 	pairingRes := fields_bls24315.E24{}
-	pairingRes.FinalExponentiation(api, milRes, ateLoop, ext)
+	pairingRes.FinalExponentiation(api, milRes)
 
 	mustbeEq(api, pairingRes, &circuit.pairingRes)
 

--- a/std/groth16_bls12377/verifier.go
+++ b/std/groth16_bls12377/verifier.go
@@ -48,7 +48,7 @@ type VerifyingKey struct {
 // pubInputNames should what r1cs.PublicInputs() outputs for the inner r1cs.
 // It creates public circuits input, corresponding to the pubInputNames slice.
 // Notations and naming are from https://eprint.iacr.org/2020/278.
-func Verify(api frontend.API, pairingInfo sw_bls12377.PairingContext, innerVk VerifyingKey, innerProof Proof, innerPubInputs []frontend.Variable) {
+func Verify(api frontend.API, innerVk VerifyingKey, innerProof Proof, innerPubInputs []frontend.Variable) {
 
 	// compute psi0 using a sequence of multiexponentiations
 	// TODO maybe implement the bucket method with c=1 when there's a large input set
@@ -70,11 +70,11 @@ func Verify(api frontend.API, pairingInfo sw_bls12377.PairingContext, innerVk Ve
 
 	var resMillerLoop fields_bls12377.E12
 	// e(psi0, -gamma)*e(-πC, -δ)*e(πA, πB)
-	sw_bls12377.TripleMillerLoop(api, [3]sw_bls12377.G1Affine{psi0, innerProof.Krs, innerProof.Ar}, [3]sw_bls12377.G2Affine{innerVk.G2.GammaNeg, innerVk.G2.DeltaNeg, innerProof.Bs}, &resMillerLoop, pairingInfo)
+	sw_bls12377.TripleMillerLoop(api, [3]sw_bls12377.G1Affine{psi0, innerProof.Krs, innerProof.Ar}, [3]sw_bls12377.G2Affine{innerVk.G2.GammaNeg, innerVk.G2.DeltaNeg, innerProof.Bs}, &resMillerLoop)
 
 	// performs the final expo
 	var resPairing fields_bls12377.E12
-	resPairing.FinalExponentiation(api, resMillerLoop, pairingInfo.AteLoop, pairingInfo.Extension)
+	resPairing.FinalExponentiation(api, resMillerLoop)
 
 	// vk.E must be equal to resPairing
 	innerVk.E.MustBeEqual(api, resPairing)

--- a/std/groth16_bls12377/verifier_test.go
+++ b/std/groth16_bls12377/verifier_test.go
@@ -113,8 +113,6 @@ func (circuit *verifierCircuit) Define(api frontend.API) error {
 	ateLoop := uint64(9586122913090633729)
 	ext := fields_bls12377.GetBLS12377ExtensionFp12(api)
 	pairingInfo := sw_bls12377.PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.A0 = 0
-	pairingInfo.BTwistCoeff.A1 = "155198655607781456406391640216936120121836107652948796323930557600032281009004493664981332883744016074664192874906"
 
 	// create the verifier cs
 	Verify(api, pairingInfo, circuit.InnerVk, circuit.InnerProof, []frontend.Variable{circuit.Hash})

--- a/std/groth16_bls12377/verifier_test.go
+++ b/std/groth16_bls12377/verifier_test.go
@@ -28,7 +28,6 @@ import (
 	backend_bls12377 "github.com/consensys/gnark/internal/backend/bls12-377/cs"
 	groth16_bls12377 "github.com/consensys/gnark/internal/backend/bls12-377/groth16"
 	"github.com/consensys/gnark/internal/backend/bls12-377/witness"
-	"github.com/consensys/gnark/std/algebra/fields_bls12377"
 	"github.com/consensys/gnark/std/algebra/sw_bls12377"
 	"github.com/consensys/gnark/std/hash/mimc"
 	"github.com/consensys/gnark/test"
@@ -108,14 +107,8 @@ type verifierCircuit struct {
 }
 
 func (circuit *verifierCircuit) Define(api frontend.API) error {
-
-	// pairing data
-	ateLoop := uint64(9586122913090633729)
-	ext := fields_bls12377.GetBLS12377ExtensionFp12(api)
-	pairingInfo := sw_bls12377.PairingContext{AteLoop: ateLoop, Extension: ext}
-
 	// create the verifier cs
-	Verify(api, pairingInfo, circuit.InnerVk, circuit.InnerProof, []frontend.Variable{circuit.Hash})
+	Verify(api, circuit.InnerVk, circuit.InnerProof, []frontend.Variable{circuit.Hash})
 
 	return nil
 }

--- a/std/groth16_bls24315/verifier.go
+++ b/std/groth16_bls24315/verifier.go
@@ -48,7 +48,7 @@ type VerifyingKey struct {
 // pubInputNames should what r1cs.PublicInputs() outputs for the inner r1cs.
 // It creates public circuits input, corresponding to the pubInputNames slice.
 // Notations and naming are from https://eprint.iacr.org/2020/278.
-func Verify(api frontend.API, pairingInfo sw_bls24315.PairingContext, innerVk VerifyingKey, innerProof Proof, innerPubInputs []frontend.Variable) {
+func Verify(api frontend.API, innerVk VerifyingKey, innerProof Proof, innerPubInputs []frontend.Variable) {
 
 	// compute psi0 using a sequence of multiexponentiations
 	// TODO maybe implement the bucket method with c=1 when there's a large input set
@@ -69,11 +69,11 @@ func Verify(api frontend.API, pairingInfo sw_bls24315.PairingContext, innerVk Ve
 
 	var resMillerLoop fields_bls24315.E24
 	// e(psi0, -gamma)*e(-πC, -δ)*e(πA, πB)
-	sw_bls24315.TripleMillerLoop(api, [3]sw_bls24315.G1Affine{psi0, innerProof.Krs, innerProof.Ar}, [3]sw_bls24315.G2Affine{innerVk.G2.GammaNeg, innerVk.G2.DeltaNeg, innerProof.Bs}, &resMillerLoop, pairingInfo)
+	sw_bls24315.TripleMillerLoop(api, [3]sw_bls24315.G1Affine{psi0, innerProof.Krs, innerProof.Ar}, [3]sw_bls24315.G2Affine{innerVk.G2.GammaNeg, innerVk.G2.DeltaNeg, innerProof.Bs}, &resMillerLoop)
 
 	// performs the final expo
 	var resPairing fields_bls24315.E24
-	resPairing.FinalExponentiation(api, resMillerLoop, pairingInfo.AteLoop, pairingInfo.Extension)
+	resPairing.FinalExponentiation(api, resMillerLoop)
 
 	// vk.E must be equal to resPairing
 	innerVk.E.MustBeEqual(api, resPairing)

--- a/std/groth16_bls24315/verifier_test.go
+++ b/std/groth16_bls24315/verifier_test.go
@@ -113,10 +113,6 @@ func (circuit *verifierCircuit) Define(api frontend.API) error {
 	ateLoop := uint64(3218079743)
 	ext := fields_bls24315.GetBLS24315ExtensionFp24(api)
 	pairingInfo := sw_bls24315.PairingContext{AteLoop: ateLoop, Extension: ext}
-	pairingInfo.BTwistCoeff.B0.A0 = 0
-	pairingInfo.BTwistCoeff.B0.A1 = 0
-	pairingInfo.BTwistCoeff.B1.A0 = 0
-	pairingInfo.BTwistCoeff.B1.A1 = "6108483493771298205388567675447533806912846525679192205394505462405828322019437284165171866703"
 
 	// create the verifier cs
 	Verify(api, pairingInfo, circuit.InnerVk, circuit.InnerProof, []frontend.Variable{circuit.Hash})

--- a/std/groth16_bls24315/verifier_test.go
+++ b/std/groth16_bls24315/verifier_test.go
@@ -28,7 +28,6 @@ import (
 	backend_bls24315 "github.com/consensys/gnark/internal/backend/bls24-315/cs"
 	groth16_bls24315 "github.com/consensys/gnark/internal/backend/bls24-315/groth16"
 	"github.com/consensys/gnark/internal/backend/bls24-315/witness"
-	"github.com/consensys/gnark/std/algebra/fields_bls24315"
 	"github.com/consensys/gnark/std/algebra/sw_bls24315"
 	"github.com/consensys/gnark/std/hash/mimc"
 	"github.com/consensys/gnark/test"
@@ -109,13 +108,8 @@ type verifierCircuit struct {
 
 func (circuit *verifierCircuit) Define(api frontend.API) error {
 
-	// pairing data
-	ateLoop := uint64(3218079743)
-	ext := fields_bls24315.GetBLS24315ExtensionFp24(api)
-	pairingInfo := sw_bls24315.PairingContext{AteLoop: ateLoop, Extension: ext}
-
 	// create the verifier cs
-	Verify(api, pairingInfo, circuit.InnerVk, circuit.InnerProof, []frontend.Variable{circuit.Hash})
+	Verify(api, circuit.InnerVk, circuit.InnerProof, []frontend.Variable{circuit.Hash})
 
 	return nil
 }


### PR DESCRIPTION
- fix: remove unused pairingContext.BTwistCoeff
- fix: remove unused pairingContext.BTwistCoeff
- clean: remove PairingContext and Extension objects from api calls in std/../pairing
