### PR TITLE
refactor: Minimize Commitment info in plonk vk

### DIFF
--- a/backend/plonk/bls12-377/marshal.go
+++ b/backend/plonk/bls12-377/marshal.go
@@ -226,6 +226,7 @@ func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toEncode {
@@ -255,6 +256,7 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		&vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toDecode {

--- a/backend/plonk/bls12-377/marshal.go
+++ b/backend/plonk/bls12-377/marshal.go
@@ -209,6 +209,15 @@ func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
 
 // WriteTo writes binary encoding of VerifyingKey to w
 func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
+	return vk.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of VerifyingKey to w without point compression
+func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
+	return vk.writeTo(w, curve.RawEncoding())
+}
+
+func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*curve.Encoder)) (n int64, err error) {
 	enc := curve.NewEncoder(w)
 
 	toEncode := []interface{}{

--- a/backend/plonk/bls12-377/marshal_test.go
+++ b/backend/plonk/bls12-377/marshal_test.go
@@ -152,6 +152,7 @@ func (vk *VerifyingKey) randomize() {
 	vk.SizeInv.SetRandom()
 	vk.Generator.SetRandom()
 	vk.NbPublicVariables = rand.Uint64()
+	vk.CommitmentConstraintIndexes = []uint64{rand.Uint64()}
 	vk.CosetShift.SetRandom()
 
 	vk.S[0] = randomPoint()

--- a/backend/plonk/bls12-377/setup.go
+++ b/backend/plonk/bls12-377/setup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/kzg"
-	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bls12-377"
 
 	kzgg "github.com/consensys/gnark-crypto/kzg"
@@ -76,7 +75,7 @@ type VerifyingKey struct {
 	// In particular Qk is not complete.
 	Ql, Qr, Qm, Qo, Qk, Qcp kzg.Digest
 
-	CommitmentInfo constraint.Commitment
+	CommitmentConstraintIndexes []uint64
 }
 
 // ProvingKey stores the data needed to generate a proof:
@@ -122,7 +121,9 @@ func Setup(spr *cs.SparseR1CS, srs *kzg.SRS) (*ProvingKey, *VerifyingKey, error)
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	vk.CommitmentInfo = spr.CommitmentInfo
+	if spr.CommitmentInfo.Is() {
+		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
+	}
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains

--- a/backend/plonk/bls12-377/verify.go
+++ b/backend/plonk/bls12-377/verify.go
@@ -110,15 +110,15 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 			}
 		}
 
-		if vk.CommitmentInfo.Is() {
-			var hashRes []fr.Element
+		for i := range vk.CommitmentConstraintIndexes {
+			var hashRes []fr.Element // TODO: when multi commits are implemented: PI2 -> PI2[i]
 			if hashRes, err = fr.Hash(proof.PI2.Marshal(), []byte("BSB22-Plonk"), 1); err != nil {
 				return err
 			}
 
 			// Computing L_{CommitmentIndex}
 
-			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentInfo.CommitmentIndex)))
+			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentConstraintIndexes[i])))
 			den.Sub(&zeta, &wPowI) // ζ-wⁱ
 
 			lagrange.SetOne().

--- a/backend/plonk/bls12-381/marshal.go
+++ b/backend/plonk/bls12-381/marshal.go
@@ -226,6 +226,7 @@ func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toEncode {
@@ -255,6 +256,7 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		&vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toDecode {

--- a/backend/plonk/bls12-381/marshal.go
+++ b/backend/plonk/bls12-381/marshal.go
@@ -209,6 +209,15 @@ func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
 
 // WriteTo writes binary encoding of VerifyingKey to w
 func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
+	return vk.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of VerifyingKey to w without point compression
+func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
+	return vk.writeTo(w, curve.RawEncoding())
+}
+
+func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*curve.Encoder)) (n int64, err error) {
 	enc := curve.NewEncoder(w)
 
 	toEncode := []interface{}{

--- a/backend/plonk/bls12-381/marshal_test.go
+++ b/backend/plonk/bls12-381/marshal_test.go
@@ -152,6 +152,7 @@ func (vk *VerifyingKey) randomize() {
 	vk.SizeInv.SetRandom()
 	vk.Generator.SetRandom()
 	vk.NbPublicVariables = rand.Uint64()
+	vk.CommitmentConstraintIndexes = []uint64{rand.Uint64()}
 	vk.CosetShift.SetRandom()
 
 	vk.S[0] = randomPoint()

--- a/backend/plonk/bls12-381/setup.go
+++ b/backend/plonk/bls12-381/setup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/kzg"
-	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bls12-381"
 
 	kzgg "github.com/consensys/gnark-crypto/kzg"
@@ -76,7 +75,7 @@ type VerifyingKey struct {
 	// In particular Qk is not complete.
 	Ql, Qr, Qm, Qo, Qk, Qcp kzg.Digest
 
-	CommitmentInfo constraint.Commitment
+	CommitmentConstraintIndexes []uint64
 }
 
 // ProvingKey stores the data needed to generate a proof:
@@ -122,7 +121,9 @@ func Setup(spr *cs.SparseR1CS, srs *kzg.SRS) (*ProvingKey, *VerifyingKey, error)
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	vk.CommitmentInfo = spr.CommitmentInfo
+	if spr.CommitmentInfo.Is() {
+		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
+	}
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains

--- a/backend/plonk/bls12-381/verify.go
+++ b/backend/plonk/bls12-381/verify.go
@@ -110,15 +110,15 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 			}
 		}
 
-		if vk.CommitmentInfo.Is() {
-			var hashRes []fr.Element
+		for i := range vk.CommitmentConstraintIndexes {
+			var hashRes []fr.Element // TODO: when multi commits are implemented: PI2 -> PI2[i]
 			if hashRes, err = fr.Hash(proof.PI2.Marshal(), []byte("BSB22-Plonk"), 1); err != nil {
 				return err
 			}
 
 			// Computing L_{CommitmentIndex}
 
-			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentInfo.CommitmentIndex)))
+			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentConstraintIndexes[i])))
 			den.Sub(&zeta, &wPowI) // ζ-wⁱ
 
 			lagrange.SetOne().

--- a/backend/plonk/bls24-315/marshal.go
+++ b/backend/plonk/bls24-315/marshal.go
@@ -226,6 +226,7 @@ func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toEncode {
@@ -255,6 +256,7 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		&vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toDecode {

--- a/backend/plonk/bls24-315/marshal.go
+++ b/backend/plonk/bls24-315/marshal.go
@@ -209,6 +209,15 @@ func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
 
 // WriteTo writes binary encoding of VerifyingKey to w
 func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
+	return vk.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of VerifyingKey to w without point compression
+func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
+	return vk.writeTo(w, curve.RawEncoding())
+}
+
+func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*curve.Encoder)) (n int64, err error) {
 	enc := curve.NewEncoder(w)
 
 	toEncode := []interface{}{

--- a/backend/plonk/bls24-315/marshal_test.go
+++ b/backend/plonk/bls24-315/marshal_test.go
@@ -152,6 +152,7 @@ func (vk *VerifyingKey) randomize() {
 	vk.SizeInv.SetRandom()
 	vk.Generator.SetRandom()
 	vk.NbPublicVariables = rand.Uint64()
+	vk.CommitmentConstraintIndexes = []uint64{rand.Uint64()}
 	vk.CosetShift.SetRandom()
 
 	vk.S[0] = randomPoint()

--- a/backend/plonk/bls24-315/setup.go
+++ b/backend/plonk/bls24-315/setup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/kzg"
-	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bls24-315"
 
 	kzgg "github.com/consensys/gnark-crypto/kzg"
@@ -76,7 +75,7 @@ type VerifyingKey struct {
 	// In particular Qk is not complete.
 	Ql, Qr, Qm, Qo, Qk, Qcp kzg.Digest
 
-	CommitmentInfo constraint.Commitment
+	CommitmentConstraintIndexes []uint64
 }
 
 // ProvingKey stores the data needed to generate a proof:
@@ -122,7 +121,9 @@ func Setup(spr *cs.SparseR1CS, srs *kzg.SRS) (*ProvingKey, *VerifyingKey, error)
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	vk.CommitmentInfo = spr.CommitmentInfo
+	if spr.CommitmentInfo.Is() {
+		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
+	}
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains

--- a/backend/plonk/bls24-315/verify.go
+++ b/backend/plonk/bls24-315/verify.go
@@ -110,15 +110,15 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 			}
 		}
 
-		if vk.CommitmentInfo.Is() {
-			var hashRes []fr.Element
+		for i := range vk.CommitmentConstraintIndexes {
+			var hashRes []fr.Element // TODO: when multi commits are implemented: PI2 -> PI2[i]
 			if hashRes, err = fr.Hash(proof.PI2.Marshal(), []byte("BSB22-Plonk"), 1); err != nil {
 				return err
 			}
 
 			// Computing L_{CommitmentIndex}
 
-			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentInfo.CommitmentIndex)))
+			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentConstraintIndexes[i])))
 			den.Sub(&zeta, &wPowI) // ζ-wⁱ
 
 			lagrange.SetOne().

--- a/backend/plonk/bls24-317/marshal.go
+++ b/backend/plonk/bls24-317/marshal.go
@@ -226,6 +226,7 @@ func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toEncode {
@@ -255,6 +256,7 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		&vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toDecode {

--- a/backend/plonk/bls24-317/marshal.go
+++ b/backend/plonk/bls24-317/marshal.go
@@ -209,6 +209,15 @@ func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
 
 // WriteTo writes binary encoding of VerifyingKey to w
 func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
+	return vk.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of VerifyingKey to w without point compression
+func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
+	return vk.writeTo(w, curve.RawEncoding())
+}
+
+func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*curve.Encoder)) (n int64, err error) {
 	enc := curve.NewEncoder(w)
 
 	toEncode := []interface{}{

--- a/backend/plonk/bls24-317/marshal_test.go
+++ b/backend/plonk/bls24-317/marshal_test.go
@@ -152,6 +152,7 @@ func (vk *VerifyingKey) randomize() {
 	vk.SizeInv.SetRandom()
 	vk.Generator.SetRandom()
 	vk.NbPublicVariables = rand.Uint64()
+	vk.CommitmentConstraintIndexes = []uint64{rand.Uint64()}
 	vk.CosetShift.SetRandom()
 
 	vk.S[0] = randomPoint()

--- a/backend/plonk/bls24-317/setup.go
+++ b/backend/plonk/bls24-317/setup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/kzg"
-	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bls24-317"
 
 	kzgg "github.com/consensys/gnark-crypto/kzg"
@@ -76,7 +75,7 @@ type VerifyingKey struct {
 	// In particular Qk is not complete.
 	Ql, Qr, Qm, Qo, Qk, Qcp kzg.Digest
 
-	CommitmentInfo constraint.Commitment
+	CommitmentConstraintIndexes []uint64
 }
 
 // ProvingKey stores the data needed to generate a proof:
@@ -122,7 +121,9 @@ func Setup(spr *cs.SparseR1CS, srs *kzg.SRS) (*ProvingKey, *VerifyingKey, error)
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	vk.CommitmentInfo = spr.CommitmentInfo
+	if spr.CommitmentInfo.Is() {
+		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
+	}
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains

--- a/backend/plonk/bls24-317/verify.go
+++ b/backend/plonk/bls24-317/verify.go
@@ -110,15 +110,15 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 			}
 		}
 
-		if vk.CommitmentInfo.Is() {
-			var hashRes []fr.Element
+		for i := range vk.CommitmentConstraintIndexes {
+			var hashRes []fr.Element // TODO: when multi commits are implemented: PI2 -> PI2[i]
 			if hashRes, err = fr.Hash(proof.PI2.Marshal(), []byte("BSB22-Plonk"), 1); err != nil {
 				return err
 			}
 
 			// Computing L_{CommitmentIndex}
 
-			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentInfo.CommitmentIndex)))
+			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentConstraintIndexes[i])))
 			den.Sub(&zeta, &wPowI) // ζ-wⁱ
 
 			lagrange.SetOne().

--- a/backend/plonk/bn254/marshal.go
+++ b/backend/plonk/bn254/marshal.go
@@ -17,7 +17,6 @@
 package plonk
 
 import (
-	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
 
 	"errors"
@@ -230,11 +229,7 @@ func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
 		vk.CommitmentConstraintIndexes,
 	}
 
-	for i, v := range toEncode {
-		if i == len(toEncode)-1 {
-			fmt.Println("			dis da one")
-		}
-		//fmt.Println("attempting to write")
+	for _, v := range toEncode {
 		if err := enc.Encode(v); err != nil {
 			return enc.BytesWritten(), err
 		}

--- a/backend/plonk/bn254/marshal.go
+++ b/backend/plonk/bn254/marshal.go
@@ -17,6 +17,7 @@
 package plonk
 
 import (
+	"fmt"
 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
 
 	"errors"
@@ -226,9 +227,14 @@ func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		vk.CommitmentConstraintIndexes,
 	}
 
-	for _, v := range toEncode {
+	for i, v := range toEncode {
+		if i == len(toEncode)-1 {
+			fmt.Println("			dis da one")
+		}
+		//fmt.Println("attempting to write")
 		if err := enc.Encode(v); err != nil {
 			return enc.BytesWritten(), err
 		}
@@ -255,6 +261,7 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		&vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toDecode {

--- a/backend/plonk/bn254/marshal.go
+++ b/backend/plonk/bn254/marshal.go
@@ -209,6 +209,15 @@ func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
 
 // WriteTo writes binary encoding of VerifyingKey to w
 func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
+	return vk.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of VerifyingKey to w without point compression
+func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
+	return vk.writeTo(w, curve.RawEncoding())
+}
+
+func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*curve.Encoder)) (n int64, err error) {
 	enc := curve.NewEncoder(w)
 
 	toEncode := []interface{}{

--- a/backend/plonk/bn254/marshal_test.go
+++ b/backend/plonk/bn254/marshal_test.go
@@ -152,6 +152,7 @@ func (vk *VerifyingKey) randomize() {
 	vk.SizeInv.SetRandom()
 	vk.Generator.SetRandom()
 	vk.NbPublicVariables = rand.Uint64()
+	vk.CommitmentConstraintIndexes = []uint64{rand.Uint64()}
 	vk.CosetShift.SetRandom()
 
 	vk.S[0] = randomPoint()

--- a/backend/plonk/bn254/setup.go
+++ b/backend/plonk/bn254/setup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/kzg"
-	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bn254"
 
 	kzgg "github.com/consensys/gnark-crypto/kzg"
@@ -76,7 +75,7 @@ type VerifyingKey struct {
 	// In particular Qk is not complete.
 	Ql, Qr, Qm, Qo, Qk, Qcp kzg.Digest
 
-	CommitmentInfo constraint.Commitment
+	CommitmentConstraintIndexes []uint64
 }
 
 // ProvingKey stores the data needed to generate a proof:
@@ -122,7 +121,9 @@ func Setup(spr *cs.SparseR1CS, srs *kzg.SRS) (*ProvingKey, *VerifyingKey, error)
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	vk.CommitmentInfo = spr.CommitmentInfo
+	if spr.CommitmentInfo.Is() {
+		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
+	}
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains

--- a/backend/plonk/bn254/verify.go
+++ b/backend/plonk/bn254/verify.go
@@ -112,15 +112,15 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 			}
 		}
 
-		if vk.CommitmentInfo.Is() {
-			var hashRes []fr.Element
+		for i := range vk.CommitmentConstraintIndexes {
+			var hashRes []fr.Element // TODO: when multi commits are implemented: PI2 -> PI2[i]
 			if hashRes, err = fr.Hash(proof.PI2.Marshal(), []byte("BSB22-Plonk"), 1); err != nil {
 				return err
 			}
 
 			// Computing L_{CommitmentIndex}
 
-			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentInfo.CommitmentIndex)))
+			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentConstraintIndexes[i])))
 			den.Sub(&zeta, &wPowI) // ζ-wⁱ
 
 			lagrange.SetOne().

--- a/backend/plonk/bw6-633/marshal.go
+++ b/backend/plonk/bw6-633/marshal.go
@@ -226,6 +226,7 @@ func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toEncode {
@@ -255,6 +256,7 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		&vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toDecode {

--- a/backend/plonk/bw6-633/marshal.go
+++ b/backend/plonk/bw6-633/marshal.go
@@ -209,6 +209,15 @@ func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
 
 // WriteTo writes binary encoding of VerifyingKey to w
 func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
+	return vk.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of VerifyingKey to w without point compression
+func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
+	return vk.writeTo(w, curve.RawEncoding())
+}
+
+func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*curve.Encoder)) (n int64, err error) {
 	enc := curve.NewEncoder(w)
 
 	toEncode := []interface{}{

--- a/backend/plonk/bw6-633/marshal_test.go
+++ b/backend/plonk/bw6-633/marshal_test.go
@@ -152,6 +152,7 @@ func (vk *VerifyingKey) randomize() {
 	vk.SizeInv.SetRandom()
 	vk.Generator.SetRandom()
 	vk.NbPublicVariables = rand.Uint64()
+	vk.CommitmentConstraintIndexes = []uint64{rand.Uint64()}
 	vk.CosetShift.SetRandom()
 
 	vk.S[0] = randomPoint()

--- a/backend/plonk/bw6-633/setup.go
+++ b/backend/plonk/bw6-633/setup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/kzg"
-	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bw6-633"
 
 	kzgg "github.com/consensys/gnark-crypto/kzg"
@@ -76,7 +75,7 @@ type VerifyingKey struct {
 	// In particular Qk is not complete.
 	Ql, Qr, Qm, Qo, Qk, Qcp kzg.Digest
 
-	CommitmentInfo constraint.Commitment
+	CommitmentConstraintIndexes []uint64
 }
 
 // ProvingKey stores the data needed to generate a proof:
@@ -122,7 +121,9 @@ func Setup(spr *cs.SparseR1CS, srs *kzg.SRS) (*ProvingKey, *VerifyingKey, error)
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	vk.CommitmentInfo = spr.CommitmentInfo
+	if spr.CommitmentInfo.Is() {
+		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
+	}
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains

--- a/backend/plonk/bw6-633/verify.go
+++ b/backend/plonk/bw6-633/verify.go
@@ -110,15 +110,15 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 			}
 		}
 
-		if vk.CommitmentInfo.Is() {
-			var hashRes []fr.Element
+		for i := range vk.CommitmentConstraintIndexes {
+			var hashRes []fr.Element // TODO: when multi commits are implemented: PI2 -> PI2[i]
 			if hashRes, err = fr.Hash(proof.PI2.Marshal(), []byte("BSB22-Plonk"), 1); err != nil {
 				return err
 			}
 
 			// Computing L_{CommitmentIndex}
 
-			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentInfo.CommitmentIndex)))
+			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentConstraintIndexes[i])))
 			den.Sub(&zeta, &wPowI) // ζ-wⁱ
 
 			lagrange.SetOne().

--- a/backend/plonk/bw6-761/marshal.go
+++ b/backend/plonk/bw6-761/marshal.go
@@ -226,6 +226,7 @@ func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toEncode {
@@ -255,6 +256,7 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		&vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toDecode {

--- a/backend/plonk/bw6-761/marshal.go
+++ b/backend/plonk/bw6-761/marshal.go
@@ -209,6 +209,15 @@ func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
 
 // WriteTo writes binary encoding of VerifyingKey to w
 func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
+	return vk.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of VerifyingKey to w without point compression
+func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
+	return vk.writeTo(w, curve.RawEncoding())
+}
+
+func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*curve.Encoder)) (n int64, err error) {
 	enc := curve.NewEncoder(w)
 
 	toEncode := []interface{}{

--- a/backend/plonk/bw6-761/marshal_test.go
+++ b/backend/plonk/bw6-761/marshal_test.go
@@ -152,6 +152,7 @@ func (vk *VerifyingKey) randomize() {
 	vk.SizeInv.SetRandom()
 	vk.Generator.SetRandom()
 	vk.NbPublicVariables = rand.Uint64()
+	vk.CommitmentConstraintIndexes = []uint64{rand.Uint64()}
 	vk.CosetShift.SetRandom()
 
 	vk.S[0] = randomPoint()

--- a/backend/plonk/bw6-761/setup.go
+++ b/backend/plonk/bw6-761/setup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/kzg"
-	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bw6-761"
 
 	kzgg "github.com/consensys/gnark-crypto/kzg"
@@ -76,7 +75,7 @@ type VerifyingKey struct {
 	// In particular Qk is not complete.
 	Ql, Qr, Qm, Qo, Qk, Qcp kzg.Digest
 
-	CommitmentInfo constraint.Commitment
+	CommitmentConstraintIndexes []uint64
 }
 
 // ProvingKey stores the data needed to generate a proof:
@@ -122,7 +121,9 @@ func Setup(spr *cs.SparseR1CS, srs *kzg.SRS) (*ProvingKey, *VerifyingKey, error)
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	vk.CommitmentInfo = spr.CommitmentInfo
+	if spr.CommitmentInfo.Is() {
+		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
+	}
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains

--- a/backend/plonk/bw6-761/verify.go
+++ b/backend/plonk/bw6-761/verify.go
@@ -110,15 +110,15 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 			}
 		}
 
-		if vk.CommitmentInfo.Is() {
-			var hashRes []fr.Element
+		for i := range vk.CommitmentConstraintIndexes {
+			var hashRes []fr.Element // TODO: when multi commits are implemented: PI2 -> PI2[i]
 			if hashRes, err = fr.Hash(proof.PI2.Marshal(), []byte("BSB22-Plonk"), 1); err != nil {
 				return err
 			}
 
 			// Computing L_{CommitmentIndex}
 
-			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentInfo.CommitmentIndex)))
+			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentConstraintIndexes[i])))
 			den.Sub(&zeta, &wPowI) // ζ-wⁱ
 
 			lagrange.SetOne().

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.5.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/bavard v0.1.13
-	github.com/consensys/gnark-crypto v0.9.2-0.20230329155745-a57dcc3b53de
+	github.com/consensys/gnark-crypto v0.10.1-0.20230409144652-f385aa74853e
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/pprof v0.0.0-20230309165930-d61513b1440d

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
-github.com/consensys/gnark-crypto v0.9.2-0.20230329155745-a57dcc3b53de h1:W5lRxU8Rk8CDLHMTeyNst0VESbcU5RZ3U1TS9MNGgCQ=
-github.com/consensys/gnark-crypto v0.9.2-0.20230329155745-a57dcc3b53de/go.mod h1:Iq/P3HHl0ElSjsg2E1gsMwhAyxnxoKK5nVyZKd+/KhU=
+github.com/consensys/gnark-crypto v0.10.1-0.20230409144652-f385aa74853e h1:Ot7heRTeRrEy1t/MB0wCxNmCADSCE2yCewrq8z0IZBo=
+github.com/consensys/gnark-crypto v0.10.1-0.20230409144652-f385aa74853e/go.mod h1:Iq/P3HHl0ElSjsg2E1gsMwhAyxnxoKK5nVyZKd+/KhU=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.marshal.go.tmpl
@@ -190,6 +190,15 @@ func (pk *ProvingKey) ReadFrom(r io.Reader) (int64, error) {
 
 // WriteTo writes binary encoding of VerifyingKey to w
 func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
+	return vk.writeTo(w)
+}
+
+// WriteRawTo writes binary encoding of VerifyingKey to w without point compression
+func (vk *VerifyingKey) WriteRawTo(w io.Writer) (int64, error) {
+	return vk.writeTo(w, curve.RawEncoding())
+}
+
+func (vk *VerifyingKey) writeTo(w io.Writer, options ...func(*curve.Encoder)) (n int64, err error) {
 	enc := curve.NewEncoder(w)
 
 	toEncode := []interface{}{

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.marshal.go.tmpl
@@ -207,6 +207,7 @@ func (vk *VerifyingKey) WriteTo(w io.Writer) (n int64, err error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toEncode {
@@ -236,6 +237,7 @@ func (vk *VerifyingKey) ReadFrom(r io.Reader) (int64, error) {
 		&vk.Qo,
 		&vk.Qk,
 		&vk.Qcp,
+		&vk.CommitmentConstraintIndexes,
 	}
 
 	for _, v := range toDecode {

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.setup.go.tmpl
@@ -3,7 +3,6 @@ import (
 	{{- template "import_kzg" . }}
 	{{- template "import_fr" . }}
 	{{- template "import_fft" . }}
-	"github.com/consensys/gnark/constraint"
 	{{- template "import_backend_cs" . }}
 	"github.com/consensys/gnark-crypto/ecc/{{toLower .Curve}}/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc"
@@ -58,7 +57,7 @@ type VerifyingKey struct {
 	// In particular Qk is not complete.
 	Ql, Qr, Qm, Qo, Qk, Qcp kzg.Digest
 
-	CommitmentInfo constraint.Commitment
+	CommitmentConstraintIndexes []uint64
 }
 
 // ProvingKey stores the data needed to generate a proof:
@@ -104,7 +103,9 @@ func Setup(spr *cs.SparseR1CS, srs *kzg.SRS) (*ProvingKey, *VerifyingKey, error)
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	vk.CommitmentInfo = spr.CommitmentInfo
+	if spr.CommitmentInfo.Is() {
+		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
+	}
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.verify.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.verify.go.tmpl
@@ -91,22 +91,22 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 			}
 		}
 
-		if vk.CommitmentInfo.Is() {
-			var hashRes []fr.Element
+		for i := range vk.CommitmentConstraintIndexes {
+			var hashRes []fr.Element	// TODO: when multi commits are implemented: PI2 -> PI2[i]
 			if hashRes, err = fr.Hash(proof.PI2.Marshal(), []byte("BSB22-Plonk"), 1); err != nil {
 				return err
 			}
 
 			// Computing L_{CommitmentIndex}
 
-			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentInfo.CommitmentIndex)))
+			wPowI.Exp(vk.Generator, big.NewInt(int64(vk.NbPublicVariables)+int64(vk.CommitmentConstraintIndexes[i])))
 			den.Sub(&zeta, &wPowI) // ζ-wⁱ
 
 			lagrange.SetOne().
-				Sub(&zeta, &lagrange).       // ζ-1
-				Mul(&lagrange, &wPowI).      // wⁱ(ζ-1)
-				Div(&lagrange, &den).        // wⁱ(ζ-1)/(ζ-wⁱ)
-				Mul(&lagrange, &lagrangeOne) // wⁱ/n (ζⁿ-1)/(ζ-wⁱ)
+			Sub(&zeta, &lagrange).       // ζ-1
+			Mul(&lagrange, &wPowI).      // wⁱ(ζ-1)
+			Div(&lagrange, &den).        // wⁱ(ζ-1)/(ζ-wⁱ)
+			Mul(&lagrange, &lagrangeOne) // wⁱ/n (ζⁿ-1)/(ζ-wⁱ)
 
 			xiLi.Mul(&lagrange, &hashRes[0])
 			pi.Add(&pi, &xiLi)

--- a/internal/generator/backend/template/zkpschemes/plonk/tests/marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/tests/marshal.go.tmpl
@@ -133,6 +133,7 @@ func (vk *VerifyingKey) randomize() {
 	vk.SizeInv.SetRandom()
 	vk.Generator.SetRandom()
 	vk.NbPublicVariables = rand.Uint64()
+	vk.CommitmentConstraintIndexes = []uint64{rand.Uint64()}
 	vk.CosetShift.SetRandom()
 
 	vk.S[0] = randomPoint()


### PR DESCRIPTION
This small PR removes some unnecessary info from the Plonk vk, making it easier to pass it around in Solidity.
Incidentally, it also implements some of the verifier side of multi-commits.