### PR TITLE
fix: allocate new variable in engine.MulAcc

### DIFF
--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -185,12 +185,12 @@ func (f *Field[T]) mul(a, b *Element[T], nextOverflow uint) *Element[T] {
 		for i := 1; i < len(mulResult); i++ {
 			w.Lsh(w, uint(c))
 			if i < len(a.Limbs) {
-				l = f.api.Add(l, f.api.Mul(a.Limbs[i], w))
+				l = f.api.MulAcc(l, a.Limbs[i], w)
 			}
 			if i < len(b.Limbs) {
-				r = f.api.Add(r, f.api.Mul(b.Limbs[i], w))
+				r = f.api.MulAcc(r, b.Limbs[i], w)
 			}
-			o = f.api.Add(o, f.api.Mul(mulResult[i], w))
+			o = f.api.MulAcc(o, mulResult[i], w)
 		}
 		f.api.AssertIsEqual(f.api.Mul(l, r), o)
 	}

--- a/test/engine.go
+++ b/test/engine.go
@@ -161,8 +161,9 @@ func (e *engine) MulAcc(a, b, c frontend.Variable) frontend.Variable {
 	bc := pool.BigInt.Get()
 	bc.Mul(e.toBigInt(b), e.toBigInt(c))
 
+	res := new(big.Int)
 	_a := e.toBigInt(a)
-	_a.Add(_a, bc).Mod(_a, e.modulus())
+	res.Add(_a, bc).Mod(res, e.modulus())
 
 	pool.BigInt.Put(bc)
 	return _a

--- a/test/engine.go
+++ b/test/engine.go
@@ -166,7 +166,7 @@ func (e *engine) MulAcc(a, b, c frontend.Variable) frontend.Variable {
 	res.Add(_a, bc).Mod(res, e.modulus())
 
 	pool.BigInt.Put(bc)
-	return _a
+	return res
 }
 
 func (e *engine) Sub(i1, i2 frontend.Variable, in ...frontend.Variable) frontend.Variable {


### PR DESCRIPTION
We previously modified the result inline, but the behaviour may be inconsistent with actual frontend/compiler. When variable is a Term or LinearExpression, then
```
   b := a
```
copies value of a into b and after that these variables are independent. For example, with MulAcc(b, x, y) we won't modify the variable a. But, as test engine modified variable inline, then doing MulAcc(b, x, y) also changed value of a (as they are just *big.Int). This lead to inconsistent results.