### PR TITLE
fix: handle stack traces with deferred function

### DIFF
--- a/backend/witness/witness_test.go
+++ b/backend/witness/witness_test.go
@@ -1,6 +1,8 @@
 package witness_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -47,11 +49,17 @@ func ExampleWitness() {
 
 	// first get the circuit expected schema
 	schema, _ := frontend.NewSchema(assignment)
-	json, _ := reconstructed.ToJSON(schema)
+	ret, _ := reconstructed.ToJSON(schema)
 
-	fmt.Println(string(json))
+	var b bytes.Buffer
+	json.Indent(&b, ret, "", "\t")
+	fmt.Println(b.String())
 	// Output:
-	// {"X":42,"Y":8000,"E":1}
+	// {
+	//	"X": 42,
+	//	"Y": 8000,
+	//	"E": 1
+	// }
 
 }
 

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -56,7 +56,7 @@ func writeStack(sbb *strings.Builder, forceClean ...bool) {
 			if strings.Contains(frame.File, "test/engine.go") {
 				continue
 			}
-			if strings.Contains(frame.File, "gnark/frontend") {
+			if strings.Contains(frame.File, "gnark/frontend/cs") {
 				continue
 			}
 			file = filepath.Base(file)

--- a/debug/symbol_table.go
+++ b/debug/symbol_table.go
@@ -61,7 +61,7 @@ func (st *SymbolTable) CollectStack() []int {
 			if strings.Contains(frame.File, "test/engine.go") {
 				continue
 			}
-			if strings.Contains(frame.File, "gnark/frontend") {
+			if strings.Contains(frame.File, "gnark/frontend/cs") {
 				continue
 			}
 			frame.File = filepath.Base(frame.File)

--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -124,7 +124,7 @@ func parseCircuit(builder Builder, circuit Circuit) (err error) {
 		return fmt.Errorf("define circuit: %w", err)
 	}
 	if err = callDeferred(builder); err != nil {
-		return fmt.Errorf("")
+		return fmt.Errorf("deferred: %w", err)
 	}
 
 	return

--- a/test/engine.go
+++ b/test/engine.go
@@ -125,10 +125,8 @@ func IsSolved(circuit, witness frontend.Circuit, field *big.Int, opts ...TestEng
 	if err = c.Define(e); err != nil {
 		return fmt.Errorf("define: %w", err)
 	}
-	for i, cb := range circuitdefer.GetAll[func(frontend.API) error](e) {
-		if err = cb(e); err != nil {
-			return fmt.Errorf("defer %d: %w", i, err)
-		}
+	if err = callDeferred(e); err != nil {
+		return fmt.Errorf("deferred: %w", err)
 	}
 
 	log.Debug().Uint64("add", cptAdd).
@@ -139,6 +137,15 @@ func IsSolved(circuit, witness frontend.Circuit, field *big.Int, opts ...TestEng
 		Uint64("fromBinary", cptFromBinary).Msg("counters")
 
 	return
+}
+
+func callDeferred(builder *engine) error {
+	for i, cb := range circuitdefer.GetAll[func(frontend.API) error](builder) {
+		if err := cb(builder); err != nil {
+			return fmt.Errorf("defer fn %d: %w", i, err)
+		}
+	}
+	return nil
 }
 
 var cptAdd, cptMul, cptSub, cptToBinary, cptFromBinary, cptAssertIsEqual uint64

--- a/test/solver_test.go
+++ b/test/solver_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/consensys/gnark/frontend/cs/scs"
 	"github.com/consensys/gnark/frontend/schema"
 	"github.com/consensys/gnark/internal/backend/circuits"
-	"github.com/consensys/gnark/internal/circuitdefer"
 	"github.com/consensys/gnark/internal/kvstore"
 	"github.com/consensys/gnark/internal/tinyfield"
 	"github.com/consensys/gnark/internal/utils"
@@ -209,10 +208,8 @@ func isSolvedEngine(c frontend.Circuit, field *big.Int, opts ...TestEngineOption
 	if err = c.Define(e); err != nil {
 		return fmt.Errorf("define: %w", err)
 	}
-	for i, cb := range circuitdefer.GetAll[func(frontend.API) error](e) {
-		if err = cb(e); err != nil {
-			return fmt.Errorf("defer %d: %w", i, err)
-		}
+	if err = callDeferred(e); err != nil {
+		return fmt.Errorf("")
 	}
 
 	return


### PR DESCRIPTION
This PR improves the stacks with deferred functions. We previously stopped stack collection when encountered method `Define`. I tried adding another break for if we encounter the method `callDeferred`. However, when running in non-debug mode, then there was a override for functions in files in `frontend/` directory. This override overrode the `callDeferred` breakpoint. I further specified it to `frontend/cs` so that the function `callDeferred` in `frontend/compile.go` wouldn't be skipped.

Added `callDeferred` to test engine to have consistent behaviour.

This seems to fix the failing tests in #472 (non-determinism).