### PR TITLE
feat: add EVM precompiles

### DIFF
--- a/std/evmprecompiles/01-ecrecover.go
+++ b/std/evmprecompiles/01-ecrecover.go
@@ -33,7 +33,7 @@ func ECRecover(api frontend.API, msg emulated.Element[emulated.Secp256k1Fr],
 	if err != nil {
 		panic(fmt.Sprintf("new curve: %v", err))
 	}
-	// we cannot directly use the field emulation hint calling wrappers as we work between to fields.
+	// we cannot directly use the field emulation hint calling wrappers as we work between two fields.
 	Rlimbs, err := api.Compiler().NewHint(recoverPointHint, 2*int(emfp.NbLimbs()), recoverPointHintArgs(v, r)...)
 	if err != nil {
 		panic(fmt.Sprintf("point hint: %v", err))
@@ -42,7 +42,7 @@ func ECRecover(api frontend.API, msg emulated.Element[emulated.Secp256k1Fr],
 		X: *fpField.NewElement(Rlimbs[0:emfp.NbLimbs()]),
 		Y: *fpField.NewElement(Rlimbs[emfp.NbLimbs() : 2*emfp.NbLimbs()]),
 	}
-	// we cannot directly use the field emulation hint calling wrappers as we work between to fields.
+	// we cannot directly use the field emulation hint calling wrappers as we work between two fields.
 	Plimbs, err := api.Compiler().NewHint(recoverPublicKeyHint, 2*int(emfp.NbLimbs()), recoverPublicKeyHintArgs(msg, v, r, s)...)
 	if err != nil {
 		panic(fmt.Sprintf("point hint: %v", err))

--- a/std/evmprecompiles/01-ecrecover.go
+++ b/std/evmprecompiles/01-ecrecover.go
@@ -1,0 +1,79 @@
+package evmprecompiles
+
+import (
+	"fmt"
+
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
+	"github.com/consensys/gnark/std/math/bits"
+	"github.com/consensys/gnark/std/math/emulated"
+)
+
+// ECRecover implements [ECRECOVER] precompile contract at address 0x01.
+//
+// [ECRECOVER]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/ecrecover/index.html
+func ECRecover(api frontend.API, msg emulated.Element[emulated.Secp256k1Fr],
+	v frontend.Variable, r, s emulated.Element[emulated.Secp256k1Fr]) *sw_emulated.AffinePoint[emulated.Secp256k1Fp] {
+	// EVM uses v \in {27, 28}, but everyone else v >= 0. Convert back
+	v = api.Sub(v, 27)
+	var emfp emulated.Secp256k1Fp
+	var emfr emulated.Secp256k1Fr
+	fpField, err := emulated.NewField[emulated.Secp256k1Fp](api)
+	if err != nil {
+		panic(fmt.Sprintf("new field: %v", err))
+	}
+	frField, err := emulated.NewField[emulated.Secp256k1Fr](api)
+	if err != nil {
+		panic(fmt.Sprintf("new field: %v", err))
+	}
+	// with the encoding we may have that r,s < 2*Fr (i.e. not r,s < Fr). Apply more thorough checks.
+	frField.AssertIsLessOrEqual(&r, frField.Modulus())
+	frField.AssertIsLessOrEqual(&s, frField.Modulus())
+	curve, err := sw_emulated.New[emulated.Secp256k1Fp, emulated.Secp256k1Fr](api, sw_emulated.GetSecp256k1Params())
+	if err != nil {
+		panic(fmt.Sprintf("new curve: %v", err))
+	}
+	// we cannot directly use the field emulation hint calling wrappers as we work between to fields.
+	Rlimbs, err := api.Compiler().NewHint(recoverPointHint, 2*int(emfp.NbLimbs()), recoverPointHintArgs(v, r)...)
+	if err != nil {
+		panic(fmt.Sprintf("point hint: %v", err))
+	}
+	R := sw_emulated.AffinePoint[emulated.Secp256k1Fp]{
+		X: *fpField.NewElement(Rlimbs[0:emfp.NbLimbs()]),
+		Y: *fpField.NewElement(Rlimbs[emfp.NbLimbs() : 2*emfp.NbLimbs()]),
+	}
+	// we cannot directly use the field emulation hint calling wrappers as we work between to fields.
+	Plimbs, err := api.Compiler().NewHint(recoverPublicKeyHint, 2*int(emfp.NbLimbs()), recoverPublicKeyHintArgs(msg, v, r, s)...)
+	if err != nil {
+		panic(fmt.Sprintf("point hint: %v", err))
+	}
+	P := sw_emulated.AffinePoint[emulated.Secp256k1Fp]{
+		X: *fpField.NewElement(Plimbs[0:emfp.NbLimbs()]),
+		Y: *fpField.NewElement(Plimbs[emfp.NbLimbs() : 2*emfp.NbLimbs()]),
+	}
+	// check that len(v) = 2
+	vbits := bits.ToBinary(api, v, bits.WithNbDigits(2))
+	// check that Rx is correct: x = r+v[1]*fr
+	tmp := fpField.Select(vbits[1], fpField.NewElement(emfr.Modulus()), fpField.NewElement(0))
+	rbits := frField.ToBits(&r)
+	rfp := fpField.FromBits(rbits...)
+	tmp = fpField.Add(rfp, tmp)
+	fpField.AssertIsEqual(tmp, &R.X)
+	// check that Ry is correct: highbit(y) = v[0]
+	Rynormal := fpField.Reduce(&R.Y)
+	Rybits := fpField.ToBits(Rynormal)
+	api.AssertIsEqual(vbits[0], Rybits[emfp.Modulus().BitLen()-1])
+	// compute rinv = r^{-1} mod fr
+	rinv := frField.Inverse(&r)
+	// compute u1 = -msg * rinv
+	u1 := frField.MulMod(&msg, rinv)
+	u1 = frField.Neg(u1)
+	// compute u2 = s * rinv
+	u2 := frField.MulMod(&s, rinv)
+	// check u1 * G + u2 R == P
+	A := curve.ScalarMulBase(u1)
+	B := curve.ScalarMul(&R, u2)
+	C := curve.Add(A, B)
+	curve.AssertIsEqual(C, &P)
+	return &P
+}

--- a/std/evmprecompiles/01-ecrecover_test.go
+++ b/std/evmprecompiles/01-ecrecover_test.go
@@ -91,10 +91,6 @@ func TestECRecoverCircuitShort(t *testing.T) {
 
 func TestECRecoverCircuitFull(t *testing.T) {
 	t.Skip("skipping very long test")
-	if testing.Short() {
-		t.Skip("skipping full ECRecover in short mode")
-		return
-	}
 	assert := test.NewAssert(t)
 	circuit, witness := testRoutineECRecover(t)
 	assert.ProverSucceeded(circuit, witness,

--- a/std/evmprecompiles/01-ecrecover_test.go
+++ b/std/evmprecompiles/01-ecrecover_test.go
@@ -1,0 +1,104 @@
+package evmprecompiles
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/secp256k1/ecdsa"
+	"github.com/consensys/gnark-crypto/ecc/secp256k1/fr"
+	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/test"
+)
+
+func TestSignForRecoverCorrectness(t *testing.T) {
+	sk, err := ecdsa.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal("generate", err)
+	}
+	pk := sk.PublicKey
+	msg := []byte("test")
+	_, r, s, err := sk.SignForRecover(msg, nil)
+	if err != nil {
+		t.Fatal("sign", err)
+	}
+	var sig ecdsa.Signature
+	r.FillBytes(sig.R[:fr.Bytes])
+	s.FillBytes(sig.S[:fr.Bytes])
+	sigM := sig.Bytes()
+	ok, err := pk.Verify(sigM, msg, nil)
+	if err != nil {
+		t.Fatal("verify", err)
+	}
+	if !ok {
+		t.Fatal("not verified")
+	}
+}
+
+type ecrecoverCircuit struct {
+	Message  emulated.Element[emulated.Secp256k1Fr]
+	V        frontend.Variable
+	R        emulated.Element[emulated.Secp256k1Fr]
+	S        emulated.Element[emulated.Secp256k1Fr]
+	Expected sw_emulated.AffinePoint[emulated.Secp256k1Fp]
+}
+
+func (c *ecrecoverCircuit) Define(api frontend.API) error {
+	curve, err := sw_emulated.New[emulated.Secp256k1Fp, emulated.Secp256k1Fr](api, sw_emulated.GetSecp256k1Params())
+	if err != nil {
+		return fmt.Errorf("new curve: %w", err)
+	}
+	res := ECRecover(api, c.Message, c.V, c.R, c.S)
+	curve.AssertIsEqual(&c.Expected, res)
+	return nil
+}
+
+func testRoutineECRecover(t *testing.T) (circ, wit frontend.Circuit) {
+	sk, err := ecdsa.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal("generate", err)
+	}
+	pk := sk.PublicKey
+	msg := []byte("test")
+	v, r, s, err := sk.SignForRecover(msg, nil)
+	if err != nil {
+		t.Fatal("sign", err)
+	}
+	circuit := ecrecoverCircuit{}
+	witness := ecrecoverCircuit{
+		Message: emulated.ValueOf[emulated.Secp256k1Fr](ecdsa.HashToInt(msg)),
+		V:       v + 27, // EVM constant
+		R:       emulated.ValueOf[emulated.Secp256k1Fr](r),
+		S:       emulated.ValueOf[emulated.Secp256k1Fr](s),
+		Expected: sw_emulated.AffinePoint[emulated.Secp256k1Fp]{
+			X: emulated.ValueOf[emulated.Secp256k1Fp](pk.A.X),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](pk.A.Y),
+		},
+	}
+	return &circuit, &witness
+}
+
+func TestECRecoverCircuitShort(t *testing.T) {
+	assert := test.NewAssert(t)
+	circuit, witness := testRoutineECRecover(t)
+	err := test.IsSolved(circuit, witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}
+
+func TestECRecoverCircuitFull(t *testing.T) {
+	t.Skip("skipping very long test")
+	if testing.Short() {
+		t.Skip("skipping full ECRecover in short mode")
+		return
+	}
+	assert := test.NewAssert(t)
+	circuit, witness := testRoutineECRecover(t)
+	assert.ProverSucceeded(circuit, witness,
+		test.NoFuzzing(), test.NoSerialization(),
+		test.WithBackends(backend.GROTH16, backend.PLONK), test.WithCurves(ecc.BN254),
+	)
+}

--- a/std/evmprecompiles/02-sha256.go
+++ b/std/evmprecompiles/02-sha256.go
@@ -1,0 +1,3 @@
+package evmprecompiles
+
+// will implement later

--- a/std/evmprecompiles/04-id.go
+++ b/std/evmprecompiles/04-id.go
@@ -1,0 +1,3 @@
+package evmprecompiles
+
+// not going to implement. It is trivial.

--- a/std/evmprecompiles/05-expmod.go
+++ b/std/evmprecompiles/05-expmod.go
@@ -1,0 +1,1 @@
+package evmprecompiles

--- a/std/evmprecompiles/06-bnadd.go
+++ b/std/evmprecompiles/06-bnadd.go
@@ -1,0 +1,19 @@
+package evmprecompiles
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
+	"github.com/consensys/gnark/std/math/emulated"
+)
+
+// ECAdd implements [ALT_BN128_ADD] precompile contract at address 0x06.
+//
+// [ALT_BN128_ADD]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/alt_bn128/index.html#alt-bn128-add
+func ECAdd(api frontend.API, P, Q *sw_emulated.AffinePoint[emulated.BN254Fp]) *sw_emulated.AffinePoint[emulated.BN254Fp] {
+	curve, err := sw_emulated.New[emulated.BN254Fp, emulated.BN254Fr](api, sw_emulated.GetBN254Params())
+	if err != nil {
+		panic(err)
+	}
+	res := curve.Add(P, Q)
+	return res
+}

--- a/std/evmprecompiles/07-bnmul.go
+++ b/std/evmprecompiles/07-bnmul.go
@@ -1,0 +1,19 @@
+package evmprecompiles
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
+	"github.com/consensys/gnark/std/math/emulated"
+)
+
+// ECMul implements [ALT_BN128_MUL] precompile contract at address 0x07.
+//
+// [ALT_BN128_MUL]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/alt_bn128/index.html#alt-bn128-mul
+func ECMul(api frontend.API, P *sw_emulated.AffinePoint[emulated.BN254Fp], u *emulated.Element[emulated.BN254Fr]) *sw_emulated.AffinePoint[emulated.BN254Fp] {
+	curve, err := sw_emulated.New[emulated.BN254Fp, emulated.BN254Fr](api, sw_emulated.GetBN254Params())
+	if err != nil {
+		panic(err)
+	}
+	res := curve.ScalarMul(P, u)
+	return res
+}

--- a/std/evmprecompiles/08-bnpairing.go
+++ b/std/evmprecompiles/08-bnpairing.go
@@ -8,14 +8,12 @@ import (
 // ECPair implements [ALT_BN128_PAIRING_CHECK] precompile contract at address 0x08.
 //
 // [ALT_BN128_PAIRING_CHECK]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/alt_bn128/index.html#alt-bn128-pairing-check
-func ECPair(api frontend.API, P *sw_bn254.G1Affine, Q *sw_bn254.G2Affine) *sw_bn254.GTEl {
+func ECPair(api frontend.API, P *sw_bn254.G1Affine, Q *sw_bn254.G2Affine) {
 	pair, err := sw_bn254.NewPairing(api)
 	if err != nil {
 		panic(err)
 	}
-	R, err := pair.Pair([]*sw_bn254.G1Affine{P}, []*sw_bn254.G2Affine{Q})
-	if err != nil {
+	if err := pair.PairingCheck([]*sw_bn254.G1Affine{P}, []*sw_bn254.G2Affine{Q}); err != nil {
 		panic(err)
 	}
-	return R
 }

--- a/std/evmprecompiles/08-bnpairing.go
+++ b/std/evmprecompiles/08-bnpairing.go
@@ -8,12 +8,12 @@ import (
 // ECPair implements [ALT_BN128_PAIRING_CHECK] precompile contract at address 0x08.
 //
 // [ALT_BN128_PAIRING_CHECK]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/alt_bn128/index.html#alt-bn128-pairing-check
-func ECPair(api frontend.API, P *sw_bn254.G1Affine, Q *sw_bn254.G2Affine) {
+func ECPair(api frontend.API, P []*sw_bn254.G1Affine, Q []*sw_bn254.G2Affine) {
 	pair, err := sw_bn254.NewPairing(api)
 	if err != nil {
 		panic(err)
 	}
-	if err := pair.PairingCheck([]*sw_bn254.G1Affine{P}, []*sw_bn254.G2Affine{Q}); err != nil {
+	if err := pair.PairingCheck(P, Q); err != nil {
 		panic(err)
 	}
 }

--- a/std/evmprecompiles/08-bnpairing.go
+++ b/std/evmprecompiles/08-bnpairing.go
@@ -1,0 +1,21 @@
+package evmprecompiles
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
+)
+
+// ECPair implements [ALT_BN128_PAIRING_CHECK] precompile contract at address 0x08.
+//
+// [ALT_BN128_PAIRING_CHECK]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/alt_bn128/index.html#alt-bn128-pairing-check
+func ECPair(api frontend.API, P *sw_bn254.G1Affine, Q *sw_bn254.G2Affine) *sw_bn254.GTEl {
+	pair, err := sw_bn254.NewPairing(api)
+	if err != nil {
+		panic(err)
+	}
+	R, err := pair.Pair([]*sw_bn254.G1Affine{P}, []*sw_bn254.G2Affine{Q})
+	if err != nil {
+		panic(err)
+	}
+	return R
+}

--- a/std/evmprecompiles/bn_test.go
+++ b/std/evmprecompiles/bn_test.go
@@ -123,6 +123,7 @@ func TestECMulCircuitShort(t *testing.T) {
 }
 
 func TestECMulCircuitFull(t *testing.T) {
+	t.Skip("skipping very long test")
 	assert := test.NewAssert(t)
 	circuit, witness := testRoutineECMul(t)
 	assert.ProverSucceeded(circuit, witness,

--- a/std/evmprecompiles/bn_test.go
+++ b/std/evmprecompiles/bn_test.go
@@ -133,9 +133,8 @@ func TestECMulCircuitFull(t *testing.T) {
 }
 
 type ecpairCircuit struct {
-	P        [2]sw_bn254.G1Affine
-	Q        [2]sw_bn254.G2Affine
-	Expected sw_bn254.GTEl
+	P [2]sw_bn254.G1Affine
+	Q [2]sw_bn254.G2Affine
 }
 
 func (c *ecpairCircuit) Define(api frontend.API) error {
@@ -148,10 +147,19 @@ func (c *ecpairCircuit) Define(api frontend.API) error {
 func TestECPairCircuitShort(t *testing.T) {
 	assert := test.NewAssert(t)
 	_, _, p1, q1 := bn254.Generators()
+
+	var u, v fr.Element
+	u.SetRandom()
+	v.SetRandom()
+
+	p1.ScalarMultiplication(&p1, u.BigInt(new(big.Int)))
+	q1.ScalarMultiplication(&q1, v.BigInt(new(big.Int)))
+
 	var p2 bn254.G1Affine
 	var q2 bn254.G2Affine
 	p2.Neg(&p1)
 	q2.Set(&q1)
+
 	err := test.IsSolved(&ecpairCircuit{}, &ecpairCircuit{
 		P: [2]sw_bn254.G1Affine{sw_bn254.NewG1Affine(p1), sw_bn254.NewG1Affine(p2)},
 		Q: [2]sw_bn254.G2Affine{sw_bn254.NewG2Affine(q1), sw_bn254.NewG2Affine(q2)},

--- a/std/evmprecompiles/bn_test.go
+++ b/std/evmprecompiles/bn_test.go
@@ -1,0 +1,172 @@
+package evmprecompiles
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/test"
+)
+
+type ecaddCircuit struct {
+	X0       sw_emulated.AffinePoint[emulated.BN254Fp]
+	X1       sw_emulated.AffinePoint[emulated.BN254Fp]
+	Expected sw_emulated.AffinePoint[emulated.BN254Fp]
+}
+
+func (c *ecaddCircuit) Define(api frontend.API) error {
+	curve, err := sw_emulated.New[emulated.BN254Fp, emulated.BN254Fr](api, sw_emulated.GetBN254Params())
+	if err != nil {
+		return err
+	}
+	res := ECAdd(api, &c.X0, &c.X1)
+	curve.AssertIsEqual(res, &c.Expected)
+	return nil
+}
+
+func testRoutineECAdd(t *testing.T) (circ, wit frontend.Circuit) {
+	_, _, G, _ := bn254.Generators()
+	var u, v fr.Element
+	u.SetRandom()
+	v.SetRandom()
+	var P, Q bn254.G1Affine
+	P.ScalarMultiplication(&G, u.BigInt(new(big.Int)))
+	Q.ScalarMultiplication(&G, v.BigInt(new(big.Int)))
+	var expected bn254.G1Affine
+	expected.Add(&P, &Q)
+	circuit := ecaddCircuit{}
+	witness := ecaddCircuit{
+		X0: sw_emulated.AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](P.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](P.Y),
+		},
+		X1: sw_emulated.AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](Q.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](Q.Y),
+		},
+		Expected: sw_emulated.AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](expected.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](expected.Y),
+		},
+	}
+	return &circuit, &witness
+}
+
+func TestECAddCircuitShort(t *testing.T) {
+	assert := test.NewAssert(t)
+	circuit, witness := testRoutineECAdd(t)
+	err := test.IsSolved(circuit, witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}
+
+func TestECAddCircuitFull(t *testing.T) {
+	assert := test.NewAssert(t)
+	circuit, witness := testRoutineECAdd(t)
+	assert.ProverSucceeded(circuit, witness,
+		test.NoFuzzing(), test.NoSerialization(),
+		test.WithBackends(backend.GROTH16, backend.PLONK), test.WithCurves(ecc.BN254),
+	)
+}
+
+type ecmulCircuit struct {
+	X0       sw_emulated.AffinePoint[emulated.BN254Fp]
+	U        emulated.Element[emulated.BN254Fr]
+	Expected sw_emulated.AffinePoint[emulated.BN254Fp]
+}
+
+func (c *ecmulCircuit) Define(api frontend.API) error {
+	curve, err := sw_emulated.New[emulated.BN254Fp, emulated.BN254Fr](api, sw_emulated.GetBN254Params())
+	if err != nil {
+		return err
+	}
+	res := ECMul(api, &c.X0, &c.U)
+	curve.AssertIsEqual(res, &c.Expected)
+	return nil
+}
+
+func testRoutineECMul(t *testing.T) (circ, wit frontend.Circuit) {
+	_, _, G, _ := bn254.Generators()
+	var u, v fr.Element
+	u.SetRandom()
+	v.SetRandom()
+	var P bn254.G1Affine
+	P.ScalarMultiplication(&G, u.BigInt(new(big.Int)))
+	var expected bn254.G1Affine
+	expected.ScalarMultiplication(&P, v.BigInt(new(big.Int)))
+	circuit := ecmulCircuit{}
+	witness := ecmulCircuit{
+		X0: sw_emulated.AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](P.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](P.Y),
+		},
+		U: emulated.ValueOf[emulated.BN254Fr](v),
+		Expected: sw_emulated.AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](expected.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](expected.Y),
+		},
+	}
+	return &circuit, &witness
+}
+
+func TestECMulCircuitShort(t *testing.T) {
+	assert := test.NewAssert(t)
+	circuit, witness := testRoutineECMul(t)
+	err := test.IsSolved(circuit, witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}
+
+func TestECMulCircuitFull(t *testing.T) {
+	assert := test.NewAssert(t)
+	circuit, witness := testRoutineECMul(t)
+	assert.ProverSucceeded(circuit, witness,
+		test.NoFuzzing(), test.NoSerialization(),
+		test.WithBackends(backend.GROTH16, backend.PLONK), test.WithCurves(ecc.BN254),
+	)
+}
+
+type ecpairCircuit struct {
+	P        sw_bn254.G1Affine
+	Q        sw_bn254.G2Affine
+	Expected sw_bn254.GTEl
+}
+
+func (c *ecpairCircuit) Define(api frontend.API) error {
+	pair, err := sw_bn254.NewPairing(api)
+	if err != nil {
+		return err
+	}
+	res := ECPair(api, &c.P, &c.Q)
+	pair.AssertIsEqual(res, &c.Expected)
+	return nil
+}
+
+func TestECPairCircuitShort(t *testing.T) {
+	_, _, G1, G2 := bn254.Generators()
+	var u, v fr.Element
+	u.SetRandom()
+	v.SetRandom()
+	var P bn254.G1Affine
+	P.ScalarMultiplication(&G1, u.BigInt(new(big.Int)))
+	var Q bn254.G2Affine
+	Q.ScalarMultiplication(&G2, v.BigInt(new(big.Int)))
+	expected, err := bn254.Pair([]bn254.G1Affine{P}, []bn254.G2Affine{Q})
+	if err != nil {
+		t.Fatal(err)
+	}
+	circuit := ecpairCircuit{}
+	witness := ecpairCircuit{
+		P:        sw_bn254.NewG1Affine(P),
+		Q:        sw_bn254.NewG2Affine(Q),
+		Expected: sw_bn254.NewGTEl(expected),
+	}
+	assert := test.NewAssert(t)
+	err = test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}

--- a/std/evmprecompiles/compose.go
+++ b/std/evmprecompiles/compose.go
@@ -1,0 +1,37 @@
+package evmprecompiles
+
+import (
+	"fmt"
+	"math/big"
+)
+
+func recompose(inputs []*big.Int, nbBits uint) *big.Int {
+	res := new(big.Int)
+	if len(inputs) == 0 {
+		return res
+	}
+	for i := range inputs {
+		res.Lsh(res, nbBits)
+		res.Add(res, inputs[len(inputs)-i-1])
+	}
+	return res
+}
+
+func decompose(input *big.Int, nbBits uint, res []*big.Int) error {
+	// limb modulus
+	if input.BitLen() > len(res)*int(nbBits) {
+		return fmt.Errorf("decomposed integer does not fit into res")
+	}
+	for _, r := range res {
+		if r == nil {
+			return fmt.Errorf("result slice element uninitalized")
+		}
+	}
+	base := new(big.Int).Lsh(big.NewInt(1), nbBits)
+	tmp := new(big.Int).Set(input)
+	for i := 0; i < len(res); i++ {
+		res[i].Mod(tmp, base)
+		tmp.Rsh(tmp, nbBits)
+	}
+	return nil
+}

--- a/std/evmprecompiles/doc.go
+++ b/std/evmprecompiles/doc.go
@@ -1,0 +1,18 @@
+// Package evmprecompiles implements the Ethereum VM precompile contracts.
+//
+// This package collects all the precompile functions into a single location for
+// easier integration. The main functionality is implemented elsewhere. This
+// package right now implements:
+//  1. ECRECOVER ✅ -- function [ECRecover]
+//  2. SHA256 ❌ -- in progress
+//  3. RIPEMD160 ❌ -- postponed
+//  4. ID ❌ -- trivial to implement without function
+//  5. EXPMOD ❌ -- in progress
+//  6. BN_ADD ✅ -- function [ECAdd]
+//  7. BN_MUL ✅ -- function [ECMul]
+//  8. SNARKV ✅ -- function [ECPair]
+//  9. BLAKE2F ❌ -- postponed
+//
+// This package uses local representation for the arguments. It is up to the
+// user to instantiate corresponding types from their application-specific data.
+package evmprecompiles

--- a/std/evmprecompiles/hints.go
+++ b/std/evmprecompiles/hints.go
@@ -1,0 +1,97 @@
+package evmprecompiles
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc/secp256k1/ecdsa"
+	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/emulated"
+)
+
+func init() {
+	solver.RegisterHint(GetHints()...)
+}
+
+// GetHints returns all the hints used in this package.
+func GetHints() []solver.Hint {
+	return []solver.Hint{recoverPointHint, recoverPublicKeyHint}
+}
+
+func recoverPointHintArgs(v frontend.Variable, r emulated.Element[emulated.Secp256k1Fr]) []frontend.Variable {
+	args := []frontend.Variable{v}
+	args = append(args, r.Limbs...)
+	return args
+}
+
+func recoverPointHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	var emfp emulated.Secp256k1Fp
+	if len(inputs) != int(emfp.NbLimbs())+1 {
+		return fmt.Errorf("expected input %d limbs got %d", emfp.NbLimbs()+1, len(inputs))
+	}
+	if !inputs[0].IsInt64() {
+		return fmt.Errorf("first input supposed to be in [0,3]")
+	}
+	if len(outputs) != 2*int(emfp.NbLimbs()) {
+		return fmt.Errorf("expected output %d limbs got %d", 2*emfp.NbLimbs(), len(outputs))
+	}
+	v := inputs[0].Uint64()
+	r := recompose(inputs[1:], emfp.BitsPerLimb())
+	P, err := ecdsa.RecoverP(uint(v), r)
+	if err != nil {
+		return fmt.Errorf("recover: %s", err)
+	}
+	if err := decompose(P.X.BigInt(new(big.Int)), emfp.BitsPerLimb(), outputs[0:emfp.NbLimbs()]); err != nil {
+		return fmt.Errorf("decompose x: %w", err)
+	}
+	if err := decompose(P.Y.BigInt(new(big.Int)), emfp.BitsPerLimb(), outputs[emfp.NbLimbs():]); err != nil {
+		return fmt.Errorf("decompose y: %w", err)
+	}
+	return nil
+}
+
+func recoverPublicKeyHintArgs(msg emulated.Element[emulated.Secp256k1Fr],
+	v frontend.Variable, r, s emulated.Element[emulated.Secp256k1Fr]) []frontend.Variable {
+	args := msg.Limbs
+	args = append(args, v)
+	args = append(args, r.Limbs...)
+	args = append(args, s.Limbs...)
+	return args
+}
+
+func recoverPublicKeyHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	// message -nb limbs
+	// then v - 1
+	// r -- nb limbs
+	// s -- nb limbs
+	// return 2x nb limbs
+	var emfr emulated.Secp256k1Fr
+	var emfp emulated.Secp256k1Fp
+	if len(inputs) != int(emfr.NbLimbs())*3+1 {
+		return fmt.Errorf("expected %d limbs got %d", emfr.NbLimbs()*3+1, len(inputs))
+	}
+	if !inputs[emfr.NbLimbs()].IsInt64() {
+		return fmt.Errorf("second input input must be in [0,3]")
+	}
+	if len(outputs) != 2*int(emfp.NbLimbs()) {
+		return fmt.Errorf("expected output %d limbs got %d", 2*emfp.NbLimbs(), len(outputs))
+	}
+	msg := recompose(inputs[:emfr.NbLimbs()], emfr.BitsPerLimb())
+	v := inputs[emfr.NbLimbs()].Uint64()
+	r := recompose(inputs[emfr.NbLimbs()+1:2*emfr.NbLimbs()+1], emfr.BitsPerLimb())
+	s := recompose(inputs[2*emfr.NbLimbs()+1:3*emfr.NbLimbs()+1], emfr.BitsPerLimb())
+	var pk ecdsa.PublicKey
+	if err := pk.RecoverFrom(msg.Bytes(), uint(v), r, s); err != nil {
+		return fmt.Errorf("recover public key: %w", err)
+	}
+	Px := pk.A.X.BigInt(new(big.Int))
+	Py := pk.A.Y.BigInt(new(big.Int))
+	if err := decompose(Px, emfp.BitsPerLimb(), outputs[0:emfp.NbLimbs()]); err != nil {
+		return fmt.Errorf("decompose x: %w", err)
+	}
+	if err := decompose(Py, emfp.BitsPerLimb(), outputs[emfp.NbLimbs():2*emfp.NbLimbs()]); err != nil {
+		return fmt.Errorf("decompose y: %w", err)
+	}
+	return nil
+}

--- a/std/hints.go
+++ b/std/hints.go
@@ -6,6 +6,7 @@ import (
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls12377"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls24315"
+	"github.com/consensys/gnark/std/evmprecompiles"
 	"github.com/consensys/gnark/std/math/bits"
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/std/rangecheck"
@@ -35,4 +36,5 @@ func registerHints() {
 	solver.RegisterHint(selector.GetHints()...)
 	solver.RegisterHint(emulated.GetHints()...)
 	solver.RegisterHint(rangecheck.CountHint, rangecheck.DecomposeHint)
+	solver.RegisterHint(evmprecompiles.GetHints()...)
 }

--- a/std/math/emulated/field.go
+++ b/std/math/emulated/field.go
@@ -109,11 +109,6 @@ func (f *Field[T]) NewElement(v interface{}) *Element[T] {
 		return f.packLimbs([]frontend.Variable{v}, true)
 	}
 	if e, ok := v.([]frontend.Variable); ok {
-		for _, sv := range e {
-			if !frontend.IsCanonical(sv) {
-				panic("[]frontend.Variable that are not canonical (known to the compiler) is not a valid input")
-			}
-		}
 		return f.packLimbs(e, true)
 	}
 	c := ValueOf[T](v)


### PR DESCRIPTION
Closes #466.

Even if we have many primitives, then this PR is introducing tightly coupled circuits for using with EVM precompiles. The goal is that we can take verbatim precompile call arguments and return whatever implementations would return.

Still WIP, but starting a draft PR for discussions on interfaces etc. Need to fix #484 as with test engine right now get errors where shouldn't.

More specifically:
- [x] ECRecover - will have several variations with and without Keccak hashing the public key. Without hashing will rely on the prover to perform the hashing. But for consistency with the package promise will add variant with Keccak hashing. Mostly done, need to add a few in-circuit checks.
- [ ] sha256 - lower priority right now.
- [x] identity - pointless
- [ ] expmod - definitely needs rangechecking. I assume will be most complicated. Plan is to use Montgomery multiplication and textbook square-and-mul algorithm.
- [x] BN254 add - need to implement compatible interface.
- [x] BN254 scalar mul - need to implement compatible interface.
- [x] BN254 pairing - need to implement compatible interface.
- [ ] Blake2

Tasks:
- [x] right now for testing ECRecover I have a local version of gnark-crypto which outputs compatible signatures (with `v`). Need to polish the implementation and merge in gnark-crypto for better maintainability. 
