### PR TITLE
feat: reintroduce hints for field emulation

### DIFF
--- a/std/math/emulated/field_hint.go
+++ b/std/math/emulated/field_hint.go
@@ -1,0 +1,92 @@
+package emulated
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+)
+
+func (f *Field[T]) wrapHint(nonnativeInputs ...*Element[T]) []frontend.Variable {
+	res := []frontend.Variable{f.fParams.BitsPerLimb(), f.fParams.NbLimbs()}
+	res = append(res, f.Modulus().Limbs...)
+	res = append(res, len(nonnativeInputs))
+	for i := range nonnativeInputs {
+		res = append(res, len(nonnativeInputs[i].Limbs))
+		res = append(res, nonnativeInputs[i].Limbs...)
+	}
+	return res
+}
+
+func UnwrapHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int, nonNativeHint solver.Hint) error {
+	if len(nativeInputs) < 2 {
+		return fmt.Errorf("hint wrapper header is 2 elements")
+	}
+	if !nativeInputs[0].IsInt64() || !nativeInputs[1].IsInt64() {
+		return fmt.Errorf("header must be castable to int64")
+	}
+	nbBits := int(nativeInputs[0].Int64())
+	nbLimbs := int(nativeInputs[1].Int64())
+	if len(nativeInputs) < 2+nbLimbs {
+		return fmt.Errorf("hint wrapper header is 2+nbLimbs elements")
+	}
+	nonnativeMod := new(big.Int)
+	if err := recompose(nativeInputs[2:2+nbLimbs], uint(nbBits), nonnativeMod); err != nil {
+		return fmt.Errorf("cannot recover nonnative mod: %w", err)
+	}
+	if !nativeInputs[2+nbLimbs].IsInt64() {
+		return fmt.Errorf("number of nonnative elements must be castable to int64")
+	}
+	nbInputs := int(nativeInputs[2+nbLimbs].Int64())
+	nonnativeInputs := make([]*big.Int, nbInputs)
+	readPtr := 3 + nbLimbs
+	for i := 0; i < nbInputs; i++ {
+		if len(nativeInputs) < readPtr+1 {
+			return fmt.Errorf("can not read %d-th native input", i)
+		}
+		if !nativeInputs[readPtr].IsInt64() {
+			return fmt.Errorf("corrupted %d-th native input", i)
+		}
+		currentInputLen := int(nativeInputs[readPtr].Int64())
+		if len(nativeInputs) < (readPtr + 1 + currentInputLen) {
+			return fmt.Errorf("cannot read %d-th nonnative element", i)
+		}
+		nonnativeInputs[i] = new(big.Int)
+		if err := recompose(nativeInputs[readPtr+1:readPtr+1+currentInputLen], uint(nbBits), nonnativeInputs[i]); err != nil {
+			return fmt.Errorf("recompose %d-th element: %w", i, err)
+		}
+		readPtr += 1 + currentInputLen
+	}
+	if len(nativeOutputs)%nbLimbs != 0 {
+		return fmt.Errorf("output count doesn't divide limb count")
+	}
+	nonnativeOutputs := make([]*big.Int, len(nativeOutputs)/nbLimbs)
+	for i := range nonnativeOutputs {
+		nonnativeOutputs[i] = new(big.Int)
+	}
+	if err := nonNativeHint(nonnativeMod, nonnativeInputs, nonnativeOutputs); err != nil {
+		return fmt.Errorf("nonnative hint: %w", err)
+	}
+	for i := range nonnativeOutputs {
+		nonnativeOutputs[i].Mod(nonnativeOutputs[i], nonnativeMod)
+		if err := decompose(nonnativeOutputs[i], uint(nbBits), nativeOutputs[i*nbLimbs:(i+1)*nbLimbs]); err != nil {
+			return fmt.Errorf("decompose %d-th element: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (f *Field[T]) NewHint(hf solver.Hint, nbOutputs int, inputs ...*Element[T]) ([]*Element[T], error) {
+	nativeInputs := f.wrapHint(inputs...)
+	nbNativeOutputs := int(f.fParams.NbLimbs()) * nbOutputs
+	nativeOutputs, err := f.api.Compiler().NewHint(hf, nbNativeOutputs, nativeInputs...)
+	if err != nil {
+		return nil, fmt.Errorf("call hint: %w", err)
+	}
+	outputs := make([]*Element[T], nbOutputs)
+	for i := 0; i < nbOutputs; i++ {
+		outputs[i] = f.packLimbs(nativeOutputs[i*int(f.fParams.NbLimbs()):(i+1)*int(f.fParams.NbLimbs())], true)
+	}
+	return outputs, nil
+}

--- a/std/math/emulated/field_hint.go
+++ b/std/math/emulated/field_hint.go
@@ -19,7 +19,7 @@ func (f *Field[T]) wrapHint(nonnativeInputs ...*Element[T]) []frontend.Variable 
 	return res
 }
 
-func UnwrapHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int, nonNativeHint solver.Hint) error {
+func UnwrapHint(nativeInputs, nativeOutputs []*big.Int, nonNativeHint solver.Hint) error {
 	if len(nativeInputs) < 2 {
 		return fmt.Errorf("hint wrapper header is 2 elements")
 	}

--- a/std/math/emulated/field_hint_test.go
+++ b/std/math/emulated/field_hint_test.go
@@ -1,0 +1,71 @@
+package emulated_test
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/test"
+)
+
+func DivTestHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int) error {
+	return emulated.UnwrapHint(nativeMod, nativeInputs, nativeOutputs,
+		func(mod *big.Int, inputs, outputs []*big.Int) error {
+			nominator := inputs[0]
+			denominator := inputs[1]
+			res := new(big.Int).ModInverse(denominator, mod)
+			if res == nil {
+				return fmt.Errorf("no modular inverse")
+			}
+			res.Mul(res, nominator)
+			res.Mod(res, mod)
+			outputs[0].Set(res)
+			return nil
+		})
+}
+
+type testDivHintCircuit[T emulated.FieldParams] struct {
+	Nominator   emulated.Element[T]
+	Denominator emulated.Element[T]
+	Expected    emulated.Element[T]
+}
+
+func (c *testDivHintCircuit[T]) Define(api frontend.API) error {
+	field, err := emulated.NewField[T](api)
+	if err != nil {
+		return err
+	}
+	res, err := field.NewHint(DivTestHint, 1, &c.Nominator, &c.Denominator)
+	if err != nil {
+		return err
+	}
+	m := field.Mul(res[0], &c.Denominator)
+	field.AssertIsEqual(m, &c.Nominator)
+	field.AssertIsEqual(res[0], &c.Expected)
+	return nil
+}
+
+func TestDivWithHInt(t *testing.T) {
+	var a, b, c fr.Element
+	a.SetRandom()
+	b.SetRandom()
+	c.Div(&a, &b)
+
+	circuit := testDivHintCircuit[emulated.BN254Fr]{}
+	witness := testDivHintCircuit[emulated.BN254Fr]{
+		Nominator:   emulated.ValueOf[emulated.BN254Fr](a),
+		Denominator: emulated.ValueOf[emulated.BN254Fr](b),
+		Expected:    emulated.ValueOf[emulated.BN254Fr](c),
+	}
+	assert := test.NewAssert(t)
+	assert.ProverSucceeded(&circuit, &witness, test.NoFuzzing(), test.NoSerialization(), test.WithCurves(ecc.BN254),
+		test.WithBackends(backend.PLONK),
+		test.WithSolverOpts(solver.WithHints(DivTestHint)),
+	)
+}

--- a/std/math/emulated/field_hint_test.go
+++ b/std/math/emulated/field_hint_test.go
@@ -3,45 +3,52 @@ package emulated_test
 import (
 	"fmt"
 	"math/big"
-	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/std/math/emulated"
-	"github.com/consensys/gnark/test"
 )
 
-func DivTestHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int) error {
-	return emulated.UnwrapHint(nativeInputs, nativeOutputs,
-		func(mod *big.Int, inputs, outputs []*big.Int) error {
-			nominator := inputs[0]
-			denominator := inputs[1]
-			res := new(big.Int).ModInverse(denominator, mod)
-			if res == nil {
-				return fmt.Errorf("no modular inverse")
-			}
-			res.Mul(res, nominator)
-			res.Mod(res, mod)
-			outputs[0].Set(res)
-			return nil
-		})
+// HintExample is a hint for field emulation which returns the division of the
+// first and second input.
+func HintExample(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int) error {
+	// nativeInputs are the limbs of the input non-native elements. We wrap the
+	// actual hint function with [emulated.UnwrapHint] to get actual [*big.Int]
+	// values of the non-native elements.
+	return emulated.UnwrapHint(nativeInputs, nativeOutputs, func(mod *big.Int, inputs, outputs []*big.Int) error {
+		// this hint computes the division of first and second input and returns it.
+		nominator := inputs[0]
+		denominator := inputs[1]
+		res := new(big.Int).ModInverse(denominator, mod)
+		if res == nil {
+			return fmt.Errorf("no modular inverse")
+		}
+		res.Mul(res, nominator)
+		res.Mod(res, mod)
+		outputs[0].Set(res)
+		return nil
+	})
+	// when the internal hint function returns, the UnwrapHint function
+	// decomposes the non-native value into limbs.
 }
 
-type testDivHintCircuit[T emulated.FieldParams] struct {
+type emulationHintCircuit[T emulated.FieldParams] struct {
 	Nominator   emulated.Element[T]
 	Denominator emulated.Element[T]
 	Expected    emulated.Element[T]
 }
 
-func (c *testDivHintCircuit[T]) Define(api frontend.API) error {
+func (c *emulationHintCircuit[T]) Define(api frontend.API) error {
 	field, err := emulated.NewField[T](api)
 	if err != nil {
 		return err
 	}
-	res, err := field.NewHint(DivTestHint, 1, &c.Nominator, &c.Denominator)
+	res, err := field.NewHint(HintExample, 1, &c.Nominator, &c.Denominator)
 	if err != nil {
 		return err
 	}
@@ -51,21 +58,59 @@ func (c *testDivHintCircuit[T]) Define(api frontend.API) error {
 	return nil
 }
 
-func TestDivWithHInt(t *testing.T) {
+// Example of using hints with emulated elements.
+func ExampleField_NewHint() {
 	var a, b, c fr.Element
 	a.SetRandom()
 	b.SetRandom()
 	c.Div(&a, &b)
 
-	circuit := testDivHintCircuit[emulated.BN254Fr]{}
-	witness := testDivHintCircuit[emulated.BN254Fr]{
+	circuit := emulationHintCircuit[emulated.BN254Fr]{}
+	witness := emulationHintCircuit[emulated.BN254Fr]{
 		Nominator:   emulated.ValueOf[emulated.BN254Fr](a),
 		Denominator: emulated.ValueOf[emulated.BN254Fr](b),
 		Expected:    emulated.ValueOf[emulated.BN254Fr](c),
 	}
-	assert := test.NewAssert(t)
-	assert.ProverSucceeded(&circuit, &witness, test.NoFuzzing(), test.NoSerialization(), test.WithCurves(ecc.BN254),
-		test.WithBackends(backend.PLONK),
-		test.WithSolverOpts(solver.WithHints(DivTestHint)),
-	)
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("compiled")
+	}
+	witnessData, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("secret witness parsed")
+	}
+	publicWitnessData, err := witnessData.Public()
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("public witness parsed")
+	}
+	pk, vk, err := groth16.Setup(ccs)
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("setup done")
+	}
+	proof, err := groth16.Prove(ccs, pk, witnessData, backend.WithSolverOptions(solver.WithHints(HintExample)))
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("proved")
+	}
+	err = groth16.Verify(proof, vk, publicWitnessData)
+	if err != nil {
+		panic(err)
+	} else {
+		fmt.Println("verified")
+	}
+	// Output: compiled
+	// secret witness parsed
+	// public witness parsed
+	// setup done
+	// proved
+	// verified
 }

--- a/std/math/emulated/field_hint_test.go
+++ b/std/math/emulated/field_hint_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func DivTestHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int) error {
-	return emulated.UnwrapHint(nativeMod, nativeInputs, nativeOutputs,
+	return emulated.UnwrapHint(nativeInputs, nativeOutputs,
 		func(mod *big.Int, inputs, outputs []*big.Int) error {
 			nominator := inputs[0]
 			denominator := inputs[1]

--- a/test/options.go
+++ b/test/options.go
@@ -89,6 +89,7 @@ func WithProverOpts(proverOpts ...backend.ProverOption) TestingOption {
 // calling constraint system solver.
 func WithSolverOpts(solverOpts ...solver.Option) TestingOption {
 	return func(opt *testingConfig) error {
+		opt.proverOpts = append(opt.proverOpts, backend.WithSolverOptions(solverOpts...))
 		opt.solverOpts = solverOpts
 		return nil
 	}


### PR DESCRIPTION
We used to have hints when we hade fake-API. @yelhousni recommends reintroducing as it is helpful for optimising non-native algebra (pairings etc). When I tried to reintroduce the implementation then I realized that actually the old code (already removed few months ago) was kind of broken. We wrapped the hint functions and created anonymous hint functions, which cannot really work.

So, I rewrote it, making defining hints slightly more inconvenient. So instead of writing:
```go
func HintFn(mod *big.Int, inputs []*big.Int, outputs []*big.Int) error {
    // work here
}
```
we do
```go
func HintFn(mod *big.Int, inputs, outputs []*big.Int) error {
	return emulated.UnwrapHint(inputs, outputs,
		func(mod *big.Int, inputs, outputs []*big.Int) error { // NB we shadow initial input, output, mod to avoid accidental overwrite!
                         // here all inputs and outputs are modulo nonnative mod. we decompose them automatically
			// work here
		})
}
```

Keeping draft for now as it seems really convenient for internal hint uses in field emulation (div. inv etc.).