### PR TITLE
perf: allocate less in test engine

### DIFF
--- a/internal/backend/circuits/div.go
+++ b/internal/backend/circuits/div.go
@@ -31,6 +31,7 @@ func init() {
 	m := ecc.BN254.ScalarField()
 	var c big.Int
 	c.ModInverse(b, m).Mul(&c, a)
+	c.Mod(&c, m)
 
 	// good.A = a
 	good.A = a


### PR DESCRIPTION
At every API call utils.FromInterface method was called. This method always
allocates new *big.Int, which is very stressful for the runtime. Instead, we
first check if the variable is already *big.Int and return it otherwise. Only
if type assertion fails do we allocate new *big.Int.

Now, as we do not allocate every time, we had to change the API calls to
allocate a new result, so that we wouldn't mutate the passed in values.