### PR TITLE
docs: correct `WithNbDigits` description

### DIFF
--- a/std/math/bits/conversion.go
+++ b/std/math/bits/conversion.go
@@ -56,9 +56,10 @@ type baseConversionConfig struct {
 // BaseConversionOption configures the behaviour of scalar decomposition.
 type BaseConversionOption func(opt *baseConversionConfig) error
 
-// WithNbDigits set the resulting number of digits to be used in the base conversion.
-// nbDigits must be > 0. If nbDigits is lower than the length of full
-// decomposition, then nbDigits least significant digits are returned. If the
+// WithNbDigits sets the resulting number of digits (nbDigits) to be used in the
+// base conversion. nbDigits must be > 0. If nbDigits is lower than the length of full
+// decomposition and WithUnconstrainedOutputs option is not used,
+// then a proof can not be generated. If WithNbDigits
 // option is not set, then the full decomposition is returned.
 func WithNbDigits(nbDigits int) BaseConversionOption {
 	return func(opt *baseConversionConfig) error {

--- a/std/math/bits/conversion.go
+++ b/std/math/bits/conversion.go
@@ -56,11 +56,10 @@ type baseConversionConfig struct {
 // BaseConversionOption configures the behaviour of scalar decomposition.
 type BaseConversionOption func(opt *baseConversionConfig) error
 
-// WithNbDigits sets the resulting number of digits (nbDigits) to be used in the
-// base conversion. nbDigits must be > 0. If nbDigits is lower than the length of full
-// decomposition and WithUnconstrainedOutputs option is not used,
-// then a proof can not be generated. If WithNbDigits
-// option is not set, then the full decomposition is returned.
+// WithNbDigits sets the resulting number of digits (nbDigits) to be used in the base conversion.
+// nbDigits must be > 0. If nbDigits is lower than the length of full decomposition and
+// WithUnconstrainedOutputs option is not used, then this function generates an unsatisfiable
+// constraint. If WithNbDigits option is not set, then the full decomposition is returned.
 func WithNbDigits(nbDigits int) BaseConversionOption {
 	return func(opt *baseConversionConfig) error {
 		if nbDigits <= 0 {

--- a/std/math/bits/conversion_test.go
+++ b/std/math/bits/conversion_test.go
@@ -31,6 +31,13 @@ func (c *toBinaryCircuit) Define(api frontend.API) error {
 func TestToBinary(t *testing.T) {
 	assert := test.NewAssert(t)
 	assert.ProverSucceeded(&toBinaryCircuit{}, &toBinaryCircuit{A: 5, B0: 1, B1: 0, B2: 1})
+
+	assert.ProverSucceeded(&toBinaryCircuit{}, &toBinaryCircuit{A: 3, B0: 1, B1: 1, B2: 0})
+
+	// prover fails when the binary representation of A has more than 3 bits
+	assert.ProverFailed(&toBinaryCircuit{}, &toBinaryCircuit{A: 8, B0: 0, B1: 0, B2: 0})
+
+	assert.ProverFailed(&toBinaryCircuit{}, &toBinaryCircuit{A: 10, B0: 0, B1: 1, B2: 0})
 }
 
 type toTernaryCircuit struct {


### PR DESCRIPTION
When `nbDigits` is set to a number that is less than the length of the binary representation of the input, a proof can not be generated. That's because the `api.AssertIsEqual(Σbi, v)` constraint can not be satisfied. The description of `WithNbDigits` needs to be fixed.