### PR TITLE
refactor: allow builder to interact with schema parser

### DIFF
--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"math/big"
+	"reflect"
 
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend/schema"
@@ -65,6 +66,10 @@ type Builder interface {
 
 	// Compile is called after circuit.Define() to produce a final IR (CompiledConstraintSystem)
 	Compile() (CompiledConstraintSystem, error)
+
+	// VariableCount returns the number of native elements required to represent
+	// the given reflected type as a witness.
+	VariableCount(reflect.Type) int
 
 	// SetSchema is used internally by frontend.Compile to set the circuit schema
 	SetSchema(*schema.Schema)

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -76,9 +76,9 @@ type Builder interface {
 
 	// AddPublicVariable is called by the compiler when parsing the circuit schema. It panics if
 	// called inside circuit.Define()
-	AddPublicVariable(name string) Variable
+	AddPublicVariable(field *schema.Field) Variable
 
 	// AddSecretVariable is called by the compiler when parsing the circuit schema. It panics if
 	// called inside circuit.Define()
-	AddSecretVariable(name string) Variable
+	AddSecretVariable(field *schema.Field) Variable
 }

--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -79,25 +79,25 @@ func parseCircuit(builder Builder, circuit Circuit) (err error) {
 
 	// leaf handlers are called when encoutering leafs in the circuit data struct
 	// leafs are Constraints that need to be initialized in the context of compiling a circuit
-	var handler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
+	adderHandler := func(f *schema.Field, tInput reflect.Value) error {
 		if tInput.CanSet() {
 			// log.Trace().Str("name", name).Str("visibility", visibility.String()).Msg("init input wire")
-			switch visibility {
+			switch f.Visibility {
 			case schema.Secret:
-				tInput.Set(reflect.ValueOf(builder.AddSecretVariable(name)))
+				tInput.Set(reflect.ValueOf(builder.AddSecretVariable(f)))
 			case schema.Public:
-				tInput.Set(reflect.ValueOf(builder.AddPublicVariable(name)))
+				tInput.Set(reflect.ValueOf(builder.AddPublicVariable(f)))
 			case schema.Unset:
-				return errors.New("can't set val " + name + " visibility is unset")
+				return errors.New("can't set val " + f.FullName + " visibility is unset")
 			}
 
 			return nil
 		}
-		return errors.New("can't set val " + name)
+		return errors.New("can't set val " + f.FullName)
 	}
 	// recursively parse through reflection the circuits members to find all Constraints that need to be allocated
 	// (secret or public inputs)
-	_, err = schema.Parse(circuit, tVariable, handler)
+	_, err = schema.Parse(circuit, tVariable, adderHandler)
 	if err != nil {
 		return err
 	}

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -523,7 +523,7 @@ func (system *r1cs) Println(a ...frontend.Variable) {
 func printArg(log *compiled.LogEntry, sbb *strings.Builder, a frontend.Variable) {
 
 	count := 0
-	counter := func(visibility schema.Visibility, name string, tValue reflect.Value) error {
+	counter := func(f *schema.Field, tValue reflect.Value) error {
 		count++
 		return nil
 	}
@@ -537,9 +537,9 @@ func printArg(log *compiled.LogEntry, sbb *strings.Builder, a frontend.Variable)
 	}
 
 	sbb.WriteByte('{')
-	printer := func(visibility schema.Visibility, name string, tValue reflect.Value) error {
+	printer := func(f *schema.Field, tValue reflect.Value) error {
 		count--
-		sbb.WriteString(name)
+		sbb.WriteString(f.FullName)
 		sbb.WriteString(": ")
 		sbb.WriteString("%s")
 		if count != 0 {

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -96,6 +96,10 @@ func (system *r1cs) newInternalVariable() compiled.LinearExpression {
 	}
 }
 
+func (system *r1cs) VariableCount(t reflect.Type) int {
+	return 1
+}
+
 // AddPublicVariable creates a new public Variable
 func (system *r1cs) AddPublicVariable(name string) frontend.Variable {
 	idx := len(system.Public)

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -101,18 +101,18 @@ func (system *r1cs) VariableCount(t reflect.Type) int {
 }
 
 // AddPublicVariable creates a new public Variable
-func (system *r1cs) AddPublicVariable(name string) frontend.Variable {
+func (system *r1cs) AddPublicVariable(f *schema.Field) frontend.Variable {
 	idx := len(system.Public)
-	system.Public = append(system.Public, name)
+	system.Public = append(system.Public, f.FullName)
 	return compiled.LinearExpression{
 		compiled.Pack(idx, compiled.CoeffIdOne, schema.Public),
 	}
 }
 
 // AddSecretVariable creates a new secret Variable
-func (system *r1cs) AddSecretVariable(name string) frontend.Variable {
+func (system *r1cs) AddSecretVariable(f *schema.Field) frontend.Variable {
 	idx := len(system.Secret) + system.NbPublicVariables
-	system.Secret = append(system.Secret, name)
+	system.Secret = append(system.Secret, f.FullName)
 	return compiled.LinearExpression{
 		compiled.Pack(idx, compiled.CoeffIdOne, schema.Secret),
 	}

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -443,7 +443,7 @@ func (system *scs) Println(a ...frontend.Variable) {
 func printArg(log *compiled.LogEntry, sbb *strings.Builder, a frontend.Variable) {
 
 	count := 0
-	counter := func(visibility schema.Visibility, name string, tValue reflect.Value) error {
+	counter := func(f *schema.Field, tValue reflect.Value) error {
 		count++
 		return nil
 	}
@@ -457,9 +457,9 @@ func printArg(log *compiled.LogEntry, sbb *strings.Builder, a frontend.Variable)
 	}
 
 	sbb.WriteByte('{')
-	printer := func(visibility schema.Visibility, name string, tValue reflect.Value) error {
+	printer := func(f *schema.Field, tValue reflect.Value) error {
 		count--
-		sbb.WriteString(name)
+		sbb.WriteString(f.FullName)
 		sbb.WriteString(": ")
 		sbb.WriteString("%s")
 		if count != 0 {

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -116,16 +116,16 @@ func (system *scs) VariableCount(t reflect.Type) int {
 }
 
 // AddPublicVariable creates a new Public Variable
-func (system *scs) AddPublicVariable(name string) frontend.Variable {
+func (system *scs) AddPublicVariable(f *schema.Field) frontend.Variable {
 	idx := len(system.Public)
-	system.Public = append(system.Public, name)
+	system.Public = append(system.Public, f.FullName)
 	return compiled.Pack(idx, compiled.CoeffIdOne, schema.Public)
 }
 
 // AddSecretVariable creates a new Secret Variable
-func (system *scs) AddSecretVariable(name string) frontend.Variable {
+func (system *scs) AddSecretVariable(f *schema.Field) frontend.Variable {
 	idx := len(system.Secret) + system.NbPublicVariables
-	system.Secret = append(system.Secret, name)
+	system.Secret = append(system.Secret, f.FullName)
 	return compiled.Pack(idx, compiled.CoeffIdOne, schema.Secret)
 }
 

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -111,6 +111,10 @@ func (system *scs) newInternalVariable() compiled.Term {
 	return compiled.Pack(idx, compiled.CoeffIdOne, schema.Internal)
 }
 
+func (system *scs) VariableCount(t reflect.Type) int {
+	return 1
+}
+
 // AddPublicVariable creates a new Public Variable
 func (system *scs) AddPublicVariable(name string) frontend.Variable {
 	idx := len(system.Public)

--- a/frontend/schema/field.go
+++ b/frontend/schema/field.go
@@ -20,6 +20,7 @@ package schema
 type Field struct {
 	Name       string
 	NameTag    string
+	FullName   string
 	Visibility Visibility
 	Type       FieldType
 	SubFields  []Field // will be set only if it's a struct, or an array of struct

--- a/frontend/schema/tags_test.go
+++ b/frontend/schema/tags_test.go
@@ -13,11 +13,11 @@ func TestStructTags(t *testing.T) {
 	testParseTags := func(t *testing.T, input interface{}, expected map[string]Visibility) {
 		assert := require.New(t)
 		collected := make(map[string]Visibility)
-		var collectHandler LeafHandler = func(visibility Visibility, name string, _ reflect.Value) error {
-			if _, ok := collected[name]; ok {
+		collectHandler := func(f *Field, _ reflect.Value) error {
+			if _, ok := collected[f.FullName]; ok {
 				return errors.New("duplicate name collected")
 			}
-			collected[name] = visibility
+			collected[f.FullName] = f.Visibility
 			return nil
 		}
 

--- a/internal/backend/bls12-377/witness/witness.go
+++ b/internal/backend/bls12-377/witness/witness.go
@@ -106,27 +106,27 @@ func (witness *Witness) FromAssignment(assignment interface{}, leafType reflect.
 	var i, j int // indexes for secret / public variables
 	i = nbPublic // offset
 
-	var collectHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if publicOnly && visibility != schema.Public {
+	collectHandler := func(f *schema.Field, tInput reflect.Value) error {
+		if publicOnly && f.Visibility != schema.Public {
 			return nil
 		}
 		if tInput.IsNil() {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 		v := tInput.Interface()
 
 		if v == nil {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 
-		if !publicOnly && visibility == schema.Secret {
+		if !publicOnly && f.Visibility == schema.Secret {
 			if _, err := (*witness)[i].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			i++
-		} else if visibility == schema.Public {
+		} else if f.Visibility == schema.Public {
 			if _, err := (*witness)[j].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			j++
 		}
@@ -141,8 +141,8 @@ func (witness *Witness) ToAssignment(assignment interface{}, leafType reflect.Ty
 	i := 0
 	setAddr := leafType.Kind() == reflect.Ptr
 	setHandler := func(v schema.Visibility) schema.LeafHandler {
-		return func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-			if visibility == v {
+		return func(f *schema.Field, tInput reflect.Value) error {
+			if f.Visibility == v {
 				if setAddr {
 					tInput.Set(reflect.ValueOf((&(*witness)[i])))
 				} else {

--- a/internal/backend/bls12-381/witness/witness.go
+++ b/internal/backend/bls12-381/witness/witness.go
@@ -106,27 +106,27 @@ func (witness *Witness) FromAssignment(assignment interface{}, leafType reflect.
 	var i, j int // indexes for secret / public variables
 	i = nbPublic // offset
 
-	var collectHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if publicOnly && visibility != schema.Public {
+	collectHandler := func(f *schema.Field, tInput reflect.Value) error {
+		if publicOnly && f.Visibility != schema.Public {
 			return nil
 		}
 		if tInput.IsNil() {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 		v := tInput.Interface()
 
 		if v == nil {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 
-		if !publicOnly && visibility == schema.Secret {
+		if !publicOnly && f.Visibility == schema.Secret {
 			if _, err := (*witness)[i].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			i++
-		} else if visibility == schema.Public {
+		} else if f.Visibility == schema.Public {
 			if _, err := (*witness)[j].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			j++
 		}
@@ -141,8 +141,8 @@ func (witness *Witness) ToAssignment(assignment interface{}, leafType reflect.Ty
 	i := 0
 	setAddr := leafType.Kind() == reflect.Ptr
 	setHandler := func(v schema.Visibility) schema.LeafHandler {
-		return func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-			if visibility == v {
+		return func(f *schema.Field, tInput reflect.Value) error {
+			if f.Visibility == v {
 				if setAddr {
 					tInput.Set(reflect.ValueOf((&(*witness)[i])))
 				} else {

--- a/internal/backend/bls24-315/witness/witness.go
+++ b/internal/backend/bls24-315/witness/witness.go
@@ -106,27 +106,27 @@ func (witness *Witness) FromAssignment(assignment interface{}, leafType reflect.
 	var i, j int // indexes for secret / public variables
 	i = nbPublic // offset
 
-	var collectHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if publicOnly && visibility != schema.Public {
+	collectHandler := func(f *schema.Field, tInput reflect.Value) error {
+		if publicOnly && f.Visibility != schema.Public {
 			return nil
 		}
 		if tInput.IsNil() {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 		v := tInput.Interface()
 
 		if v == nil {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 
-		if !publicOnly && visibility == schema.Secret {
+		if !publicOnly && f.Visibility == schema.Secret {
 			if _, err := (*witness)[i].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			i++
-		} else if visibility == schema.Public {
+		} else if f.Visibility == schema.Public {
 			if _, err := (*witness)[j].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			j++
 		}
@@ -141,8 +141,8 @@ func (witness *Witness) ToAssignment(assignment interface{}, leafType reflect.Ty
 	i := 0
 	setAddr := leafType.Kind() == reflect.Ptr
 	setHandler := func(v schema.Visibility) schema.LeafHandler {
-		return func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-			if visibility == v {
+		return func(f *schema.Field, tInput reflect.Value) error {
+			if f.Visibility == v {
 				if setAddr {
 					tInput.Set(reflect.ValueOf((&(*witness)[i])))
 				} else {

--- a/internal/backend/bn254/witness/witness.go
+++ b/internal/backend/bn254/witness/witness.go
@@ -106,27 +106,27 @@ func (witness *Witness) FromAssignment(assignment interface{}, leafType reflect.
 	var i, j int // indexes for secret / public variables
 	i = nbPublic // offset
 
-	var collectHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if publicOnly && visibility != schema.Public {
+	collectHandler := func(f *schema.Field, tInput reflect.Value) error {
+		if publicOnly && f.Visibility != schema.Public {
 			return nil
 		}
 		if tInput.IsNil() {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 		v := tInput.Interface()
 
 		if v == nil {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 
-		if !publicOnly && visibility == schema.Secret {
+		if !publicOnly && f.Visibility == schema.Secret {
 			if _, err := (*witness)[i].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			i++
-		} else if visibility == schema.Public {
+		} else if f.Visibility == schema.Public {
 			if _, err := (*witness)[j].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			j++
 		}
@@ -141,8 +141,8 @@ func (witness *Witness) ToAssignment(assignment interface{}, leafType reflect.Ty
 	i := 0
 	setAddr := leafType.Kind() == reflect.Ptr
 	setHandler := func(v schema.Visibility) schema.LeafHandler {
-		return func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-			if visibility == v {
+		return func(f *schema.Field, tInput reflect.Value) error {
+			if f.Visibility == v {
 				if setAddr {
 					tInput.Set(reflect.ValueOf((&(*witness)[i])))
 				} else {

--- a/internal/backend/bw6-633/witness/witness.go
+++ b/internal/backend/bw6-633/witness/witness.go
@@ -106,27 +106,27 @@ func (witness *Witness) FromAssignment(assignment interface{}, leafType reflect.
 	var i, j int // indexes for secret / public variables
 	i = nbPublic // offset
 
-	var collectHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if publicOnly && visibility != schema.Public {
+	collectHandler := func(f *schema.Field, tInput reflect.Value) error {
+		if publicOnly && f.Visibility != schema.Public {
 			return nil
 		}
 		if tInput.IsNil() {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 		v := tInput.Interface()
 
 		if v == nil {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 
-		if !publicOnly && visibility == schema.Secret {
+		if !publicOnly && f.Visibility == schema.Secret {
 			if _, err := (*witness)[i].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			i++
-		} else if visibility == schema.Public {
+		} else if f.Visibility == schema.Public {
 			if _, err := (*witness)[j].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			j++
 		}
@@ -141,8 +141,8 @@ func (witness *Witness) ToAssignment(assignment interface{}, leafType reflect.Ty
 	i := 0
 	setAddr := leafType.Kind() == reflect.Ptr
 	setHandler := func(v schema.Visibility) schema.LeafHandler {
-		return func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-			if visibility == v {
+		return func(f *schema.Field, tInput reflect.Value) error {
+			if f.Visibility == v {
 				if setAddr {
 					tInput.Set(reflect.ValueOf((&(*witness)[i])))
 				} else {

--- a/internal/backend/bw6-761/witness/witness.go
+++ b/internal/backend/bw6-761/witness/witness.go
@@ -106,27 +106,27 @@ func (witness *Witness) FromAssignment(assignment interface{}, leafType reflect.
 	var i, j int // indexes for secret / public variables
 	i = nbPublic // offset
 
-	var collectHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if publicOnly && visibility != schema.Public {
+	collectHandler := func(f *schema.Field, tInput reflect.Value) error {
+		if publicOnly && f.Visibility != schema.Public {
 			return nil
 		}
 		if tInput.IsNil() {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 		v := tInput.Interface()
 
 		if v == nil {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 
-		if !publicOnly && visibility == schema.Secret {
+		if !publicOnly && f.Visibility == schema.Secret {
 			if _, err := (*witness)[i].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			i++
-		} else if visibility == schema.Public {
+		} else if f.Visibility == schema.Public {
 			if _, err := (*witness)[j].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			j++
 		}
@@ -141,8 +141,8 @@ func (witness *Witness) ToAssignment(assignment interface{}, leafType reflect.Ty
 	i := 0
 	setAddr := leafType.Kind() == reflect.Ptr
 	setHandler := func(v schema.Visibility) schema.LeafHandler {
-		return func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-			if visibility == v {
+		return func(f *schema.Field, tInput reflect.Value) error {
+			if f.Visibility == v {
 				if setAddr {
 					tInput.Set(reflect.ValueOf((&(*witness)[i])))
 				} else {

--- a/internal/generator/backend/template/representations/witness.go.tmpl
+++ b/internal/generator/backend/template/representations/witness.go.tmpl
@@ -91,27 +91,27 @@ func (witness *Witness) FromAssignment(assignment interface{}, leafType reflect.
     var i, j int // indexes for secret / public variables
     i = nbPublic // offset
 
-    var collectHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-        if publicOnly && visibility != schema.Public {
+    collectHandler := func(f *schema.Field, tInput reflect.Value) error {
+        if publicOnly && f.Visibility != schema.Public {
             return nil 
         }
         if tInput.IsNil() {
-            return fmt.Errorf("when parsing variable %s: missing assignment", name)
+            return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
         }
         v := tInput.Interface()
 
         if v == nil {
-            return fmt.Errorf("when parsing variable %s: missing assignment", name) 
+            return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName) 
         }
 
-        if !publicOnly && visibility == schema.Secret {
+        if !publicOnly && f.Visibility == schema.Secret {
             if _, err := (*witness)[i].SetInterface(v) ; err != nil {
-                return fmt.Errorf("when parsing variable %s: %v", name, err) 
+                return fmt.Errorf("when parsing variable %s: %v", f.FullName, err) 
             }
             i++
-        } else if visibility == schema.Public {
+        } else if f.Visibility == schema.Public {
             if _, err := (*witness)[j].SetInterface(v) ; err != nil {
-                return fmt.Errorf("when parsing variable %s: %v", name, err) 
+                return fmt.Errorf("when parsing variable %s: %v", f.FullName, err) 
             }
             j++
         }
@@ -126,8 +126,8 @@ func (witness *Witness) ToAssignment(assignment interface{}, leafType reflect.Ty
     i := 0
 	setAddr := leafType.Kind() == reflect.Ptr 
 	setHandler := func(v schema.Visibility) schema.LeafHandler {
-		return func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-			if visibility == v {
+		return func(f *schema.Field, tInput reflect.Value) error {
+			if f.Visibility == v {
 				if setAddr {
 					tInput.Set(reflect.ValueOf((&(*witness)[i])))
 				} else {

--- a/internal/tinyfield/witness/witness.go
+++ b/internal/tinyfield/witness/witness.go
@@ -106,27 +106,27 @@ func (witness *Witness) FromAssignment(assignment interface{}, leafType reflect.
 	var i, j int // indexes for secret / public variables
 	i = nbPublic // offset
 
-	var collectHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if publicOnly && visibility != schema.Public {
+	collectHandler := func(f *schema.Field, tInput reflect.Value) error {
+		if publicOnly && f.Visibility != schema.Public {
 			return nil
 		}
 		if tInput.IsNil() {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 		v := tInput.Interface()
 
 		if v == nil {
-			return fmt.Errorf("when parsing variable %s: missing assignment", name)
+			return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 		}
 
-		if !publicOnly && visibility == schema.Secret {
+		if !publicOnly && f.Visibility == schema.Secret {
 			if _, err := (*witness)[i].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			i++
-		} else if visibility == schema.Public {
+		} else if f.Visibility == schema.Public {
 			if _, err := (*witness)[j].SetInterface(v); err != nil {
-				return fmt.Errorf("when parsing variable %s: %v", name, err)
+				return fmt.Errorf("when parsing variable %s: %v", f.FullName, err)
 			}
 			j++
 		}
@@ -141,8 +141,8 @@ func (witness *Witness) ToAssignment(assignment interface{}, leafType reflect.Ty
 	i := 0
 	setAddr := leafType.Kind() == reflect.Ptr
 	setHandler := func(v schema.Visibility) schema.LeafHandler {
-		return func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-			if visibility == v {
+		return func(f *schema.Field, tInput reflect.Value) error {
+			if f.Visibility == v {
 				if setAddr {
 					tInput.Set(reflect.ValueOf((&(*witness)[i])))
 				} else {

--- a/test/engine.go
+++ b/test/engine.go
@@ -478,12 +478,12 @@ func shallowClone(circuit frontend.Circuit) frontend.Circuit {
 func copyWitness(to, from frontend.Circuit) {
 	var wValues []interface{}
 
-	var collectHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
+	collectHandler := func(f *schema.Field, tInput reflect.Value) error {
 		v := tInput.Interface().(frontend.Variable)
 
-		if visibility == schema.Secret || visibility == schema.Public {
+		if f.Visibility == schema.Secret || f.Visibility == schema.Public {
 			if v == nil {
-				return fmt.Errorf("when parsing variable %s: missing assignment", name)
+				return fmt.Errorf("when parsing variable %s: missing assignment", f.FullName)
 			}
 			wValues = append(wValues, v)
 		}
@@ -494,8 +494,8 @@ func copyWitness(to, from frontend.Circuit) {
 	}
 
 	i := 0
-	var setHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if visibility == schema.Secret || visibility == schema.Public {
+	setHandler := func(f *schema.Field, tInput reflect.Value) error {
+		if f.Visibility == schema.Secret || f.Visibility == schema.Public {
 			tInput.Set(reflect.ValueOf((wValues[i])))
 			i++
 		}

--- a/test/fuzz.go
+++ b/test/fuzz.go
@@ -113,8 +113,8 @@ func randomFiller(w frontend.Circuit, curve ecc.ID) {
 }
 
 func fill(w frontend.Circuit, nextValue func() interface{}) {
-	var setHandler schema.LeafHandler = func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if visibility == schema.Secret || visibility == schema.Public {
+	setHandler := func(f *schema.Field, tInput reflect.Value) error {
+		if f.Visibility == schema.Secret || f.Visibility == schema.Public {
 			v := nextValue()
 			tInput.Set(reflect.ValueOf((v)))
 		}

--- a/test/solver_test.go
+++ b/test/solver_test.go
@@ -178,16 +178,16 @@ func isSolvedEngine(c frontend.Circuit, field *big.Int, opts ...TestEngineOption
 // values are assumed to be ordered [public | secret]
 func copyWitnessFromVector(to frontend.Circuit, from []tinyfield.Element) {
 	i := 0
-	schema.Parse(to, tVariable, func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if visibility == schema.Public {
+	schema.Parse(to, tVariable, func(f *schema.Field, tInput reflect.Value) error {
+		if f.Visibility == schema.Public {
 			tInput.Set(reflect.ValueOf((from[i])))
 			i++
 		}
 		return nil
 	})
 
-	schema.Parse(to, tVariable, func(visibility schema.Visibility, name string, tInput reflect.Value) error {
-		if visibility == schema.Secret {
+	schema.Parse(to, tVariable, func(f *schema.Field, tInput reflect.Value) error {
+		if f.Visibility == schema.Secret {
 			tInput.Set(reflect.ValueOf((from[i])))
 			i++
 		}


### PR DESCRIPTION
In the upcoming fake-API for field emulation branch I have implemented a wrapper for `frontend.Builder` which initialises the variables in the circuit witness. The builder also needs to modify the parsed schema (for example, we need a native element for every limb). For that, the `LeafHandler` now takes as input `*schema.Field` which it can modify in-place.

I think this PR may not be optimal. Will try to rebase fake-API branch on top of this one to see how it would be used in practice.