### PR TITLE
feat: differentiate ecrecover with strict and lax check for s

### DIFF
--- a/std/evmprecompiles/01-ecrecover.go
+++ b/std/evmprecompiles/01-ecrecover.go
@@ -2,6 +2,7 @@ package evmprecompiles
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
@@ -13,7 +14,8 @@ import (
 //
 // [ECRECOVER]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/ecrecover/index.html
 func ECRecover(api frontend.API, msg emulated.Element[emulated.Secp256k1Fr],
-	v frontend.Variable, r, s emulated.Element[emulated.Secp256k1Fr]) *sw_emulated.AffinePoint[emulated.Secp256k1Fp] {
+	v frontend.Variable, r, s emulated.Element[emulated.Secp256k1Fr],
+	strictRange frontend.Variable) *sw_emulated.AffinePoint[emulated.Secp256k1Fp] {
 	// EVM uses v \in {27, 28}, but everyone else v >= 0. Convert back
 	v = api.Sub(v, 27)
 	var emfp emulated.Secp256k1Fp
@@ -28,7 +30,14 @@ func ECRecover(api frontend.API, msg emulated.Element[emulated.Secp256k1Fr],
 	}
 	// with the encoding we may have that r,s < 2*Fr (i.e. not r,s < Fr). Apply more thorough checks.
 	frField.AssertIsLessOrEqual(&r, frField.Modulus())
-	frField.AssertIsLessOrEqual(&s, frField.Modulus())
+	// Ethereum Yellow Paper defines that the check for s should be more strict
+	// when checking transaction signatures (Appendix F). There we should check
+	// that s <= (Fr-1)/2
+	halfFr := new(big.Int).Sub(emfr.Modulus(), big.NewInt(1))
+	halfFr.Div(halfFr, big.NewInt(2))
+	bound := frField.Select(strictRange, frField.NewElement(halfFr), frField.Modulus())
+	frField.AssertIsLessOrEqual(&s, bound)
+
 	curve, err := sw_emulated.New[emulated.Secp256k1Fp, emulated.Secp256k1Fr](api, sw_emulated.GetSecp256k1Params())
 	if err != nil {
 		panic(fmt.Sprintf("new curve: %v", err))

--- a/std/evmprecompiles/01-ecrecover_test.go
+++ b/std/evmprecompiles/01-ecrecover_test.go
@@ -3,6 +3,7 @@ package evmprecompiles
 import (
 	"crypto/rand"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -44,6 +45,7 @@ type ecrecoverCircuit struct {
 	V        frontend.Variable
 	R        emulated.Element[emulated.Secp256k1Fr]
 	S        emulated.Element[emulated.Secp256k1Fr]
+	Strict   frontend.Variable
 	Expected sw_emulated.AffinePoint[emulated.Secp256k1Fp]
 }
 
@@ -52,21 +54,35 @@ func (c *ecrecoverCircuit) Define(api frontend.API) error {
 	if err != nil {
 		return fmt.Errorf("new curve: %w", err)
 	}
-	res := ECRecover(api, c.Message, c.V, c.R, c.S)
+	res := ECRecover(api, c.Message, c.V, c.R, c.S, c.Strict)
 	curve.AssertIsEqual(&c.Expected, res)
 	return nil
 }
 
-func testRoutineECRecover(t *testing.T) (circ, wit frontend.Circuit) {
+func testRoutineECRecover(t *testing.T, wantStrict bool) (circ, wit *ecrecoverCircuit, largeS bool) {
+	halfFr := new(big.Int).Sub(fr.Modulus(), big.NewInt(1))
+	halfFr.Div(halfFr, big.NewInt(2))
+
 	sk, err := ecdsa.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal("generate", err)
 	}
 	pk := sk.PublicKey
 	msg := []byte("test")
-	v, r, s, err := sk.SignForRecover(msg, nil)
-	if err != nil {
-		t.Fatal("sign", err)
+	var r, s *big.Int
+	var v uint
+	for {
+		v, r, s, err = sk.SignForRecover(msg, nil)
+		if err != nil {
+			t.Fatal("sign", err)
+		}
+		if !wantStrict || halfFr.Cmp(s) > 0 {
+			break
+		}
+	}
+	strict := 0
+	if wantStrict {
+		strict = 1
 	}
 	circuit := ecrecoverCircuit{}
 	witness := ecrecoverCircuit{
@@ -74,25 +90,50 @@ func testRoutineECRecover(t *testing.T) (circ, wit frontend.Circuit) {
 		V:       v + 27, // EVM constant
 		R:       emulated.ValueOf[emulated.Secp256k1Fr](r),
 		S:       emulated.ValueOf[emulated.Secp256k1Fr](s),
+		Strict:  strict,
 		Expected: sw_emulated.AffinePoint[emulated.Secp256k1Fp]{
 			X: emulated.ValueOf[emulated.Secp256k1Fp](pk.A.X),
 			Y: emulated.ValueOf[emulated.Secp256k1Fp](pk.A.Y),
 		},
 	}
-	return &circuit, &witness
+	return &circuit, &witness, halfFr.Cmp(s) <= 0
 }
 
-func TestECRecoverCircuitShort(t *testing.T) {
+func TestECRecoverCircuitShortStrict(t *testing.T) {
 	assert := test.NewAssert(t)
-	circuit, witness := testRoutineECRecover(t)
+	circuit, witness, _ := testRoutineECRecover(t, true)
 	err := test.IsSolved(circuit, witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
+}
+
+func TestECRecoverCircuitShortLax(t *testing.T) {
+	assert := test.NewAssert(t)
+	circuit, witness, _ := testRoutineECRecover(t, false)
+	err := test.IsSolved(circuit, witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}
+
+func TestECRecoverCircuitShortMismatch(t *testing.T) {
+	assert := test.NewAssert(t)
+	halfFr := new(big.Int).Sub(fr.Modulus(), big.NewInt(1))
+	halfFr.Div(halfFr, big.NewInt(2))
+	var circuit, witness *ecrecoverCircuit
+	var largeS bool
+	for {
+		circuit, witness, largeS = testRoutineECRecover(t, false)
+		if largeS {
+			witness.Strict = 1
+			break
+		}
+	}
+	err := test.IsSolved(circuit, witness, ecc.BN254.ScalarField())
+	assert.Error(err)
 }
 
 func TestECRecoverCircuitFull(t *testing.T) {
 	t.Skip("skipping very long test")
 	assert := test.NewAssert(t)
-	circuit, witness := testRoutineECRecover(t)
+	circuit, witness, _ := testRoutineECRecover(t, false)
 	assert.ProverSucceeded(circuit, witness,
 		test.NoFuzzing(), test.NoSerialization(),
 		test.WithBackends(backend.GROTH16, backend.PLONK), test.WithCurves(ecc.BN254),


### PR DESCRIPTION
Ethereum Yellow paper defines two initial conditions for ECRecover:
* in case of checking transaction signatures, `s` should be `s < N+2 + 1`
* in case of ECREC precompile, `s` should be `s < N`.

This PR updates the current precompile method which takes additional variable which defines the upper bound to compare s against. Also added test cases (strict check, lax check, assumed failure).

This is based on top of `fix/ecdsa-v` which depends on update in gnark-crypto. So have to wait for other PRs being merged before can merge this one.

CC: @AlexandreBelling, @OlivierBBB -- can you confirm this behaviour is good?