### PR TITLE
fix: fixed Lagrange polynomials construction

### DIFF
--- a/internal/backend/bls12-377/plonkfri/prove.go
+++ b/internal/backend/bls12-377/plonkfri/prove.go
@@ -231,9 +231,6 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls12_377witness.Witn
 	bOpeningPosition.SetBytes(frOpeningPosition.Marshal()).Mod(&bOpeningPosition, &bFriSize)
 	openingPosition := bOpeningPosition.Uint64()
 
-	// derive a query position, which is 0<=i<domain[1].Size
-	// openingPosition := uint64(2)
-
 	// ql, qr, qm, qo, qkIncomplete
 	proof.OpeningsQlQrQmQoQkincompletemp[0], err = pk.Vk.Iopp.Open(pk.CQl, openingPosition)
 	if err != nil {

--- a/internal/backend/bls12-377/plonkfri/verify.go
+++ b/internal/backend/bls12-377/plonkfri/verify.go
@@ -358,14 +358,22 @@ func completeQk(publicWitness bls12_377witness.Witness, vk *VerifyingKey, zeta f
 
 	var res fr.Element
 
-	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
+	// compute l1(zeta). Exceptional case: if zeta=1, then l1(zeta)=1,
+	// we need to manually initialise l to this value otherwise there
+	// is a denominator equal to zero in the formula.
 	var l, tmp, acc, one fr.Element
 	one.SetOne()
 	acc.SetOne()
-	l.Sub(&zeta, &one).Inverse(&l).Mul(&l, &vk.SizeInv)
-	tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
-	l.Mul(&l, &tmp)
+	l.Sub(&zeta, &one)
+	if l.IsZero() {
+		l.SetOne()
+	} else {
+		l.Inverse(&l).Mul(&l, &vk.SizeInv)
+		tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
+		l.Mul(&l, &tmp)
+	}
 
+	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
 	for i := 0; i < len(publicWitness); i++ {
 
 		tmp.Mul(&l, &publicWitness[i])
@@ -375,7 +383,14 @@ func completeQk(publicWitness bls12_377witness.Witness, vk *VerifyingKey, zeta f
 		l.Mul(&l, &tmp).Mul(&l, &vk.Generator)
 		acc.Mul(&acc, &vk.Generator)
 		tmp.Sub(&zeta, &acc)
-		l.Div(&l, &tmp)
+		// if tmp==0, then zeta=vk.Generator**i, so l_i(zeta)=1. We need
+		// to manually set the value to 1, exacty as in the case l_0 before
+		// the loop, otherwise the generic formula leads to a division by zero.
+		if tmp.IsZero() {
+			l.SetOne()
+		} else {
+			l.Div(&l, &tmp)
+		}
 	}
 
 	return res

--- a/internal/backend/bls12-381/plonkfri/prove.go
+++ b/internal/backend/bls12-381/plonkfri/prove.go
@@ -231,9 +231,6 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls12_381witness.Witn
 	bOpeningPosition.SetBytes(frOpeningPosition.Marshal()).Mod(&bOpeningPosition, &bFriSize)
 	openingPosition := bOpeningPosition.Uint64()
 
-	// derive a query position, which is 0<=i<domain[1].Size
-	// openingPosition := uint64(2)
-
 	// ql, qr, qm, qo, qkIncomplete
 	proof.OpeningsQlQrQmQoQkincompletemp[0], err = pk.Vk.Iopp.Open(pk.CQl, openingPosition)
 	if err != nil {

--- a/internal/backend/bls12-381/plonkfri/verify.go
+++ b/internal/backend/bls12-381/plonkfri/verify.go
@@ -358,14 +358,22 @@ func completeQk(publicWitness bls12_381witness.Witness, vk *VerifyingKey, zeta f
 
 	var res fr.Element
 
-	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
+	// compute l1(zeta). Exceptional case: if zeta=1, then l1(zeta)=1,
+	// we need to manually initialise l to this value otherwise there
+	// is a denominator equal to zero in the formula.
 	var l, tmp, acc, one fr.Element
 	one.SetOne()
 	acc.SetOne()
-	l.Sub(&zeta, &one).Inverse(&l).Mul(&l, &vk.SizeInv)
-	tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
-	l.Mul(&l, &tmp)
+	l.Sub(&zeta, &one)
+	if l.IsZero() {
+		l.SetOne()
+	} else {
+		l.Inverse(&l).Mul(&l, &vk.SizeInv)
+		tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
+		l.Mul(&l, &tmp)
+	}
 
+	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
 	for i := 0; i < len(publicWitness); i++ {
 
 		tmp.Mul(&l, &publicWitness[i])
@@ -375,7 +383,14 @@ func completeQk(publicWitness bls12_381witness.Witness, vk *VerifyingKey, zeta f
 		l.Mul(&l, &tmp).Mul(&l, &vk.Generator)
 		acc.Mul(&acc, &vk.Generator)
 		tmp.Sub(&zeta, &acc)
-		l.Div(&l, &tmp)
+		// if tmp==0, then zeta=vk.Generator**i, so l_i(zeta)=1. We need
+		// to manually set the value to 1, exacty as in the case l_0 before
+		// the loop, otherwise the generic formula leads to a division by zero.
+		if tmp.IsZero() {
+			l.SetOne()
+		} else {
+			l.Div(&l, &tmp)
+		}
 	}
 
 	return res

--- a/internal/backend/bls24-315/plonkfri/prove.go
+++ b/internal/backend/bls24-315/plonkfri/prove.go
@@ -231,9 +231,6 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls24_315witness.Witn
 	bOpeningPosition.SetBytes(frOpeningPosition.Marshal()).Mod(&bOpeningPosition, &bFriSize)
 	openingPosition := bOpeningPosition.Uint64()
 
-	// derive a query position, which is 0<=i<domain[1].Size
-	// openingPosition := uint64(2)
-
 	// ql, qr, qm, qo, qkIncomplete
 	proof.OpeningsQlQrQmQoQkincompletemp[0], err = pk.Vk.Iopp.Open(pk.CQl, openingPosition)
 	if err != nil {

--- a/internal/backend/bls24-317/plonkfri/prove.go
+++ b/internal/backend/bls24-317/plonkfri/prove.go
@@ -231,9 +231,6 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bls24_317witness.Witn
 	bOpeningPosition.SetBytes(frOpeningPosition.Marshal()).Mod(&bOpeningPosition, &bFriSize)
 	openingPosition := bOpeningPosition.Uint64()
 
-	// derive a query position, which is 0<=i<domain[1].Size
-	// openingPosition := uint64(2)
-
 	// ql, qr, qm, qo, qkIncomplete
 	proof.OpeningsQlQrQmQoQkincompletemp[0], err = pk.Vk.Iopp.Open(pk.CQl, openingPosition)
 	if err != nil {

--- a/internal/backend/bls24-317/plonkfri/verify.go
+++ b/internal/backend/bls24-317/plonkfri/verify.go
@@ -358,14 +358,22 @@ func completeQk(publicWitness bls24_317witness.Witness, vk *VerifyingKey, zeta f
 
 	var res fr.Element
 
-	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
+	// compute l1(zeta). Exceptional case: if zeta=1, then l1(zeta)=1,
+	// we need to manually initialise l to this value otherwise there
+	// is a denominator equal to zero in the formula.
 	var l, tmp, acc, one fr.Element
 	one.SetOne()
 	acc.SetOne()
-	l.Sub(&zeta, &one).Inverse(&l).Mul(&l, &vk.SizeInv)
-	tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
-	l.Mul(&l, &tmp)
+	l.Sub(&zeta, &one)
+	if l.IsZero() {
+		l.SetOne()
+	} else {
+		l.Inverse(&l).Mul(&l, &vk.SizeInv)
+		tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
+		l.Mul(&l, &tmp)
+	}
 
+	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
 	for i := 0; i < len(publicWitness); i++ {
 
 		tmp.Mul(&l, &publicWitness[i])
@@ -375,7 +383,14 @@ func completeQk(publicWitness bls24_317witness.Witness, vk *VerifyingKey, zeta f
 		l.Mul(&l, &tmp).Mul(&l, &vk.Generator)
 		acc.Mul(&acc, &vk.Generator)
 		tmp.Sub(&zeta, &acc)
-		l.Div(&l, &tmp)
+		// if tmp==0, then zeta=vk.Generator**i, so l_i(zeta)=1. We need
+		// to manually set the value to 1, exacty as in the case l_0 before
+		// the loop, otherwise the generic formula leads to a division by zero.
+		if tmp.IsZero() {
+			l.SetOne()
+		} else {
+			l.Div(&l, &tmp)
+		}
 	}
 
 	return res

--- a/internal/backend/bn254/plonkfri/prove.go
+++ b/internal/backend/bn254/plonkfri/prove.go
@@ -231,9 +231,6 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bn254witness.Witness,
 	bOpeningPosition.SetBytes(frOpeningPosition.Marshal()).Mod(&bOpeningPosition, &bFriSize)
 	openingPosition := bOpeningPosition.Uint64()
 
-	// derive a query position, which is 0<=i<domain[1].Size
-	// openingPosition := uint64(2)
-
 	// ql, qr, qm, qo, qkIncomplete
 	proof.OpeningsQlQrQmQoQkincompletemp[0], err = pk.Vk.Iopp.Open(pk.CQl, openingPosition)
 	if err != nil {

--- a/internal/backend/bn254/plonkfri/verify.go
+++ b/internal/backend/bn254/plonkfri/verify.go
@@ -358,14 +358,22 @@ func completeQk(publicWitness bn254witness.Witness, vk *VerifyingKey, zeta fr.El
 
 	var res fr.Element
 
-	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
+	// compute l1(zeta). Exceptional case: if zeta=1, then l1(zeta)=1,
+	// we need to manually initialise l to this value otherwise there
+	// is a denominator equal to zero in the formula.
 	var l, tmp, acc, one fr.Element
 	one.SetOne()
 	acc.SetOne()
-	l.Sub(&zeta, &one).Inverse(&l).Mul(&l, &vk.SizeInv)
-	tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
-	l.Mul(&l, &tmp)
+	l.Sub(&zeta, &one)
+	if l.IsZero() {
+		l.SetOne()
+	} else {
+		l.Inverse(&l).Mul(&l, &vk.SizeInv)
+		tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
+		l.Mul(&l, &tmp)
+	}
 
+	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
 	for i := 0; i < len(publicWitness); i++ {
 
 		tmp.Mul(&l, &publicWitness[i])
@@ -375,7 +383,14 @@ func completeQk(publicWitness bn254witness.Witness, vk *VerifyingKey, zeta fr.El
 		l.Mul(&l, &tmp).Mul(&l, &vk.Generator)
 		acc.Mul(&acc, &vk.Generator)
 		tmp.Sub(&zeta, &acc)
-		l.Div(&l, &tmp)
+		// if tmp==0, then zeta=vk.Generator**i, so l_i(zeta)=1. We need
+		// to manually set the value to 1, exacty as in the case l_0 before
+		// the loop, otherwise the generic formula leads to a division by zero.
+		if tmp.IsZero() {
+			l.SetOne()
+		} else {
+			l.Div(&l, &tmp)
+		}
 	}
 
 	return res

--- a/internal/backend/bw6-633/plonkfri/prove.go
+++ b/internal/backend/bw6-633/plonkfri/prove.go
@@ -231,9 +231,6 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bw6_633witness.Witnes
 	bOpeningPosition.SetBytes(frOpeningPosition.Marshal()).Mod(&bOpeningPosition, &bFriSize)
 	openingPosition := bOpeningPosition.Uint64()
 
-	// derive a query position, which is 0<=i<domain[1].Size
-	// openingPosition := uint64(2)
-
 	// ql, qr, qm, qo, qkIncomplete
 	proof.OpeningsQlQrQmQoQkincompletemp[0], err = pk.Vk.Iopp.Open(pk.CQl, openingPosition)
 	if err != nil {

--- a/internal/backend/bw6-633/plonkfri/verify.go
+++ b/internal/backend/bw6-633/plonkfri/verify.go
@@ -358,14 +358,22 @@ func completeQk(publicWitness bw6_633witness.Witness, vk *VerifyingKey, zeta fr.
 
 	var res fr.Element
 
-	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
+	// compute l1(zeta). Exceptional case: if zeta=1, then l1(zeta)=1,
+	// we need to manually initialise l to this value otherwise there
+	// is a denominator equal to zero in the formula.
 	var l, tmp, acc, one fr.Element
 	one.SetOne()
 	acc.SetOne()
-	l.Sub(&zeta, &one).Inverse(&l).Mul(&l, &vk.SizeInv)
-	tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
-	l.Mul(&l, &tmp)
+	l.Sub(&zeta, &one)
+	if l.IsZero() {
+		l.SetOne()
+	} else {
+		l.Inverse(&l).Mul(&l, &vk.SizeInv)
+		tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
+		l.Mul(&l, &tmp)
+	}
 
+	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
 	for i := 0; i < len(publicWitness); i++ {
 
 		tmp.Mul(&l, &publicWitness[i])
@@ -375,7 +383,14 @@ func completeQk(publicWitness bw6_633witness.Witness, vk *VerifyingKey, zeta fr.
 		l.Mul(&l, &tmp).Mul(&l, &vk.Generator)
 		acc.Mul(&acc, &vk.Generator)
 		tmp.Sub(&zeta, &acc)
-		l.Div(&l, &tmp)
+		// if tmp==0, then zeta=vk.Generator**i, so l_i(zeta)=1. We need
+		// to manually set the value to 1, exacty as in the case l_0 before
+		// the loop, otherwise the generic formula leads to a division by zero.
+		if tmp.IsZero() {
+			l.SetOne()
+		} else {
+			l.Div(&l, &tmp)
+		}
 	}
 
 	return res

--- a/internal/backend/bw6-761/plonkfri/prove.go
+++ b/internal/backend/bw6-761/plonkfri/prove.go
@@ -231,9 +231,6 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness bw6_761witness.Witnes
 	bOpeningPosition.SetBytes(frOpeningPosition.Marshal()).Mod(&bOpeningPosition, &bFriSize)
 	openingPosition := bOpeningPosition.Uint64()
 
-	// derive a query position, which is 0<=i<domain[1].Size
-	// openingPosition := uint64(2)
-
 	// ql, qr, qm, qo, qkIncomplete
 	proof.OpeningsQlQrQmQoQkincompletemp[0], err = pk.Vk.Iopp.Open(pk.CQl, openingPosition)
 	if err != nil {

--- a/internal/backend/bw6-761/plonkfri/verify.go
+++ b/internal/backend/bw6-761/plonkfri/verify.go
@@ -358,14 +358,22 @@ func completeQk(publicWitness bw6_761witness.Witness, vk *VerifyingKey, zeta fr.
 
 	var res fr.Element
 
-	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
+	// compute l1(zeta). Exceptional case: if zeta=1, then l1(zeta)=1,
+	// we need to manually initialise l to this value otherwise there
+	// is a denominator equal to zero in the formula.
 	var l, tmp, acc, one fr.Element
 	one.SetOne()
 	acc.SetOne()
-	l.Sub(&zeta, &one).Inverse(&l).Mul(&l, &vk.SizeInv)
-	tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
-	l.Mul(&l, &tmp)
+	l.Sub(&zeta, &one)
+	if l.IsZero() {
+		l.SetOne()
+	} else {
+		l.Inverse(&l).Mul(&l, &vk.SizeInv)
+		tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
+		l.Mul(&l, &tmp)
+	}
 
+	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
 	for i := 0; i < len(publicWitness); i++ {
 
 		tmp.Mul(&l, &publicWitness[i])
@@ -375,7 +383,14 @@ func completeQk(publicWitness bw6_761witness.Witness, vk *VerifyingKey, zeta fr.
 		l.Mul(&l, &tmp).Mul(&l, &vk.Generator)
 		acc.Mul(&acc, &vk.Generator)
 		tmp.Sub(&zeta, &acc)
-		l.Div(&l, &tmp)
+		// if tmp==0, then zeta=vk.Generator**i, so l_i(zeta)=1. We need
+		// to manually set the value to 1, exacty as in the case l_0 before
+		// the loop, otherwise the generic formula leads to a division by zero.
+		if tmp.IsZero() {
+			l.SetOne()
+		} else {
+			l.Div(&l, &tmp)
+		}
 	}
 
 	return res

--- a/internal/generator/backend/template/zkpschemes/plonkfri/plonk.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonkfri/plonk.prove.go.tmpl
@@ -209,9 +209,6 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness {{ toLower .CurveID }
 	bOpeningPosition.SetBytes(frOpeningPosition.Marshal()).Mod(&bOpeningPosition, &bFriSize)
 	openingPosition := bOpeningPosition.Uint64()
 
-	// derive a query position, which is 0<=i<domain[1].Size
-	// openingPosition := uint64(2)
-
 	// ql, qr, qm, qo, qkIncomplete
 	proof.OpeningsQlQrQmQoQkincompletemp[0], err = pk.Vk.Iopp.Open(pk.CQl, openingPosition)
 	if err != nil {

--- a/internal/generator/backend/template/zkpschemes/plonkfri/plonk.verify.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonkfri/plonk.verify.go.tmpl
@@ -340,14 +340,22 @@ func completeQk(publicWitness {{ toLower .CurveID }}witness.Witness, vk *Verifyi
 
 	var res fr.Element
 
-	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
+	// compute l1(zeta). Exceptional case: if zeta=1, then l1(zeta)=1,
+	// we need to manually initialise l to this value otherwise there
+	// is a denominator equal to zero in the formula.
 	var l, tmp, acc, one fr.Element
 	one.SetOne()
 	acc.SetOne()
-	l.Sub(&zeta, &one).Inverse(&l).Mul(&l, &vk.SizeInv)
-	tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
-	l.Mul(&l, &tmp)
+	l.Sub(&zeta, &one)
+	if l.IsZero() {
+		l.SetOne()
+	} else {
+		l.Inverse(&l).Mul(&l, &vk.SizeInv)
+		tmp.Exp(zeta, big.NewInt(int64(vk.Size))).Sub(&tmp, &one)
+		l.Mul(&l, &tmp)
+	}
 
+	// use L_i+1 = w*Li*(X-z**i)/(X-z**i+1)
 	for i := 0; i < len(publicWitness); i++ {
 
 		tmp.Mul(&l, &publicWitness[i])
@@ -357,7 +365,14 @@ func completeQk(publicWitness {{ toLower .CurveID }}witness.Witness, vk *Verifyi
 		l.Mul(&l, &tmp).Mul(&l, &vk.Generator)
 		acc.Mul(&acc, &vk.Generator)
 		tmp.Sub(&zeta, &acc)
-		l.Div(&l, &tmp)
+		// if tmp==0, then zeta=vk.Generator**i, so l_i(zeta)=1. We need
+		// to manually set the value to 1, exacty as in the case l_0 before
+		// the loop, otherwise the generic formula leads to a division by zero.
+		if tmp.IsZero() {
+			l.SetOne()
+		} else {
+			l.Div(&l, &tmp)
+		}
 	}
 
 	return res

--- a/test/assert.go
+++ b/test/assert.go
@@ -164,7 +164,6 @@ func (assert *Assert) ProverSucceeded(circuit frontend.Circuit, validAssignment 
 					checkError(err)
 
 				case backend.PLONKFRI:
-
 					pk, vk, err := plonkfri.Setup(ccs)
 					checkError(err)
 


### PR DESCRIPTION
# Fixed Witness completion in plonk with fri

During the completion of the public witness in the verification phase, we compute a linear combination whose coefficients are the Lagrange polynomials, evaluated at a challenge point. With FRI, the set of challenges contains the vanishing domain of the polynomial relations. If the challenge belongs to this domain, then the recursive formulas to compute the Lagrange polynomials fails because there is a division by zero.

This exceptional case is handled now.

Fixes #349 