### PR TITLE
[BUG FIX] constraint: serializeCommitment

### DIFF
--- a/constraint/commitment.go
+++ b/constraint/commitment.go
@@ -44,9 +44,9 @@ func (i *Commitment) SerializeCommitment(privateCommitment []byte, publicCommitt
 	copy(res, privateCommitment)
 
 	offset := len(privateCommitment)
-	for j, inJ := range publicCommitted {
-		offset += j * fieldByteLen
+	for _, inJ := range publicCommitted {
 		inJ.FillBytes(res[offset : offset+fieldByteLen])
+		offset += fieldByteLen
 	}
 
 	return res


### PR DESCRIPTION
See the issue here: #645 

Change the original code:
```go
func (i *Commitment) SerializeCommitment(privateCommitment []byte, publicCommitted []*big.Int, fieldByteLen int) []byte {

	res := make([]byte, len(privateCommitment)+len(publicCommitted)*fieldByteLen)
	copy(res, privateCommitment)

	offset := len(privateCommitment)
	for j, inJ := range publicCommitted {
		offset += j * fieldByteLen
		inJ.FillBytes(res[offset : offset+fieldByteLen])
	}

	return res
}
```

to

```go
func (i *Commitment) SerializeCommitment(privateCommitment []byte, publicCommitted []*big.Int, fieldByteLen int) []byte {

	res := make([]byte, len(privateCommitment)+len(publicCommitted)*fieldByteLen)
	copy(res, privateCommitment)

	offset := len(privateCommitment)
	for _, inJ := range publicCommitted {
		inJ.FillBytes(res[offset : offset+fieldByteLen])
		offset += fieldByteLen
	}

	return res
}
```