### PR TITLE
perf: use `api.Select` for 2 to 1 mux

### DIFF
--- a/std/selector/multiplexer.go
+++ b/std/selector/multiplexer.go
@@ -14,6 +14,7 @@ package selector
 
 import (
 	"fmt"
+	"github.com/consensys/gnark/std/math/bits"
 	"math/big"
 
 	"github.com/consensys/gnark/constraint/solver"
@@ -66,7 +67,16 @@ func generateSelector(api frontend.API, wantMux bool, sel frontend.Variable,
 		if len(values) == 2 {
 			return api.Select(sel, values[1], values[0])
 		}
+
+		if len(values) == 4 {
+			// api.Lookup2 adds constraints for the boolean assertion, so we use
+			// bits.WithUnconstrainedOutputs()
+			selBits := bits.ToBinary(api, sel, bits.WithNbDigits(2), bits.WithUnconstrainedOutputs())
+			return api.Lookup2(selBits[0], selBits[1], values[0], values[1], values[2], values[3])
+		}
+
 		indicators, err = api.Compiler().NewHint(muxIndicators, len(values), sel)
+
 	} else {
 		indicators, err = api.Compiler().NewHint(mapIndicators, len(keys), append(keys, sel)...)
 	}

--- a/std/selector/multiplexer.go
+++ b/std/selector/multiplexer.go
@@ -63,6 +63,9 @@ func generateSelector(api frontend.API, wantMux bool, sel frontend.Variable,
 	var indicators []frontend.Variable
 	var err error
 	if wantMux {
+		if len(values) == 2 {
+			return api.Select(sel, values[1], values[0])
+		}
 		indicators, err = api.Compiler().NewHint(muxIndicators, len(values), sel)
 	} else {
 		indicators, err = api.Compiler().NewHint(mapIndicators, len(keys), append(keys, sel)...)

--- a/std/selector/multiplexer_test.go
+++ b/std/selector/multiplexer_test.go
@@ -36,6 +36,19 @@ func (c *ignoredOutputMuxCircuit) Define(api frontend.API) error {
 	return nil
 }
 
+type mux2to1Circuit struct {
+	SEL    frontend.Variable
+	I0, I1 frontend.Variable
+	OUT    frontend.Variable
+}
+
+func (c *mux2to1Circuit) Define(api frontend.API) error {
+	// We ignore the output
+	out := selector.Mux(api, c.SEL, c.I0, c.I1)
+	api.AssertIsEqual(out, c.OUT)
+	return nil
+}
+
 func TestMux(t *testing.T) {
 	assert := test.NewAssert(t)
 
@@ -59,6 +72,13 @@ func TestMux(t *testing.T) {
 	assert.ProverFailed(&ignoredOutputMuxCircuit{}, &ignoredOutputMuxCircuit{SEL: 3, I0: 0, I1: 1, I2: 2})
 
 	assert.ProverFailed(&ignoredOutputMuxCircuit{}, &ignoredOutputMuxCircuit{SEL: -1, I0: 0, I1: 1, I2: 2})
+
+	// 2 to 1 mux
+	assert.ProverSucceeded(&mux2to1Circuit{}, &mux2to1Circuit{SEL: 1, I0: 10, I1: 20, OUT: 20})
+
+	assert.ProverSucceeded(&mux2to1Circuit{}, &mux2to1Circuit{SEL: 0, I0: 10, I1: 20, OUT: 10})
+
+	assert.ProverFailed(&mux2to1Circuit{}, &mux2to1Circuit{SEL: 2, I0: 10, I1: 20, OUT: 20})
 }
 
 // Map tests:

--- a/std/selector/multiplexer_test.go
+++ b/std/selector/multiplexer_test.go
@@ -49,6 +49,18 @@ func (c *mux2to1Circuit) Define(api frontend.API) error {
 	return nil
 }
 
+type mux4to1Circuit struct {
+	SEL frontend.Variable
+	In  [4]frontend.Variable
+	OUT frontend.Variable
+}
+
+func (c *mux4to1Circuit) Define(api frontend.API) error {
+	out := selector.Mux(api, c.SEL, c.In[:]...)
+	api.AssertIsEqual(out, c.OUT)
+	return nil
+}
+
 func TestMux(t *testing.T) {
 	assert := test.NewAssert(t)
 
@@ -79,6 +91,25 @@ func TestMux(t *testing.T) {
 	assert.ProverSucceeded(&mux2to1Circuit{}, &mux2to1Circuit{SEL: 0, I0: 10, I1: 20, OUT: 10})
 
 	assert.ProverFailed(&mux2to1Circuit{}, &mux2to1Circuit{SEL: 2, I0: 10, I1: 20, OUT: 20})
+
+	// 4 to 1 mux
+	assert.ProverSucceeded(&mux4to1Circuit{}, &mux4to1Circuit{
+		SEL: 3,
+		In:  [4]frontend.Variable{11, 22, 33, 44},
+		OUT: 44,
+	})
+
+	assert.ProverSucceeded(&mux4to1Circuit{}, &mux4to1Circuit{
+		SEL: 1,
+		In:  [4]frontend.Variable{11, 22, 33, 44},
+		OUT: 22,
+	})
+
+	assert.ProverFailed(&mux4to1Circuit{}, &mux4to1Circuit{
+		SEL: 4,
+		In:  [4]frontend.Variable{11, 22, 33, 44},
+		OUT: 44,
+	})
 }
 
 // Map tests:


### PR DESCRIPTION
A 2 to 1 multiplexer is a special case and has an efficient solution which can not be generalized to other cases:
```
out == sel * i_1 + (1 - sel) * i_0
sel * (sel - 1) == 0
```
Therefore, we should use `api.Select` for constructing 2 to 1 multiplexers as a special case.