### PR TITLE
fix: add shortcut for const input in MulConst

### DIFF
--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -136,6 +136,10 @@ func (f *Field[T]) MulConst(a *Element[T], c *big.Int) *Element[T] {
 	}
 	return f.reduceAndOp(
 		func(a, _ *Element[T], u uint) *Element[T] {
+			if ba, aConst := f.constantValue(a); aConst {
+				ba.Mul(ba, c)
+				return newElementPtr[T](ba)
+			}
 			limbs := make([]frontend.Variable, len(a.Limbs))
 			for i := range a.Limbs {
 				limbs[i] = f.api.Mul(a.Limbs[i], c)


### PR DESCRIPTION
Previously the result of MulConst had non-zero overflow when multipling a constant by a small constant. This panics Reduce method which assumes that constants have zero overflow.

Fixes #431

The PR doesn't include the initial test because circuit called `EnforceWidth()` on the public witness and as fuzzer provides random inputs (where the width of the witness may be longer than assumed), then leads false failure. See also #296.