### PR TITLE
fix: fixed a bug in the emulated field's _select function

### DIFF
--- a/std/math/emulated/element.go
+++ b/std/math/emulated/element.go
@@ -539,6 +539,7 @@ func (f *field[T]) sub(a, b Element[T], nextOverflow uint) Element[T] {
 // assumes a overflow == b overflow
 func (f *field[T]) _select(selector frontend.Variable, a, b Element[T]) Element[T] {
 	e := NewElement[T](nil)
+	e.Limbs = make([]frontend.Variable, len(a.Limbs))
 	e.overflow = a.overflow
 	for i := range a.Limbs {
 		e.Limbs[i] = f.api.Select(selector, a.Limbs[i], b.Limbs[i])


### PR DESCRIPTION
Gnark will throw an array access out of bounds error in the __select_ function if the _a_ and _b_ parameter has more than one limb.