### PR TITLE
feat: add defer to the Compiler interface

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -75,5 +75,8 @@ func writeStack(sbb *strings.Builder, forceClean ...bool) {
 		if strings.HasSuffix(function, "Define") {
 			break
 		}
+		if strings.HasSuffix(function, "callDeferred") {
+			break
+		}
 	}
 }

--- a/debug/symbol_table.go
+++ b/debug/symbol_table.go
@@ -76,6 +76,9 @@ func (st *SymbolTable) CollectStack() []int {
 		if strings.HasSuffix(function, "Define") {
 			break
 		}
+		if strings.HasSuffix(function, "callDeferred") {
+			break
+		}
 	}
 	return r
 }

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -55,6 +55,11 @@ type Compiler interface {
 	// ! Experimental
 	// TENTATIVE: Functions regarding fiat-shamir-ed proofs over enormous statements  TODO finalize
 	Commit(...Variable) (Variable, error)
+
+	// Defer is called after circuit.Define() and before Compile(). This method
+	// allows for the circuits to register callbacks which finalize batching
+	// operations etc. Unlike Go defer, it is not locally scoped.
+	Defer(cb func(api API) error)
 }
 
 // Builder represents a constraint system builder

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/internal/expr"
 	"github.com/consensys/gnark/frontend/schema"
+	"github.com/consensys/gnark/internal/circuitdefer"
 	"github.com/consensys/gnark/internal/kvstore"
 	"github.com/consensys/gnark/internal/tinyfield"
 	"github.com/consensys/gnark/internal/utils"
@@ -451,4 +452,8 @@ func (builder *builder) compress(le expr.LinearExpression) expr.LinearExpression
 	t := builder.newInternalVariable()
 	builder.cs.AddConstraint(builder.newR1C(le, one, t))
 	return t
+}
+
+func (builder *builder) Defer(cb func(frontend.API) error) {
+	circuitdefer.Put(builder, cb)
 }

--- a/frontend/cs/r1cs/r1cs_test.go
+++ b/frontend/cs/r1cs/r1cs_test.go
@@ -135,3 +135,28 @@ func BenchmarkReduce(b *testing.B) {
 		}
 	})
 }
+
+type EmptyCircuit struct {
+	X  frontend.Variable
+	cb func(frontend.API) error
+}
+
+func (c *EmptyCircuit) Define(api frontend.API) error {
+	api.AssertIsEqual(c.X, 0)
+	api.Compiler().Defer(c.cb)
+	return nil
+}
+
+func TestPreCompileHook(t *testing.T) {
+	var called bool
+	c := &EmptyCircuit{
+		cb: func(a frontend.API) error { called = true; return nil },
+	}
+	_, err := frontend.Compile(ecc.BN254.ScalarField(), NewBuilder, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("callback not called")
+	}
+}

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/consensys/gnark/frontend/cs"
 	"github.com/consensys/gnark/frontend/internal/expr"
 	"github.com/consensys/gnark/frontend/schema"
+	"github.com/consensys/gnark/internal/circuitdefer"
 	"github.com/consensys/gnark/internal/kvstore"
 	"github.com/consensys/gnark/internal/tinyfield"
 	"github.com/consensys/gnark/internal/utils"
@@ -390,4 +391,8 @@ func (builder *scs) newDebugInfo(errName string, in ...interface{}) constraint.D
 
 	return builder.cs.NewDebugInfo(errName, in...)
 
+}
+
+func (builder *scs) Defer(cb func(frontend.API) error) {
+	circuitdefer.Put(builder, cb)
 }

--- a/internal/circuitdefer/defer.go
+++ b/internal/circuitdefer/defer.go
@@ -4,9 +4,7 @@ import (
 	"github.com/consensys/gnark/internal/kvstore"
 )
 
-type DeferKey struct{}
-
-// type DeferFn func(frontend.API) error
+type deferKey struct{}
 
 func Put[T any](builder any, cb T) {
 	// we use generics for type safety but to avoid import cycles.
@@ -15,7 +13,7 @@ func Put[T any](builder any, cb T) {
 	if !ok {
 		panic("builder does not implement kvstore.Store")
 	}
-	val := kv.GetKeyValue(DeferKey{})
+	val := kv.GetKeyValue(deferKey{})
 	var deferred []T
 	if val == nil {
 		deferred = []T{cb}
@@ -27,7 +25,7 @@ func Put[T any](builder any, cb T) {
 		}
 	}
 	deferred = append(deferred, cb)
-	kv.SetKeyValue(DeferKey{}, deferred)
+	kv.SetKeyValue(deferKey{}, deferred)
 }
 
 func GetAll[T any](builder any) []T {
@@ -35,7 +33,7 @@ func GetAll[T any](builder any) []T {
 	if !ok {
 		panic("builder does not implement kvstore.Store")
 	}
-	val := kv.GetKeyValue(DeferKey{})
+	val := kv.GetKeyValue(deferKey{})
 	if val == nil {
 		return nil
 	}

--- a/internal/circuitdefer/defer.go
+++ b/internal/circuitdefer/defer.go
@@ -1,0 +1,47 @@
+package circuitdefer
+
+import (
+	"github.com/consensys/gnark/internal/kvstore"
+)
+
+type DeferKey struct{}
+
+// type DeferFn func(frontend.API) error
+
+func Put[T any](builder any, cb T) {
+	// we use generics for type safety but to avoid import cycles.
+	// TODO: compare with using any and type asserting at caller
+	kv, ok := builder.(kvstore.Store)
+	if !ok {
+		panic("builder does not implement kvstore.Store")
+	}
+	val := kv.GetKeyValue(DeferKey{})
+	var deferred []T
+	if val == nil {
+		deferred = []T{cb}
+	} else {
+		var ok bool
+		deferred, ok = val.([]T)
+		if !ok {
+			panic("stored deferred functions not []func(frontend.API) error")
+		}
+	}
+	deferred = append(deferred, cb)
+	kv.SetKeyValue(DeferKey{}, deferred)
+}
+
+func GetAll[T any](builder any) []T {
+	kv, ok := builder.(kvstore.Store)
+	if !ok {
+		panic("builder does not implement kvstore.Store")
+	}
+	val := kv.GetKeyValue(DeferKey{})
+	if val == nil {
+		return nil
+	}
+	deferred, ok := val.([]T)
+	if !ok {
+		panic("stored deferred functions not []func(frontend.API) error")
+	}
+	return deferred
+}

--- a/test/engine_test.go
+++ b/test/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark"
+	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/hint"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/math/bits"
@@ -68,4 +69,34 @@ func TestBuiltinHints(t *testing.T) {
 		}
 	}
 
+}
+
+var isDeferCalled bool
+
+type EmptyCircuit struct {
+	X frontend.Variable
+}
+
+func (c *EmptyCircuit) Define(api frontend.API) error {
+	api.AssertIsEqual(c.X, 0)
+	api.Compiler().Defer(func(api frontend.API) error {
+		isDeferCalled = true
+		return nil
+	})
+	return nil
+}
+
+func TestPreCompileHook(t *testing.T) {
+	c := &EmptyCircuit{}
+	w := &EmptyCircuit{
+		X: 0,
+	}
+	isDeferCalled = false
+	err := IsSolved(c, w, ecc.BN254.ScalarField())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isDeferCalled {
+		t.Error("callback not called")
+	}
 }

--- a/test/solver_test.go
+++ b/test/solver_test.go
@@ -152,11 +152,10 @@ func (p *permutter) solveR1CS() error {
 // isSolvedEngine behaves like test.IsSolved except it doesn't clone the circuit
 func isSolvedEngine(c frontend.Circuit, field *big.Int, opts ...TestEngineOption) (err error) {
 	e := &engine{
-		curveID:    utils.FieldToCurve(field),
-		q:          new(big.Int).Set(field),
-		apiWrapper: func(a frontend.API) frontend.API { return a },
-		constVars:  false,
-		Store:      kvstore.New(),
+		curveID:   utils.FieldToCurve(field),
+		q:         new(big.Int).Set(field),
+		constVars: false,
+		Store:     kvstore.New(),
 	}
 	for _, opt := range opts {
 		if err := opt(e); err != nil {
@@ -170,8 +169,7 @@ func isSolvedEngine(c frontend.Circuit, field *big.Int, opts ...TestEngineOption
 		}
 	}()
 
-	api := e.apiWrapper(e)
-	err = c.Define(api)
+	err = c.Define(e)
 
 	return
 }


### PR DESCRIPTION
See discussion in #472. This PR adds `PreCompileHook(cb func(API) error)` method to the `frontend.Compiler`. The intent of the method is to register all callback which should be called after the `Define` method of the circuit is called. These callbacks can be used by gadgets to safely defer any necessary closing tasks (e.g. range checking builds actual constraints, permutation networks build the permutations etc.) without requiring any interaction from the user.

I don't like the implementation though, I think it is really fragile. However, the problem is that I do not want to make `frontend.Compile` interface any more complex than it barely should, and this also means that there isn't a method to get all the callbacks which the `frontend.Compile` method can use. That is why I have embedded calling the callback in every builder's `Compile` method. But this is really really ugly solution.
A better way would definitely be to make list of all callback available to `frontend.Compile` without making `frontend.Compiler` interface bigger. One option, for example, would be to use the key-value store with some internal key. For example the implementation for registering callback:
```go

// type CallbackKey is in frontend/internal/XXX

func (b *builder) PreCompileHook(cb func(frontend.API) error) {
    cbs := b.GetKeyValueStore(CallbackKey{})
    b.SetKeyValueStore(callbackKey{}, append(cbs, cb))
}
```

and then in `frontend.Compile`:
```go
function Compile() {
// ...
    cbs := builder.GetKeyValue(CallbackKey{})
    // call all callbacks
    builder.Compile()
}
```