### PR TITLE
clean: std/groth16 uses same notation as out-of-circuit groth16

### DIFF
--- a/std/groth16_bls12377/verifier.go
+++ b/std/groth16_bls12377/verifier.go
@@ -20,61 +20,58 @@ package groth16_bls12377
 import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/fields_bls12377"
-	"github.com/consensys/gnark/std/algebra/sw_bls12377"
+	bls12377 "github.com/consensys/gnark/std/algebra/sw_bls12377"
 )
 
-// Proof represents a groth16 proof in a r1cs
+// Proof represents a Groth16 proof
+// Notation follows Figure 4. in DIZK paper https://eprint.iacr.org/2018/691.pdf
 type Proof struct {
-	Ar, Krs sw_bls12377.G1Affine // πA, πC in https://eprint.iacr.org/2020/278.pdf
-	Bs      sw_bls12377.G2Affine // πB in https://eprint.iacr.org/2020/278.pdf
+	Ar, Krs bls12377.G1Affine
+	Bs      bls12377.G2Affine
 }
 
-// VerifyingKey represents the groth16 verifying key in a r1cs
+// VerifyingKey represents a Groth16 verifying key
+// Notation follows Figure 4. in DIZK paper https://eprint.iacr.org/2018/691.pdf
 type VerifyingKey struct {
-
 	// e(α, β)
 	E fields_bls12377.E12
 
 	// -[γ]2, -[δ]2
 	G2 struct {
-		GammaNeg, DeltaNeg sw_bls12377.G2Affine
+		GammaNeg, DeltaNeg bls12377.G2Affine
 	}
 
-	// [Kvk]1 (part of the verifying key yielding psi0, cf https://eprint.iacr.org/2020/278.pdf)
-	G1 []sw_bls12377.G1Affine // The indexes correspond to the public wires
+	// [Kvk]1
+	G1 struct {
+		K []bls12377.G1Affine // The indexes correspond to the public wires
+	}
 }
 
-// Verify implements the verification function of groth16.
-// pubInputNames should what r1cs.PublicInputs() outputs for the inner r1cs.
-// It creates public circuits input, corresponding to the pubInputNames slice.
-// Notations and naming are from https://eprint.iacr.org/2020/278.
-func Verify(api frontend.API, innerVk VerifyingKey, innerProof Proof, innerPubInputs []frontend.Variable) {
-
-	// compute psi0 using a sequence of multiexponentiations
-	// TODO maybe implement the bucket method with c=1 when there's a large input set
-	var psi0, tmp sw_bls12377.G1Affine
-
-	if len(innerVk.G1) == 0 {
+// Verify implements the verification function of Groth16.
+// Notation follows Figure 4. in DIZK paper https://eprint.iacr.org/2018/691.pdf
+// publicInputs do NOT contain the ONE_WIRE
+func Verify(api frontend.API, vk VerifyingKey, proof Proof, publicInputs []frontend.Variable) {
+	if len(vk.G1.K) == 0 {
 		panic("innver verifying key needs at least one point; VerifyingKey.G1 must be initialized before compiling circuit")
 	}
 
-	// assign the initial psi0 to the part of the public key corresponding to one_wire
-	// note this assumes ONE_WIRE is at position 0
-	psi0.X = innerVk.G1[0].X
-	psi0.Y = innerVk.G1[0].Y
+	// compute kSum = Σx.[Kvk(t)]1
+	var kSum bls12377.G1Affine
 
-	for k, v := range innerPubInputs {
-		tmp.ScalarMul(api, innerVk.G1[k+1], v)
-		psi0.AddAssign(api, tmp)
+	// kSum = Kvk[0] (assumes ONE_WIRE is at position 0)
+	kSum.X = vk.G1.K[0].X
+	kSum.Y = vk.G1.K[0].Y
+
+	for k, v := range publicInputs {
+		var ki bls12377.G1Affine
+		ki.ScalarMul(api, vk.G1.K[k+1], v)
+		kSum.AddAssign(api, ki)
 	}
 
-	// e(psi0, -gamma)*e(-πC, -δ)*e(πA, πB)
-	resMillerLoop, _ := sw_bls12377.MillerLoop(api, []sw_bls12377.G1Affine{psi0, innerProof.Krs, innerProof.Ar}, []sw_bls12377.G2Affine{innerVk.G2.GammaNeg, innerVk.G2.DeltaNeg, innerProof.Bs})
+	// compute e(Σx.[Kvk(t)]1, -[γ]2) * e(Krs,δ) * e(Ar,Bs)
+	ml, _ := bls12377.MillerLoop(api, []bls12377.G1Affine{kSum, proof.Krs, proof.Ar}, []bls12377.G2Affine{vk.G2.GammaNeg, vk.G2.DeltaNeg, proof.Bs})
+	pairing := bls12377.FinalExponentiation(api, ml)
 
-	// performs the final expo
-	resPairing := sw_bls12377.FinalExponentiation(api, resMillerLoop)
-
-	// vk.E must be equal to resPairing
-	innerVk.E.AssertIsEqual(api, resPairing)
-
+	// vk.E must be equal to pairing
+	vk.E.AssertIsEqual(api, pairing)
 }

--- a/std/groth16_bls12377/verifier_test.go
+++ b/std/groth16_bls12377/verifier_test.go
@@ -122,7 +122,7 @@ func TestVerifier(t *testing.T) {
 
 	// create an empty cs
 	var circuit verifierCircuit
-	circuit.InnerVk.G1 = make([]sw_bls12377.G1Affine, len(innerVk.G1.K))
+	circuit.InnerVk.G1.K = make([]sw_bls12377.G1Affine, len(innerVk.G1.K))
 
 	// create assignment, the private part consists of the proof,
 	// the public part is exactly the public part of the inner proof,
@@ -139,9 +139,9 @@ func TestVerifier(t *testing.T) {
 	}
 	witness.InnerVk.E.Assign(&e)
 
-	witness.InnerVk.G1 = make([]sw_bls12377.G1Affine, len(innerVk.G1.K))
+	witness.InnerVk.G1.K = make([]sw_bls12377.G1Affine, len(innerVk.G1.K))
 	for i, vkg := range innerVk.G1.K {
-		witness.InnerVk.G1[i].Assign(&vkg)
+		witness.InnerVk.G1.K[i].Assign(&vkg)
 	}
 	var deltaNeg, gammaNeg bls12377.G2Affine
 	deltaNeg.Neg(&innerVk.G2.Delta)
@@ -187,7 +187,7 @@ func BenchmarkCompile(b *testing.B) {
 
 	// create an empty cs
 	var circuit verifierCircuit
-	circuit.InnerVk.G1 = make([]sw_bls12377.G1Affine, len(innerVk.G1.K))
+	circuit.InnerVk.G1.K = make([]sw_bls12377.G1Affine, len(innerVk.G1.K))
 
 	var ccs frontend.CompiledConstraintSystem
 	b.ResetTimer()

--- a/std/groth16_bls24315/verifier.go
+++ b/std/groth16_bls24315/verifier.go
@@ -20,60 +20,59 @@ package groth16_bls24315
 import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/fields_bls24315"
-	"github.com/consensys/gnark/std/algebra/sw_bls24315"
+	bls24315 "github.com/consensys/gnark/std/algebra/sw_bls24315"
 )
 
-// Proof represents a groth16 proof in a r1cs
+// Proof represents a Groth16 proof
+// Notation follows Figure 4. in DIZK paper https://eprint.iacr.org/2018/691.pdf
 type Proof struct {
-	Ar, Krs sw_bls24315.G1Affine // πA, πC in https://eprint.iacr.org/2020/278.pdf
-	Bs      sw_bls24315.G2Affine // πB in https://eprint.iacr.org/2020/278.pdf
+	Ar, Krs bls24315.G1Affine
+	Bs      bls24315.G2Affine
 }
 
-// VerifyingKey represents the groth16 verifying key in a r1cs
+// VerifyingKey represents a Groth16 verifying key
+// Notation follows Figure 4. in DIZK paper https://eprint.iacr.org/2018/691.pdf
 type VerifyingKey struct {
-
 	// e(α, β)
 	E fields_bls24315.E24
 
 	// -[γ]2, -[δ]2
 	G2 struct {
-		GammaNeg, DeltaNeg sw_bls24315.G2Affine
+		GammaNeg, DeltaNeg bls24315.G2Affine
 	}
 
-	// [Kvk]1 (part of the verifying key yielding psi0, cf https://eprint.iacr.org/2020/278.pdf)
-	G1 []sw_bls24315.G1Affine // The indexes correspond to the public wires
+	// [Kvk]1
+	G1 struct {
+		K []bls24315.G1Affine // The indexes correspond to the public wires
+	}
 }
 
-// Verify implements the verification function of groth16.
-// pubInputNames should what r1cs.PublicInputs() outputs for the inner r1cs.
-// It creates public circuits input, corresponding to the pubInputNames slice.
-// Notations and naming are from https://eprint.iacr.org/2020/278.
-func Verify(api frontend.API, innerVk VerifyingKey, innerProof Proof, innerPubInputs []frontend.Variable) {
-
-	// compute psi0 using a sequence of multiexponentiations
-	// TODO maybe implement the bucket method with c=1 when there's a large input set
-	var psi0, tmp sw_bls24315.G1Affine
-
-	// assign the initial psi0 to the part of the public key corresponding to one_wire
-	// note this assumes ONE_WIRE is at position 0
-	if len(innerVk.G1) == 0 {
+// Verify implements the verification function of Groth16.
+// Notation follows Figure 4. in DIZK paper https://eprint.iacr.org/2018/691.pdf
+// publicInputs do NOT contain the ONE_WIRE
+func Verify(api frontend.API, vk VerifyingKey, proof Proof, publicInputs []frontend.Variable) {
+	if len(vk.G1.K) == 0 {
 		panic("innver verifying key needs at least one point; VerifyingKey.G1 must be initialized before compiling circuit")
 	}
-	psi0.X = innerVk.G1[0].X
-	psi0.Y = innerVk.G1[0].Y
 
-	for k, v := range innerPubInputs {
-		tmp.ScalarMul(api, innerVk.G1[k+1], v)
-		psi0.AddAssign(api, tmp)
+	// compute kSum = Σx.[Kvk(t)]1
+	var kSum bls24315.G1Affine
+
+	// kSum = Kvk[0] (assumes ONE_WIRE is at position 0)
+	kSum.X = vk.G1.K[0].X
+	kSum.Y = vk.G1.K[0].Y
+
+	for k, v := range publicInputs {
+		var ki bls24315.G1Affine
+		ki.ScalarMul(api, vk.G1.K[k+1], v)
+		kSum.AddAssign(api, ki)
 	}
 
-	// e(psi0, -gamma)*e(-πC, -δ)*e(πA, πB)
-	resMillerLoop, _ := sw_bls24315.MillerLoop(api, []sw_bls24315.G1Affine{psi0, innerProof.Krs, innerProof.Ar}, []sw_bls24315.G2Affine{innerVk.G2.GammaNeg, innerVk.G2.DeltaNeg, innerProof.Bs})
+	// compute e(Σx.[Kvk(t)]1, -[γ]2) * e(Krs,δ) * e(Ar,Bs)
+	ml, _ := bls24315.MillerLoop(api, []bls24315.G1Affine{kSum, proof.Krs, proof.Ar}, []bls24315.G2Affine{vk.G2.GammaNeg, vk.G2.DeltaNeg, proof.Bs})
+	pairing := bls24315.FinalExponentiation(api, ml)
 
-	// performs the final expo
-	resPairing := sw_bls24315.FinalExponentiation(api, resMillerLoop)
-
-	// vk.E must be equal to resPairing
-	innerVk.E.AssertIsEqual(api, resPairing)
+	// vk.E must be equal to pairing
+	vk.E.AssertIsEqual(api, pairing)
 
 }

--- a/std/groth16_bls24315/verifier_test.go
+++ b/std/groth16_bls24315/verifier_test.go
@@ -36,12 +36,14 @@ import (
 //--------------------------------------------------------------------
 // utils
 
-const preimage string = "4992816046196248432836492760315135318126925090839638585255611512962528270024"
-const publicHash string = "740442171083661049659184837119506324904268940878674425328909705936292585001"
+const (
+	preImage   = "4992816046196248432836492760315135318126925090839638585255611512962528270024"
+	publicHash = "740442171083661049659184837119506324904268940878674425328909705936292585001"
+)
 
 type mimcCircuit struct {
-	Data frontend.Variable
-	Hash frontend.Variable `gnark:",public"`
+	PreImage frontend.Variable
+	Hash     frontend.Variable `gnark:",public"`
 }
 
 func (circuit *mimcCircuit) Define(api frontend.API) error {
@@ -49,10 +51,8 @@ func (circuit *mimcCircuit) Define(api frontend.API) error {
 	if err != nil {
 		return err
 	}
-	//result := mimc.Sum(circuit.Data)
-	mimc.Write(circuit.Data)
-	result := mimc.Sum()
-	api.AssertIsEqual(result, circuit.Hash)
+	mimc.Write(circuit.PreImage)
+	api.AssertIsEqual(mimc.Sum(), circuit.Hash)
 	return nil
 }
 
@@ -61,18 +61,23 @@ func (circuit *mimcCircuit) Define(api frontend.API) error {
 func generateBls24315InnerProof(t *testing.T, vk *groth16_bls24315.VerifyingKey, proof *groth16_bls24315.Proof) {
 
 	// create a mock cs: knowing the preimage of a hash using mimc
-	var circuit, w mimcCircuit
+	var circuit, assignment mimcCircuit
 	r1cs, err := frontend.Compile(ecc.BLS24_315, r1cs.NewBuilder, &circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	w.Data = preimage
-	w.Hash = publicHash
+	assignment.PreImage = preImage
+	assignment.Hash = publicHash
 
-	correctAssignment := witness.Witness{}
+	var witness, publicWitness witness.Witness
 
-	_, err = correctAssignment.FromAssignment(&w, tVariable, false)
+	_, err = witness.FromAssignment(&assignment, tVariable, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = publicWitness.FromAssignment(&assignment, tVariable, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +85,7 @@ func generateBls24315InnerProof(t *testing.T, vk *groth16_bls24315.VerifyingKey,
 	// generate the data to return for the bls24315 proof
 	var pk groth16_bls24315.ProvingKey
 	groth16_bls24315.Setup(r1cs.(*backend_bls24315.R1CS), &pk, vk)
-	_proof, err := groth16_bls24315.Prove(r1cs.(*backend_bls24315.R1CS), &pk, correctAssignment, backend.ProverConfig{})
+	_proof, err := groth16_bls24315.Prove(r1cs.(*backend_bls24315.R1CS), &pk, witness, backend.ProverConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,14 +93,8 @@ func generateBls24315InnerProof(t *testing.T, vk *groth16_bls24315.VerifyingKey,
 	proof.Bs = _proof.Bs
 	proof.Krs = _proof.Krs
 
-	correctAssignmentPublic := witness.Witness{}
-	_, err = correctAssignmentPublic.FromAssignment(&w, tVariable, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// before returning verifies that the proof passes on bls24315
-	if err := groth16_bls24315.Verify(proof, vk, correctAssignmentPublic); err != nil {
+	if err := groth16_bls24315.Verify(proof, vk, publicWitness); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -123,7 +122,7 @@ func TestVerifier(t *testing.T) {
 
 	// create an empty cs
 	var circuit verifierCircuit
-	circuit.InnerVk.G1 = make([]sw_bls24315.G1Affine, len(innerVk.G1.K))
+	circuit.InnerVk.G1.K = make([]sw_bls24315.G1Affine, len(innerVk.G1.K))
 
 	// create assignment, the private part consists of the proof,
 	// the public part is exactly the public part of the inner proof,
@@ -140,9 +139,9 @@ func TestVerifier(t *testing.T) {
 	}
 	witness.InnerVk.E.Assign(&e)
 
-	witness.InnerVk.G1 = make([]sw_bls24315.G1Affine, len(innerVk.G1.K))
+	witness.InnerVk.G1.K = make([]sw_bls24315.G1Affine, len(innerVk.G1.K))
 	for i, vkg := range innerVk.G1.K {
-		witness.InnerVk.G1[i].Assign(&vkg)
+		witness.InnerVk.G1.K[i].Assign(&vkg)
 	}
 	var deltaNeg, gammaNeg bls24315.G2Affine
 	deltaNeg.Neg(&innerVk.G2.Delta)
@@ -187,7 +186,7 @@ func BenchmarkCompile(b *testing.B) {
 
 	// create an empty cs
 	var circuit verifierCircuit
-	circuit.InnerVk.G1 = make([]sw_bls24315.G1Affine, len(innerVk.G1.K))
+	circuit.InnerVk.G1.K = make([]sw_bls24315.G1Affine, len(innerVk.G1.K))
 
 	var ccs frontend.CompiledConstraintSystem
 	b.ResetTimer()


### PR DESCRIPTION
- clean: std/groth16 notation matches out-of-circuit Groth16 notation
- clean: std/groth16 notation matches out-of-circuit Groth16 notation
