### PR TITLE
fix: misspelled ("decsribes" ->  "describes")

### DIFF
--- a/internal/backend/bls12-377/cs/r1cs.go
+++ b/internal/backend/bls12-377/cs/r1cs.go
@@ -42,7 +42,7 @@ import (
 	bls12_377witness "github.com/consensys/gnark/internal/backend/bls12-377/witness"
 )
 
-// R1CS decsribes a set of R1CS constraint
+// R1CS describes a set of R1CS constraint
 type R1CS struct {
 	compiled.R1CS
 	Coefficients []fr.Element // R1C coefficients indexes point here

--- a/internal/backend/bls12-381/cs/r1cs.go
+++ b/internal/backend/bls12-381/cs/r1cs.go
@@ -42,7 +42,7 @@ import (
 	bls12_381witness "github.com/consensys/gnark/internal/backend/bls12-381/witness"
 )
 
-// R1CS decsribes a set of R1CS constraint
+// R1CS describes a set of R1CS constraint
 type R1CS struct {
 	compiled.R1CS
 	Coefficients []fr.Element // R1C coefficients indexes point here

--- a/internal/backend/bls24-315/cs/r1cs.go
+++ b/internal/backend/bls24-315/cs/r1cs.go
@@ -42,7 +42,7 @@ import (
 	bls24_315witness "github.com/consensys/gnark/internal/backend/bls24-315/witness"
 )
 
-// R1CS decsribes a set of R1CS constraint
+// R1CS describes a set of R1CS constraint
 type R1CS struct {
 	compiled.R1CS
 	Coefficients []fr.Element // R1C coefficients indexes point here

--- a/internal/backend/bn254/cs/r1cs.go
+++ b/internal/backend/bn254/cs/r1cs.go
@@ -42,7 +42,7 @@ import (
 	bn254witness "github.com/consensys/gnark/internal/backend/bn254/witness"
 )
 
-// R1CS decsribes a set of R1CS constraint
+// R1CS describes a set of R1CS constraint
 type R1CS struct {
 	compiled.R1CS
 	Coefficients []fr.Element // R1C coefficients indexes point here

--- a/internal/backend/bw6-633/cs/r1cs.go
+++ b/internal/backend/bw6-633/cs/r1cs.go
@@ -42,7 +42,7 @@ import (
 	bw6_633witness "github.com/consensys/gnark/internal/backend/bw6-633/witness"
 )
 
-// R1CS decsribes a set of R1CS constraint
+// R1CS describes a set of R1CS constraint
 type R1CS struct {
 	compiled.R1CS
 	Coefficients []fr.Element // R1C coefficients indexes point here

--- a/internal/backend/bw6-761/cs/r1cs.go
+++ b/internal/backend/bw6-761/cs/r1cs.go
@@ -42,7 +42,7 @@ import (
 	bw6_761witness "github.com/consensys/gnark/internal/backend/bw6-761/witness"
 )
 
-// R1CS decsribes a set of R1CS constraint
+// R1CS describes a set of R1CS constraint
 type R1CS struct {
 	compiled.R1CS
 	Coefficients []fr.Element // R1C coefficients indexes point here

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -24,7 +24,7 @@ import (
 )
 
 
-// R1CS decsribes a set of R1CS constraint
+// R1CS describes a set of R1CS constraint
 type R1CS struct {
 	compiled.R1CS
 	Coefficients []fr.Element // R1C coefficients indexes point here


### PR DESCRIPTION
fix misspelled word  `decsribes` to `describes` in the comment of struct `R1CS` 