### PR TITLE
fix: engine.Println to take strings

### DIFF
--- a/test/engine.go
+++ b/test/engine.go
@@ -405,8 +405,12 @@ func (e *engine) Println(a ...frontend.Variable) {
 	}
 
 	for i := 0; i < len(a); i++ {
-		v := e.toBigInt(a[i])
-		sbb.WriteString(v.String())
+		if s, ok := a[i].(string); ok {
+			sbb.WriteString(s)
+		} else {
+			v := e.toBigInt(a[i])
+			sbb.WriteString(v.String())
+		}
 		sbb.WriteByte(' ')
 	}
 	fmt.Println(sbb.String())

--- a/test/engine.go
+++ b/test/engine.go
@@ -409,7 +409,13 @@ func (e *engine) Println(a ...frontend.Variable) {
 			sbb.WriteString(s)
 		} else {
 			v := e.toBigInt(a[i])
-			sbb.WriteString(v.String())
+			var vAsNeg big.Int
+			vAsNeg.Sub(v, e.q)
+			if vAsNeg.IsInt64() {
+				sbb.WriteString(strconv.FormatInt(vAsNeg.Int64(), 10))
+			} else {
+				sbb.WriteString(v.String())
+			}
 		}
 		sbb.WriteByte(' ')
 	}


### PR DESCRIPTION
Currently such a test fails:
```go
type testPrintCircuit struct {
	Var frontend.Variable
}

func (c *testPrintCircuit) Define(api frontend.API) error {
	api.Println("testing", c.Var)
	api.AssertIsEqual(c.Var, 0)
	return nil
}

func TestPrintSolve(t *testing.T) {
	circuit := testPrintCircuit{}
	assignment := testPrintCircuit{0}
	NewAssert(t).SolvingSucceeded(
		&circuit, &assignment, WithBackends(backend.GROTH16), WithCurves(ecc.BN254))
}
```
It is useful to have descriptive strings in print statements. This PR enables that.