### PR TITLE
feat: add NoFuzzing() testing option

### DIFF
--- a/test/assert.go
+++ b/test/assert.go
@@ -170,11 +170,13 @@ func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment 
 		}
 	}
 
-	// TODO may not be the right place, but ensures all our tests call these minimal tests
-	// (like filling a witness with zeroes, or binary values, ...)
-	assert.Run(func(assert *Assert) {
-		assert.Fuzz(circuit, 5, opts...)
-	}, "fuzz")
+	if opt.fuzzing {
+		// TODO may not be the right place, but ensures all our tests call these minimal tests
+		// (like filling a witness with zeroes, or binary values, ...)
+		assert.Run(func(assert *Assert) {
+			assert.Fuzz(circuit, 5, opts...)
+		}, "fuzz")
+	}
 }
 
 // ProverSucceeded fails the test if any of the following step errored:
@@ -458,6 +460,7 @@ func (assert *Assert) options(opts ...TestingOption) testingConfig {
 		witnessSerialization: true,
 		backends:             backend.Implemented(),
 		curves:               gnark.Curves(),
+		fuzzing:              true,
 	}
 	for _, option := range opts {
 		err := option(&opt)

--- a/test/options.go
+++ b/test/options.go
@@ -33,6 +33,7 @@ type testingConfig struct {
 	witnessSerialization bool
 	proverOpts           []backend.ProverOption
 	compileOpts          []frontend.CompileOption
+	fuzzing              bool
 }
 
 // WithBackends is testing option which restricts the backends the assertions are
@@ -60,6 +61,14 @@ func WithCurves(c ecc.ID, curves ...ecc.ID) TestingOption {
 func NoSerialization() TestingOption {
 	return func(opt *testingConfig) error {
 		opt.witnessSerialization = false
+		return nil
+	}
+}
+
+// NoFuzzing is a testing option which disables fuzzing tests in assertions.
+func NoFuzzing() TestingOption {
+	return func(opt *testingConfig) error {
+		opt.fuzzing = false
 		return nil
 	}
 }


### PR DESCRIPTION
The new testing option allows to run assertions on `test.Assert` without fuzzing. My use case for running tests without fuzzing is in gadget where some errors panic to simplify the API.

Additionally, I was not sure if we should omit fuzzing when the tests are run in short mode? Should we?