### PR TITLE
feat: compress linear expression

### DIFF
--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -149,6 +149,7 @@ type CompileConfig struct {
 	Capacity                  int
 	IgnoreUnconstrainedInputs bool
 	wrapper                   BuilderWrapper
+	CompressThreshold         int
 }
 
 // WithCapacity is a compile option that specifies the estimated capacity needed
@@ -184,6 +185,26 @@ type BuilderWrapper func(Builder) Builder
 func WithBuilderWrapper(wrapper BuilderWrapper) CompileOption {
 	return func(opt *CompileConfig) error {
 		opt.wrapper = wrapper
+		return nil
+	}
+}
+
+// WithCompressThreshold is a compile option which enforces automatic variable
+// compression if the length of the linear expression in the variable exceeds
+// given threshold.
+//
+// This option is usable in arithmetisations where the variable is a linear
+// combination, as for example in R1CS. If variable is not a linear combination,
+// then this option does not change the compile behaviour.
+//
+// This compile option should be used in cases when it is known that there are
+// long addition chains and the compile time and memory usage start are growing
+// fast. The compression adds some overhead in the number of constraints. The
+// overhead and compile performance depends on threshold value, and it should be
+// chosen carefully.
+func WithCompressThreshold(threshold int) CompileOption {
+	return func(opt *CompileConfig) error {
+		opt.CompressThreshold = threshold
 		return nil
 	}
 }

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -113,6 +113,9 @@ func (builder *builder) add(vars []expr.LinearExpression, sub bool, capacity int
 		// keep the linear expression valid (assertIsSet)
 		res = expr.NewLinearExpression(0, constraint.Coeff{})
 	}
+	// if the linear expression LE is too long then record an equality
+	// constraint LE * 1 = t and return short linear expression instead.
+	res = builder.compress(res)
 
 	return res
 }

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -421,3 +421,18 @@ func (builder *builder) newDebugInfo(errName string, in ...interface{}) constrai
 	return constraint.NewDebugInfo(errName, in...)
 
 }
+
+// compress checks the length of the linear expression le and if it is larger or
+// equal than CompressThreshold in the configuration, replaces it with a linear
+// expression of one term. In that case it adds an equality constraint enforcing
+// the correctness of the returned linear expression.
+func (builder *builder) compress(le expr.LinearExpression) expr.LinearExpression {
+	if builder.config.CompressThreshold <= 0 || len(le) < builder.config.CompressThreshold {
+		return le
+	}
+
+	one := builder.cstOne()
+	t := builder.newInternalVariable()
+	builder.cs.AddConstraint(builder.newR1C(le, one, t))
+	return t
+}

--- a/frontend/cs/r1cs/r1cs_test.go
+++ b/frontend/cs/r1cs/r1cs_test.go
@@ -72,6 +72,26 @@ func TestReduce(t *testing.T) {
 
 }
 
+func TestCompress(t *testing.T) {
+	cs := newBuilder(ecc.BN254.ScalarField(), frontend.CompileConfig{CompressThreshold: 3})
+	vars := make([]frontend.Variable, 4)
+	for i := range vars {
+		v := cs.newInternalVariable()
+		vars[i] = cs.Mul(v, 1<<i)
+	}
+
+	// if add two variables, then should not compress
+	v1 := cs.Add(vars[0], vars[1])
+	if vli1 := v1.(expr.LinearExpression); len(vli1) != 2 {
+		t.Fatalf("expected linear expression length 2, got %d", len(vli1))
+	}
+	// if add three vars, then should compress
+	v2 := cs.Add(vars[0], vars[1], vars[2])
+	if vli2 := v2.(expr.LinearExpression); len(vli2) != 1 {
+		t.Fatalf("expected linear expression length 1, got %d", len(vli2))
+	}
+}
+
 func BenchmarkReduce(b *testing.B) {
 	cs := newBuilder(ecc.BN254.ScalarField(), frontend.CompileConfig{})
 	// 4 interesting cases;


### PR DESCRIPTION
Closes #417.

With the refactored frontend and constraint system, the memory usage has gone down a lot and the operations are a lot more efficient with fr.Elements. This option isn't necessary for keccak-f and emulated ECDSA anymore, and helps slightly for  BN254 pairing, but I didn't try too much different parameters.