### PR TITLE
fix: handle recursive hints in level builder

### DIFF
--- a/constraint/bls12-377/r1cs_test.go
+++ b/constraint/bls12-377/r1cs_test.go
@@ -79,6 +79,7 @@ func TestSerialization(t *testing.T) {
 						"arithEngine",
 						"CoeffTable.mCoeffs",
 						"System.lbWireLevel",
+						"System.lbHints",
 						"System.SymbolTable",
 						"System.lbOutputs",
 						"System.bitLen")); diff != "" {

--- a/constraint/bls12-381/r1cs_test.go
+++ b/constraint/bls12-381/r1cs_test.go
@@ -79,6 +79,7 @@ func TestSerialization(t *testing.T) {
 						"arithEngine",
 						"CoeffTable.mCoeffs",
 						"System.lbWireLevel",
+						"System.lbHints",
 						"System.SymbolTable",
 						"System.lbOutputs",
 						"System.bitLen")); diff != "" {

--- a/constraint/bls24-315/r1cs_test.go
+++ b/constraint/bls24-315/r1cs_test.go
@@ -79,6 +79,7 @@ func TestSerialization(t *testing.T) {
 						"arithEngine",
 						"CoeffTable.mCoeffs",
 						"System.lbWireLevel",
+						"System.lbHints",
 						"System.SymbolTable",
 						"System.lbOutputs",
 						"System.bitLen")); diff != "" {

--- a/constraint/bls24-317/r1cs_test.go
+++ b/constraint/bls24-317/r1cs_test.go
@@ -79,6 +79,7 @@ func TestSerialization(t *testing.T) {
 						"arithEngine",
 						"CoeffTable.mCoeffs",
 						"System.lbWireLevel",
+						"System.lbHints",
 						"System.SymbolTable",
 						"System.lbOutputs",
 						"System.bitLen")); diff != "" {

--- a/constraint/bn254/r1cs_test.go
+++ b/constraint/bn254/r1cs_test.go
@@ -79,6 +79,7 @@ func TestSerialization(t *testing.T) {
 						"arithEngine",
 						"CoeffTable.mCoeffs",
 						"System.lbWireLevel",
+						"System.lbHints",
 						"System.SymbolTable",
 						"System.lbOutputs",
 						"System.bitLen")); diff != "" {

--- a/constraint/bw6-633/r1cs_test.go
+++ b/constraint/bw6-633/r1cs_test.go
@@ -79,6 +79,7 @@ func TestSerialization(t *testing.T) {
 						"arithEngine",
 						"CoeffTable.mCoeffs",
 						"System.lbWireLevel",
+						"System.lbHints",
 						"System.SymbolTable",
 						"System.lbOutputs",
 						"System.bitLen")); diff != "" {

--- a/constraint/bw6-761/r1cs_test.go
+++ b/constraint/bw6-761/r1cs_test.go
@@ -82,6 +82,7 @@ func TestSerialization(t *testing.T) {
 						"arithEngine",
 						"CoeffTable.mCoeffs",
 						"System.lbWireLevel",
+						"System.lbHints",
 						"System.SymbolTable",
 						"System.lbOutputs",
 						"System.bitLen")); diff != "" {

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -142,8 +142,9 @@ type System struct {
 	bitLen int      `cbor:"-"`
 
 	// level builder
-	lbWireLevel []int    `cbor:"-"` // at which level we solve a wire. init at -1.
-	lbOutputs   []uint32 `cbor:"-"` // wire outputs for current constraint.
+	lbWireLevel []int              `cbor:"-"` // at which level we solve a wire. init at -1.
+	lbOutputs   []uint32           `cbor:"-"` // wire outputs for current constraint.
+	lbHints     map[*Hint]struct{} `cbor:"-"` // hints we processed in current round
 
 	CommitmentInfo Commitment
 }
@@ -159,6 +160,7 @@ func NewSystem(scalarField *big.Int) System {
 		MHintsDependencies: make(map[hint.ID]string),
 		q:                  new(big.Int).Set(scalarField),
 		bitLen:             scalarField.BitLen(),
+		lbHints:            map[*Hint]struct{}{},
 	}
 }
 

--- a/constraint/tinyfield/r1cs_test.go
+++ b/constraint/tinyfield/r1cs_test.go
@@ -82,6 +82,7 @@ func TestSerialization(t *testing.T) {
 						"arithEngine",
 						"CoeffTable.mCoeffs",
 						"System.lbWireLevel",
+						"System.lbHints",
 						"System.SymbolTable",
 						"System.lbOutputs",
 						"System.bitLen")); diff != "" {

--- a/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
@@ -70,6 +70,7 @@ func TestSerialization(t *testing.T) {
 					 "arithEngine",
 					 "CoeffTable.mCoeffs",
 					 "System.lbWireLevel",
+					 "System.lbHints",
 					 "System.SymbolTable",
 					 "System.lbOutputs",
 					 "System.bitLen")); diff != "" {


### PR DESCRIPTION
When building dependency graph of constraints, we can encounter in a single constraint many wires which are the output of a hint h1. 
This hint h1 can have itself many inputs; this PR just marks hints as already "visited" to avoid an exponential blowup. 