### PR TITLE
perf(ecdsa): JoinScalarMulBase avoids 0 edge-cases

### DIFF
--- a/std/evmprecompiles/01-ecrecover.go
+++ b/std/evmprecompiles/01-ecrecover.go
@@ -71,9 +71,7 @@ func ECRecover(api frontend.API, msg emulated.Element[emulated.Secp256k1Fr],
 	// compute u2 = s * rinv
 	u2 := frField.MulMod(&s, rinv)
 	// check u1 * G + u2 R == P
-	A := curve.ScalarMulBase(u1)
-	B := curve.ScalarMul(&R, u2)
-	C := curve.AddUnified(A, B)
+	C := curve.JointScalarMulBase(&R, u2, u1)
 	curve.AssertIsEqual(C, &P)
 	return &P
 }

--- a/std/signature/ecdsa/ecdsa.go
+++ b/std/signature/ecdsa/ecdsa.go
@@ -50,9 +50,8 @@ func (pk PublicKey[T, S]) Verify(api frontend.API, params sw_emulated.CurveParam
 	msInv := scalarApi.MulMod(msg, sInv)
 	rsInv := scalarApi.MulMod(&sig.R, sInv)
 
-	qa := cr.ScalarMulBase(msInv)
-	qb := cr.ScalarMul(&pkpt, rsInv)
-	q := cr.AddUnified(qa, qb)
+	// q = [rsInv]pkpt + [msInv]g
+	q := cr.JointScalarMulBase(&pkpt, rsInv, msInv)
 	qx := baseApi.Reduce(&q.X)
 	qxBits := baseApi.ToBits(qx)
 	rbits := scalarApi.ToBits(&sig.R)


### PR DESCRIPTION
In ECDSA verification (or ECRecover), we compute `[r/s]pubKey + [h/s]g` where `(r,s)` is the signature, `h` the hash of the message and `g` the canonical generator of the subgroup. Previously, we took into consideration the edge cases where either or both `r` and `h` can be 0 and also `pubKey=(0,0)`, but the [EYP](https://ethereum.github.io/yellowpaper/paper.pdf) rules out these:

- `s ≠ 0` and `r ≠ 0`

<img width="729" alt="image" src="https://user-images.githubusercontent.com/16170090/234554978-e21a3673-9955-46bf-994f-872e91d37528.png">

- `pubKey ≠ (0,0)` (because private key `≠ 0`)

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/16170090/234555732-f69c5b02-5c02-4fb2-897c-bd95b038884d.png">


The PR introduces the `JointScalarMulBase` method which performs `[s1]p1 + [s2]g` assuming that `s1` and `s2` are nonzero and `p1` not the infinity `(0,0)`. This saves ~17k constraints in ECDSA verifier gadget.

