### PR TITLE
fix: IsZero bug will make Cmp panic

### DIFF
--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -352,7 +352,7 @@ func (system *scs) Lookup2(b0, b1 frontend.Variable, i0, i1, i2, i3 frontend.Var
 func (system *scs) IsZero(i1 frontend.Variable) frontend.Variable {
 	if a, ok := system.ConstantValue(i1); ok {
 		if !(a.IsUint64() && a.Uint64() == 0) {
-			panic("input should be zero")
+			return 0
 		}
 		return 1
 	}


### PR DESCRIPTION
A code will trigger the bug:

func isNegative(api frontend.API, x frontend.Variable) frontend.Variable {
	c := frontend.Variable("10944121435919637611123202872628637544274182200208017171849102093287904247808")
	return api.Cmp(x, c)
}