### PR TITLE
refactor: define Committer interface for builders

### DIFF
--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -48,13 +48,6 @@ type Compiler interface {
 
 	// FieldBitLen returns the number of bits needed to represent an element in the scalar field
 	FieldBitLen() int
-
-	// Commit returns a commitment to the given variables, to be used as initial randomness in
-	// Fiat-Shamir when the statement to prove is particularly large.
-	// TODO cite paper
-	// ! Experimental
-	// TENTATIVE: Functions regarding fiat-shamir-ed proofs over enormous statements  TODO finalize
-	Commit(...Variable) (Variable, error)
 }
 
 // Builder represents a constraint system builder
@@ -72,4 +65,11 @@ type Builder interface {
 	// SecretVariable is called by the compiler when parsing the circuit schema. It panics if
 	// called inside circuit.Define()
 	SecretVariable(schema.LeafInfo) Variable
+}
+
+// Committer allows to commit to the variables and returns the commitment. The
+// commitment can be used as a challenge using Fiat-Shamir heuristic.
+type Committer interface {
+	// Commit commits to the variables and returns the commitment.
+	Commit(toCommit ...Variable) (commitment Variable, err error)
 }

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -44,6 +44,7 @@ import (
 )
 
 // NewBuilder returns a new R1CS builder which implements frontend.API.
+// Additionally, this builder also implements [frontend.Committer].
 func NewBuilder(field *big.Int, config frontend.CompileConfig) (frontend.Builder, error) {
 	return newBuilder(field, config), nil
 }

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scs
 
 import (
-	"fmt"
 	"math/big"
 	"reflect"
 	"sort"
@@ -355,10 +354,6 @@ func (builder *scs) splitProd(acc expr.TermToRefactor, r expr.LinearExpressionTo
 	o := builder.newInternalVariable()
 	builder.addPlonkConstraint(acc, r[0], o, constraint.CoeffIdZero, constraint.CoeffIdZero, cl, cr, constraint.CoeffIdMinusOne, constraint.CoeffIdZero)
 	return builder.splitProd(o, r[1:])
-}
-
-func (builder *scs) Commit(v ...frontend.Variable) (frontend.Variable, error) {
-	return nil, fmt.Errorf("not implemented")
 }
 
 // newDebugInfo this is temporary to restore debug logs

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/leanovate/gopter v0.2.9
 	github.com/rs/zerolog v1.29.0
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/crypto v0.6.0
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 )
 
@@ -23,7 +24,6 @@ require (
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/backend/bls12-377/groth16/commitment_test.go
+++ b/internal/backend/bls12-377/groth16/commitment_test.go
@@ -17,6 +17,9 @@
 package groth16_test
 
 import (
+	"fmt"
+	"testing"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/backend/witness"
@@ -24,7 +27,6 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type singleSecretCommittedCircuit struct {
@@ -33,7 +35,11 @@ type singleSecretCommittedCircuit struct {
 
 func (c *singleSecretCommittedCircuit) Define(api frontend.API) error {
 	api.AssertIsEqual(c.One, 1)
-	commit, err := api.Compiler().Commit(c.One)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One)
 	if err != nil {
 		return err
 	}
@@ -119,8 +125,11 @@ type oneSecretOnePublicCommittedCircuit struct {
 }
 
 func (c *oneSecretOnePublicCommittedCircuit) Define(api frontend.API) error {
-
-	commit, err := api.Compiler().Commit(c.One, c.Two)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One, c.Two)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bls12-381/groth16/commitment_test.go
+++ b/internal/backend/bls12-381/groth16/commitment_test.go
@@ -17,6 +17,9 @@
 package groth16_test
 
 import (
+	"fmt"
+	"testing"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/backend/witness"
@@ -24,7 +27,6 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type singleSecretCommittedCircuit struct {
@@ -33,7 +35,11 @@ type singleSecretCommittedCircuit struct {
 
 func (c *singleSecretCommittedCircuit) Define(api frontend.API) error {
 	api.AssertIsEqual(c.One, 1)
-	commit, err := api.Compiler().Commit(c.One)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One)
 	if err != nil {
 		return err
 	}
@@ -119,8 +125,11 @@ type oneSecretOnePublicCommittedCircuit struct {
 }
 
 func (c *oneSecretOnePublicCommittedCircuit) Define(api frontend.API) error {
-
-	commit, err := api.Compiler().Commit(c.One, c.Two)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One, c.Two)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bls24-315/groth16/commitment_test.go
+++ b/internal/backend/bls24-315/groth16/commitment_test.go
@@ -17,6 +17,9 @@
 package groth16_test
 
 import (
+	"fmt"
+	"testing"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/backend/witness"
@@ -24,7 +27,6 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type singleSecretCommittedCircuit struct {
@@ -33,7 +35,11 @@ type singleSecretCommittedCircuit struct {
 
 func (c *singleSecretCommittedCircuit) Define(api frontend.API) error {
 	api.AssertIsEqual(c.One, 1)
-	commit, err := api.Compiler().Commit(c.One)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One)
 	if err != nil {
 		return err
 	}
@@ -119,8 +125,11 @@ type oneSecretOnePublicCommittedCircuit struct {
 }
 
 func (c *oneSecretOnePublicCommittedCircuit) Define(api frontend.API) error {
-
-	commit, err := api.Compiler().Commit(c.One, c.Two)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One, c.Two)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bls24-317/groth16/commitment_test.go
+++ b/internal/backend/bls24-317/groth16/commitment_test.go
@@ -17,6 +17,9 @@
 package groth16_test
 
 import (
+	"fmt"
+	"testing"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/backend/witness"
@@ -24,7 +27,6 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type singleSecretCommittedCircuit struct {
@@ -33,7 +35,11 @@ type singleSecretCommittedCircuit struct {
 
 func (c *singleSecretCommittedCircuit) Define(api frontend.API) error {
 	api.AssertIsEqual(c.One, 1)
-	commit, err := api.Compiler().Commit(c.One)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One)
 	if err != nil {
 		return err
 	}
@@ -119,8 +125,11 @@ type oneSecretOnePublicCommittedCircuit struct {
 }
 
 func (c *oneSecretOnePublicCommittedCircuit) Define(api frontend.API) error {
-
-	commit, err := api.Compiler().Commit(c.One, c.Two)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One, c.Two)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bn254/groth16/commitment_test.go
+++ b/internal/backend/bn254/groth16/commitment_test.go
@@ -17,6 +17,9 @@
 package groth16_test
 
 import (
+	"fmt"
+	"testing"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/backend/witness"
@@ -24,7 +27,6 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type singleSecretCommittedCircuit struct {
@@ -33,7 +35,11 @@ type singleSecretCommittedCircuit struct {
 
 func (c *singleSecretCommittedCircuit) Define(api frontend.API) error {
 	api.AssertIsEqual(c.One, 1)
-	commit, err := api.Compiler().Commit(c.One)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One)
 	if err != nil {
 		return err
 	}
@@ -119,8 +125,11 @@ type oneSecretOnePublicCommittedCircuit struct {
 }
 
 func (c *oneSecretOnePublicCommittedCircuit) Define(api frontend.API) error {
-
-	commit, err := api.Compiler().Commit(c.One, c.Two)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One, c.Two)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bw6-633/groth16/commitment_test.go
+++ b/internal/backend/bw6-633/groth16/commitment_test.go
@@ -17,6 +17,9 @@
 package groth16_test
 
 import (
+	"fmt"
+	"testing"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/backend/witness"
@@ -24,7 +27,6 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type singleSecretCommittedCircuit struct {
@@ -33,7 +35,11 @@ type singleSecretCommittedCircuit struct {
 
 func (c *singleSecretCommittedCircuit) Define(api frontend.API) error {
 	api.AssertIsEqual(c.One, 1)
-	commit, err := api.Compiler().Commit(c.One)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One)
 	if err != nil {
 		return err
 	}
@@ -119,8 +125,11 @@ type oneSecretOnePublicCommittedCircuit struct {
 }
 
 func (c *oneSecretOnePublicCommittedCircuit) Define(api frontend.API) error {
-
-	commit, err := api.Compiler().Commit(c.One, c.Two)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One, c.Two)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/bw6-761/groth16/commitment_test.go
+++ b/internal/backend/bw6-761/groth16/commitment_test.go
@@ -17,6 +17,9 @@
 package groth16_test
 
 import (
+	"fmt"
+	"testing"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/backend/witness"
@@ -24,7 +27,6 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type singleSecretCommittedCircuit struct {
@@ -33,7 +35,11 @@ type singleSecretCommittedCircuit struct {
 
 func (c *singleSecretCommittedCircuit) Define(api frontend.API) error {
 	api.AssertIsEqual(c.One, 1)
-	commit, err := api.Compiler().Commit(c.One)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One)
 	if err != nil {
 		return err
 	}
@@ -119,8 +125,11 @@ type oneSecretOnePublicCommittedCircuit struct {
 }
 
 func (c *oneSecretOnePublicCommittedCircuit) Define(api frontend.API) error {
-
-	commit, err := api.Compiler().Commit(c.One, c.Two)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One, c.Two)
 	if err != nil {
 		return err
 	}

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.commitment.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.commitment.go.tmpl
@@ -1,4 +1,7 @@
 import (
+	"testing"
+	"fmt"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/backend/witness"
@@ -6,7 +9,6 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type singleSecretCommittedCircuit struct {
@@ -15,7 +17,11 @@ type singleSecretCommittedCircuit struct {
 
 func (c *singleSecretCommittedCircuit) Define(api frontend.API) error {
 	api.AssertIsEqual(c.One, 1)
-	commit, err := api.Compiler().Commit(c.One)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One)
 	if err != nil {
 		return err
 	}
@@ -101,8 +107,11 @@ type oneSecretOnePublicCommittedCircuit struct {
 }
 
 func (c *oneSecretOnePublicCommittedCircuit) Define(api frontend.API) error {
-
-	commit, err := api.Compiler().Commit(c.One, c.Two)
+	commitCompiler, ok := api.Compiler().(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("compiler does not commit")
+	}
+	commit, err := commitCompiler.Commit(c.One, c.Two)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Right now `Commit` is part of the `frontend.Compiler` API. But this doesn't work well in case where the builders actually do not implement commitment (e.g. PLONK). We will get a runtime panic but this is really difficult to detect in a way which is sustainable long term (string handling etc.).

So instead, I add a new interface `Committer` with a single method `Commit` (as previously in `frontend.Compiler`). If the builder implements commitments, then any user can type assert and use the method and otherwise rely on some locally-defined fallback.

I also added a simple and hopefully fast enough commitment to the test engine. And removed the commitment from PLONK for now until we implement augmented-PLONK