### PR TITLE
refactor: rename ScalarMultiplication -> ScalarMul

### DIFF
--- a/internal/backend/bls12-377/groth16/marshal_test.go
+++ b/internal/backend/bls12-377/groth16/marshal_test.go
@@ -254,7 +254,7 @@ func GenG1() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g1 curve.G1Affine
-		g1.ScalarMultiplication(&g1GenAff, &scalar)
+		g1.ScalarMul(&g1GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g1, gopter.NoShrinker)
 		return genResult
@@ -268,7 +268,7 @@ func GenG2() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g2 curve.G2Affine
-		g2.ScalarMultiplication(&g2GenAff, &scalar)
+		g2.ScalarMul(&g2GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g2, gopter.NoShrinker)
 		return genResult

--- a/internal/backend/bls12-377/groth16/prove.go
+++ b/internal/backend/bls12-377/groth16/prove.go
@@ -147,7 +147,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, opt 
 	_s.ToBigInt(&s)
 
 	// computes r[δ], s[δ], kr[δ]
-	deltas := curve.BatchScalarMultiplicationG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
+	deltas := curve.BatchScalarMulG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
 
 	proof := &Proof{}
 	var bs1, ar curve.G1Jac
@@ -211,14 +211,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, opt 
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&ar, &s)
+				p1.ScalarMul(&ar, &s)
 				krs.AddAssign(&p1)
 			case err := <-chBs1Done:
 				if err != nil {
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&bs1, &r)
+				p1.ScalarMul(&bs1, &r)
 				krs.AddAssign(&p1)
 			}
 			n--
@@ -243,7 +243,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_377witness.Witness, opt 
 		}
 
 		deltaS.FromAffine(&pk.G2.Delta)
-		deltaS.ScalarMultiplication(&deltaS, &s)
+		deltaS.ScalarMul(&deltaS, &s)
 		Bs.AddAssign(&deltaS)
 		Bs.AddMixed(&pk.G2.Beta)
 

--- a/internal/backend/bls12-377/groth16/setup.go
+++ b/internal/backend/bls12-377/groth16/setup.go
@@ -107,7 +107,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// To fill in the Proving and Verifying keys, we need to perform a lot of ecc scalar multiplication (with generator)
 	// and convert the resulting points to affine
-	// this is done using the curve.BatchScalarMultiplicationGX API, which takes as input the base point
+	// this is done using the curve.BatchScalarMulGX API, which takes as input the base point
 	// (in our case the generator) and the list of scalars, and outputs a list of points (len(points) == len(scalars))
 	// to use this batch call, we need to order our scalars in the same slice
 	// we have 1 batch call for G1 and 1 batch call for G1
@@ -207,7 +207,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	g1Scalars = append(g1Scalars, Z...)
 	g1Scalars = append(g1Scalars, vkK...)
 
-	g1PointsAff := curve.BatchScalarMultiplicationG1(&g1, g1Scalars)
+	g1PointsAff := curve.BatchScalarMulG1(&g1, g1Scalars)
 
 	// sets pk: [α]1, [β]1, [δ]1
 	pk.G1.Alpha = g1PointsAff[0]
@@ -242,7 +242,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// compute our batch scalar multiplication with g2 elements
 	g2Scalars := append(B, toxicWaste.betaReg, toxicWaste.deltaReg, toxicWaste.gammaReg)
 
-	g2PointsAff := curve.BatchScalarMultiplicationG2(&g2, g2Scalars)
+	g2PointsAff := curve.BatchScalarMulG2(&g2, g2Scalars)
 
 	pk.G2.B = g2PointsAff[:len(B)]
 
@@ -449,11 +449,11 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r1Aff curve.G1Affine
 	var b big.Int
 	g1, g2, _, _ := curve.Generators()
-	r1Jac.ScalarMultiplication(&g1, toxicWaste.alphaReg.ToBigInt(&b))
+	r1Jac.ScalarMul(&g1, toxicWaste.alphaReg.ToBigInt(&b))
 	r1Aff.FromJacobian(&r1Jac)
 	var r2Jac curve.G2Jac
 	var r2Aff curve.G2Affine
-	r2Jac.ScalarMultiplication(&g2, &b)
+	r2Jac.ScalarMul(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
 	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff

--- a/internal/backend/bls12-377/plonk/prove.go
+++ b/internal/backend/bls12-377/plonk/prove.go
@@ -325,10 +325,10 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls12_377witness.Witn
 	zetaPowerm.Exp(zeta, &bSize)
 	zetaPowerm.ToBigIntRegular(&bZetaPowerm)
 	foldedHDigest := proof.H[2]
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[1])                   // ζᵐ⁺²*Comm(h3)
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[0])                   // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[1])        // ζᵐ⁺²*Comm(h3)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[0])        // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
 
 	// foldedH = h1 + ζ*h2 + ζ²*h3
 	foldedH := h3

--- a/internal/backend/bls12-377/plonk/verify.go
+++ b/internal/backend/bls12-377/plonk/verify.go
@@ -159,9 +159,9 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness bls12_377witness.Witne
 	var zetaMPlusTwoBigInt big.Int
 	zetaMPlusTwo.ToBigIntRegular(&zetaMPlusTwoBigInt)
 	foldedH := proof.H[2]
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[1])
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[0])
 
 	// Compute the commitment to the linearized polynomial

--- a/internal/backend/bls12-381/groth16/marshal_test.go
+++ b/internal/backend/bls12-381/groth16/marshal_test.go
@@ -254,7 +254,7 @@ func GenG1() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g1 curve.G1Affine
-		g1.ScalarMultiplication(&g1GenAff, &scalar)
+		g1.ScalarMul(&g1GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g1, gopter.NoShrinker)
 		return genResult
@@ -268,7 +268,7 @@ func GenG2() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g2 curve.G2Affine
-		g2.ScalarMultiplication(&g2GenAff, &scalar)
+		g2.ScalarMul(&g2GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g2, gopter.NoShrinker)
 		return genResult

--- a/internal/backend/bls12-381/groth16/prove.go
+++ b/internal/backend/bls12-381/groth16/prove.go
@@ -147,7 +147,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, opt 
 	_s.ToBigInt(&s)
 
 	// computes r[δ], s[δ], kr[δ]
-	deltas := curve.BatchScalarMultiplicationG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
+	deltas := curve.BatchScalarMulG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
 
 	proof := &Proof{}
 	var bs1, ar curve.G1Jac
@@ -211,14 +211,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, opt 
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&ar, &s)
+				p1.ScalarMul(&ar, &s)
 				krs.AddAssign(&p1)
 			case err := <-chBs1Done:
 				if err != nil {
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&bs1, &r)
+				p1.ScalarMul(&bs1, &r)
 				krs.AddAssign(&p1)
 			}
 			n--
@@ -243,7 +243,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls12_381witness.Witness, opt 
 		}
 
 		deltaS.FromAffine(&pk.G2.Delta)
-		deltaS.ScalarMultiplication(&deltaS, &s)
+		deltaS.ScalarMul(&deltaS, &s)
 		Bs.AddAssign(&deltaS)
 		Bs.AddMixed(&pk.G2.Beta)
 

--- a/internal/backend/bls12-381/groth16/setup.go
+++ b/internal/backend/bls12-381/groth16/setup.go
@@ -107,7 +107,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// To fill in the Proving and Verifying keys, we need to perform a lot of ecc scalar multiplication (with generator)
 	// and convert the resulting points to affine
-	// this is done using the curve.BatchScalarMultiplicationGX API, which takes as input the base point
+	// this is done using the curve.BatchScalarMulGX API, which takes as input the base point
 	// (in our case the generator) and the list of scalars, and outputs a list of points (len(points) == len(scalars))
 	// to use this batch call, we need to order our scalars in the same slice
 	// we have 1 batch call for G1 and 1 batch call for G1
@@ -207,7 +207,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	g1Scalars = append(g1Scalars, Z...)
 	g1Scalars = append(g1Scalars, vkK...)
 
-	g1PointsAff := curve.BatchScalarMultiplicationG1(&g1, g1Scalars)
+	g1PointsAff := curve.BatchScalarMulG1(&g1, g1Scalars)
 
 	// sets pk: [α]1, [β]1, [δ]1
 	pk.G1.Alpha = g1PointsAff[0]
@@ -242,7 +242,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// compute our batch scalar multiplication with g2 elements
 	g2Scalars := append(B, toxicWaste.betaReg, toxicWaste.deltaReg, toxicWaste.gammaReg)
 
-	g2PointsAff := curve.BatchScalarMultiplicationG2(&g2, g2Scalars)
+	g2PointsAff := curve.BatchScalarMulG2(&g2, g2Scalars)
 
 	pk.G2.B = g2PointsAff[:len(B)]
 
@@ -449,11 +449,11 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r1Aff curve.G1Affine
 	var b big.Int
 	g1, g2, _, _ := curve.Generators()
-	r1Jac.ScalarMultiplication(&g1, toxicWaste.alphaReg.ToBigInt(&b))
+	r1Jac.ScalarMul(&g1, toxicWaste.alphaReg.ToBigInt(&b))
 	r1Aff.FromJacobian(&r1Jac)
 	var r2Jac curve.G2Jac
 	var r2Aff curve.G2Affine
-	r2Jac.ScalarMultiplication(&g2, &b)
+	r2Jac.ScalarMul(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
 	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff

--- a/internal/backend/bls12-381/plonk/prove.go
+++ b/internal/backend/bls12-381/plonk/prove.go
@@ -325,10 +325,10 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls12_381witness.Witn
 	zetaPowerm.Exp(zeta, &bSize)
 	zetaPowerm.ToBigIntRegular(&bZetaPowerm)
 	foldedHDigest := proof.H[2]
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[1])                   // ζᵐ⁺²*Comm(h3)
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[0])                   // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[1])        // ζᵐ⁺²*Comm(h3)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[0])        // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
 
 	// foldedH = h1 + ζ*h2 + ζ²*h3
 	foldedH := h3

--- a/internal/backend/bls12-381/plonk/verify.go
+++ b/internal/backend/bls12-381/plonk/verify.go
@@ -159,9 +159,9 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness bls12_381witness.Witne
 	var zetaMPlusTwoBigInt big.Int
 	zetaMPlusTwo.ToBigIntRegular(&zetaMPlusTwoBigInt)
 	foldedH := proof.H[2]
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[1])
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[0])
 
 	// Compute the commitment to the linearized polynomial

--- a/internal/backend/bls24-315/groth16/marshal_test.go
+++ b/internal/backend/bls24-315/groth16/marshal_test.go
@@ -254,7 +254,7 @@ func GenG1() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g1 curve.G1Affine
-		g1.ScalarMultiplication(&g1GenAff, &scalar)
+		g1.ScalarMul(&g1GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g1, gopter.NoShrinker)
 		return genResult
@@ -268,7 +268,7 @@ func GenG2() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g2 curve.G2Affine
-		g2.ScalarMultiplication(&g2GenAff, &scalar)
+		g2.ScalarMul(&g2GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g2, gopter.NoShrinker)
 		return genResult

--- a/internal/backend/bls24-315/groth16/prove.go
+++ b/internal/backend/bls24-315/groth16/prove.go
@@ -147,7 +147,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, opt 
 	_s.ToBigInt(&s)
 
 	// computes r[δ], s[δ], kr[δ]
-	deltas := curve.BatchScalarMultiplicationG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
+	deltas := curve.BatchScalarMulG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
 
 	proof := &Proof{}
 	var bs1, ar curve.G1Jac
@@ -211,14 +211,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, opt 
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&ar, &s)
+				p1.ScalarMul(&ar, &s)
 				krs.AddAssign(&p1)
 			case err := <-chBs1Done:
 				if err != nil {
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&bs1, &r)
+				p1.ScalarMul(&bs1, &r)
 				krs.AddAssign(&p1)
 			}
 			n--
@@ -243,7 +243,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bls24_315witness.Witness, opt 
 		}
 
 		deltaS.FromAffine(&pk.G2.Delta)
-		deltaS.ScalarMultiplication(&deltaS, &s)
+		deltaS.ScalarMul(&deltaS, &s)
 		Bs.AddAssign(&deltaS)
 		Bs.AddMixed(&pk.G2.Beta)
 

--- a/internal/backend/bls24-315/groth16/setup.go
+++ b/internal/backend/bls24-315/groth16/setup.go
@@ -107,7 +107,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// To fill in the Proving and Verifying keys, we need to perform a lot of ecc scalar multiplication (with generator)
 	// and convert the resulting points to affine
-	// this is done using the curve.BatchScalarMultiplicationGX API, which takes as input the base point
+	// this is done using the curve.BatchScalarMulGX API, which takes as input the base point
 	// (in our case the generator) and the list of scalars, and outputs a list of points (len(points) == len(scalars))
 	// to use this batch call, we need to order our scalars in the same slice
 	// we have 1 batch call for G1 and 1 batch call for G1
@@ -207,7 +207,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	g1Scalars = append(g1Scalars, Z...)
 	g1Scalars = append(g1Scalars, vkK...)
 
-	g1PointsAff := curve.BatchScalarMultiplicationG1(&g1, g1Scalars)
+	g1PointsAff := curve.BatchScalarMulG1(&g1, g1Scalars)
 
 	// sets pk: [α]1, [β]1, [δ]1
 	pk.G1.Alpha = g1PointsAff[0]
@@ -242,7 +242,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// compute our batch scalar multiplication with g2 elements
 	g2Scalars := append(B, toxicWaste.betaReg, toxicWaste.deltaReg, toxicWaste.gammaReg)
 
-	g2PointsAff := curve.BatchScalarMultiplicationG2(&g2, g2Scalars)
+	g2PointsAff := curve.BatchScalarMulG2(&g2, g2Scalars)
 
 	pk.G2.B = g2PointsAff[:len(B)]
 
@@ -449,11 +449,11 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r1Aff curve.G1Affine
 	var b big.Int
 	g1, g2, _, _ := curve.Generators()
-	r1Jac.ScalarMultiplication(&g1, toxicWaste.alphaReg.ToBigInt(&b))
+	r1Jac.ScalarMul(&g1, toxicWaste.alphaReg.ToBigInt(&b))
 	r1Aff.FromJacobian(&r1Jac)
 	var r2Jac curve.G2Jac
 	var r2Aff curve.G2Affine
-	r2Jac.ScalarMultiplication(&g2, &b)
+	r2Jac.ScalarMul(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
 	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff

--- a/internal/backend/bls24-315/plonk/prove.go
+++ b/internal/backend/bls24-315/plonk/prove.go
@@ -325,10 +325,10 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls24_315witness.Witn
 	zetaPowerm.Exp(zeta, &bSize)
 	zetaPowerm.ToBigIntRegular(&bZetaPowerm)
 	foldedHDigest := proof.H[2]
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[1])                   // ζᵐ⁺²*Comm(h3)
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[0])                   // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[1])        // ζᵐ⁺²*Comm(h3)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[0])        // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
 
 	// foldedH = h1 + ζ*h2 + ζ²*h3
 	foldedH := h3

--- a/internal/backend/bls24-315/plonk/verify.go
+++ b/internal/backend/bls24-315/plonk/verify.go
@@ -159,9 +159,9 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness bls24_315witness.Witne
 	var zetaMPlusTwoBigInt big.Int
 	zetaMPlusTwo.ToBigIntRegular(&zetaMPlusTwoBigInt)
 	foldedH := proof.H[2]
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[1])
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[0])
 
 	// Compute the commitment to the linearized polynomial

--- a/internal/backend/bn254/groth16/marshal_test.go
+++ b/internal/backend/bn254/groth16/marshal_test.go
@@ -254,7 +254,7 @@ func GenG1() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g1 curve.G1Affine
-		g1.ScalarMultiplication(&g1GenAff, &scalar)
+		g1.ScalarMul(&g1GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g1, gopter.NoShrinker)
 		return genResult
@@ -268,7 +268,7 @@ func GenG2() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g2 curve.G2Affine
-		g2.ScalarMultiplication(&g2GenAff, &scalar)
+		g2.ScalarMul(&g2GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g2, gopter.NoShrinker)
 		return genResult

--- a/internal/backend/bn254/groth16/prove.go
+++ b/internal/backend/bn254/groth16/prove.go
@@ -147,7 +147,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, opt back
 	_s.ToBigInt(&s)
 
 	// computes r[δ], s[δ], kr[δ]
-	deltas := curve.BatchScalarMultiplicationG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
+	deltas := curve.BatchScalarMulG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
 
 	proof := &Proof{}
 	var bs1, ar curve.G1Jac
@@ -211,14 +211,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, opt back
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&ar, &s)
+				p1.ScalarMul(&ar, &s)
 				krs.AddAssign(&p1)
 			case err := <-chBs1Done:
 				if err != nil {
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&bs1, &r)
+				p1.ScalarMul(&bs1, &r)
 				krs.AddAssign(&p1)
 			}
 			n--
@@ -243,7 +243,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bn254witness.Witness, opt back
 		}
 
 		deltaS.FromAffine(&pk.G2.Delta)
-		deltaS.ScalarMultiplication(&deltaS, &s)
+		deltaS.ScalarMul(&deltaS, &s)
 		Bs.AddAssign(&deltaS)
 		Bs.AddMixed(&pk.G2.Beta)
 

--- a/internal/backend/bn254/groth16/setup.go
+++ b/internal/backend/bn254/groth16/setup.go
@@ -107,7 +107,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// To fill in the Proving and Verifying keys, we need to perform a lot of ecc scalar multiplication (with generator)
 	// and convert the resulting points to affine
-	// this is done using the curve.BatchScalarMultiplicationGX API, which takes as input the base point
+	// this is done using the curve.BatchScalarMulGX API, which takes as input the base point
 	// (in our case the generator) and the list of scalars, and outputs a list of points (len(points) == len(scalars))
 	// to use this batch call, we need to order our scalars in the same slice
 	// we have 1 batch call for G1 and 1 batch call for G1
@@ -207,7 +207,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	g1Scalars = append(g1Scalars, Z...)
 	g1Scalars = append(g1Scalars, vkK...)
 
-	g1PointsAff := curve.BatchScalarMultiplicationG1(&g1, g1Scalars)
+	g1PointsAff := curve.BatchScalarMulG1(&g1, g1Scalars)
 
 	// sets pk: [α]1, [β]1, [δ]1
 	pk.G1.Alpha = g1PointsAff[0]
@@ -242,7 +242,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// compute our batch scalar multiplication with g2 elements
 	g2Scalars := append(B, toxicWaste.betaReg, toxicWaste.deltaReg, toxicWaste.gammaReg)
 
-	g2PointsAff := curve.BatchScalarMultiplicationG2(&g2, g2Scalars)
+	g2PointsAff := curve.BatchScalarMulG2(&g2, g2Scalars)
 
 	pk.G2.B = g2PointsAff[:len(B)]
 
@@ -449,11 +449,11 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r1Aff curve.G1Affine
 	var b big.Int
 	g1, g2, _, _ := curve.Generators()
-	r1Jac.ScalarMultiplication(&g1, toxicWaste.alphaReg.ToBigInt(&b))
+	r1Jac.ScalarMul(&g1, toxicWaste.alphaReg.ToBigInt(&b))
 	r1Aff.FromJacobian(&r1Jac)
 	var r2Jac curve.G2Jac
 	var r2Aff curve.G2Affine
-	r2Jac.ScalarMultiplication(&g2, &b)
+	r2Jac.ScalarMul(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
 	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff

--- a/internal/backend/bn254/plonk/prove.go
+++ b/internal/backend/bn254/plonk/prove.go
@@ -325,10 +325,10 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bn254witness.Witness,
 	zetaPowerm.Exp(zeta, &bSize)
 	zetaPowerm.ToBigIntRegular(&bZetaPowerm)
 	foldedHDigest := proof.H[2]
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[1])                   // ζᵐ⁺²*Comm(h3)
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[0])                   // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[1])        // ζᵐ⁺²*Comm(h3)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[0])        // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
 
 	// foldedH = h1 + ζ*h2 + ζ²*h3
 	foldedH := h3

--- a/internal/backend/bn254/plonk/verify.go
+++ b/internal/backend/bn254/plonk/verify.go
@@ -159,9 +159,9 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness bn254witness.Witness) 
 	var zetaMPlusTwoBigInt big.Int
 	zetaMPlusTwo.ToBigIntRegular(&zetaMPlusTwoBigInt)
 	foldedH := proof.H[2]
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[1])
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[0])
 
 	// Compute the commitment to the linearized polynomial

--- a/internal/backend/bw6-633/groth16/marshal_test.go
+++ b/internal/backend/bw6-633/groth16/marshal_test.go
@@ -254,7 +254,7 @@ func GenG1() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g1 curve.G1Affine
-		g1.ScalarMultiplication(&g1GenAff, &scalar)
+		g1.ScalarMul(&g1GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g1, gopter.NoShrinker)
 		return genResult
@@ -268,7 +268,7 @@ func GenG2() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g2 curve.G2Affine
-		g2.ScalarMultiplication(&g2GenAff, &scalar)
+		g2.ScalarMul(&g2GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g2, gopter.NoShrinker)
 		return genResult

--- a/internal/backend/bw6-633/groth16/prove.go
+++ b/internal/backend/bw6-633/groth16/prove.go
@@ -147,7 +147,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_633witness.Witness, opt ba
 	_s.ToBigInt(&s)
 
 	// computes r[δ], s[δ], kr[δ]
-	deltas := curve.BatchScalarMultiplicationG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
+	deltas := curve.BatchScalarMulG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
 
 	proof := &Proof{}
 	var bs1, ar curve.G1Jac
@@ -211,14 +211,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_633witness.Witness, opt ba
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&ar, &s)
+				p1.ScalarMul(&ar, &s)
 				krs.AddAssign(&p1)
 			case err := <-chBs1Done:
 				if err != nil {
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&bs1, &r)
+				p1.ScalarMul(&bs1, &r)
 				krs.AddAssign(&p1)
 			}
 			n--
@@ -243,7 +243,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_633witness.Witness, opt ba
 		}
 
 		deltaS.FromAffine(&pk.G2.Delta)
-		deltaS.ScalarMultiplication(&deltaS, &s)
+		deltaS.ScalarMul(&deltaS, &s)
 		Bs.AddAssign(&deltaS)
 		Bs.AddMixed(&pk.G2.Beta)
 

--- a/internal/backend/bw6-633/groth16/setup.go
+++ b/internal/backend/bw6-633/groth16/setup.go
@@ -107,7 +107,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// To fill in the Proving and Verifying keys, we need to perform a lot of ecc scalar multiplication (with generator)
 	// and convert the resulting points to affine
-	// this is done using the curve.BatchScalarMultiplicationGX API, which takes as input the base point
+	// this is done using the curve.BatchScalarMulGX API, which takes as input the base point
 	// (in our case the generator) and the list of scalars, and outputs a list of points (len(points) == len(scalars))
 	// to use this batch call, we need to order our scalars in the same slice
 	// we have 1 batch call for G1 and 1 batch call for G1
@@ -207,7 +207,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	g1Scalars = append(g1Scalars, Z...)
 	g1Scalars = append(g1Scalars, vkK...)
 
-	g1PointsAff := curve.BatchScalarMultiplicationG1(&g1, g1Scalars)
+	g1PointsAff := curve.BatchScalarMulG1(&g1, g1Scalars)
 
 	// sets pk: [α]1, [β]1, [δ]1
 	pk.G1.Alpha = g1PointsAff[0]
@@ -242,7 +242,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// compute our batch scalar multiplication with g2 elements
 	g2Scalars := append(B, toxicWaste.betaReg, toxicWaste.deltaReg, toxicWaste.gammaReg)
 
-	g2PointsAff := curve.BatchScalarMultiplicationG2(&g2, g2Scalars)
+	g2PointsAff := curve.BatchScalarMulG2(&g2, g2Scalars)
 
 	pk.G2.B = g2PointsAff[:len(B)]
 
@@ -449,11 +449,11 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r1Aff curve.G1Affine
 	var b big.Int
 	g1, g2, _, _ := curve.Generators()
-	r1Jac.ScalarMultiplication(&g1, toxicWaste.alphaReg.ToBigInt(&b))
+	r1Jac.ScalarMul(&g1, toxicWaste.alphaReg.ToBigInt(&b))
 	r1Aff.FromJacobian(&r1Jac)
 	var r2Jac curve.G2Jac
 	var r2Aff curve.G2Affine
-	r2Jac.ScalarMultiplication(&g2, &b)
+	r2Jac.ScalarMul(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
 	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff

--- a/internal/backend/bw6-633/plonk/prove.go
+++ b/internal/backend/bw6-633/plonk/prove.go
@@ -325,10 +325,10 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bw6_633witness.Witnes
 	zetaPowerm.Exp(zeta, &bSize)
 	zetaPowerm.ToBigIntRegular(&bZetaPowerm)
 	foldedHDigest := proof.H[2]
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[1])                   // ζᵐ⁺²*Comm(h3)
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[0])                   // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[1])        // ζᵐ⁺²*Comm(h3)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[0])        // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
 
 	// foldedH = h1 + ζ*h2 + ζ²*h3
 	foldedH := h3

--- a/internal/backend/bw6-633/plonk/verify.go
+++ b/internal/backend/bw6-633/plonk/verify.go
@@ -159,9 +159,9 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness bw6_633witness.Witness
 	var zetaMPlusTwoBigInt big.Int
 	zetaMPlusTwo.ToBigIntRegular(&zetaMPlusTwoBigInt)
 	foldedH := proof.H[2]
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[1])
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[0])
 
 	// Compute the commitment to the linearized polynomial

--- a/internal/backend/bw6-761/groth16/marshal_test.go
+++ b/internal/backend/bw6-761/groth16/marshal_test.go
@@ -254,7 +254,7 @@ func GenG1() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g1 curve.G1Affine
-		g1.ScalarMultiplication(&g1GenAff, &scalar)
+		g1.ScalarMul(&g1GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g1, gopter.NoShrinker)
 		return genResult
@@ -268,7 +268,7 @@ func GenG2() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g2 curve.G2Affine
-		g2.ScalarMultiplication(&g2GenAff, &scalar)
+		g2.ScalarMul(&g2GenAff, &scalar)
 
 		genResult := gopter.NewGenResult(g2, gopter.NoShrinker)
 		return genResult

--- a/internal/backend/bw6-761/groth16/prove.go
+++ b/internal/backend/bw6-761/groth16/prove.go
@@ -147,7 +147,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, opt ba
 	_s.ToBigInt(&s)
 
 	// computes r[δ], s[δ], kr[δ]
-	deltas := curve.BatchScalarMultiplicationG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
+	deltas := curve.BatchScalarMulG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
 
 	proof := &Proof{}
 	var bs1, ar curve.G1Jac
@@ -211,14 +211,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, opt ba
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&ar, &s)
+				p1.ScalarMul(&ar, &s)
 				krs.AddAssign(&p1)
 			case err := <-chBs1Done:
 				if err != nil {
 					chKrsDone <- err
 					return
 				}
-				p1.ScalarMultiplication(&bs1, &r)
+				p1.ScalarMul(&bs1, &r)
 				krs.AddAssign(&p1)
 			}
 			n--
@@ -243,7 +243,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness bw6_761witness.Witness, opt ba
 		}
 
 		deltaS.FromAffine(&pk.G2.Delta)
-		deltaS.ScalarMultiplication(&deltaS, &s)
+		deltaS.ScalarMul(&deltaS, &s)
 		Bs.AddAssign(&deltaS)
 		Bs.AddMixed(&pk.G2.Beta)
 

--- a/internal/backend/bw6-761/groth16/setup.go
+++ b/internal/backend/bw6-761/groth16/setup.go
@@ -107,7 +107,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// To fill in the Proving and Verifying keys, we need to perform a lot of ecc scalar multiplication (with generator)
 	// and convert the resulting points to affine
-	// this is done using the curve.BatchScalarMultiplicationGX API, which takes as input the base point
+	// this is done using the curve.BatchScalarMulGX API, which takes as input the base point
 	// (in our case the generator) and the list of scalars, and outputs a list of points (len(points) == len(scalars))
 	// to use this batch call, we need to order our scalars in the same slice
 	// we have 1 batch call for G1 and 1 batch call for G1
@@ -207,7 +207,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	g1Scalars = append(g1Scalars, Z...)
 	g1Scalars = append(g1Scalars, vkK...)
 
-	g1PointsAff := curve.BatchScalarMultiplicationG1(&g1, g1Scalars)
+	g1PointsAff := curve.BatchScalarMulG1(&g1, g1Scalars)
 
 	// sets pk: [α]1, [β]1, [δ]1
 	pk.G1.Alpha = g1PointsAff[0]
@@ -242,7 +242,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// compute our batch scalar multiplication with g2 elements
 	g2Scalars := append(B, toxicWaste.betaReg, toxicWaste.deltaReg, toxicWaste.gammaReg)
 
-	g2PointsAff := curve.BatchScalarMultiplicationG2(&g2, g2Scalars)
+	g2PointsAff := curve.BatchScalarMulG2(&g2, g2Scalars)
 
 	pk.G2.B = g2PointsAff[:len(B)]
 
@@ -449,11 +449,11 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r1Aff curve.G1Affine
 	var b big.Int
 	g1, g2, _, _ := curve.Generators()
-	r1Jac.ScalarMultiplication(&g1, toxicWaste.alphaReg.ToBigInt(&b))
+	r1Jac.ScalarMul(&g1, toxicWaste.alphaReg.ToBigInt(&b))
 	r1Aff.FromJacobian(&r1Jac)
 	var r2Jac curve.G2Jac
 	var r2Aff curve.G2Affine
-	r2Jac.ScalarMultiplication(&g2, &b)
+	r2Jac.ScalarMul(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
 	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff

--- a/internal/backend/bw6-761/plonk/prove.go
+++ b/internal/backend/bw6-761/plonk/prove.go
@@ -325,10 +325,10 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bw6_761witness.Witnes
 	zetaPowerm.Exp(zeta, &bSize)
 	zetaPowerm.ToBigIntRegular(&bZetaPowerm)
 	foldedHDigest := proof.H[2]
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[1])                   // ζᵐ⁺²*Comm(h3)
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
-	foldedHDigest.Add(&foldedHDigest, &proof.H[0])                   // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[1])        // ζᵐ⁺²*Comm(h3)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
+	foldedHDigest.Add(&foldedHDigest, &proof.H[0])        // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
 
 	// foldedH = h1 + ζ*h2 + ζ²*h3
 	foldedH := h3

--- a/internal/backend/bw6-761/plonk/verify.go
+++ b/internal/backend/bw6-761/plonk/verify.go
@@ -159,9 +159,9 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness bw6_761witness.Witness
 	var zetaMPlusTwoBigInt big.Int
 	zetaMPlusTwo.ToBigIntRegular(&zetaMPlusTwoBigInt)
 	foldedH := proof.H[2]
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[1])
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[0])
 
 	// Compute the commitment to the linearized polynomial

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -126,7 +126,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 	_s.ToBigInt(&s)
 
 	// computes r[δ], s[δ], kr[δ]
-	deltas := curve.BatchScalarMultiplicationG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
+	deltas := curve.BatchScalarMulG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
 
 	proof := &Proof{}
 	var bs1, ar curve.G1Jac
@@ -190,14 +190,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 					chKrsDone <- err
 					return 
 				}
-				p1.ScalarMultiplication(&ar, &s)
+				p1.ScalarMul(&ar, &s)
 				krs.AddAssign(&p1)
 			case err := <-chBs1Done:
 				if err != nil {
 					chKrsDone <- err
 					return 
 				}
-				p1.ScalarMultiplication(&bs1, &r)
+				p1.ScalarMul(&bs1, &r)
 				krs.AddAssign(&p1)
 			}
 			n--
@@ -222,7 +222,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, witness {{ toLower .CurveID }}witness.
 		}
 
 		deltaS.FromAffine(&pk.G2.Delta)
-		deltaS.ScalarMultiplication(&deltaS, &s)
+		deltaS.ScalarMul(&deltaS, &s)
 		Bs.AddAssign(&deltaS)
 		Bs.AddMixed(&pk.G2.Beta)
 

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -86,7 +86,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// To fill in the Proving and Verifying keys, we need to perform a lot of ecc scalar multiplication (with generator)
 	// and convert the resulting points to affine
-	// this is done using the curve.BatchScalarMultiplicationGX API, which takes as input the base point
+	// this is done using the curve.BatchScalarMulGX API, which takes as input the base point
 	// (in our case the generator) and the list of scalars, and outputs a list of points (len(points) == len(scalars))
 	// to use this batch call, we need to order our scalars in the same slice
 	// we have 1 batch call for G1 and 1 batch call for G1
@@ -186,7 +186,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	g1Scalars = append(g1Scalars, Z...)
 	g1Scalars = append(g1Scalars, vkK...)
 
-	g1PointsAff := curve.BatchScalarMultiplicationG1(&g1, g1Scalars)
+	g1PointsAff := curve.BatchScalarMulG1(&g1, g1Scalars)
 
 	// sets pk: [α]1, [β]1, [δ]1
 	pk.G1.Alpha = g1PointsAff[0]
@@ -221,7 +221,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	// compute our batch scalar multiplication with g2 elements
 	g2Scalars := append(B, toxicWaste.betaReg, toxicWaste.deltaReg, toxicWaste.gammaReg)
 
-	g2PointsAff := curve.BatchScalarMultiplicationG2(&g2, g2Scalars)
+	g2PointsAff := curve.BatchScalarMulG2(&g2, g2Scalars)
 
 	pk.G2.B = g2PointsAff[:len(B)]
 
@@ -428,11 +428,11 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 	var r1Aff curve.G1Affine
 	var b big.Int
 	g1, g2, _, _ := curve.Generators()
-	r1Jac.ScalarMultiplication(&g1, toxicWaste.alphaReg.ToBigInt(&b))
+	r1Jac.ScalarMul(&g1, toxicWaste.alphaReg.ToBigInt(&b))
 	r1Aff.FromJacobian(&r1Jac)
 	var r2Jac curve.G2Jac
 	var r2Aff curve.G2Affine
-	r2Jac.ScalarMultiplication(&g2, &b)
+	r2Jac.ScalarMul(&g2, &b)
 	r2Aff.FromJacobian(&r2Jac)
 	for i := 0; i < len(pk.G1.A); i++ {
 		pk.G1.A[i] = r1Aff

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.marshal.go.tmpl
@@ -244,7 +244,7 @@ func GenG1() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g1 curve.G1Affine
-		g1.ScalarMultiplication(&g1GenAff, &scalar)
+		g1.ScalarMul(&g1GenAff, &scalar)
 
 
 		genResult := gopter.NewGenResult(g1, gopter.NoShrinker)
@@ -259,7 +259,7 @@ func GenG2() gopter.Gen {
 		scalar.SetUint64(genParams.NextUint64())
 
 		var g2 curve.G2Affine
-		g2.ScalarMultiplication(&g2GenAff, &scalar)
+		g2.ScalarMul(&g2GenAff, &scalar)
 
 
 		genResult := gopter.NewGenResult(g2, gopter.NoShrinker)

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
@@ -302,9 +302,9 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness {{ toLower .CurveID }
 	zetaPowerm.Exp(zeta, &bSize)
 	zetaPowerm.ToBigIntRegular(&bZetaPowerm)
 	foldedHDigest := proof.H[2]
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm)
 	foldedHDigest.Add(&foldedHDigest, &proof.H[1])                   // ζᵐ⁺²*Comm(h3)
-	foldedHDigest.ScalarMultiplication(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
+	foldedHDigest.ScalarMul(&foldedHDigest, &bZetaPowerm) // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2)
 	foldedHDigest.Add(&foldedHDigest, &proof.H[0])                   // ζ²⁽ᵐ⁺²⁾*Comm(h3) + ζᵐ⁺²*Comm(h2) + Comm(h1)
 
 	// foldedH = h1 + ζ*h2 + ζ²*h3

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.verify.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.verify.go.tmpl
@@ -138,9 +138,9 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness {{ toLower .CurveID }}
 	var zetaMPlusTwoBigInt big.Int
 	zetaMPlusTwo.ToBigIntRegular(&zetaMPlusTwoBigInt)
 	foldedH := proof.H[2]
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[1])
-	foldedH.ScalarMultiplication(&foldedH, &zetaMPlusTwoBigInt)
+	foldedH.ScalarMul(&foldedH, &zetaMPlusTwoBigInt)
 	foldedH.Add(&foldedH, &proof.H[0])
 
 	// Compute the commitment to the linearized polynomial

--- a/std/algebra/sw_bls12377/g1_test.go
+++ b/std/algebra/sw_bls12377/g1_test.go
@@ -283,7 +283,7 @@ func TestConstantScalarMulG1(t *testing.T) {
 	r.ToBigIntRegular(br)
 	// br is a circuit parameter
 	circuit.R = br
-	_a.ScalarMultiplication(&_a, br)
+	_a.ScalarMul(&_a, br)
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -320,7 +320,7 @@ func TestVarScalarMulG1(t *testing.T) {
 	witness.A.Assign(&a)
 	// compute the result
 	var br big.Int
-	_a.ScalarMultiplication(&_a, r.ToBigIntRegular(&br))
+	_a.ScalarMul(&_a, r.ToBigIntRegular(&br))
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -360,7 +360,7 @@ func TestScalarMulG1(t *testing.T) {
 	witness.A.Assign(&a)
 	// compute the result
 	var br big.Int
-	_a.ScalarMultiplication(&_a, r.ToBigIntRegular(&br))
+	_a.ScalarMul(&_a, r.ToBigIntRegular(&br))
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -375,7 +375,7 @@ func randomPointG1() bls12377.G1Jac {
 	var r1 fr.Element
 	var b big.Int
 	_, _ = r1.SetRandom()
-	p1.ScalarMultiplication(&p1, r1.ToBigIntRegular(&b))
+	p1.ScalarMul(&p1, r1.ToBigIntRegular(&b))
 
 	return p1
 }

--- a/std/algebra/sw_bls12377/g2_test.go
+++ b/std/algebra/sw_bls12377/g2_test.go
@@ -290,7 +290,7 @@ func TestConstantScalarMulG2(t *testing.T) {
 	r.ToBigIntRegular(br)
 	// br is a circuit parameter
 	circuit.R = br
-	_a.ScalarMultiplication(&_a, br)
+	_a.ScalarMul(&_a, br)
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -327,7 +327,7 @@ func TestVarScalarMulG2(t *testing.T) {
 	witness.A.Assign(&a)
 	// compute the result
 	var br big.Int
-	_a.ScalarMultiplication(&_a, r.ToBigIntRegular(&br))
+	_a.ScalarMul(&_a, r.ToBigIntRegular(&br))
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -367,7 +367,7 @@ func TestScalarMulG2(t *testing.T) {
 	witness.A.Assign(&a)
 	// compute the result
 	var br big.Int
-	_a.ScalarMultiplication(&_a, r.ToBigIntRegular(&br))
+	_a.ScalarMul(&_a, r.ToBigIntRegular(&br))
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -380,7 +380,7 @@ func randomPointG2() bls12377.G2Jac {
 	var r1 fr.Element
 	var b big.Int
 	_, _ = r1.SetRandom()
-	p2.ScalarMultiplication(&p2, r1.ToBigIntRegular(&b))
+	p2.ScalarMul(&p2, r1.ToBigIntRegular(&b))
 	return p2
 }
 

--- a/std/algebra/sw_bls12377/pairing_test.go
+++ b/std/algebra/sw_bls12377/pairing_test.go
@@ -143,8 +143,8 @@ func triplePairingData() (P [3]bls12377.G1Affine, Q [3]bls12377.G2Affine, pairin
 		_, _ = v.SetRandom()
 		u.ToBigIntRegular(&_u)
 		v.ToBigIntRegular(&_v)
-		P[i].ScalarMultiplication(&P[0], &_u)
-		Q[i].ScalarMultiplication(&Q[0], &_v)
+		P[i].ScalarMul(&P[0], &_u)
+		Q[i].ScalarMul(&Q[0], &_v)
 	}
 	milRes, _ := bls12377.MillerLoop([]bls12377.G1Affine{P[0], P[1], P[2]}, []bls12377.G2Affine{Q[0], Q[1], Q[2]})
 	pairingRes = bls12377.FinalExponentiation(&milRes)

--- a/std/algebra/sw_bls24315/g1_test.go
+++ b/std/algebra/sw_bls24315/g1_test.go
@@ -283,7 +283,7 @@ func TestConstantScalarMulG1(t *testing.T) {
 	r.ToBigIntRegular(br)
 	// br is a circuit parameter
 	circuit.R = br
-	_a.ScalarMultiplication(&_a, br)
+	_a.ScalarMul(&_a, br)
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -320,7 +320,7 @@ func TestVarScalarMulG1(t *testing.T) {
 	witness.A.Assign(&a)
 	// compute the result
 	var br big.Int
-	_a.ScalarMultiplication(&_a, r.ToBigIntRegular(&br))
+	_a.ScalarMul(&_a, r.ToBigIntRegular(&br))
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -360,7 +360,7 @@ func TestScalarMulG1(t *testing.T) {
 	witness.A.Assign(&a)
 	// compute the result
 	var br big.Int
-	_a.ScalarMultiplication(&_a, r.ToBigIntRegular(&br))
+	_a.ScalarMul(&_a, r.ToBigIntRegular(&br))
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -375,7 +375,7 @@ func randomPointG1() bls24315.G1Jac {
 	var r1 fr.Element
 	var b big.Int
 	_, _ = r1.SetRandom()
-	p1.ScalarMultiplication(&p1, r1.ToBigIntRegular(&b))
+	p1.ScalarMul(&p1, r1.ToBigIntRegular(&b))
 
 	return p1
 }

--- a/std/algebra/sw_bls24315/g2_test.go
+++ b/std/algebra/sw_bls24315/g2_test.go
@@ -290,7 +290,7 @@ func TestConstantScalarMulG2(t *testing.T) {
 	r.ToBigIntRegular(br)
 	// br is a circuit parameter
 	circuit.R = br
-	_a.ScalarMultiplication(&_a, br)
+	_a.ScalarMul(&_a, br)
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -327,7 +327,7 @@ func TestVarScalarMulG2(t *testing.T) {
 	witness.A.Assign(&a)
 	// compute the result
 	var br big.Int
-	_a.ScalarMultiplication(&_a, r.ToBigIntRegular(&br))
+	_a.ScalarMul(&_a, r.ToBigIntRegular(&br))
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -367,7 +367,7 @@ func TestScalarMulG2(t *testing.T) {
 	witness.A.Assign(&a)
 	// compute the result
 	var br big.Int
-	_a.ScalarMultiplication(&_a, r.ToBigIntRegular(&br))
+	_a.ScalarMul(&_a, r.ToBigIntRegular(&br))
 	c.FromJacobian(&_a)
 	witness.C.Assign(&c)
 
@@ -380,7 +380,7 @@ func randomPointG2() bls24315.G2Jac {
 	var r1 fr.Element
 	var b big.Int
 	_, _ = r1.SetRandom()
-	p2.ScalarMultiplication(&p2, r1.ToBigIntRegular(&b))
+	p2.ScalarMul(&p2, r1.ToBigIntRegular(&b))
 	return p2
 }
 

--- a/std/algebra/sw_bls24315/pairing_test.go
+++ b/std/algebra/sw_bls24315/pairing_test.go
@@ -144,8 +144,8 @@ func triplePairingData() (P [3]bls24315.G1Affine, Q [3]bls24315.G2Affine, pairin
 		_, _ = v.SetRandom()
 		u.ToBigIntRegular(&_u)
 		v.ToBigIntRegular(&_v)
-		P[i].ScalarMultiplication(&P[0], &_u)
-		Q[i].ScalarMultiplication(&Q[0], &_v)
+		P[i].ScalarMul(&P[0], &_u)
+		Q[i].ScalarMul(&Q[0], &_v)
 	}
 	milRes, _ := bls24315.MillerLoop([]bls24315.G1Affine{P[0], P[1], P[2]}, []bls24315.G2Affine{Q[0], Q[1], Q[2]})
 	pairingRes = bls24315.FinalExponentiation(&milRes)


### PR DESCRIPTION
Rename `ScalarMultiplication()` to `ScalarMul()`. Needs https://github.com/ConsenSys/gnark-crypto/pull/220 PR to be merged first.