### PR TITLE
feat: implement test engine options

### DIFF
--- a/test/assert.go
+++ b/test/assert.go
@@ -132,7 +132,7 @@ func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment 
 				checkError(err)
 
 				// must not error with big int test engine (only the curveID is needed for this test)
-				err = IsSolved(circuit, validAssignment, curve, backend.UNKNOWN)
+				err = IsSolved(circuit, validAssignment, curve)
 				checkError(err)
 
 				assert.t.Parallel()
@@ -211,7 +211,7 @@ func (assert *Assert) ProverFailed(circuit frontend.Circuit, invalidAssignment f
 				checkError(err)
 
 				// must error with big int test engine (only the curveID is needed here)
-				err = IsSolved(circuit, invalidAssignment, curve, backend.UNKNOWN)
+				err = IsSolved(circuit, invalidAssignment, curve)
 				mustError(err)
 
 				assert.t.Parallel()
@@ -274,7 +274,7 @@ func (assert *Assert) solvingSucceeded(circuit frontend.Circuit, validAssignment
 	checkError(err)
 
 	// must not error with big int test engine
-	err = IsSolved(circuit, validAssignment, curve, b)
+	err = IsSolved(circuit, validAssignment, curve, WithBackend(b))
 	checkError(err)
 
 	err = ccs.IsSolved(validWitness, opt.proverOpts...)
@@ -309,7 +309,7 @@ func (assert *Assert) solvingFailed(circuit frontend.Circuit, invalidAssignment 
 	checkError(err)
 
 	// must error with big int test engine
-	err = IsSolved(circuit, invalidAssignment, curve, b)
+	err = IsSolved(circuit, invalidAssignment, curve, WithBackend(b))
 	mustError(err)
 
 	err = ccs.IsSolved(invalidWitness, opt.proverOpts...)
@@ -383,9 +383,10 @@ func (assert *Assert) fuzzer(fuzzer filler, circuit, w frontend.Circuit, b backe
 	// fuzz a witness
 	fuzzer(w, curve)
 
-	err := IsSolved(circuit, w, curve, b)
+	errVars := IsSolved(circuit, w, curve, WithBackend(b))
+	errConsts := IsSolved(circuit, w, curve, WithBackend(b), SetAllVariablesAsConstants())
 
-	if err == nil {
+	if errVars == nil && errConsts == nil {
 		// valid witness
 		assert.solvingSucceeded(circuit, w, b, curve, opt)
 		return 1

--- a/test/engine_test.go
+++ b/test/engine_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark"
-	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/math/bits"
@@ -50,14 +49,14 @@ func TestBuiltinHints(t *testing.T) {
 		if err := IsSolved(&hintCircuit{}, &hintCircuit{
 			A: (0b1000),
 			B: (0),
-		}, curve, backend.UNKNOWN); err != nil {
+		}, curve); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := IsSolved(&hintCircuit{}, &hintCircuit{
 			A: (0b10),
 			B: (1),
-		}, curve, backend.UNKNOWN); err == nil {
+		}, curve); err == nil {
 			t.Fatal("witness shouldn't solve circuit")
 		}
 	}


### PR DESCRIPTION
Added options for the test engine and moved a an argument into the option. Additionally, added a new option for wrapping API and a boolean for defining the return value of the methods `ConstantValue` and `IsConstant`.

API wrapping was done to ease the testing of existing circuits using non-native field arithmetic.

Option for defining the constant values can be used to verify different code-paths in the circuits. I also changed the way fuzzer works -- now it checks that the test engine solves the circuit for both option and only if the test engine succeeds for both options (all vars constants or not), calls the actual prover.