### PR TITLE
Fix/xor cst var plonk

### DIFF
--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -281,14 +281,9 @@ func (system *r1cs) Xor(_a, _b frontend.Variable) frontend.Variable {
 	system.AssertIsBoolean(a)
 	system.AssertIsBoolean(b)
 
-	// the formulation used is for easing up the conversion to sparse r1cs
-	res := system.newInternalVariable()
+	t := system.Mul(2, system.Mul(_a, _b))
+	res := system.Sub(system.Add(_a, _b), t)
 	system.MarkBoolean(res)
-	c := system.Neg(res).(compiled.LinearExpression)
-	c = append(c, a...)
-	c = append(c, b...)
-	aa := system.Mul(a, 2)
-	system.addConstraint(newR1C(aa, b, c))
 
 	return res
 }

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -137,8 +137,14 @@ func (system *r1cs) reduce(l compiled.LinearExpression) compiled.LinearExpressio
 	mod := system.Field()
 	c := new(big.Int)
 	for i := 1; i < len(l); i++ {
+		fmt.Printf("%d\n", i)
 		pcID, pvID, pVis := l[i-1].Unpack()
 		ccID, cvID, cVis := l[i].Unpack()
+		// if the coefficient is zero, we remove it
+		if ccID == compiled.CoeffIdZero {
+			l = append(l[:i], l[i+1:]...)
+			continue
+		}
 		if pVis == cVis && pvID == cvID {
 			// we have redundancy
 			c.Add(&system.st.Coeffs[pcID], &system.st.Coeffs[ccID])

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -137,7 +137,6 @@ func (system *r1cs) reduce(l compiled.LinearExpression) compiled.LinearExpressio
 	mod := system.Field()
 	c := new(big.Int)
 	for i := 1; i < len(l); i++ {
-		fmt.Printf("%d\n", i)
 		pcID, pvID, pVis := l[i-1].Unpack()
 		ccID, cvID, cVis := l[i].Unpack()
 		// if the coefficient is zero, we remove it

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -193,6 +193,7 @@ func (system *scs) FromBinary(b ...frontend.Variable) frontend.Variable {
 // Xor returns a ^ b
 // a and b must be 0 or 1
 func (system *scs) Xor(a, b frontend.Variable) frontend.Variable {
+
 	system.AssertIsBoolean(a)
 	system.AssertIsBoolean(b)
 	_a, aConstant := system.ConstantValue(a)
@@ -211,8 +212,12 @@ func (system *scs) Xor(a, b frontend.Variable) frontend.Variable {
 	}
 	if bConstant {
 		l := a.(compiled.Term)
-		bNeg := new(big.Int).Neg(_b)
-		system.addPlonkConstraint(l, l, res, compiled.CoeffIdMinusOne, compiled.CoeffIdZero, compiled.CoeffIdTwo, system.st.CoeffID(_b), compiled.CoeffIdOne, system.st.CoeffID(bNeg))
+		r := l
+		oneMinusTwoB := big.NewInt(2)
+		oneMinusTwoB.Mul(oneMinusTwoB, _b)
+		one := big.NewInt(1)
+		oneMinusTwoB.Sub(one, oneMinusTwoB)
+		system.addPlonkConstraint(l, r, res, system.st.CoeffID(oneMinusTwoB), compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdMinusOne, system.st.CoeffID(_b))
 		return res
 	}
 	l := a.(compiled.Term)

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -212,10 +212,7 @@ func (system *scs) Xor(a, b frontend.Variable) frontend.Variable {
 	if bConstant {
 		l := a.(compiled.Term)
 		r := l
-		one := big.NewInt(1)
-		_b.Lsh(_b, 1).Sub(_b, one)
-		idl := system.st.CoeffID(_b)
-		system.addPlonkConstraint(l, r, res, idl, compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdOne, compiled.CoeffIdZero)
+		system.addPlonkConstraint(l, r, res, l.CoeffID(), compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdMinusOne, compiled.CoeffIdMinusOne)
 		return res
 	}
 	l := a.(compiled.Term)

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -205,6 +205,7 @@ func (system *scs) Xor(a, b frontend.Variable) frontend.Variable {
 	}
 
 	res := system.newInternalVariable()
+	system.MarkBoolean(res)
 	if aConstant {
 		a, b = b, a
 		bConstant = aConstant
@@ -239,6 +240,7 @@ func (system *scs) Or(a, b frontend.Variable) frontend.Variable {
 		return _a
 	}
 	res := system.newInternalVariable()
+	system.MarkBoolean(res)
 	if aConstant {
 		a, b = b, a
 		_b = _a
@@ -265,7 +267,9 @@ func (system *scs) Or(a, b frontend.Variable) frontend.Variable {
 func (system *scs) And(a, b frontend.Variable) frontend.Variable {
 	system.AssertIsBoolean(a)
 	system.AssertIsBoolean(b)
-	return system.Mul(a, b)
+	res := system.Mul(a, b)
+	system.MarkBoolean(res)
+	return res
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -211,8 +211,8 @@ func (system *scs) Xor(a, b frontend.Variable) frontend.Variable {
 	}
 	if bConstant {
 		l := a.(compiled.Term)
-		r := l
-		system.addPlonkConstraint(l, r, res, l.CoeffID(), compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdMinusOne, compiled.CoeffIdMinusOne)
+		bNeg := new(big.Int).Neg(_b)
+		system.addPlonkConstraint(l, l, res, compiled.CoeffIdMinusOne, compiled.CoeffIdZero, compiled.CoeffIdTwo, system.st.CoeffID(_b), compiled.CoeffIdOne, system.st.CoeffID(bNeg))
 		return res
 	}
 	l := a.(compiled.Term)

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -213,10 +213,8 @@ func (system *scs) Xor(a, b frontend.Variable) frontend.Variable {
 	if bConstant {
 		l := a.(compiled.Term)
 		r := l
-		oneMinusTwoB := big.NewInt(2)
-		oneMinusTwoB.Mul(oneMinusTwoB, _b)
-		one := big.NewInt(1)
-		oneMinusTwoB.Sub(one, oneMinusTwoB)
+		oneMinusTwoB := big.NewInt(1)
+		oneMinusTwoB.Sub(oneMinusTwoB, _b).Sub(oneMinusTwoB, _b)
 		system.addPlonkConstraint(l, r, res, system.st.CoeffID(oneMinusTwoB), compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdZero, compiled.CoeffIdMinusOne, system.st.CoeffID(_b))
 		return res
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -50,33 +50,28 @@ func TestIntegrationAPI(t *testing.T) {
 			backends = []backend.ID{backend.GROTH16, backend.PLONK}
 		}
 
-		backends = []backend.ID{backend.PLONK}
-		if name == "xorCstVar" {
+		assert.Run(func(assert *test.Assert) {
+			for i := range tData.ValidAssignments {
+				assert.Run(func(assert *test.Assert) {
+					assert.ProverSucceeded(
+						tData.Circuit, tData.ValidAssignments[i],
+						test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
+						test.WithCurves(tData.Curves[0], tData.Curves[1:]...),
+						test.WithBackends(backends[0], backends[1:]...))
+				}, fmt.Sprintf("valid-%d", i))
+			}
 
-			assert.Run(func(assert *test.Assert) {
-				for i := range tData.ValidAssignments {
-					assert.Run(func(assert *test.Assert) {
-						assert.ProverSucceeded(
-							tData.Circuit, tData.ValidAssignments[i],
-							test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
-							test.WithCurves(tData.Curves[0], tData.Curves[1:]...),
-							test.WithBackends(backends[0], backends[1:]...))
-					}, fmt.Sprintf("valid-%d", i))
-				}
-
-				for i := range tData.InvalidAssignments {
-					assert.Run(func(assert *test.Assert) {
-						assert.ProverFailed(
-							tData.Circuit,
-							tData.InvalidAssignments[i],
-							test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
-							test.WithCurves(tData.Curves[0], tData.Curves[1:]...),
-							test.WithBackends(backends[0], backends[1:]...))
-					}, fmt.Sprintf("invalid-%d", i))
-				}
-			}, name)
-		}
-
+			for i := range tData.InvalidAssignments {
+				assert.Run(func(assert *test.Assert) {
+					assert.ProverFailed(
+						tData.Circuit,
+						tData.InvalidAssignments[i],
+						test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
+						test.WithCurves(tData.Curves[0], tData.Curves[1:]...),
+						test.WithBackends(backends[0], backends[1:]...))
+				}, fmt.Sprintf("invalid-%d", i))
+			}
+		}, name)
 	}
 
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -50,28 +50,32 @@ func TestIntegrationAPI(t *testing.T) {
 			backends = []backend.ID{backend.GROTH16, backend.PLONK}
 		}
 
-		assert.Run(func(assert *test.Assert) {
-			for i := range tData.ValidAssignments {
-				assert.Run(func(assert *test.Assert) {
-					assert.ProverSucceeded(
-						tData.Circuit, tData.ValidAssignments[i],
-						test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
-						test.WithCurves(tData.Curves[0], tData.Curves[1:]...),
-						test.WithBackends(backends[0], backends[1:]...))
-				}, fmt.Sprintf("valid-%d", i))
-			}
+		backends = []backend.ID{backend.PLONK}
+		if name == "xorCstVar" {
 
-			for i := range tData.InvalidAssignments {
-				assert.Run(func(assert *test.Assert) {
-					assert.ProverFailed(
-						tData.Circuit,
-						tData.InvalidAssignments[i],
-						test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
-						test.WithCurves(tData.Curves[0], tData.Curves[1:]...),
-						test.WithBackends(backends[0], backends[1:]...))
-				}, fmt.Sprintf("invalid-%d", i))
-			}
-		}, name)
+			assert.Run(func(assert *test.Assert) {
+				for i := range tData.ValidAssignments {
+					assert.Run(func(assert *test.Assert) {
+						assert.ProverSucceeded(
+							tData.Circuit, tData.ValidAssignments[i],
+							test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
+							test.WithCurves(tData.Curves[0], tData.Curves[1:]...),
+							test.WithBackends(backends[0], backends[1:]...))
+					}, fmt.Sprintf("valid-%d", i))
+				}
+
+				for i := range tData.InvalidAssignments {
+					assert.Run(func(assert *test.Assert) {
+						assert.ProverFailed(
+							tData.Circuit,
+							tData.InvalidAssignments[i],
+							test.WithProverOpts(backend.WithHints(tData.HintFunctions...)),
+							test.WithCurves(tData.Curves[0], tData.Curves[1:]...),
+							test.WithBackends(backends[0], backends[1:]...))
+					}, fmt.Sprintf("invalid-%d", i))
+				}
+			}, name)
+		}
 
 	}
 

--- a/internal/backend/circuits/xor.go
+++ b/internal/backend/circuits/xor.go
@@ -33,17 +33,10 @@ func init() {
 			XorOne:  0,
 			XorZero: 1,
 		},
-<<<<<<< Updated upstream
 		&xorCircuitVarCst{
-			Op:      0,
-			XorOne:  1,
-			XorZero: 0,
-=======
-		&XorCircuitVarCst{
 			Op:      (0),
 			XorOne:  (1),
 			XorZero: (0),
->>>>>>> Stashed changes
 		},
 	}
 
@@ -53,25 +46,14 @@ func init() {
 			XorOne:  0,
 			XorZero: 1,
 		},
-<<<<<<< Updated upstream
 		&xorCircuitVarCst{
-			Op:      1,
-			XorOne:  1,
-			XorZero: 1,
-		},
-	}
-
-	addNewEntry("xorCstVar", &xorCircuitVarCst{}, good, bad, []ecc.ID{ecc.BN254})
-=======
-		&XorCircuitVarCst{
 			Op:      (1),
 			XorOne:  (1),
 			XorZero: (0),
 		},
 	}
 
-	addNewEntry("xorCstVar", &XorCircuitVarCst{}, good, bad, []ecc.ID{ecc.BN254})
->>>>>>> Stashed changes
+	addNewEntry("xorCstVar", &xorCircuitVarCst{}, good, bad, []ecc.ID{ecc.BN254})
 
 }
 

--- a/internal/backend/circuits/xor.go
+++ b/internal/backend/circuits/xor.go
@@ -33,10 +33,17 @@ func init() {
 			XorOne:  0,
 			XorZero: 1,
 		},
+<<<<<<< Updated upstream
 		&xorCircuitVarCst{
 			Op:      0,
 			XorOne:  1,
 			XorZero: 0,
+=======
+		&XorCircuitVarCst{
+			Op:      (0),
+			XorOne:  (1),
+			XorZero: (0),
+>>>>>>> Stashed changes
 		},
 	}
 
@@ -46,6 +53,7 @@ func init() {
 			XorOne:  0,
 			XorZero: 1,
 		},
+<<<<<<< Updated upstream
 		&xorCircuitVarCst{
 			Op:      1,
 			XorOne:  1,
@@ -54,6 +62,16 @@ func init() {
 	}
 
 	addNewEntry("xorCstVar", &xorCircuitVarCst{}, good, bad, []ecc.ID{ecc.BN254})
+=======
+		&XorCircuitVarCst{
+			Op:      (1),
+			XorOne:  (1),
+			XorZero: (0),
+		},
+	}
+
+	addNewEntry("xorCstVar", &XorCircuitVarCst{}, good, bad, []ecc.ID{ecc.BN254})
+>>>>>>> Stashed changes
 
 }
 

--- a/internal/backend/circuits/xor.go
+++ b/internal/backend/circuits/xor.go
@@ -2,7 +2,6 @@ package circuits
 
 import (
 	"github.com/consensys/gnark"
-	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -53,7 +52,7 @@ func init() {
 		},
 	}
 
-	addNewEntry("xorCstVar", &xorCircuitVarCst{}, good, bad, []ecc.ID{ecc.BN254})
+	addNewEntry("xorCstVar", &xorCircuitVarCst{}, good, bad, gnark.Curves())
 
 }
 

--- a/internal/backend/circuits/xor.go
+++ b/internal/backend/circuits/xor.go
@@ -2,9 +2,58 @@ package circuits
 
 import (
 	"github.com/consensys/gnark"
+	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
 )
 
+// one input is constant
+type XorCircuitVarCst struct {
+	Op      frontend.Variable
+	XorOne  frontend.Variable `gnark:“,public”`
+	XorZero frontend.Variable `gnark:“,public”`
+}
+
+func (circuit *XorCircuitVarCst) Define(api frontend.API) error {
+	a := api.Xor(circuit.Op, 1)
+	b := api.Xor(circuit.Op, 0)
+	api.AssertIsEqual(a, circuit.XorOne)
+	api.AssertIsEqual(b, circuit.XorZero)
+	return nil
+}
+
+func init() {
+
+	good := []frontend.Circuit{
+		&XorCircuitVarCst{
+			Op:      (1),
+			XorOne:  (0),
+			XorZero: (1),
+		},
+		&XorCircuitVarCst{
+			Op:      (0),
+			XorOne:  (1),
+			XorZero: (1),
+		},
+	}
+
+	bad := []frontend.Circuit{
+		&XorCircuitVarCst{
+			Op:      (0),
+			XorOne:  (0),
+			XorZero: (1),
+		},
+		&XorCircuitVarCst{
+			Op:      (1),
+			XorOne:  (1),
+			XorZero: (1),
+		},
+	}
+
+	addNewEntry("xorCstVar", &xorCircuit{}, good, bad, []ecc.ID{ecc.BN254})
+
+}
+
+// both inputs are variable
 type xorCircuit struct {
 	Op1, Op2, Res frontend.Variable
 }

--- a/internal/backend/circuits/xor.go
+++ b/internal/backend/circuits/xor.go
@@ -7,49 +7,53 @@ import (
 )
 
 // one input is constant
-type XorCircuitVarCst struct {
+type xorCircuitVarCst struct {
 	Op      frontend.Variable
 	XorOne  frontend.Variable `gnark:",public"`
 	XorZero frontend.Variable `gnark:",public"`
 }
 
-func (circuit *XorCircuitVarCst) Define(api frontend.API) error {
+func (circuit *xorCircuitVarCst) Define(api frontend.API) error {
 	a := api.Xor(circuit.Op, 1)
 	b := api.Xor(circuit.Op, 0)
+	c := api.Xor(1, circuit.Op)
+	d := api.Xor(0, circuit.Op)
 	api.AssertIsEqual(a, circuit.XorOne)
 	api.AssertIsEqual(b, circuit.XorZero)
+	api.AssertIsEqual(c, circuit.XorOne)
+	api.AssertIsEqual(d, circuit.XorZero)
 	return nil
 }
 
 func init() {
 
 	good := []frontend.Circuit{
-		&XorCircuitVarCst{
-			Op:      (1),
-			XorOne:  (0),
-			XorZero: (1),
+		&xorCircuitVarCst{
+			Op:      1,
+			XorOne:  0,
+			XorZero: 1,
 		},
-		&XorCircuitVarCst{
-			Op:      (0),
-			XorOne:  (1),
-			XorZero: (1),
+		&xorCircuitVarCst{
+			Op:      0,
+			XorOne:  1,
+			XorZero: 0,
 		},
 	}
 
 	bad := []frontend.Circuit{
-		&XorCircuitVarCst{
-			Op:      (0),
-			XorOne:  (0),
-			XorZero: (1),
+		&xorCircuitVarCst{
+			Op:      0,
+			XorOne:  0,
+			XorZero: 1,
 		},
-		&XorCircuitVarCst{
-			Op:      (1),
-			XorOne:  (1),
-			XorZero: (1),
+		&xorCircuitVarCst{
+			Op:      1,
+			XorOne:  1,
+			XorZero: 1,
 		},
 	}
 
-	addNewEntry("xorCstVar", &xorCircuit{}, good, bad, []ecc.ID{ecc.BN254})
+	addNewEntry("xorCstVar", &xorCircuitVarCst{}, good, bad, []ecc.ID{ecc.BN254})
 
 }
 
@@ -69,56 +73,56 @@ func init() {
 
 	good := []frontend.Circuit{
 		&xorCircuit{
-			Op1: (1),
-			Op2: (1),
-			Res: (0),
+			Op1: 1,
+			Op2: 1,
+			Res: 0,
 		},
 		&xorCircuit{
-			Op1: (1),
-			Op2: (0),
-			Res: (1),
+			Op1: 1,
+			Op2: 0,
+			Res: 1,
 		},
 		&xorCircuit{
-			Op1: (0),
-			Op2: (1),
-			Res: (1),
+			Op1: 0,
+			Op2: 1,
+			Res: 1,
 		},
 		&xorCircuit{
-			Op1: (0),
-			Op2: (0),
-			Res: (0),
+			Op1: 0,
+			Op2: 0,
+			Res: 0,
 		},
 	}
 
 	bad := []frontend.Circuit{
 		&xorCircuit{
-			Op1: (1),
-			Op2: (1),
-			Res: (1),
+			Op1: 1,
+			Op2: 1,
+			Res: 1,
 		},
 		&xorCircuit{
-			Op1: (1),
-			Op2: (0),
-			Res: (0),
+			Op1: 1,
+			Op2: 0,
+			Res: 0,
 		},
 		&xorCircuit{
-			Op1: (0),
-			Op2: (1),
-			Res: (0),
+			Op1: 0,
+			Op2: 1,
+			Res: 0,
 		},
 		&xorCircuit{
-			Op1: (0),
-			Op2: (0),
-			Res: (1),
+			Op1: 0,
+			Op2: 0,
+			Res: 1,
 		},
 		&xorCircuit{
 			Op1: (42),
-			Op2: (1),
-			Res: (1),
+			Op2: 1,
+			Res: 1,
 		},
 		&xorCircuit{
-			Op1: (1),
-			Op2: (1),
+			Op1: 1,
+			Op2: 1,
 			Res: (42),
 		},
 	}

--- a/internal/backend/circuits/xor.go
+++ b/internal/backend/circuits/xor.go
@@ -9,8 +9,8 @@ import (
 // one input is constant
 type XorCircuitVarCst struct {
 	Op      frontend.Variable
-	XorOne  frontend.Variable `gnark:“,public”`
-	XorZero frontend.Variable `gnark:“,public”`
+	XorOne  frontend.Variable `gnark:",public"`
+	XorZero frontend.Variable `gnark:",public"`
 }
 
 func (circuit *XorCircuitVarCst) Define(api frontend.API) error {


### PR DESCRIPTION
Changes:

- Addition of tests for Xor( var, <cst> )
- Simplified the writing of Xor in the r1cs API
- Fixed the Xor in sparseR1cs when one of the operands is constant

in the `reduce` method of the r1cs, the terms multiplied by zeroes are removed:
```
	// if the coefficient is zero, we remove it
        if ccID == compiled.CoeffIdZero {
	        l = append(l[:i], l[i+1:]...)
	        continue
        }
```