### PR TITLE
Test/hints in tests

### DIFF
--- a/constraint/bls12-377/r1cs.go
+++ b/constraint/bls12-377/r1cs.go
@@ -465,3 +465,11 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
+	O, ok := o.(*R1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+}

--- a/constraint/bls12-377/r1cs.go
+++ b/constraint/bls12-377/r1cs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -34,10 +35,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 )
@@ -472,8 +469,8 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*R1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bls12-377/r1cs.go
+++ b/constraint/bls12-377/r1cs.go
@@ -35,6 +35,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 )
 

--- a/constraint/bls12-377/r1cs_sparse.go
+++ b/constraint/bls12-377/r1cs_sparse.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -33,10 +34,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 )
@@ -517,8 +514,8 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*SparseR1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bls12-377/r1cs_sparse.go
+++ b/constraint/bls12-377/r1cs_sparse.go
@@ -34,6 +34,10 @@ import (
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 )
 
@@ -512,5 +516,9 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 }
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
-	return false
+	O, ok := o.(*SparseR1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
 }

--- a/constraint/bls12-377/r1cs_sparse.go
+++ b/constraint/bls12-377/r1cs_sparse.go
@@ -510,3 +510,7 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
+	return false
+}

--- a/constraint/bls12-381/r1cs.go
+++ b/constraint/bls12-381/r1cs.go
@@ -465,3 +465,11 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
+	O, ok := o.(*R1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+}

--- a/constraint/bls12-381/r1cs.go
+++ b/constraint/bls12-381/r1cs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -34,10 +35,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 )
@@ -472,8 +469,8 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*R1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bls12-381/r1cs.go
+++ b/constraint/bls12-381/r1cs.go
@@ -35,6 +35,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 )
 

--- a/constraint/bls12-381/r1cs_sparse.go
+++ b/constraint/bls12-381/r1cs_sparse.go
@@ -34,6 +34,10 @@ import (
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 )
 
@@ -512,5 +516,9 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 }
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
-	return false
+	O, ok := o.(*SparseR1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
 }

--- a/constraint/bls12-381/r1cs_sparse.go
+++ b/constraint/bls12-381/r1cs_sparse.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -33,10 +34,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 )
@@ -517,8 +514,8 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*SparseR1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bls12-381/r1cs_sparse.go
+++ b/constraint/bls12-381/r1cs_sparse.go
@@ -510,3 +510,7 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
+	return false
+}

--- a/constraint/bls24-315/r1cs.go
+++ b/constraint/bls24-315/r1cs.go
@@ -465,3 +465,11 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
+	O, ok := o.(*R1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+}

--- a/constraint/bls24-315/r1cs.go
+++ b/constraint/bls24-315/r1cs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -34,10 +35,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 )
@@ -472,8 +469,8 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*R1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bls24-315/r1cs.go
+++ b/constraint/bls24-315/r1cs.go
@@ -35,6 +35,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 )
 

--- a/constraint/bls24-315/r1cs_sparse.go
+++ b/constraint/bls24-315/r1cs_sparse.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -33,10 +34,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 )
@@ -517,8 +514,8 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*SparseR1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bls24-315/r1cs_sparse.go
+++ b/constraint/bls24-315/r1cs_sparse.go
@@ -34,6 +34,10 @@ import (
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 )
 
@@ -512,5 +516,9 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 }
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
-	return false
+	O, ok := o.(*SparseR1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
 }

--- a/constraint/bls24-315/r1cs_sparse.go
+++ b/constraint/bls24-315/r1cs_sparse.go
@@ -510,3 +510,7 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
+	return false
+}

--- a/constraint/bls24-317/r1cs.go
+++ b/constraint/bls24-317/r1cs.go
@@ -35,6 +35,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 )
 

--- a/constraint/bls24-317/r1cs.go
+++ b/constraint/bls24-317/r1cs.go
@@ -465,3 +465,11 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
+	O, ok := o.(*R1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+}

--- a/constraint/bls24-317/r1cs.go
+++ b/constraint/bls24-317/r1cs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -34,10 +35,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 )
@@ -472,8 +469,8 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*R1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bls24-317/r1cs_sparse.go
+++ b/constraint/bls24-317/r1cs_sparse.go
@@ -34,6 +34,10 @@ import (
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 )
 
@@ -512,5 +516,9 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 }
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
-	return false
+	O, ok := o.(*SparseR1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
 }

--- a/constraint/bls24-317/r1cs_sparse.go
+++ b/constraint/bls24-317/r1cs_sparse.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -33,10 +34,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 )
@@ -517,8 +514,8 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*SparseR1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bls24-317/r1cs_sparse.go
+++ b/constraint/bls24-317/r1cs_sparse.go
@@ -510,3 +510,7 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
+	return false
+}

--- a/constraint/bn254/r1cs.go
+++ b/constraint/bn254/r1cs.go
@@ -35,6 +35,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 )
 

--- a/constraint/bn254/r1cs.go
+++ b/constraint/bn254/r1cs.go
@@ -465,3 +465,11 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
+	O, ok := o.(*R1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+}

--- a/constraint/bn254/r1cs.go
+++ b/constraint/bn254/r1cs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -34,10 +35,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 )
@@ -472,8 +469,8 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*R1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bn254/r1cs_sparse.go
+++ b/constraint/bn254/r1cs_sparse.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -33,10 +34,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 )
@@ -517,8 +514,8 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*SparseR1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bn254/r1cs_sparse.go
+++ b/constraint/bn254/r1cs_sparse.go
@@ -510,3 +510,7 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
+	return false
+}

--- a/constraint/bn254/r1cs_sparse.go
+++ b/constraint/bn254/r1cs_sparse.go
@@ -34,6 +34,10 @@ import (
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 )
 
@@ -512,5 +516,9 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 }
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
-	return false
+	O, ok := o.(*SparseR1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
 }

--- a/constraint/bw6-633/r1cs.go
+++ b/constraint/bw6-633/r1cs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -34,10 +35,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 )
@@ -472,8 +469,8 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*R1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bw6-633/r1cs.go
+++ b/constraint/bw6-633/r1cs.go
@@ -465,3 +465,11 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
+	O, ok := o.(*R1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+}

--- a/constraint/bw6-633/r1cs.go
+++ b/constraint/bw6-633/r1cs.go
@@ -35,6 +35,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 )
 

--- a/constraint/bw6-633/r1cs_sparse.go
+++ b/constraint/bw6-633/r1cs_sparse.go
@@ -34,6 +34,10 @@ import (
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 )
 
@@ -512,5 +516,9 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 }
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
-	return false
+	O, ok := o.(*SparseR1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
 }

--- a/constraint/bw6-633/r1cs_sparse.go
+++ b/constraint/bw6-633/r1cs_sparse.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -33,10 +34,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 )
@@ -517,8 +514,8 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*SparseR1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bw6-633/r1cs_sparse.go
+++ b/constraint/bw6-633/r1cs_sparse.go
@@ -510,3 +510,7 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
+	return false
+}

--- a/constraint/bw6-761/r1cs.go
+++ b/constraint/bw6-761/r1cs.go
@@ -465,3 +465,11 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
+	O, ok := o.(*R1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+}

--- a/constraint/bw6-761/r1cs.go
+++ b/constraint/bw6-761/r1cs.go
@@ -35,6 +35,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 )
 

--- a/constraint/bw6-761/r1cs.go
+++ b/constraint/bw6-761/r1cs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -34,10 +35,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 )
@@ -472,8 +469,8 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*R1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bw6-761/r1cs_sparse.go
+++ b/constraint/bw6-761/r1cs_sparse.go
@@ -34,6 +34,10 @@ import (
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 )
 
@@ -512,5 +516,9 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 }
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
-	return false
+	O, ok := o.(*SparseR1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
 }

--- a/constraint/bw6-761/r1cs_sparse.go
+++ b/constraint/bw6-761/r1cs_sparse.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -33,10 +34,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 )
@@ -517,8 +514,8 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*SparseR1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/bw6-761/r1cs_sparse.go
+++ b/constraint/bw6-761/r1cs_sparse.go
@@ -510,3 +510,7 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
+	return false
+}

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"reflect"
 
 	"github.com/blang/semver/v4"
 	"github.com/consensys/gnark"
@@ -293,4 +294,28 @@ func (system *System) VariableToString(vID int) string {
 	}
 	vID -= nbSecret
 	return fmt.Sprintf("v%d", vID) // TODO @gbotrel  vs strconv.Itoa.
+}
+
+func (system *System) Equal(o *System) bool {
+	return reflect.DeepEqual(system.GnarkVersion, o.GnarkVersion) &&
+		reflect.DeepEqual(system.ScalarField, o.ScalarField) &&
+		reflect.DeepEqual(system.NbInternalVariables, o.NbInternalVariables) &&
+		reflect.DeepEqual(system.Public, o.Public) &&
+		reflect.DeepEqual(system.Secret, o.Secret) &&
+		reflect.DeepEqual(system.Logs, o.Logs) &&
+		reflect.DeepEqual(system.DebugInfo, o.DebugInfo) &&
+		reflect.DeepEqual(system.SymbolTable, o.SymbolTable) &&
+		reflect.DeepEqual(system.MDebug, o.MDebug) &&
+		reflect.DeepEqual(system.MHints, o.MHints) &&
+		reflect.DeepEqual(system.MHintsDependencies, o.MHintsDependencies) &&
+		//reflect.DeepEqual(system.InjectedVariables, o.InjectedVariables) &&	anticipating injected var PR
+		//reflect.DeepEqual(system.MInjectedVariables, o.MInjectedVariables) &&
+		reflect.DeepEqual(system.Levels, o.Levels) &&
+		reflect.DeepEqual(system.q, o.q) &&
+		reflect.DeepEqual(system.bitLen, o.bitLen) &&
+		reflect.DeepEqual(system.lbWireLevel, o.lbWireLevel) &&
+		reflect.DeepEqual(system.lbOutputs, o.lbOutputs) &&
+		//reflect.DeepEqual(system.lbHints, o.lbHints) &&	// causes trouble
+		//reflect.DeepEqual(system.lbInjected, o.lbInjected) &&
+		reflect.DeepEqual(system.CommitmentInfo, o.CommitmentInfo)
 }

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -71,6 +71,9 @@ type ConstraintSystem interface {
 	// CheckUnconstrainedWires returns and error if the constraint system has wires that are not uniquely constrained.
 	// This is experimental.
 	CheckUnconstrainedWires() error
+
+	// Equal is used for testing purposes: making sure if compilation is deterministic
+	Equal(o ConstraintSystem) bool
 }
 
 type Iterable interface {

--- a/constraint/tinyfield/r1cs.go
+++ b/constraint/tinyfield/r1cs.go
@@ -465,3 +465,11 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
+	O, ok := o.(*R1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+}

--- a/constraint/tinyfield/r1cs.go
+++ b/constraint/tinyfield/r1cs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/fxamacker/cbor/v2"
 	"io"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -34,10 +35,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	fr "github.com/consensys/gnark/internal/tinyfield"
 )
@@ -472,8 +469,8 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*R1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/tinyfield/r1cs.go
+++ b/constraint/tinyfield/r1cs.go
@@ -35,6 +35,10 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"math"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	fr "github.com/consensys/gnark/internal/tinyfield"
 )
 

--- a/constraint/tinyfield/r1cs_sparse.go
+++ b/constraint/tinyfield/r1cs_sparse.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"io"
 	"math"
+	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -33,10 +34,6 @@ import (
 	"github.com/consensys/gnark/internal/backend/ioutils"
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	fr "github.com/consensys/gnark/internal/tinyfield"
 )
@@ -517,8 +514,8 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*SparseR1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/constraint/tinyfield/r1cs_sparse.go
+++ b/constraint/tinyfield/r1cs_sparse.go
@@ -34,6 +34,10 @@ import (
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	fr "github.com/consensys/gnark/internal/tinyfield"
 )
 
@@ -512,5 +516,9 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 }
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
-	return false
+	O, ok := o.(*SparseR1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
 }

--- a/constraint/tinyfield/r1cs_sparse.go
+++ b/constraint/tinyfield/r1cs_sparse.go
@@ -510,3 +510,7 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
+	return false
+}

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -461,3 +461,10 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 	return int64(decoder.NumBytesRead()), nil
 }
 
+func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
+	O, ok := o.(*R1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+}

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -2,6 +2,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"runtime"
 	"time"
 	"sync"
@@ -16,10 +17,6 @@ import (
 
 	"math"
 	"github.com/consensys/gnark-crypto/ecc"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	{{ template "import_fr" . }}
 )
@@ -467,8 +464,8 @@ func (cs *R1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *R1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*R1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, R1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -17,6 +17,10 @@ import (
 	"math"
 	"github.com/consensys/gnark-crypto/ecc"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	{{ template "import_fr" . }}
 )
 

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -16,6 +16,10 @@ import (
 	"github.com/consensys/gnark/profile"
 	"github.com/consensys/gnark/backend/witness"
 
+	"github.com/consensys/gnark/debug"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
     {{ template "import_fr" . }}
 )
 
@@ -503,5 +507,9 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 }
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
-	return false
+	O, ok := o.(*SparseR1CS)
+	if !ok {
+		return false
+	}
+	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
 }

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -501,3 +501,7 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(decoder.NumBytesRead()), nil
 }
+
+func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
+	return false
+}

--- a/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.sparse.go.tmpl
@@ -4,6 +4,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/consensys/gnark-crypto/ecc"
 	"sync"
+	"reflect"
 	"runtime"
 	"math"
 	"errors"
@@ -15,10 +16,6 @@ import (
 	"github.com/consensys/gnark/logger"
 	"github.com/consensys/gnark/profile"
 	"github.com/consensys/gnark/backend/witness"
-
-	"github.com/consensys/gnark/debug"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
     {{ template "import_fr" . }}
 )
@@ -508,8 +505,8 @@ func (cs *SparseR1CS) ReadFrom(r io.Reader) (int64, error) {
 
 func (cs *SparseR1CS) Equal(o constraint.ConstraintSystem) bool {
 	O, ok := o.(*SparseR1CS)
-	if !ok {
-		return false
-	}
-	return cmp.Equal(*cs, *O, cmp.AllowUnexported(debug.SymbolTable{}, CoeffTable{}, SparseR1CS{}), cmpopts.IgnoreUnexported(constraint.System{}))
+	return ok &&
+		reflect.DeepEqual(cs.CoeffTable, O.CoeffTable) &&
+		reflect.DeepEqual(cs.Constraints, O.Constraints) &&
+		cs.System.Equal(&O.System)
 }

--- a/std/hints_test.go
+++ b/std/hints_test.go
@@ -2,9 +2,8 @@ package std
 
 import (
 	"fmt"
-	"github.com/consensys/gnark-crypto/ecc"
-	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/constraint"
+	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/test"
 	"math/big"
@@ -33,7 +32,7 @@ func idHint(_ *big.Int, in []*big.Int, out []*big.Int) error {
 		return fmt.Errorf("in/out length mismatch %d≠%d", len(in), len(out))
 	}
 	for i := range in {
-		*out[i] = *in[i]
+		out[i].Set(in[i])
 	}
 	return nil
 }
@@ -52,6 +51,7 @@ func (c *idHintCircuit) Define(api frontend.API) error {
 }
 
 func TestIdHint(t *testing.T) {
+	solver.RegisterHint(idHint)
 	assignment := idHintCircuit{0}
-	test.NewAssert(t).SolvingSucceeded(&idHintCircuit{}, &assignment, test.WithCurves(ecc.BN254), test.WithBackends(backend.GROTH16))
+	test.NewAssert(t).SolvingSucceeded(&idHintCircuit{}, &assignment)
 }

--- a/test/assert.go
+++ b/test/assert.go
@@ -431,7 +431,7 @@ func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendI
 		return nil, fmt.Errorf("%w: %v", ErrCompilationNotDeterministic, err)
 	}
 
-	if !reflect.DeepEqual(ccs, _ccs) {
+	if !ccs.Equal(_ccs) {
 		return nil, ErrCompilationNotDeterministic
 	}
 


### PR DESCRIPTION
The following simple test
```go
func idHint(_ *big.Int, in []*big.Int, out []*big.Int) error {
	if len(in) != len(out) {
		return fmt.Errorf("in/out length mismatch %d≠%d", len(in), len(out))
	}
	for i := range in {
		out[i].Set(in[i])
	}
	return nil
}

type idHintCircuit struct {
	X frontend.Variable
}

func (c *idHintCircuit) Define(api frontend.API) error {
	x, err := api.Compiler().NewHint(idHint, 1, c.X)
	if err != nil {
		return err
	}
	api.AssertIsEqual(x[0], c.X)
	return nil
}

func TestIdHint(t *testing.T) {
	solver.RegisterHint(idHint)
	assignment := idHintCircuit{0}
	test.NewAssert(t).SolvingSucceeded(&idHintCircuit{}, &assignment)
}
```
should pass, but currently gets a nondeterministic circuit error. This PR fixes that by ignoring the unexported fields of `constraint.System`.