### PR TITLE
feat: add inherit circuit tag

### DIFF
--- a/frontend/circuit.go
+++ b/frontend/circuit.go
@@ -16,28 +16,24 @@ limitations under the License.
 
 package frontend
 
-// Circuit must be implemented by user-defined circuits
+// Circuit must be implemented by user-defined circuit. The best way to define a
+// circuit is define a type which contains all the witness elements as fields
+// and declare `Define` method on the type.
 //
-// the tag format is as follow:
-//
-//	type MyCircuit struct {
-//		Y frontend.Variable `gnark:"name,option"`
-//	}
-//
-// if empty, default resolves to variable name (here "Y") and secret visibility
-// similarly to json or xml struct tags, these are valid:
-//
-//	`gnark:",public"` or `gnark:"-"`
-//
-// using "-" marks the variable as ignored by the Compile method. This can be useful when you need to
-// declare variables as aliases that are already allocated. For example
+// For example, the following is a minimal valid circuit:
 //
 //	type MyCircuit struct {
-//		Y frontend.Variable `gnark:",public"`
-//		Z frontend.Variable `gnark:"-"`
+//	    X frontend.Variable `gnark:"-,public"`
+//	    Y frontend.Variable `gnark:"-,secret"`
 //	}
 //
-// it is then the developer responsability to do circuit.Z = circuit.Y in the Define() method
+//	func (c *MyCircuit) Define(api frontend.API) error {
+//	    api.AssertIsEqual(c.X, c.Y)
+//		return nil
+//	}
+//
+// See the documentation for [schema.TagOpt] for how to use tags to define the
+// behaviour of the compiler and schema parser.
 type Circuit interface {
 	// Define declares the circuit's Constraints
 	Define(api API) error

--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -13,7 +13,7 @@ import (
 
 // Compile will generate a ConstraintSystem from the given circuit
 //
-// 1. it will first allocate the user inputs (see type Tag for more info)
+// 1. it will first allocate the user inputs (see [schema.TagOpt] and [Circuit] for more info)
 // example:
 //
 //	type MyCircuit struct {

--- a/frontend/schema/schema_test.go
+++ b/frontend/schema/schema_test.go
@@ -163,7 +163,48 @@ func TestSchemaInherit(t *testing.T) {
 		assert.Equal(3, s.NbPublic)
 		assert.Equal(1, s.NbSecret)
 	}
+}
 
+type InheritingType struct {
+	C1 variable
+	C2 variable `gnark:"C2"`
+	C3 variable `gnark:",inherit"`
+}
+
+type DoubleInheritingType struct {
+	D1 InheritingType
+	D2 InheritingType `gnark:"D2"`
+	D3 InheritingType `gnark:",inherit"`
+}
+
+type InheritCircuit struct {
+	A1 InheritingType
+	A2 InheritingType `gnark:"A2"`
+	A3 InheritingType `gnark:",public"`
+	A4 InheritingType `gnark:",secret"`
+	A5 DoubleInheritingType
+	A6 DoubleInheritingType `gnark:"DD"`
+	A7 DoubleInheritingType `gnark:",public"`
+	A8 DoubleInheritingType `gnark:",secret"`
+}
+
+type InvalidInheritingCircuit struct {
+	B1 InheritingType       `gnark:",inherit"`
+	B2 DoubleInheritingType `gnark:",inherit"`
+}
+
+func TestSchemaInherit2(t *testing.T) {
+	assert := require.New(t)
+	{
+		c := InheritCircuit{}
+		_, err := Parse(&c, tVariable, nil)
+		assert.NoError(err)
+	}
+	{
+		c := InvalidInheritingCircuit{}
+		_, err := Parse(&c, tVariable, nil)
+		assert.Error(err)
+	}
 }
 
 var tVariable reflect.Type

--- a/frontend/schema/tags.go
+++ b/frontend/schema/tags.go
@@ -5,36 +5,82 @@ import (
 	"unicode"
 )
 
-// Tag is a (optional) struct tag one can add to Variable
-// to specify compiler.Compile() behavior
+// TagOpt is a (optional) struct tag one can add to a Variable field in the
+// circuit definition to specify compiler behaviour and witness parsing. The
+// order of the tag matters, the first element in the tag list is always the
+// assumed name of the witness element and the rest of the tags define the
+// properties of the witness element. Valid tag options are given by constants
+//   - [TagOptPublic] ("public"): element belongs to the public part of the witness;
+//   - [TagOptSecret] ("secret"): element belongs to the secret part of the witness;
+//   - [TagOptInherit] ("inherit"): element's visibility is inherited from its
+//     parent visibility. Is useful for defining custom types to allow consistent
+//     visibility;
+//   - [TagOptOmit] ("-"): do not insert the element into a witness.
 //
-// the tag format is as follow:
+// # Examples
+//
+// In the code, it would look like this:
 //
 //	type MyCircuit struct {
-//		Y frontend.Variable `gnark:"name,option"`
+//	    Y frontend.Variable `gnark:"name,option"`
+//	 }
+//
+// If no tags are defined, then the parser by default deduces the name from the
+// field name in the struct. If the witness element is defined on the circuit
+// type level, then applies "secret" visibility and otherwise inherits the
+// visibility of its parent. For example, for a circuit defined as:
+//
+//	type DefaultCircuit struct {
+//	    X frontend.Variable
+//	 }
+//
+// the assumed name of the field "X" would be "X" and its visibility would be
+// "secret".
+//
+// To define only a name tag, the options part of tag can be left empty i.e.:
+//
+//	type NameOnlyCircuit struct {
+//	    X frontend.Variable `gnark:"Result"`   // assumed visibility "secret"
 //	}
 //
-// if empty, default resolves to variable name (here "Y") and secret visibility
-// similarly to json or xml struct tags, these are valid:
+// To define only options tag (and have the parser assume the name for the
+// witness element), keep the name part empty i.e.:
 //
-//	`gnark:",public"` or `gnark:"-"`
+//	type OptionOnlyCircuit struct {
+//	    X frontend.Variable `gnark:",public"` // assumed name "X"
+//	 }
 //
-// using "-" marks the variable as ignored by the Compile method. This can be useful when you need to
-// declare variables as aliases that are already allocated. For example
+// The tag "-" instructs the compiler to ignore the variable in parsing and
+// compiling. In that case, it is the responsibility of the developer to assign
+// a value to the ignored variable in circuit. Such circuit would look like:
 //
-//	type MyCircuit struct {
-//		Y frontend.Variable `gnark:",public"`
-//		Z frontend.Variable `gnark:"-"`
+//	type NoWitnessCircuit struct {
+//	    X frontend.Variable `gnark:"-"`
 //	}
 //
-// it is then the developer responsability to do circuit.Z = circuit.Y in the Define() method
-type Tag string
+// When defining a custom type we use the "inherit" tag. For example, if there
+// is a custom type
+//
+//	type List struct {
+//	    Vals []frontend.Variable `gnark:",inherit"`
+//	}
+//
+// then we can use this type in the in the circuit definition:
+//
+//	type ListCircuit struct {
+//	    X List `gnark:",secret"`
+//	}
+type TagOpt string
 
 const (
-	tagKey    Tag = "gnark"
-	optPublic Tag = "public"
-	optSecret Tag = "secret"
-	optOmit   Tag = "-"
+	TagOptPublic  TagOpt = "public"  // public witness element
+	TagOptSecret  TagOpt = "secret"  // secret witness element
+	TagOptInherit TagOpt = "inherit" // inherit the visibility of the witness element from its parent.
+	TagOptOmit    TagOpt = "-"       // do not parse the field as witness element
+)
+
+const (
+	tagKey string = "gnark"
 )
 
 // Copyright 2011 The Go Authors. All rights reserved.
@@ -59,14 +105,14 @@ func parseTag(tag string) (string, tagOptions) {
 // contains reports whether a comma-separated list of options
 // contains a particular substr flag. substr must be surrounded by a
 // string boundary or commas.
-func (o tagOptions) contains(optionName string) bool {
+func (o tagOptions) contains(optionName TagOpt) bool {
 	if len(o) == 0 {
 		return false
 	}
 	s := string(o)
 	optList := strings.Split(s, ",")
 	for i := 0; i < len(optList); i++ {
-		if strings.TrimSpace(optList[i]) == optionName {
+		if strings.TrimSpace(optList[i]) == string(optionName) {
 			return true
 		}
 	}

--- a/std/math/emulated/element.go
+++ b/std/math/emulated/element.go
@@ -40,7 +40,7 @@ func (e errOverflow) Error() string {
 // value of the element is split into limbs of nbBits lengths and represented as
 // a slice of limbs.
 type Element[T FieldParams] struct {
-	Limbs []frontend.Variable `gnark:"limbs"` // in little-endian (least significant limb first) encoding
+	Limbs []frontend.Variable `gnark:"limbs,inherit"` // in little-endian (least significant limb first) encoding
 
 	// overflow indicates the number of additions on top of the normal form. To
 	// ensure that none of the limbs overflow the scalar field of the snark

--- a/std/math/emulated/element_test.go
+++ b/std/math/emulated/element_test.go
@@ -762,3 +762,16 @@ func testFourMuls[T FieldParams](t *testing.T) {
 		assert.ProverSucceeded(&circuit, &witness, test.WithCurves(testCurve), test.NoSerialization(), test.WithBackends(backend.GROTH16, backend.PLONK))
 	}, testName[T]())
 }
+
+type PublicElement struct {
+	Y Element[BN254Fp] `gnark:",public"`
+}
+
+func (c *PublicElement) Define(api frontend.API) error {
+	return nil
+}
+
+func TestPublicElement(t *testing.T) {
+	assert := test.NewAssert(t)
+	assert.ProverSucceeded(&PublicElement{}, &PublicElement{}, test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()))
+}


### PR DESCRIPTION
Resolves #385.

This PR adds new "inherit" tag to the circuit which allows inherit the visibility of the parent object. Useful for custom defined types.

Meanwhile, updated also some comments to take advantage of new go doc formatting rules (links and lists).