### PR TITLE
feat: add generic binary comparison functions

### DIFF
--- a/std/cmp/binary.go
+++ b/std/cmp/binary.go
@@ -1,0 +1,36 @@
+package cmp
+
+import (
+	"github.com/consensys/gnark/frontend"
+)
+
+// BinaryIsLess TODO: determine the relation of this function with BoundedComparator methods
+func BinaryIsLess(api frontend.API, aBits, bBits []frontend.Variable) frontend.Variable {
+	if len(aBits) != len(bBits) {
+		panic("a and b must have the same length")
+	}
+	return isLessRecursive(api, aBits, bBits, false)
+}
+
+// BinaryIsLessEq is ...
+func BinaryIsLessEq(api frontend.API, aBits, bBits []frontend.Variable) frontend.Variable {
+	if len(aBits) != len(bBits) {
+		panic("a and b must have the same length")
+	}
+	return isLessRecursive(api, aBits, bBits, true)
+}
+
+func isLessRecursive(api frontend.API, a, b []frontend.Variable, acceptEquality bool) frontend.Variable {
+	n := len(a)
+	if n == 0 {
+		if acceptEquality {
+			return 1
+		} else {
+			return 0
+		}
+	}
+	// out = (a[n-1] + b[n-1] - 2*a[n-1]*b[n-1])*(b[n-1] - cmp) + cmp
+	eq := api.Add(a[n-1], b[n-1], api.Mul(-2, a[n-1], b[n-1]))
+	cmp := isLessRecursive(api, a[:n-1], b[:n-1], acceptEquality)
+	return api.Add(cmp, api.Mul(eq, api.Sub(b[n-1], cmp)))
+}

--- a/std/cmp/binary_test.go
+++ b/std/cmp/binary_test.go
@@ -1,0 +1,98 @@
+package cmp
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/bits"
+	"github.com/consensys/gnark/test"
+	"testing"
+)
+
+type isLessRecursiveCircuit struct {
+	A, B                 frontend.Variable
+	WantLess, WantLessEq frontend.Variable
+}
+
+// Define defines the arithmetic circuit.
+func (c *isLessRecursiveCircuit) Define(api frontend.API) error {
+	aBits := bits.ToBinary(api, c.A, bits.WithNbDigits(4))
+	bBits := bits.ToBinary(api, c.B, bits.WithNbDigits(4))
+	gotLess := isLessRecursive(api, aBits, bBits, false)
+	gotLessEq := isLessRecursive(api, aBits, bBits, true)
+	api.AssertIsEqual(gotLess, c.WantLess)
+	api.AssertIsEqual(gotLessEq, c.WantLessEq)
+	return nil
+}
+
+func Test_isLess(t *testing.T) {
+	assert := test.NewAssert(t)
+
+	assert.ProverSucceeded(&isLessRecursiveCircuit{}, &isLessRecursiveCircuit{
+		A:          10,
+		B:          11,
+		WantLess:   1,
+		WantLessEq: 1,
+	})
+
+	assert.ProverSucceeded(&isLessRecursiveCircuit{}, &isLessRecursiveCircuit{
+		A:          11,
+		B:          11,
+		WantLess:   0,
+		WantLessEq: 1,
+	})
+
+	assert.ProverSucceeded(&isLessRecursiveCircuit{}, &isLessRecursiveCircuit{
+		A:          12,
+		B:          11,
+		WantLess:   0,
+		WantLessEq: 0,
+	})
+
+	assert.ProverSucceeded(&isLessRecursiveCircuit{}, &isLessRecursiveCircuit{
+		A:          0,
+		B:          1,
+		WantLess:   1,
+		WantLessEq: 1,
+	})
+
+	assert.ProverSucceeded(&isLessRecursiveCircuit{}, &isLessRecursiveCircuit{
+		A:          0,
+		B:          0,
+		WantLess:   0,
+		WantLessEq: 1,
+	})
+
+	assert.ProverSucceeded(&isLessRecursiveCircuit{}, &isLessRecursiveCircuit{
+		A:          14,
+		B:          15,
+		WantLess:   1,
+		WantLessEq: 1,
+	})
+
+	assert.ProverSucceeded(&isLessRecursiveCircuit{}, &isLessRecursiveCircuit{
+		A:          4,
+		B:          12,
+		WantLess:   1,
+		WantLessEq: 1,
+	})
+
+	assert.ProverSucceeded(&isLessRecursiveCircuit{}, &isLessRecursiveCircuit{
+		A:          6,
+		B:          2,
+		WantLess:   0,
+		WantLessEq: 0,
+	})
+
+	assert.ProverSucceeded(&isLessRecursiveCircuit{}, &isLessRecursiveCircuit{
+		A:          8,
+		B:          8,
+		WantLess:   0,
+		WantLessEq: 1,
+	})
+
+	assert.ProverSucceeded(&isLessRecursiveCircuit{}, &isLessRecursiveCircuit{
+		A:          2,
+		B:          1,
+		WantLess:   0,
+		WantLessEq: 0,
+	})
+}

--- a/std/cmp/doc_cmp_test.go
+++ b/std/cmp/doc_cmp_test.go
@@ -1,0 +1,43 @@
+package cmp_test
+
+import (
+	"fmt"
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/std/cmp"
+	"github.com/consensys/gnark/std/math/bits"
+)
+
+type apiCircuit struct {
+	A, B frontend.Variable
+}
+
+// Define defines the arithmetic circuit.
+func (c *apiCircuit) Define(api frontend.API) error {
+	api.AssertIsLessOrEqual(c.A, c.B)
+	return nil
+}
+
+type isLessCircuit struct {
+	A, B frontend.Variable
+	// Expected frontend.Variable
+}
+
+func (c *isLessCircuit) Define(api frontend.API) error {
+	result := cmp.BinaryIsLessEq(api, bits.ToBinary(api, c.A), bits.ToBinary(api, c.B))
+	api.AssertIsEqual(result, 1)
+	return nil
+}
+
+func ExampleBinaryIsLessEq() {
+	ccs, _ := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &apiCircuit{})
+	fmt.Println("api.AssertIsLessOrEqual:", ccs.GetNbConstraints())
+
+	ccs, _ = frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &isLessCircuit{})
+	fmt.Println("cmp.BinaryIsLessEq:", ccs.GetNbConstraints())
+
+	// Output:
+	// api.AssertIsLessOrEqual: 1270
+	// cmp.BinaryIsLessEq: 1019
+}


### PR DESCRIPTION
This PR adds functions for comparing any two numbers given their binary representations. This implementation defines `2*n` R1CS constraints. 

Both `api.AssertIsLessOrEqual` and `api.Cmp` functions can be improved using this implementation. However it seems that binary return value is more useful than thet ternary return value of `api.Cmp`.

In general for comparing numbers `BoundedComparator` methods are more efficient (they generate `n` constraints), but these functions do not have the limitations of `BoundedComparator` methods. 
