### PR TITLE
feat: add a partition selector

### DIFF
--- a/std/hints.go
+++ b/std/hints.go
@@ -33,5 +33,6 @@ func registerHints() {
 	hint.Register(bits.NBits)
 	hint.Register(selector.MuxIndicators)
 	hint.Register(selector.MapIndicators)
+	hint.Register(selector.StepOutput)
 	hint.Register(emulated.GetHints()...)
 }

--- a/std/selector/doc_partition_test.go
+++ b/std/selector/doc_partition_test.go
@@ -1,0 +1,80 @@
+package selector_test
+
+import "github.com/consensys/gnark/frontend"
+
+import (
+	"fmt"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/backend/groth16"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/std/selector"
+)
+
+// adderCircuit adds first Count number of its input array In.
+type adderCircuit struct {
+	Count       frontend.Variable
+	In          [10]frontend.Variable
+	ExpectedSum frontend.Variable
+}
+
+// Define defines the arithmetic circuit.
+func (c *adderCircuit) Define(api frontend.API) error {
+	selectedPart := selector.Partition(api, c.Count, false, c.In[:])
+	sum := api.Add(0, 0, selectedPart...)
+	api.AssertIsEqual(sum, c.ExpectedSum)
+	return nil
+}
+
+// ExamplePartition gives an example on how to use selector.Partition to make a circuit that accepts a Count and an
+// input array In, and then calculates the sum of first Count numbers of the input array.
+func ExamplePartition() {
+	circuit := adderCircuit{}
+	witness := adderCircuit{
+		Count:       6,
+		In:          [10]frontend.Variable{0, 2, 4, 6, 8, 10, 12, 14, 16, 18},
+		ExpectedSum: 30,
+	}
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("compiled")
+	}
+	pk, vk, err := groth16.Setup(ccs)
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("setup done")
+	}
+	secretWitness, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("secret witness")
+	}
+	publicWitness, err := secretWitness.Public()
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("public witness")
+	}
+	proof, err := groth16.Prove(ccs, pk, secretWitness)
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("proof")
+	}
+	err = groth16.Verify(proof, vk, publicWitness)
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("verify")
+	}
+	// Output: compiled
+	// setup done
+	// secret witness
+	// public witness
+	// proof
+	// verify
+}

--- a/std/selector/doc_partition_test.go
+++ b/std/selector/doc_partition_test.go
@@ -21,7 +21,7 @@ type adderCircuit struct {
 // Define defines the arithmetic circuit.
 func (c *adderCircuit) Define(api frontend.API) error {
 	selectedPart := selector.Partition(api, c.Count, false, c.In[:])
-	sum := api.Add(0, 0, selectedPart...)
+	sum := api.Add(selectedPart[0], selectedPart[1], selectedPart[2:]...)
 	api.AssertIsEqual(sum, c.ExpectedSum)
 	return nil
 }

--- a/std/selector/slice.go
+++ b/std/selector/slice.go
@@ -1,0 +1,79 @@
+package selector
+
+import (
+	"github.com/consensys/gnark/backend/hint"
+	"github.com/consensys/gnark/frontend"
+	"math/big"
+)
+
+func init() {
+	// register hints
+	hint.Register(StepOutput)
+}
+
+// Partition selects left or right side of the input array, with respect to the pivotPosition.
+// More precisely when rightSide is false, for each i:
+//
+//	if i < pivotPosition
+//	    out[i] = input[i]
+//	else
+//	    out[i] = 0
+//
+// and when rightSide is true, for each i we have:
+//
+//	if i >= pivotPosition
+//	    out[i] = input[i]
+//	else
+//	    out[i] = 0
+//
+// We must have pivotPosition >= 1 and pivotPosition <= len(input)-1, otherwise no proof can be generated.
+func Partition(api frontend.API, pivotPosition frontend.Variable, rightSide bool,
+	input []frontend.Variable) []frontend.Variable {
+	out := make([]frontend.Variable, len(input))
+	var mask []frontend.Variable
+	if rightSide {
+		mask = StepMask(api, len(input), pivotPosition, 0, 1)
+	} else {
+		mask = StepMask(api, len(input), pivotPosition, 1, 0)
+	}
+	for i := 0; i < len(out); i++ {
+		out[i] = api.Mul(mask[i], input[i])
+	}
+	return out
+}
+
+func StepMask(api frontend.API, outputLen int,
+	stepPosition, startValue, endValue frontend.Variable) []frontend.Variable {
+	if outputLen < 2 {
+		panic("output len must be >= 2")
+	}
+	// Get the output as a hint
+	out, _ := api.Compiler().NewHint(StepOutput, outputLen, stepPosition, startValue, endValue)
+
+	// Add boundary constraints
+	api.AssertIsEqual(out[0], startValue)
+	api.AssertIsEqual(out[len(out)-1], endValue)
+
+	// Add constraints for the correct form of a step function that steps at the stepPosition
+	for i := 1; i < len(out); i++ {
+		// (out[i] - out[i-1]) * (i - stepPosition) == 0
+		api.AssertIsEqual(api.Mul(api.Sub(out[i], out[i-1]), api.Sub(i, stepPosition)), 0)
+	}
+	return out
+}
+
+// StepOutput is a hint function used within [StepMask] function. It must be
+// provided to the prover when circuit uses it.
+func StepOutput(_ *big.Int, inputs, results []*big.Int) error {
+	stepPos := inputs[0]
+	startValue := inputs[1]
+	endValue := inputs[2]
+	for i := 0; i < len(results); i++ {
+		if i < int(stepPos.Int64()) {
+			results[i].Set(startValue)
+		} else {
+			results[i].Set(endValue)
+		}
+	}
+	return nil
+}

--- a/std/selector/slice.go
+++ b/std/selector/slice.go
@@ -26,15 +26,16 @@ func init() {
 //	else
 //	    out[i] = 0
 //
-// We must have pivotPosition >= 1 and pivotPosition <= len(input)-1, otherwise no proof can be generated.
+// We must have pivotPosition >= 1 and pivotPosition <= len(input), otherwise a proof cannot be generated.
 func Partition(api frontend.API, pivotPosition frontend.Variable, rightSide bool,
 	input []frontend.Variable) []frontend.Variable {
 	out := make([]frontend.Variable, len(input))
 	var mask []frontend.Variable
+	// we create a mask of len(input)+1 to be able to handle the case pivotPosition == len(input)
 	if rightSide {
-		mask = StepMask(api, len(input), pivotPosition, 0, 1)
+		mask = StepMask(api, len(input)+1, pivotPosition, 0, 1)
 	} else {
-		mask = StepMask(api, len(input), pivotPosition, 1, 0)
+		mask = StepMask(api, len(input)+1, pivotPosition, 1, 0)
 	}
 	for i := 0; i < len(out); i++ {
 		out[i] = api.Mul(mask[i], input[i])

--- a/std/selector/slice.go
+++ b/std/selector/slice.go
@@ -26,16 +26,16 @@ func init() {
 //	else
 //	    out[i] = 0
 //
-// We must have pivotPosition >= 1 and pivotPosition <= len(input), otherwise a proof cannot be generated.
+// We must have pivotPosition >= 1 and pivotPosition <= len(input)-1, otherwise a proof cannot be generated.
 func Partition(api frontend.API, pivotPosition frontend.Variable, rightSide bool,
 	input []frontend.Variable) (out []frontend.Variable) {
 	out = make([]frontend.Variable, len(input))
 	var mask []frontend.Variable
 	// we create a mask of len(input)+1 to be able to handle the case pivotPosition == len(input)
 	if rightSide {
-		mask = StepMask(api, len(input)+1, pivotPosition, 0, 1)
+		mask = StepMask(api, len(input), pivotPosition, 0, 1)
 	} else {
-		mask = StepMask(api, len(input)+1, pivotPosition, 1, 0)
+		mask = StepMask(api, len(input), pivotPosition, 1, 0)
 	}
 	for i := 0; i < len(out); i++ {
 		out[i] = api.Mul(mask[i], input[i])

--- a/std/selector/slice.go
+++ b/std/selector/slice.go
@@ -12,7 +12,7 @@ func init() {
 }
 
 // Partition selects left or right side of the input array, with respect to the pivotPosition.
-// More precisely when rightSide is false, for each i:
+// More precisely when rightSide is false, for each i we have:
 //
 //	if i < pivotPosition
 //	    out[i] = input[i]
@@ -28,8 +28,8 @@ func init() {
 //
 // We must have pivotPosition >= 1 and pivotPosition <= len(input), otherwise a proof cannot be generated.
 func Partition(api frontend.API, pivotPosition frontend.Variable, rightSide bool,
-	input []frontend.Variable) []frontend.Variable {
-	out := make([]frontend.Variable, len(input))
+	input []frontend.Variable) (out []frontend.Variable) {
+	out = make([]frontend.Variable, len(input))
 	var mask []frontend.Variable
 	// we create a mask of len(input)+1 to be able to handle the case pivotPosition == len(input)
 	if rightSide {
@@ -40,22 +40,29 @@ func Partition(api frontend.API, pivotPosition frontend.Variable, rightSide bool
 	for i := 0; i < len(out); i++ {
 		out[i] = api.Mul(mask[i], input[i])
 	}
-	return out
+	return
 }
 
+// StepMask generates a step like function into an output array of a given length.
+// The output is an array of length outputLen,
+// such that its first stepPosition elements are equal to startValue and the remaining elements are equal to
+// endValue. Note that outputLen cannot be a circuit variable.
+//
+// We must have stepPosition >= 1 and stepPosition <= outputLen, otherwise a proof cannot be generated.
+// This function panics when outputLen is less than 2.
 func StepMask(api frontend.API, outputLen int,
 	stepPosition, startValue, endValue frontend.Variable) []frontend.Variable {
 	if outputLen < 2 {
 		panic("output len must be >= 2")
 	}
-	// Get the output as a hint
+	// get the output as a hint
 	out, _ := api.Compiler().NewHint(StepOutput, outputLen, stepPosition, startValue, endValue)
 
-	// Add boundary constraints
+	// add boundary constraints
 	api.AssertIsEqual(out[0], startValue)
 	api.AssertIsEqual(out[len(out)-1], endValue)
 
-	// Add constraints for the correct form of a step function that steps at the stepPosition
+	// add constraints for the correct form of a step function that steps at the stepPosition
 	for i := 1; i < len(out); i++ {
 		// (out[i] - out[i-1]) * (i - stepPosition) == 0
 		api.AssertIsEqual(api.Mul(api.Sub(out[i], out[i-1]), api.Sub(i, stepPosition)), 0)

--- a/std/selector/slice_test.go
+++ b/std/selector/slice_test.go
@@ -57,10 +57,10 @@ func TestPartition(t *testing.T) {
 	})
 
 	assert.ProverSucceeded(&partitionerCircuit{}, &partitionerCircuit{
-		Pivot:     6,
+		Pivot:     5,
 		In:        [6]frontend.Variable{10, 20, 30, 40, 50, 60},
-		WantLeft:  [6]frontend.Variable{10, 20, 30, 40, 50, 60},
-		WantRight: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
+		WantLeft:  [6]frontend.Variable{10, 20, 30, 40, 50, 0},
+		WantRight: [6]frontend.Variable{0, 0, 0, 0, 0, 60},
 	})
 
 	assert.ProverFailed(&partitionerCircuit{}, &partitionerCircuit{
@@ -70,13 +70,14 @@ func TestPartition(t *testing.T) {
 		WantRight: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
 	})
 
-	// Pivot is outside and the prover fails: (todo: this doesn't work. why?)
+	// Pivot is outside and the prover fails:
 	assert.ProverFailed(&partitionerCircuit{}, &partitionerCircuit{
-		Pivot:     7,
+		Pivot:     6,
 		In:        [6]frontend.Variable{10, 20, 30, 40, 50, 60},
 		WantLeft:  [6]frontend.Variable{10, 20, 30, 40, 50, 60},
 		WantRight: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
 	})
+	// todo: fails for /bls24_317/plonkFRI#04
 
 	assert.ProverFailed(&partitionerCircuit{}, &partitionerCircuit{
 		Pivot:     0,
@@ -97,7 +98,7 @@ func TestPartition(t *testing.T) {
 	})
 
 	assert.ProverFailed(&ignoredOutputPartitionerCircuit{}, &ignoredOutputPartitionerCircuit{
-		Pivot: 3,
+		Pivot: 2,
 		In:    [2]frontend.Variable{10, 20},
 	})
 }

--- a/std/selector/slice_test.go
+++ b/std/selector/slice_test.go
@@ -50,9 +50,16 @@ func TestPartition(t *testing.T) {
 		Right: [6]frontend.Variable{0, 0, 0, 0, 0, 60},
 	})
 
+	assert.ProverSucceeded(&partitionerCircuit{}, &partitionerCircuit{
+		Pivot: 6,
+		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		Left:  [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		Right: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
+	})
+
 	// Pivot is outside and the prover fails: (todo: this doesn't work. why?)
 	assert.ProverFailed(&partitionerCircuit{}, &partitionerCircuit{
-		Pivot: 6,
+		Pivot: 7,
 		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
 		Left:  [6]frontend.Variable{10, 20, 30, 40, 50, 60},
 		Right: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
@@ -64,5 +71,4 @@ func TestPartition(t *testing.T) {
 		Left:  [6]frontend.Variable{0, 0, 0, 0, 0, 0},
 		Right: [6]frontend.Variable{10, 20, 30, 40, 50, 60},
 	})
-
 }

--- a/std/selector/slice_test.go
+++ b/std/selector/slice_test.go
@@ -8,21 +8,34 @@ import (
 )
 
 type partitionerCircuit struct {
-	Pivot frontend.Variable
-	In    [6]frontend.Variable
-	Left  [6]frontend.Variable
-	Right [6]frontend.Variable
+	Pivot     frontend.Variable    `gnark:",public"`
+	In        [6]frontend.Variable `gnark:",public"`
+	WantLeft  [6]frontend.Variable `gnark:",public"`
+	WantRight [6]frontend.Variable `gnark:",public"`
 }
 
 func (c *partitionerCircuit) Define(api frontend.API) error {
-	left := selector.Partition(api, c.Pivot, false, c.In[:])
-	for i, want := range c.Left {
-		api.AssertIsEqual(want, left[i])
+	gotLeft := selector.Partition(api, c.Pivot, false, c.In[:])
+	for i, want := range c.WantLeft {
+		api.AssertIsEqual(gotLeft[i], want)
 	}
-	right := selector.Partition(api, c.Pivot, true, c.In[:])
-	for i, want := range c.Right {
-		api.AssertIsEqual(want, right[i])
+
+	gotRight := selector.Partition(api, c.Pivot, true, c.In[:])
+	for i, want := range c.WantRight {
+		api.AssertIsEqual(gotRight[i], want)
 	}
+
+	return nil
+}
+
+type ignoredOutputPartitionerCircuit struct {
+	Pivot frontend.Variable    `gnark:",public"`
+	In    [2]frontend.Variable `gnark:",public"`
+}
+
+func (c *ignoredOutputPartitionerCircuit) Define(api frontend.API) error {
+	_ = selector.Partition(api, c.Pivot, false, c.In[:])
+	_ = selector.Partition(api, c.Pivot, true, c.In[:])
 	return nil
 }
 
@@ -30,45 +43,61 @@ func TestPartition(t *testing.T) {
 	assert := test.NewAssert(t)
 
 	assert.ProverSucceeded(&partitionerCircuit{}, &partitionerCircuit{
-		Pivot: 3,
-		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
-		Left:  [6]frontend.Variable{10, 20, 30, 0, 0, 0},
-		Right: [6]frontend.Variable{0, 0, 0, 40, 50, 60},
+		Pivot:     3,
+		In:        [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		WantLeft:  [6]frontend.Variable{10, 20, 30, 0, 0, 0},
+		WantRight: [6]frontend.Variable{0, 0, 0, 40, 50, 60},
 	})
 
 	assert.ProverSucceeded(&partitionerCircuit{}, &partitionerCircuit{
-		Pivot: 1,
-		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
-		Left:  [6]frontend.Variable{10, 0, 0, 0, 0, 0},
-		Right: [6]frontend.Variable{0, 20, 30, 40, 50, 60},
+		Pivot:     1,
+		In:        [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		WantLeft:  [6]frontend.Variable{10, 0, 0, 0, 0, 0},
+		WantRight: [6]frontend.Variable{0, 20, 30, 40, 50, 60},
 	})
 
 	assert.ProverSucceeded(&partitionerCircuit{}, &partitionerCircuit{
-		Pivot: 5,
-		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
-		Left:  [6]frontend.Variable{10, 20, 30, 40, 50, 0},
-		Right: [6]frontend.Variable{0, 0, 0, 0, 0, 60},
+		Pivot:     6,
+		In:        [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		WantLeft:  [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		WantRight: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
 	})
 
-	assert.ProverSucceeded(&partitionerCircuit{}, &partitionerCircuit{
-		Pivot: 6,
-		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
-		Left:  [6]frontend.Variable{10, 20, 30, 40, 50, 60},
-		Right: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
+	assert.ProverFailed(&partitionerCircuit{}, &partitionerCircuit{
+		Pivot:     5,
+		In:        [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		WantLeft:  [6]frontend.Variable{10, 20, 30, 40, 0, 0},
+		WantRight: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
 	})
 
 	// Pivot is outside and the prover fails: (todo: this doesn't work. why?)
 	assert.ProverFailed(&partitionerCircuit{}, &partitionerCircuit{
-		Pivot: 7,
-		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
-		Left:  [6]frontend.Variable{10, 20, 30, 40, 50, 60},
-		Right: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
+		Pivot:     7,
+		In:        [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		WantLeft:  [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		WantRight: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
 	})
 
 	assert.ProverFailed(&partitionerCircuit{}, &partitionerCircuit{
+		Pivot:     0,
+		In:        [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		WantLeft:  [6]frontend.Variable{0, 0, 0, 0, 0, 0},
+		WantRight: [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+	})
+
+	// tests by ignoring the output:
+	assert.ProverSucceeded(&ignoredOutputPartitionerCircuit{}, &ignoredOutputPartitionerCircuit{
+		Pivot: 1,
+		In:    [2]frontend.Variable{10, 20},
+	})
+
+	assert.ProverFailed(&ignoredOutputPartitionerCircuit{}, &ignoredOutputPartitionerCircuit{
 		Pivot: 0,
-		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
-		Left:  [6]frontend.Variable{0, 0, 0, 0, 0, 0},
-		Right: [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		In:    [2]frontend.Variable{10, 20},
+	})
+
+	assert.ProverFailed(&ignoredOutputPartitionerCircuit{}, &ignoredOutputPartitionerCircuit{
+		Pivot: 3,
+		In:    [2]frontend.Variable{10, 20},
 	})
 }

--- a/std/selector/slice_test.go
+++ b/std/selector/slice_test.go
@@ -1,0 +1,68 @@
+package selector_test
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/selector"
+	"github.com/consensys/gnark/test"
+	"testing"
+)
+
+type partitionerCircuit struct {
+	Pivot frontend.Variable
+	In    [6]frontend.Variable
+	Left  [6]frontend.Variable
+	Right [6]frontend.Variable
+}
+
+func (c *partitionerCircuit) Define(api frontend.API) error {
+	left := selector.Partition(api, c.Pivot, false, c.In[:])
+	for i, want := range c.Left {
+		api.AssertIsEqual(want, left[i])
+	}
+	right := selector.Partition(api, c.Pivot, true, c.In[:])
+	for i, want := range c.Right {
+		api.AssertIsEqual(want, right[i])
+	}
+	return nil
+}
+
+func TestPartition(t *testing.T) {
+	assert := test.NewAssert(t)
+
+	assert.ProverSucceeded(&partitionerCircuit{}, &partitionerCircuit{
+		Pivot: 3,
+		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		Left:  [6]frontend.Variable{10, 20, 30, 0, 0, 0},
+		Right: [6]frontend.Variable{0, 0, 0, 40, 50, 60},
+	})
+
+	assert.ProverSucceeded(&partitionerCircuit{}, &partitionerCircuit{
+		Pivot: 1,
+		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		Left:  [6]frontend.Variable{10, 0, 0, 0, 0, 0},
+		Right: [6]frontend.Variable{0, 20, 30, 40, 50, 60},
+	})
+
+	assert.ProverSucceeded(&partitionerCircuit{}, &partitionerCircuit{
+		Pivot: 5,
+		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		Left:  [6]frontend.Variable{10, 20, 30, 40, 50, 0},
+		Right: [6]frontend.Variable{0, 0, 0, 0, 0, 60},
+	})
+
+	// Pivot is outside and the prover fails: (todo: this doesn't work. why?)
+	assert.ProverFailed(&partitionerCircuit{}, &partitionerCircuit{
+		Pivot: 6,
+		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		Left:  [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		Right: [6]frontend.Variable{0, 0, 0, 0, 0, 0},
+	})
+
+	assert.ProverFailed(&partitionerCircuit{}, &partitionerCircuit{
+		Pivot: 0,
+		In:    [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+		Left:  [6]frontend.Variable{0, 0, 0, 0, 0, 0},
+		Right: [6]frontend.Variable{10, 20, 30, 40, 50, 60},
+	})
+
+}


### PR DESCRIPTION
This is a simple partition selector. It selects the first count number of the input array, keeps them and zeros all other entries or vice versa. By cascading these gadgets a slice can be selected. It works using a step function as a mask.

I just had this idea and tried to implement it. I'm not sure if my implementation is good or if this is useful. Currently some tests are failing for a specific curve. I have no idea why, and I don't know how I can fix that!