### PR TITLE
fix: do not pass limb width enforcement for consts in AssertIsEqual

### DIFF
--- a/std/math/emulated/field_assert.go
+++ b/std/math/emulated/field_assert.go
@@ -142,7 +142,8 @@ func (f *Field[T]) enforceWidth(a *Element[T], modWidth bool) {
 
 // AssertIsEqual ensures that a is equal to b modulo the modulus.
 func (f *Field[T]) AssertIsEqual(a, b *Element[T]) {
-	// we omit width assertion as it is done in Sub below
+	f.enforceWidthConditional(a)
+	f.enforceWidthConditional(b)
 	ba, aConst := f.constantValue(a)
 	bb, bConst := f.constantValue(b)
 	if aConst && bConst {

--- a/test/assert.go
+++ b/test/assert.go
@@ -369,8 +369,22 @@ func (assert *Assert) fuzzer(fuzzer filler, circuit, w frontend.Circuit, b backe
 	errConsts := IsSolved(circuit, w, curve.ScalarField(), SetAllVariablesAsConstants())
 
 	if (errVars == nil) != (errConsts == nil) {
+		w, err := frontend.NewWitness(w, ecc.BN254.ScalarField())
+		if err != nil {
+			panic(err)
+		}
+		s, err := frontend.NewSchema(circuit)
+		if err != nil {
+			panic(err)
+		}
+		bb, err := w.ToJSON(s)
+		if err != nil {
+			panic(err)
+		}
+
 		assert.Log("errVars", errVars)
 		assert.Log("errConsts", errConsts)
+		assert.Log("fuzzer witness", string(bb))
 		assert.FailNow("solving circuit with values as constants vs non-constants mismatched result")
 	}
 

--- a/test/assert.go
+++ b/test/assert.go
@@ -369,7 +369,7 @@ func (assert *Assert) fuzzer(fuzzer filler, circuit, w frontend.Circuit, b backe
 	errConsts := IsSolved(circuit, w, curve.ScalarField(), SetAllVariablesAsConstants())
 
 	if (errVars == nil) != (errConsts == nil) {
-		w, err := frontend.NewWitness(w, ecc.BN254.ScalarField())
+		w, err := frontend.NewWitness(w, curve.ScalarField())
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Fixes the bugs found by the fuzzer. I also added logging to the fuzzer when it finds the inputs which create inconsistent result. Otherwise it is quite time-consuming to recreate the bug.