### PR TITLE
fix: stable levelbuilder hint mapping

### DIFF
--- a/constraint/level_builder.go
+++ b/constraint/level_builder.go
@@ -10,9 +10,9 @@ package constraint
 // --> l = max(level_of_dependencies(wire)) + 1
 func (system *System) updateLevel(cID int, c Iterable) {
 	system.lbOutputs = system.lbOutputs[:0]
-	system.lbHints = map[*HintMapping]struct{}{}
 	level := -1
 	wireIterator := c.WireIterator()
+
 	for wID := wireIterator(); wID != -1; wID = wireIterator() {
 		// iterate over all wires of the R1C
 		system.processWire(uint32(wID), &level)
@@ -36,6 +36,9 @@ func (system *System) updateLevel(cID int, c Iterable) {
 	} else {
 		system.Levels[level] = append(system.Levels[level], cID)
 	}
+	// clean the table. NB! Do not remove or move, this is required to make the
+	// compilation deterministic.
+	system.lbHints = map[*HintMapping]struct{}{}
 }
 
 func (system *System) processWire(wireID uint32, maxLevel *int) {

--- a/constraint/level_builder.go
+++ b/constraint/level_builder.go
@@ -9,7 +9,6 @@ package constraint
 // We build a graph of dependency; we say that a wire is solved at a level l
 // --> l = max(level_of_dependencies(wire)) + 1
 func (system *System) updateLevel(cID int, c Iterable) {
-	system.lbOutputs = system.lbOutputs[:0]
 	level := -1
 	wireIterator := c.WireIterator()
 
@@ -38,6 +37,7 @@ func (system *System) updateLevel(cID int, c Iterable) {
 	}
 	// clean the table. NB! Do not remove or move, this is required to make the
 	// compilation deterministic.
+	system.lbOutputs = system.lbOutputs[:0]
 	system.lbHints = map[*HintMapping]struct{}{}
 }
 

--- a/constraint/level_builder_test.go
+++ b/constraint/level_builder_test.go
@@ -1,0 +1,42 @@
+package constraint_test
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+)
+
+func idHint(_ *big.Int, in []*big.Int, out []*big.Int) error {
+	if len(in) != len(out) {
+		return fmt.Errorf("in/out length mismatch %d≠%d", len(in), len(out))
+	}
+	for i := range in {
+		out[i].Set(in[i])
+	}
+	return nil
+}
+
+type idHintCircuit struct {
+	X frontend.Variable
+}
+
+func (c *idHintCircuit) Define(api frontend.API) error {
+	x, err := api.Compiler().NewHint(idHint, 1, c.X)
+	if err != nil {
+		return err
+	}
+	api.AssertIsEqual(x[0], c.X)
+	return nil
+}
+
+func TestIdHint(t *testing.T) {
+	solver.RegisterHint(idHint)
+	assignment := idHintCircuit{0}
+	test.NewAssert(t).SolvingSucceeded(&idHintCircuit{}, &assignment, test.WithBackends(backend.GROTH16), test.WithCurves(ecc.BN254))
+}


### PR DESCRIPTION
Fixes cause from #529.

`System.lbHints` wasn't stable over different compiles and our deterministic compilation check failed. Now clean the internal cache where we use pointers.