### PR TITLE
feat: add simple key-value store to the builders

### DIFF
--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/internal/expr"
 	"github.com/consensys/gnark/frontend/schema"
+	"github.com/consensys/gnark/internal/kvstore"
 	"github.com/consensys/gnark/internal/tinyfield"
 	"github.com/consensys/gnark/internal/utils"
 	"github.com/consensys/gnark/logger"
@@ -63,6 +64,8 @@ type builder struct {
 	// buffers used to do in place api.MAC
 	mbuf1 expr.LinearExpression
 	mbuf2 expr.LinearExpression
+
+	kvstore.Store
 }
 
 // initialCapacity has quite some impact on frontend performance, especially on large circuits size
@@ -78,6 +81,7 @@ func newBuilder(field *big.Int, config frontend.CompileConfig) *builder {
 		heap:       make(minHeap, 0, 100),
 		mbuf1:      make(expr.LinearExpression, 0, macCapacity),
 		mbuf2:      make(expr.LinearExpression, 0, macCapacity),
+		Store:      kvstore.New(),
 	}
 
 	// by default the circuit is given a public wire equal to 1

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/consensys/gnark/frontend/cs"
 	"github.com/consensys/gnark/frontend/internal/expr"
 	"github.com/consensys/gnark/frontend/schema"
+	"github.com/consensys/gnark/internal/kvstore"
 	"github.com/consensys/gnark/internal/tinyfield"
 	"github.com/consensys/gnark/internal/utils"
 	"github.com/consensys/gnark/logger"
@@ -57,6 +58,8 @@ type scs struct {
 	mtBooleans map[int]struct{}
 
 	q *big.Int
+
+	kvstore.Store
 }
 
 // initialCapacity has quite some impact on frontend performance, especially on large circuits size
@@ -67,6 +70,7 @@ func newBuilder(field *big.Int, config frontend.CompileConfig) *scs {
 		mtBooleans: make(map[int]struct{}),
 		st:         cs.NewCoeffTable(),
 		config:     config,
+		Store:      kvstore.New(),
 	}
 
 	curve := utils.FieldToCurve(field)

--- a/internal/kvstore/kvstore.go
+++ b/internal/kvstore/kvstore.go
@@ -1,0 +1,38 @@
+// Package kvstore implements simple key-value store
+//
+// It is without synchronization and allows any comparable keys. The main use of
+// this package is for sharing singletons when building a circuit.
+package kvstore
+
+import (
+	"reflect"
+)
+
+type Store interface {
+	SetKeyValue(key, value any)
+	GetKeyValue(key any) (value any)
+}
+
+type impl struct {
+	db map[any]any
+}
+
+func New() Store {
+	return &impl{
+		db: make(map[any]any),
+	}
+}
+
+func (c *impl) SetKeyValue(key, value any) {
+	if !reflect.TypeOf(key).Comparable() {
+		panic("key type not comparable")
+	}
+	c.db[key] = value
+}
+
+func (c *impl) GetKeyValue(key any) any {
+	if !reflect.TypeOf(key).Comparable() {
+		panic("key type not comparable")
+	}
+	return c.db[key]
+}

--- a/test/engine.go
+++ b/test/engine.go
@@ -34,6 +34,7 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/internal/kvstore"
 	"github.com/consensys/gnark/internal/utils"
 )
 
@@ -50,6 +51,7 @@ type engine struct {
 	// mHintsFunctions map[hint.ID]hintFunction
 	constVars  bool
 	apiWrapper ApiWrapper
+	kvstore.Store
 }
 
 // TestEngineOption defines an option for the test engine.
@@ -103,6 +105,7 @@ func IsSolved(circuit, witness frontend.Circuit, field *big.Int, opts ...TestEng
 		q:          new(big.Int).Set(field),
 		apiWrapper: func(a frontend.API) frontend.API { return a },
 		constVars:  false,
+		Store:      kvstore.New(),
 	}
 	for _, opt := range opts {
 		if err := opt(e); err != nil {

--- a/test/solver_test.go
+++ b/test/solver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/consensys/gnark/frontend/cs/scs"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/internal/backend/circuits"
+	"github.com/consensys/gnark/internal/kvstore"
 	"github.com/consensys/gnark/internal/tinyfield"
 	"github.com/consensys/gnark/internal/utils"
 )
@@ -155,6 +156,7 @@ func isSolvedEngine(c frontend.Circuit, field *big.Int, opts ...TestEngineOption
 		q:          new(big.Int).Set(field),
 		apiWrapper: func(a frontend.API) frontend.API { return a },
 		constVars:  false,
+		Store:      kvstore.New(),
 	}
 	for _, opt := range opts {
 		if err := opt(e); err != nil {


### PR DESCRIPTION
With new gadgets, we may have some state we want to store over different calls. Instead of using singletons (essentially global variables), we instead add a `map[any]any` to the builders which allow to store builder-local variables.

To prevent overuse of the map, we dont publish the methods publicly in the `frontend.API`, but instead embed an instance in the builders themselves. If a gadget wants to use the storage, then they first have to type-assert the frontend.API instance to `kvstore.Store` and then on the new variable call `SetKeyValue` and `GetKeyValue`.

Another great aspect of having `any` keys is that we can use any comparable types (comparable because map implementation requires so). This allows us to avoid any collisions by enforcing that the keys are of different type. See the example below:
```go

type gadgetKey struct{}

func (c *Circuit) Define(api frontend.API) error {
    kv, ok := api.(kvstore.Store)
    if !ok {
        return fmt.Errorf("api doesn't implement Store")
    }
    kv.SetKeyValue(gadgetKey{}, "aaa") // only this package can set this key as they do not have the type
    // ...
    res := kv.GetKeyValue(gadgetKey{}) //
    // use res = "aaa"
}
```

In the previous example, we could also have for example `type gadgetKey int` and then have different values for the keys if the gadget needs to store different values.

Initially I thought about just using `context.Context` as it provides similar features, but it doesn't seem to fit in our use cases. See comments in #472.