### PR TITLE
Fix the example in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ func (circuit *CubicCircuit) Define(api frontend.API) error {
 func main() {
 	// compiles our circuit into a R1CS
 	var circuit CubicCircuit
-	ccs, _ := frontend.Compile(ecc.BN254, r1cs.NewBuilder, &circuit)
+	ccs, _ := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 
 	// groth16 zkSNARK: Setup
 	pk, vk, _ := groth16.Setup(ccs)
 
 	// witness definition
 	assignment := CubicCircuit{X: 3, Y: 35}
-	witness, _ := frontend.NewWitness(&assignment, ecc.BN254)
+	witness, _ := frontend.NewWitness(&assignment, ecc.BN254.ScalarField())
 	publicWitness, _ := witness.Public()
 
 	// groth16: Prove & Verify


### PR DESCRIPTION
Unfortunately, the example in `README.md` still does not compile. Apparently `BN254` has a `ScalarField()` method now, and should not be passed as a parameter directly.