### PR TITLE
fix: initialize new variable if field emulation multiplication check

### DIFF
--- a/frontend/api.go
+++ b/frontend/api.go
@@ -30,9 +30,16 @@ type API interface {
 	// Add returns res = i1+i2+...in
 	Add(i1, i2 Variable, in ...Variable) Variable
 
-	// MulAcc sets and return a = a + (b*c)
-	// ! may mutate a without allocating a new result
-	// ! always use MulAcc(...) result for correctness
+	// MulAcc sets and return a = a + (b*c).
+	//
+	// ! The method may mutate a without allocating a new result. If the input
+	// is used elsewhere, then first initialize new variable, for example by
+	// doing:
+	//
+	//     acopy := api.Mul(a, 1)
+	//     acopy = MulAcc(acopy, b, c)
+	//
+	// ! But it may not modify a, always use MulAcc(...) result for correctness.
 	MulAcc(a, b, c Variable) Variable
 
 	// Neg returns -i

--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -178,9 +178,9 @@ func (f *Field[T]) mul(a, b *Element[T], nextOverflow uint) *Element[T] {
 	w := new(big.Int)
 	for c := 1; c <= len(mulResult); c++ {
 		w.SetInt64(1) // c^i
-		l := a.Limbs[0]
-		r := b.Limbs[0]
-		o := mulResult[0]
+		l := f.api.Mul(a.Limbs[0], 1)
+		r := f.api.Mul(b.Limbs[0], 1)
+		o := f.api.Mul(mulResult[0], 1)
 
 		for i := 1; i < len(mulResult); i++ {
 			w.Lsh(w, uint(c))


### PR DESCRIPTION
Now we are using MulAcc, which assigns to the input argument. As the limbs are used elsewhere, then we actually modify the input arguments to `Field.Mul` and get inconsistencies.