### PR TITLE
fix: use mocked api.Commit also in Windows tests

### DIFF
--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -760,7 +760,7 @@ func (builder *builder) getCommittedVariables(i *constraint.Commitment) []fronte
 }
 
 func bsb22CommitmentComputePlaceholder(_ *big.Int, _ []*big.Int, output []*big.Int) error {
-	if (len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test")) || debug.Debug {
+	if (len(os.Args) > 0 && (strings.HasSuffix(os.Args[0], ".test") || strings.HasSuffix(os.Args[0], ".test.exe"))) || debug.Debug {
 		// usually we only run solver without prover during testing
 		log := logger.Logger()
 		log.Error().Msg("Augmented groth16 commitment hint not replaced. Proof will not be sound!")


### PR DESCRIPTION
For safety, we use mocked commitment hint only when running in tests or in debug mode. This is to avoid using it by accident in real application, as the mocked commitment is not sound.

The test if we are in testing environment didn't consider Windows and this made CI tests fail.

EDIT: another approach is to not have the check at all, but I think it gives a bit more of safety.