### PR TITLE
perf[nonnative]: implement optimisations for field emulation

### DIFF
--- a/std/math/nonnative/composition.go
+++ b/std/math/nonnative/composition.go
@@ -68,24 +68,9 @@ func decompose(input *big.Int, nbBits uint, res []*big.Int) error {
 // then no such underflow happens and s = a-b (mod p) as the padding is multiple
 // of p.
 func subPadding(params *Params, current_overflow uint, nbLimbs uint) []*big.Int {
-	// TODO: this method tries to generalize computing the padding both for
-	// reduced and unreduced element. maybe separate two methods for clarity?
 	padLimbs := make([]*big.Int, nbLimbs)
 	for i := 0; i < len(padLimbs); i++ {
 		padLimbs[i] = new(big.Int).Lsh(big.NewInt(1), uint(current_overflow)+params.nbBits)
-	}
-	topBits := 2*((uint(params.r.BitLen())-1)%params.nbBits+1) + 1
-	// here is some magic -- if the number of limbs is 2*nbLimbs-1, then we are
-	// computing the padding for the unreduced multiplication result. If the
-	// number of limbs is less then we can not assume the individual overflows
-	// of the limbs.
-	// it would be nice to keep track on the overflow for every individual limbs
-	// (and particularly in the multiplication method as the overflows are not
-	// uniformly distributed) and take this account in the construction of this
-	// padding. But we currently do not have sufficient information (i.e.
-	// anything beyond the current overflow and number of limbs) to do that.
-	if nbLimbs == 2*params.nbLimbs-1 {
-		padLimbs[nbLimbs-1] = new(big.Int).Lsh(big.NewInt(1), topBits)
 	}
 	pad := new(big.Int)
 	if err := recompose(padLimbs, params.nbBits, pad); err != nil {

--- a/std/math/nonnative/composition.go
+++ b/std/math/nonnative/composition.go
@@ -91,6 +91,9 @@ func subPadding(params *Params, current_overflow uint, nbLimbs uint) []*big.Int 
 	return ret
 }
 
+// regroupParams returns parameters which allow for most optimal regrouping of
+// limbs. In regrouping the limbs, we encode multiple existing limbs as a linear
+// combination in a single new limb.
 func regroupParams(params *Params, nbNativeBits, nbMaxOverflow uint) *Params {
 	// subtract one bit as can not potentially use all bits of Fr and one bit as
 	// grouping may overflow
@@ -110,6 +113,7 @@ func regroupParams(params *Params, nbNativeBits, nbMaxOverflow uint) *Params {
 	}
 }
 
+// regroupLimbs perform the regrouping of limbs between old and new parameters.
 func regroupLimbs(api frontend.API, params, regroupParams *Params, limbs []frontend.Variable) []frontend.Variable {
 	if params.nbBits == regroupParams.nbBits {
 		// not regrouping

--- a/std/math/nonnative/doc.go
+++ b/std/math/nonnative/doc.go
@@ -135,16 +135,15 @@ The package provides two ways to check equality -- limb-wise equality check and
 checking equality by value.
 
 In the limb-wise equality check we check that the integer values of the elements
-x and y are equal. If the overflows of the elements are equal, then we can
-perform limb-wise equality check. If the overflows are not equal, then we have
-to carry the excess using bit decomposition (which makes the computation fairly
-inefficient). To reduce the number of bit decompositions, then we instead carry
-over the excess of the difference of the limbs instead. As we take the
-difference, then similarly as computing the padding in subtraction algorithm, we
-need to add padding to the limbs before subtracting limb-wise to avoid
-underflows. However, the padding in this case is slightly different -- we do not
-need the padding to be divisible, but instead need that the padding has
-particular bit decomposition.
+x and y are equal. We have to carry the excess using bit decomposition (which
+makes the computation fairly inefficient). To reduce the number of bit
+decompositions, we instead carry over the excess of the difference of the limbs
+instead. As we take the difference, then similarly as computing the padding in
+subtraction algorithm, we need to add padding to the limbs before subtracting
+limb-wise to avoid underflows. However, the padding in this case is slightly
+different -- we do not need the padding to be divisible by the modulus, but
+instead need that the limb padding is larger than the limb which is being
+subtracted.
 
 Lets look at the algorithm itself. We assume that the overflow f of x is larger
 than y. If overflow of y is larger, then we can just swap the arguments and
@@ -162,6 +161,15 @@ to next limb:
 Finally, after we have compared all the limbs, we still need to check that the
 final carry corresponds to the padding. We add final check:
     carry_k == maxValueShift.
+
+We can further optimise the limb-wise equality check by first regrouping the
+limbs. The idea is to group several limbs so that the result would still fit
+into the scalar field. If
+    x = ∑_{i=0}^k x_i 2^{w i},
+then we can instead take w' divisible by w such that
+    x = ∑_{i=0}^(k/(w'/w)) x'_i 2^{w' i},
+where
+    x'_j = ∑_{i=0}^(w'/w) x_{j*w'/w+i} 2^{w i}.
 
 For element value equality check, we check that two elements x and y are equal
 modulo r and for that we need to show that r divides x-y. As mentioned in the

--- a/std/math/nonnative/variable.go
+++ b/std/math/nonnative/variable.go
@@ -260,8 +260,6 @@ func assertLimbsEqualitySlow(api frontend.API, l, r []frontend.Variable, nbBits,
 	maxValue := new(big.Int).Lsh(big.NewInt(1), nbBits+nbCarryBits)
 	maxValueShift := new(big.Int).Lsh(big.NewInt(1), nbCarryBits)
 
-	// TODO: group carries. xjsnark paper describes that we can actually compute
-	// a carry over multiple limbs (assuming the limbs are small enough).
 	var carry frontend.Variable = 0
 	for i := 0; i < nbLimbs; i++ {
 		diff := api.Add(maxValue, carry)
@@ -376,11 +374,6 @@ func (e *Element) Add(a, b Element) *Element {
 // Mul sets e to a*b and returns e. The returned element may not be reduced to
 // be less than the ring modulus.
 func (e *Element) Mul(a, b Element) *Element {
-	// TODO: we mistakenly assume here that the factors are completely reduced
-	// (their overflow is zero). Actually, we should be able to compute product
-	// even when the results have non-zero factor. We should add checks if the
-	// multiplication result would not fit into the scalar result and compute
-	// the overflow of the result accordingly.
 	// XXX: currently variable case only
 	// TODO: when one element is constant.
 	// TODO: check that target is initialized (has an API)

--- a/std/math/nonnative/variable.go
+++ b/std/math/nonnative/variable.go
@@ -274,16 +274,14 @@ func assertLimbsEqualitySlow(api frontend.API, l, r []frontend.Variable, nbBits,
 		if i > 0 {
 			diff = api.Sub(diff, maxValueShift)
 		}
-		// TODO: instead of full binary decomposition, do unconstrained
-		// decomposition and check that the bits are zeros. Does not make
-		// difference for R1CS but should require fever constraints for PLONK.
 		// TODO: more efficient methods for splitting a variable? Because we are
 		// splitting the value into two, then maybe we do not need the whole
 		// binary decomposition \sum_{i=0}^n a_i 2^i, but can use a * 2^nbits +
 		// b. Then we can also omit the FromBinary call.
-		diffBits := bits.ToBinary(api, diff, bits.WithNbDigits(int(nbBits+nbCarryBits+1)))
-		diffMain := bits.FromBinary(api, diffBits[:nbBits])
-		api.AssertIsEqual(diffMain, 0)
+		diffBits := bits.ToBinary(api, diff, bits.WithNbDigits(int(nbBits+nbCarryBits+1)), bits.WithUnconstrainedOutputs())
+		for j := uint(0); j < nbBits; j++ {
+			api.AssertIsEqual(diffBits[j], 0)
+		}
 		carry = bits.FromBinary(api, diffBits[nbBits:nbBits+nbCarryBits+1])
 	}
 	api.AssertIsEqual(carry, maxValueShift)

--- a/std/math/nonnative/variable.go
+++ b/std/math/nonnative/variable.go
@@ -433,7 +433,6 @@ func (e *Element) Reduce(a Element) *Element {
 	}
 	e.Limbs = r
 	e.overflow = 0
-	e.EnforceWidth()
 	e.AssertIsEqual(a)
 	return e
 }

--- a/std/math/nonnative/variable.go
+++ b/std/math/nonnative/variable.go
@@ -289,15 +289,6 @@ func assertLimbsEqualitySlow(api frontend.API, l, r []frontend.Variable, nbBits,
 // to overflow). This method does not ensure that the values are equal modulo
 // the field order. For strict equality, use AssertIsEqual.
 func (e *Element) AssertLimbsEquality(a Element) {
-	// fast path -- no overflow -- can just compare limb-wise
-	if a.overflow == e.overflow {
-		// TODO: not complete - we should also ensure that len(e.Limbs) <=
-		// len(a.Limbs) and ensure that rest of e.Limbs are zero
-		for i := range a.Limbs {
-			e.api.AssertIsEqual(a.Limbs[i], e.Limbs[i])
-		}
-		return
-	}
 	maxOverflow := e.overflow
 	if a.overflow > e.overflow {
 		maxOverflow = a.overflow

--- a/std/math/nonnative/variable.go
+++ b/std/math/nonnative/variable.go
@@ -414,7 +414,7 @@ func (e *Element) Mul(a, b Element) *Element {
 		e.api.AssertIsEqual(e.api.Mul(l, r), o)
 	}
 	e.Limbs = limbs
-	e.overflow = e.params.nbBits + uint(math.Log2(float64(2*e.params.nbLimbs-1))) + 1
+	e.overflow = e.params.nbBits + uint(math.Log2(float64(2*len(limbs)-1))) + 1 + a.overflow + b.overflow
 	// result is not reduced
 	return e
 }
@@ -455,7 +455,7 @@ func (e *Element) Set(a Element) {
 func (e *Element) AssertIsEqual(a Element) {
 	diff := e.params.Element(e.api)
 	diff.Sub(a, *e)
-	kLimbs, err := computeEqualityHint(e.api, e.params, diff.Limbs)
+	kLimbs, err := computeEqualityHint(e.api, e.params, diff)
 	if err != nil {
 		panic(fmt.Sprintf("hint error: %v", err))
 	}

--- a/std/math/nonnative/variable_test.go
+++ b/std/math/nonnative/variable_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/frontend/cs/scs"
 	"github.com/consensys/gnark/test"
 )
 
@@ -840,7 +841,10 @@ func TestOptimisation(t *testing.T) {
 	}
 	ccs, err := frontend.Compile(testCurve, r1cs.NewBuilder, &circuit)
 	assert.NoError(err)
-	assert.LessOrEqual(ccs.GetNbConstraints(), 3016)
+	assert.LessOrEqual(ccs.GetNbConstraints(), 3006)
+	ccs2, err := frontend.Compile(testCurve, scs.NewBuilder, &circuit)
+	assert.NoError(err)
+	assert.LessOrEqual(ccs2.GetNbConstraints(), 9407)
 }
 
 type RegroupCircuit struct {

--- a/std/math/nonnative/variable_test.go
+++ b/std/math/nonnative/variable_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/test"
 )
 
@@ -715,7 +716,8 @@ func TestLookup2(t *testing.T) {
 }
 
 type ComputationCircuit struct {
-	params *Params
+	params   *Params
+	noReduce bool
 
 	X1, X2, X3, X4, X5, X6 Element
 	Res                    Element
@@ -725,9 +727,13 @@ func (c *ComputationCircuit) Define(api frontend.API) error {
 	// compute x1^3 + 5*x2 + (x3-x4) / (x5+x6)
 	x13 := c.params.Element(api)
 	x13.Mul(c.X1, c.X1)
-	x13.Reduce(x13)
+	if !c.noReduce {
+		x13.Reduce(x13)
+	}
 	x13.Mul(x13, c.X1)
-	x13.Reduce(x13)
+	if !c.noReduce {
+		x13.Reduce(x13)
+	}
 
 	fx2 := c.params.Element(api)
 	five, err := c.params.ConstantFromBig(big.NewInt(5))
@@ -811,6 +817,71 @@ func TestComputation(t *testing.T) {
 				X5:     params.ConstantFromBigOrPanic(val5),
 				X6:     params.ConstantFromBigOrPanic(val6),
 				Res:    params.ConstantFromBigOrPanic(res),
+			}
+			assert.ProverSucceeded(&circuit, &witness, test.WithProverOpts(backend.WithHints(GetHints()...)), test.WithCurves(testCurve))
+		}, testName(fp))
+	}
+}
+
+func TestOptimisation(t *testing.T) {
+	assert := test.NewAssert(t)
+	params, err := NewParams(32, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	circuit := ComputationCircuit{
+		params:   params,
+		noReduce: true,
+		X1:       params.Placeholder(),
+		X2:       params.Placeholder(),
+		X3:       params.Placeholder(),
+		X4:       params.Placeholder(),
+		X5:       params.Placeholder(),
+		X6:       params.Placeholder(),
+		Res:      params.Placeholder(),
+	}
+	ccs, err := frontend.Compile(testCurve, r1cs.NewBuilder, &circuit)
+	assert.NoError(err)
+	assert.LessOrEqual(ccs.GetNbConstraints(), 3016)
+}
+
+type RegroupCircuit struct {
+	params *Params
+
+	A Element
+	B Element
+	C Element
+}
+
+func (c *RegroupCircuit) Define(api frontend.API) error {
+	res := c.params.Element(api)
+	res.Add(c.A, c.B)
+	res.AssertLimbsEquality(c.C)
+	params2 := regroupParams(c.params, uint(api.Compiler().FieldBitLen()), res.overflow)
+	res2 := params2.From(api, res)
+	C2 := params2.From(api, c.C)
+	res2.AssertLimbsEquality(C2)
+	return nil
+}
+
+func TestRegroupCircuit(t *testing.T) {
+	for _, fp := range emulatedFields(t) {
+		params := fp.params
+		assert := test.NewAssert(t)
+		assert.Run(func(assert *test.Assert) {
+			circuit := RegroupCircuit{
+				params: params,
+				A:      params.Placeholder(),
+				B:      params.Placeholder(),
+				C:      params.Placeholder(),
+			}
+
+			val1, _ := rand.Int(rand.Reader, new(big.Int).Div(params.r, big.NewInt(2)))
+			val2, _ := rand.Int(rand.Reader, new(big.Int).Div(params.r, big.NewInt(2)))
+			res := new(big.Int).Add(val1, val2)
+			witness := RegroupCircuit{
+				params: params,
+				A:      params.ConstantFromBigOrPanic(val1),
+				B:      params.ConstantFromBigOrPanic(val2),
+				C:      params.ConstantFromBigOrPanic(res),
 			}
 			assert.ProverSucceeded(&circuit, &witness, test.WithProverOpts(backend.WithHints(GetHints()...)), test.WithCurves(testCurve))
 		}, testName(fp))


### PR DESCRIPTION
Slight fixes needed for lazy reduction and limb grouping for faster equality check.

Is blocked by #302 and will rebase after it is merged.

Related #315.