### PR TITLE
Test basic hint

### DIFF
--- a/constraint/bls12-377/r1cs_test.go
+++ b/constraint/bls12-377/r1cs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/internal/backend/circuits"
+	"github.com/consensys/gnark/test"
 	"reflect"
 	"testing"
 
@@ -74,15 +75,7 @@ func TestSerialization(t *testing.T) {
 
 				// compare original and reconstructed
 				if diff := cmp.Diff(r1cs1, &reconstructed,
-					cmpopts.IgnoreFields(cs.R1CS{},
-						"System.q",
-						"arithEngine",
-						"CoeffTable.mCoeffs",
-						"System.lbWireLevel",
-						"System.lbHints",
-						"System.SymbolTable",
-						"System.lbOutputs",
-						"System.bitLen")); diff != "" {
+					cmpopts.IgnoreFields(cs.R1CS{}, test.IgnoreFieldsCsCmp()...)); diff != "" {
 					t.Fatalf("round trip mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/constraint/bls12-381/r1cs_test.go
+++ b/constraint/bls12-381/r1cs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/internal/backend/circuits"
+	"github.com/consensys/gnark/test"
 	"reflect"
 	"testing"
 
@@ -74,15 +75,7 @@ func TestSerialization(t *testing.T) {
 
 				// compare original and reconstructed
 				if diff := cmp.Diff(r1cs1, &reconstructed,
-					cmpopts.IgnoreFields(cs.R1CS{},
-						"System.q",
-						"arithEngine",
-						"CoeffTable.mCoeffs",
-						"System.lbWireLevel",
-						"System.lbHints",
-						"System.SymbolTable",
-						"System.lbOutputs",
-						"System.bitLen")); diff != "" {
+					cmpopts.IgnoreFields(cs.R1CS{}, test.IgnoreFieldsCsCmp()...)); diff != "" {
 					t.Fatalf("round trip mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/constraint/bls24-315/r1cs_test.go
+++ b/constraint/bls24-315/r1cs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/internal/backend/circuits"
+	"github.com/consensys/gnark/test"
 	"reflect"
 	"testing"
 
@@ -74,15 +75,7 @@ func TestSerialization(t *testing.T) {
 
 				// compare original and reconstructed
 				if diff := cmp.Diff(r1cs1, &reconstructed,
-					cmpopts.IgnoreFields(cs.R1CS{},
-						"System.q",
-						"arithEngine",
-						"CoeffTable.mCoeffs",
-						"System.lbWireLevel",
-						"System.lbHints",
-						"System.SymbolTable",
-						"System.lbOutputs",
-						"System.bitLen")); diff != "" {
+					cmpopts.IgnoreFields(cs.R1CS{}, test.IgnoreFieldsCsCmp()...)); diff != "" {
 					t.Fatalf("round trip mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/constraint/bls24-317/r1cs_test.go
+++ b/constraint/bls24-317/r1cs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/internal/backend/circuits"
+	"github.com/consensys/gnark/test"
 	"reflect"
 	"testing"
 
@@ -74,15 +75,7 @@ func TestSerialization(t *testing.T) {
 
 				// compare original and reconstructed
 				if diff := cmp.Diff(r1cs1, &reconstructed,
-					cmpopts.IgnoreFields(cs.R1CS{},
-						"System.q",
-						"arithEngine",
-						"CoeffTable.mCoeffs",
-						"System.lbWireLevel",
-						"System.lbHints",
-						"System.SymbolTable",
-						"System.lbOutputs",
-						"System.bitLen")); diff != "" {
+					cmpopts.IgnoreFields(cs.R1CS{}, test.IgnoreFieldsCsCmp()...)); diff != "" {
 					t.Fatalf("round trip mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/constraint/bn254/r1cs_test.go
+++ b/constraint/bn254/r1cs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/internal/backend/circuits"
+	"github.com/consensys/gnark/test"
 	"reflect"
 	"testing"
 
@@ -74,15 +75,7 @@ func TestSerialization(t *testing.T) {
 
 				// compare original and reconstructed
 				if diff := cmp.Diff(r1cs1, &reconstructed,
-					cmpopts.IgnoreFields(cs.R1CS{},
-						"System.q",
-						"arithEngine",
-						"CoeffTable.mCoeffs",
-						"System.lbWireLevel",
-						"System.lbHints",
-						"System.SymbolTable",
-						"System.lbOutputs",
-						"System.bitLen")); diff != "" {
+					cmpopts.IgnoreFields(cs.R1CS{}, test.IgnoreFieldsCsCmp()...)); diff != "" {
 					t.Fatalf("round trip mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/constraint/bw6-633/r1cs_test.go
+++ b/constraint/bw6-633/r1cs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/internal/backend/circuits"
+	"github.com/consensys/gnark/test"
 	"reflect"
 	"testing"
 
@@ -74,15 +75,7 @@ func TestSerialization(t *testing.T) {
 
 				// compare original and reconstructed
 				if diff := cmp.Diff(r1cs1, &reconstructed,
-					cmpopts.IgnoreFields(cs.R1CS{},
-						"System.q",
-						"arithEngine",
-						"CoeffTable.mCoeffs",
-						"System.lbWireLevel",
-						"System.lbHints",
-						"System.SymbolTable",
-						"System.lbOutputs",
-						"System.bitLen")); diff != "" {
+					cmpopts.IgnoreFields(cs.R1CS{}, test.IgnoreFieldsCsCmp()...)); diff != "" {
 					t.Fatalf("round trip mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/constraint/bw6-761/r1cs_test.go
+++ b/constraint/bw6-761/r1cs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/internal/backend/circuits"
+	"github.com/consensys/gnark/test"
 	"reflect"
 	"testing"
 
@@ -77,15 +78,7 @@ func TestSerialization(t *testing.T) {
 
 				// compare original and reconstructed
 				if diff := cmp.Diff(r1cs1, &reconstructed,
-					cmpopts.IgnoreFields(cs.R1CS{},
-						"System.q",
-						"arithEngine",
-						"CoeffTable.mCoeffs",
-						"System.lbWireLevel",
-						"System.lbHints",
-						"System.SymbolTable",
-						"System.lbOutputs",
-						"System.bitLen")); diff != "" {
+					cmpopts.IgnoreFields(cs.R1CS{}, test.IgnoreFieldsCsCmp()...)); diff != "" {
 					t.Fatalf("round trip mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/constraint/tinyfield/r1cs_test.go
+++ b/constraint/tinyfield/r1cs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/internal/backend/circuits"
+	"github.com/consensys/gnark/test"
 	"reflect"
 	"testing"
 
@@ -77,15 +78,7 @@ func TestSerialization(t *testing.T) {
 
 				// compare original and reconstructed
 				if diff := cmp.Diff(r1cs1, &reconstructed,
-					cmpopts.IgnoreFields(cs.R1CS{},
-						"System.q",
-						"arithEngine",
-						"CoeffTable.mCoeffs",
-						"System.lbWireLevel",
-						"System.lbHints",
-						"System.SymbolTable",
-						"System.lbOutputs",
-						"System.bitLen")); diff != "" {
+					cmpopts.IgnoreFields(cs.R1CS{}, test.IgnoreFieldsCsCmp()...)); diff != "" {
 					t.Fatalf("round trip mismatch (-want +got):\n%s", diff)
 				}
 			}

--- a/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/internal/backend/circuits"
+	"github.com/consensys/gnark/test"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -64,16 +65,8 @@ func TestSerialization(t *testing.T) {
 			}
 
 			// compare original and reconstructed
-			if diff := cmp.Diff(r1cs1, &reconstructed, 
-				cmpopts.IgnoreFields(cs.R1CS{},
-					 "System.q",
-					 "arithEngine",
-					 "CoeffTable.mCoeffs",
-					 "System.lbWireLevel",
-					 "System.lbHints",
-					 "System.SymbolTable",
-					 "System.lbOutputs",
-					 "System.bitLen")); diff != "" {
+			if diff := cmp.Diff(r1cs1, &reconstructed,
+				cmpopts.IgnoreFields(cs.R1CS{}, test.IgnoreFieldsCsCmp()...)); diff != "" {
 				t.Fatalf("round trip mismatch (-want +got):\n%s", diff)
 			}
 		}

--- a/std/hints_test.go
+++ b/std/hints_test.go
@@ -1,7 +1,13 @@
 package std
 
 import (
+	"fmt"
 	"github.com/consensys/gnark/constraint"
+	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+	"math/big"
+	"testing"
 )
 
 func ExampleRegisterHints() {
@@ -17,4 +23,35 @@ func ExampleRegisterHints() {
 
 	// then -->
 	_ = ccs.IsSolved(nil)
+}
+
+// Test the most basic hint possible
+
+func idHint(_ *big.Int, in []*big.Int, out []*big.Int) error {
+	if len(in) != len(out) {
+		return fmt.Errorf("in/out length mismatch %d≠%d", len(in), len(out))
+	}
+	for i := range in {
+		out[i].Set(in[i])
+	}
+	return nil
+}
+
+type idHintCircuit struct {
+	X frontend.Variable
+}
+
+func (c *idHintCircuit) Define(api frontend.API) error {
+	x, err := api.Compiler().NewHint(idHint, 1, c.X)
+	if err != nil {
+		return err
+	}
+	api.AssertIsEqual(x[0], c.X)
+	return nil
+}
+
+func TestIdHint(t *testing.T) {
+	solver.RegisterHint(idHint)
+	assignment := idHintCircuit{0}
+	test.NewAssert(t).SolvingSucceeded(&idHintCircuit{}, &assignment)
 }

--- a/test/assert.go
+++ b/test/assert.go
@@ -19,6 +19,8 @@ package test
 import (
 	"errors"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"reflect"
 	"strings"
 	"testing"
@@ -431,7 +433,8 @@ func (assert *Assert) compile(circuit frontend.Circuit, curveID ecc.ID, backendI
 		return nil, fmt.Errorf("%w: %v", ErrCompilationNotDeterministic, err)
 	}
 
-	if !reflect.DeepEqual(ccs, _ccs) {
+	empty := reflect.New(reflect.ValueOf(ccs).Elem().Type()).Elem().Interface() // a new CS object of the same type as ccs
+	if !cmp.Equal(ccs, _ccs, cmpopts.IgnoreFields(empty, IgnoreFieldsCsCmp()...)) {
 		return nil, ErrCompilationNotDeterministic
 	}
 

--- a/test/cmp.go
+++ b/test/cmp.go
@@ -1,0 +1,14 @@
+package test
+
+func IgnoreFieldsCsCmp() []string {
+	return []string{
+		"System.q",
+		"arithEngine",
+		"CoeffTable.mCoeffs",
+		"System.lbWireLevel",
+		"System.lbHints",
+		"System.SymbolTable",
+		"System.lbOutputs",
+		"System.bitLen",
+	}
+}


### PR DESCRIPTION
Alternative to https://github.com/ConsenSys/gnark/pull/528
Copy-pasting the problem statement

The following simple test

```go
func idHint(_ *big.Int, in []*big.Int, out []*big.Int) error {
	if len(in) != len(out) {
		return fmt.Errorf("in/out length mismatch %d≠%d", len(in), len(out))
	}
	for i := range in {
		out[i].Set(in[i])
	}
	return nil
}

type idHintCircuit struct {
	X frontend.Variable
}

func (c *idHintCircuit) Define(api frontend.API) error {
	x, err := api.Compiler().NewHint(idHint, 1, c.X)
	if err != nil {
		return err
	}
	api.AssertIsEqual(x[0], c.X)
	return nil
}

func TestIdHint(t *testing.T) {
	solver.RegisterHint(idHint)
	assignment := idHintCircuit{0}
	test.NewAssert(t).SolvingSucceeded(&idHintCircuit{}, &assignment)
}
```
should pass, but currently gets a nondeterministic circuit error. This PR fixes that by ignoring the unexported fields of constraint.System.