### PR TITLE
Reduce Commitment Info In Verifying Keys

### DIFF
--- a/backend/groth16/bls12-377/commitment.go
+++ b/backend/groth16/bls12-377/commitment.go
@@ -23,7 +23,7 @@ import (
 	"math/big"
 )
 
-func solveCommitmentWire(commitmentInfo *constraint.Commitment, commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
-	res, err := fr.Hash(commitmentInfo.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
+func solveCommitmentWire(commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
+	res, err := fr.Hash(constraint.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
 	return res[0], err
 }

--- a/backend/groth16/bls12-377/prove.go
+++ b/backend/groth16/bls12-377/prove.go
@@ -65,14 +65,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
 
-	if r1cs.CommitmentInfo.Is() {
-		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo.HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+	if r1cs.HasCommitment() {
+		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo[0].HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
 			// Perf-TODO: Converting these values to big.Int and back may be a performance bottleneck.
 			// If that is the case, figure out a way to feed the solution vector into this function
-			if len(in) != r1cs.CommitmentInfo.NbCommitted() { // TODO: Remove
+			if len(in) != r1cs.CommitmentInfo[0].NbCommitted() { // TODO: Remove
 				return fmt.Errorf("unexpected number of committed variables")
 			}
-			values := make([]fr.Element, r1cs.CommitmentInfo.NbPrivateCommitted)
+			values := make([]fr.Element, r1cs.CommitmentInfo[0].NbPrivateCommitted)
 			nbPublicCommitted := len(in) - len(values)
 			inPrivate := in[nbPublicCommitted:]
 			for i, inI := range inPrivate {
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo[0].NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))
@@ -202,8 +202,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			chKrs2Done <- err
 		}()
 
-		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
+		// filter the wire values if needed
+		_wireValues := wireValues
+		if r1cs.HasCommitment() {
+			_wireValues = filter(wireValues, r1cs.CommitmentInfo[0].PrivateToPublicGroth16())
+		}
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bls12-377/prove.go
+++ b/backend/groth16/bls12-377/prove.go
@@ -203,7 +203,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		}()
 
 		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublic())
+		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bls12-377/prove.go
+++ b/backend/groth16/bls12-377/prove.go
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&r1cs.CommitmentInfo, &proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))

--- a/backend/groth16/bls12-377/setup.go
+++ b/backend/groth16/bls12-377/setup.go
@@ -75,8 +75,9 @@ type VerifyingKey struct {
 	// e(α, β)
 	e curve.GT // not serialized
 
-	CommitmentKey  pedersen.VerifyingKey
-	CommitmentInfo constraint.Commitment // since the verifier doesn't input a constraint system, this needs to be provided here
+	CommitmentKey   pedersen.VerifyingKey
+	HasCommitment   bool  // TODO: Make CommitmentKey nullable instead
+	PublicCommitted []int // indexes of public committed variables
 }
 
 // Setup constructs the SRS
@@ -262,7 +263,8 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.CommitmentInfo = r1cs.CommitmentInfo // unfortunate but necessary
+	vk.HasCommitment = r1cs.CommitmentInfo.Is()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls12-377/setup.go
+++ b/backend/groth16/bls12-377/setup.go
@@ -264,7 +264,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls12-377/setup.go
+++ b/backend/groth16/bls12-377/setup.go
@@ -94,11 +94,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// get R1CS nb constraints, wires and public/private inputs
 	nbWires := r1cs.NbInternalVariables + r1cs.GetNbPublicVariables() + r1cs.GetNbSecretVariables()
-	nbPrivateCommittedWires := r1cs.CommitmentInfo.NbPrivateCommitted
+	nbPrivateCommittedWires := 0
+	if r1cs.HasCommitment() {
+		nbPrivateCommittedWires = r1cs.CommitmentInfo[0].NbPrivateCommitted
+	}
 	nbPublicWires := r1cs.GetNbPublicVariables()
 	nbPrivateWires := r1cs.GetNbSecretVariables() + r1cs.NbInternalVariables - nbPrivateCommittedWires
 
-	if r1cs.CommitmentInfo.Is() { // the commitment itself is defined by a hint so the prover considers it private
+	if r1cs.HasCommitment() { // the commitment itself is defined by a hint so the prover considers it private
 		nbPublicWires++  // but the verifier will need to inject the value itself so on the groth16
 		nbPrivateWires-- // level it must be considered public
 	}
@@ -151,11 +154,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vI, cI := 0, 0
-	privateCommitted := r1cs.CommitmentInfo.PrivateCommitted()
+	var privateCommitted []int
+	if r1cs.HasCommitment() {
+		privateCommitted = r1cs.CommitmentInfo[0].PrivateCommitted()
+	}
 
 	for i := range A {
 		isCommittedPrivate := cI < len(privateCommitted) && i == privateCommitted[cI]
-		isCommitment := r1cs.CommitmentInfo.Is() && i == r1cs.CommitmentInfo.CommitmentIndex
+		isCommitment := r1cs.HasCommitment() && i == r1cs.CommitmentInfo[0].CommitmentIndex
 		isPublic := i < r1cs.GetNbPublicVariables()
 
 		if isPublic || isCommittedPrivate || isCommitment {
@@ -263,8 +269,9 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
+	if vk.HasCommitment = r1cs.HasCommitment(); vk.HasCommitment {
+		vk.PublicCommitted = r1cs.CommitmentInfo[0].PublicCommitted()
+	}
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls12-377/verify.go
+++ b/backend/groth16/bls12-377/verify.go
@@ -37,7 +37,7 @@ var (
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 	nbPublicVars := len(vk.G1.K)
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		nbPublicVars--
 	}
 	if len(publicWitness) != nbPublicVars-1 {
@@ -62,20 +62,20 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 		close(chDone)
 	}()
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 
 		if err := vk.CommitmentKey.Verify(proof.Commitment, proof.CommitmentPok); err != nil {
 			return err
 		}
 
-		publicCommitted := make([]*big.Int, vk.CommitmentInfo.NbPublicCommitted())
+		publicCommitted := make([]*big.Int, len(vk.PublicCommitted))
 		for i := range publicCommitted {
 			var b big.Int
-			publicWitness[vk.CommitmentInfo.Committed[i]-1].BigInt(&b)
+			publicWitness[vk.PublicCommitted[i]-1].BigInt(&b)
 			publicCommitted[i] = &b
 		}
 
-		if res, err := solveCommitmentWire(&vk.CommitmentInfo, &proof.Commitment, publicCommitted); err == nil {
+		if res, err := solveCommitmentWire(&proof.Commitment, publicCommitted); err == nil {
 			publicWitness = append(publicWitness, res)
 		}
 	}
@@ -87,7 +87,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 	}
 	kSum.AddMixed(&vk.G1.K[0])
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		kSum.AddMixed(&proof.Commitment)
 	}
 

--- a/backend/groth16/bls12-381/commitment.go
+++ b/backend/groth16/bls12-381/commitment.go
@@ -23,7 +23,7 @@ import (
 	"math/big"
 )
 
-func solveCommitmentWire(commitmentInfo *constraint.Commitment, commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
-	res, err := fr.Hash(commitmentInfo.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
+func solveCommitmentWire(commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
+	res, err := fr.Hash(constraint.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
 	return res[0], err
 }

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -65,14 +65,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
 
-	if r1cs.CommitmentInfo.Is() {
-		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo.HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+	if r1cs.HasCommitment() {
+		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo[0].HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
 			// Perf-TODO: Converting these values to big.Int and back may be a performance bottleneck.
 			// If that is the case, figure out a way to feed the solution vector into this function
-			if len(in) != r1cs.CommitmentInfo.NbCommitted() { // TODO: Remove
+			if len(in) != r1cs.CommitmentInfo[0].NbCommitted() { // TODO: Remove
 				return fmt.Errorf("unexpected number of committed variables")
 			}
-			values := make([]fr.Element, r1cs.CommitmentInfo.NbPrivateCommitted)
+			values := make([]fr.Element, r1cs.CommitmentInfo[0].NbPrivateCommitted)
 			nbPublicCommitted := len(in) - len(values)
 			inPrivate := in[nbPublicCommitted:]
 			for i, inI := range inPrivate {
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo[0].NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))
@@ -202,8 +202,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			chKrs2Done <- err
 		}()
 
-		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
+		// filter the wire values if needed
+		_wireValues := wireValues
+		if r1cs.HasCommitment() {
+			_wireValues = filter(wireValues, r1cs.CommitmentInfo[0].PrivateToPublicGroth16())
+		}
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -203,7 +203,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		}()
 
 		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublic())
+		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&r1cs.CommitmentInfo, &proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))

--- a/backend/groth16/bls12-381/setup.go
+++ b/backend/groth16/bls12-381/setup.go
@@ -75,8 +75,9 @@ type VerifyingKey struct {
 	// e(α, β)
 	e curve.GT // not serialized
 
-	CommitmentKey  pedersen.VerifyingKey
-	CommitmentInfo constraint.Commitment // since the verifier doesn't input a constraint system, this needs to be provided here
+	CommitmentKey   pedersen.VerifyingKey
+	HasCommitment   bool  // TODO: Make CommitmentKey nullable instead
+	PublicCommitted []int // indexes of public committed variables
 }
 
 // Setup constructs the SRS
@@ -262,7 +263,8 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.CommitmentInfo = r1cs.CommitmentInfo // unfortunate but necessary
+	vk.HasCommitment = r1cs.CommitmentInfo.Is()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls12-381/setup.go
+++ b/backend/groth16/bls12-381/setup.go
@@ -264,7 +264,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls12-381/setup.go
+++ b/backend/groth16/bls12-381/setup.go
@@ -94,11 +94,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// get R1CS nb constraints, wires and public/private inputs
 	nbWires := r1cs.NbInternalVariables + r1cs.GetNbPublicVariables() + r1cs.GetNbSecretVariables()
-	nbPrivateCommittedWires := r1cs.CommitmentInfo.NbPrivateCommitted
+	nbPrivateCommittedWires := 0
+	if r1cs.HasCommitment() {
+		nbPrivateCommittedWires = r1cs.CommitmentInfo[0].NbPrivateCommitted
+	}
 	nbPublicWires := r1cs.GetNbPublicVariables()
 	nbPrivateWires := r1cs.GetNbSecretVariables() + r1cs.NbInternalVariables - nbPrivateCommittedWires
 
-	if r1cs.CommitmentInfo.Is() { // the commitment itself is defined by a hint so the prover considers it private
+	if r1cs.HasCommitment() { // the commitment itself is defined by a hint so the prover considers it private
 		nbPublicWires++  // but the verifier will need to inject the value itself so on the groth16
 		nbPrivateWires-- // level it must be considered public
 	}
@@ -151,11 +154,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vI, cI := 0, 0
-	privateCommitted := r1cs.CommitmentInfo.PrivateCommitted()
+	var privateCommitted []int
+	if r1cs.HasCommitment() {
+		privateCommitted = r1cs.CommitmentInfo[0].PrivateCommitted()
+	}
 
 	for i := range A {
 		isCommittedPrivate := cI < len(privateCommitted) && i == privateCommitted[cI]
-		isCommitment := r1cs.CommitmentInfo.Is() && i == r1cs.CommitmentInfo.CommitmentIndex
+		isCommitment := r1cs.HasCommitment() && i == r1cs.CommitmentInfo[0].CommitmentIndex
 		isPublic := i < r1cs.GetNbPublicVariables()
 
 		if isPublic || isCommittedPrivate || isCommitment {
@@ -263,8 +269,9 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
+	if vk.HasCommitment = r1cs.HasCommitment(); vk.HasCommitment {
+		vk.PublicCommitted = r1cs.CommitmentInfo[0].PublicCommitted()
+	}
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls12-381/verify.go
+++ b/backend/groth16/bls12-381/verify.go
@@ -37,7 +37,7 @@ var (
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 	nbPublicVars := len(vk.G1.K)
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		nbPublicVars--
 	}
 	if len(publicWitness) != nbPublicVars-1 {
@@ -62,20 +62,20 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 		close(chDone)
 	}()
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 
 		if err := vk.CommitmentKey.Verify(proof.Commitment, proof.CommitmentPok); err != nil {
 			return err
 		}
 
-		publicCommitted := make([]*big.Int, vk.CommitmentInfo.NbPublicCommitted())
+		publicCommitted := make([]*big.Int, len(vk.PublicCommitted))
 		for i := range publicCommitted {
 			var b big.Int
-			publicWitness[vk.CommitmentInfo.Committed[i]-1].BigInt(&b)
+			publicWitness[vk.PublicCommitted[i]-1].BigInt(&b)
 			publicCommitted[i] = &b
 		}
 
-		if res, err := solveCommitmentWire(&vk.CommitmentInfo, &proof.Commitment, publicCommitted); err == nil {
+		if res, err := solveCommitmentWire(&proof.Commitment, publicCommitted); err == nil {
 			publicWitness = append(publicWitness, res)
 		}
 	}
@@ -87,7 +87,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 	}
 	kSum.AddMixed(&vk.G1.K[0])
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		kSum.AddMixed(&proof.Commitment)
 	}
 

--- a/backend/groth16/bls24-315/commitment.go
+++ b/backend/groth16/bls24-315/commitment.go
@@ -23,7 +23,7 @@ import (
 	"math/big"
 )
 
-func solveCommitmentWire(commitmentInfo *constraint.Commitment, commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
-	res, err := fr.Hash(commitmentInfo.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
+func solveCommitmentWire(commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
+	res, err := fr.Hash(constraint.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
 	return res[0], err
 }

--- a/backend/groth16/bls24-315/prove.go
+++ b/backend/groth16/bls24-315/prove.go
@@ -65,14 +65,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
 
-	if r1cs.CommitmentInfo.Is() {
-		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo.HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+	if r1cs.HasCommitment() {
+		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo[0].HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
 			// Perf-TODO: Converting these values to big.Int and back may be a performance bottleneck.
 			// If that is the case, figure out a way to feed the solution vector into this function
-			if len(in) != r1cs.CommitmentInfo.NbCommitted() { // TODO: Remove
+			if len(in) != r1cs.CommitmentInfo[0].NbCommitted() { // TODO: Remove
 				return fmt.Errorf("unexpected number of committed variables")
 			}
-			values := make([]fr.Element, r1cs.CommitmentInfo.NbPrivateCommitted)
+			values := make([]fr.Element, r1cs.CommitmentInfo[0].NbPrivateCommitted)
 			nbPublicCommitted := len(in) - len(values)
 			inPrivate := in[nbPublicCommitted:]
 			for i, inI := range inPrivate {
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo[0].NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))
@@ -202,8 +202,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			chKrs2Done <- err
 		}()
 
-		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
+		// filter the wire values if needed
+		_wireValues := wireValues
+		if r1cs.HasCommitment() {
+			_wireValues = filter(wireValues, r1cs.CommitmentInfo[0].PrivateToPublicGroth16())
+		}
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bls24-315/prove.go
+++ b/backend/groth16/bls24-315/prove.go
@@ -203,7 +203,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		}()
 
 		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublic())
+		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bls24-315/prove.go
+++ b/backend/groth16/bls24-315/prove.go
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&r1cs.CommitmentInfo, &proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))

--- a/backend/groth16/bls24-315/setup.go
+++ b/backend/groth16/bls24-315/setup.go
@@ -75,8 +75,9 @@ type VerifyingKey struct {
 	// e(α, β)
 	e curve.GT // not serialized
 
-	CommitmentKey  pedersen.VerifyingKey
-	CommitmentInfo constraint.Commitment // since the verifier doesn't input a constraint system, this needs to be provided here
+	CommitmentKey   pedersen.VerifyingKey
+	HasCommitment   bool  // TODO: Make CommitmentKey nullable instead
+	PublicCommitted []int // indexes of public committed variables
 }
 
 // Setup constructs the SRS
@@ -262,7 +263,8 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.CommitmentInfo = r1cs.CommitmentInfo // unfortunate but necessary
+	vk.HasCommitment = r1cs.CommitmentInfo.Is()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls24-315/setup.go
+++ b/backend/groth16/bls24-315/setup.go
@@ -264,7 +264,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls24-315/setup.go
+++ b/backend/groth16/bls24-315/setup.go
@@ -94,11 +94,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// get R1CS nb constraints, wires and public/private inputs
 	nbWires := r1cs.NbInternalVariables + r1cs.GetNbPublicVariables() + r1cs.GetNbSecretVariables()
-	nbPrivateCommittedWires := r1cs.CommitmentInfo.NbPrivateCommitted
+	nbPrivateCommittedWires := 0
+	if r1cs.HasCommitment() {
+		nbPrivateCommittedWires = r1cs.CommitmentInfo[0].NbPrivateCommitted
+	}
 	nbPublicWires := r1cs.GetNbPublicVariables()
 	nbPrivateWires := r1cs.GetNbSecretVariables() + r1cs.NbInternalVariables - nbPrivateCommittedWires
 
-	if r1cs.CommitmentInfo.Is() { // the commitment itself is defined by a hint so the prover considers it private
+	if r1cs.HasCommitment() { // the commitment itself is defined by a hint so the prover considers it private
 		nbPublicWires++  // but the verifier will need to inject the value itself so on the groth16
 		nbPrivateWires-- // level it must be considered public
 	}
@@ -151,11 +154,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vI, cI := 0, 0
-	privateCommitted := r1cs.CommitmentInfo.PrivateCommitted()
+	var privateCommitted []int
+	if r1cs.HasCommitment() {
+		privateCommitted = r1cs.CommitmentInfo[0].PrivateCommitted()
+	}
 
 	for i := range A {
 		isCommittedPrivate := cI < len(privateCommitted) && i == privateCommitted[cI]
-		isCommitment := r1cs.CommitmentInfo.Is() && i == r1cs.CommitmentInfo.CommitmentIndex
+		isCommitment := r1cs.HasCommitment() && i == r1cs.CommitmentInfo[0].CommitmentIndex
 		isPublic := i < r1cs.GetNbPublicVariables()
 
 		if isPublic || isCommittedPrivate || isCommitment {
@@ -263,8 +269,9 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
+	if vk.HasCommitment = r1cs.HasCommitment(); vk.HasCommitment {
+		vk.PublicCommitted = r1cs.CommitmentInfo[0].PublicCommitted()
+	}
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls24-315/verify.go
+++ b/backend/groth16/bls24-315/verify.go
@@ -37,7 +37,7 @@ var (
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 	nbPublicVars := len(vk.G1.K)
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		nbPublicVars--
 	}
 	if len(publicWitness) != nbPublicVars-1 {
@@ -62,20 +62,20 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 		close(chDone)
 	}()
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 
 		if err := vk.CommitmentKey.Verify(proof.Commitment, proof.CommitmentPok); err != nil {
 			return err
 		}
 
-		publicCommitted := make([]*big.Int, vk.CommitmentInfo.NbPublicCommitted())
+		publicCommitted := make([]*big.Int, len(vk.PublicCommitted))
 		for i := range publicCommitted {
 			var b big.Int
-			publicWitness[vk.CommitmentInfo.Committed[i]-1].BigInt(&b)
+			publicWitness[vk.PublicCommitted[i]-1].BigInt(&b)
 			publicCommitted[i] = &b
 		}
 
-		if res, err := solveCommitmentWire(&vk.CommitmentInfo, &proof.Commitment, publicCommitted); err == nil {
+		if res, err := solveCommitmentWire(&proof.Commitment, publicCommitted); err == nil {
 			publicWitness = append(publicWitness, res)
 		}
 	}
@@ -87,7 +87,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 	}
 	kSum.AddMixed(&vk.G1.K[0])
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		kSum.AddMixed(&proof.Commitment)
 	}
 

--- a/backend/groth16/bls24-317/commitment.go
+++ b/backend/groth16/bls24-317/commitment.go
@@ -23,7 +23,7 @@ import (
 	"math/big"
 )
 
-func solveCommitmentWire(commitmentInfo *constraint.Commitment, commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
-	res, err := fr.Hash(commitmentInfo.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
+func solveCommitmentWire(commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
+	res, err := fr.Hash(constraint.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
 	return res[0], err
 }

--- a/backend/groth16/bls24-317/prove.go
+++ b/backend/groth16/bls24-317/prove.go
@@ -65,14 +65,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
 
-	if r1cs.CommitmentInfo.Is() {
-		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo.HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+	if r1cs.HasCommitment() {
+		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo[0].HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
 			// Perf-TODO: Converting these values to big.Int and back may be a performance bottleneck.
 			// If that is the case, figure out a way to feed the solution vector into this function
-			if len(in) != r1cs.CommitmentInfo.NbCommitted() { // TODO: Remove
+			if len(in) != r1cs.CommitmentInfo[0].NbCommitted() { // TODO: Remove
 				return fmt.Errorf("unexpected number of committed variables")
 			}
-			values := make([]fr.Element, r1cs.CommitmentInfo.NbPrivateCommitted)
+			values := make([]fr.Element, r1cs.CommitmentInfo[0].NbPrivateCommitted)
 			nbPublicCommitted := len(in) - len(values)
 			inPrivate := in[nbPublicCommitted:]
 			for i, inI := range inPrivate {
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo[0].NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))
@@ -202,8 +202,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			chKrs2Done <- err
 		}()
 
-		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
+		// filter the wire values if needed
+		_wireValues := wireValues
+		if r1cs.HasCommitment() {
+			_wireValues = filter(wireValues, r1cs.CommitmentInfo[0].PrivateToPublicGroth16())
+		}
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bls24-317/prove.go
+++ b/backend/groth16/bls24-317/prove.go
@@ -203,7 +203,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		}()
 
 		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublic())
+		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bls24-317/prove.go
+++ b/backend/groth16/bls24-317/prove.go
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&r1cs.CommitmentInfo, &proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))

--- a/backend/groth16/bls24-317/setup.go
+++ b/backend/groth16/bls24-317/setup.go
@@ -75,8 +75,9 @@ type VerifyingKey struct {
 	// e(α, β)
 	e curve.GT // not serialized
 
-	CommitmentKey  pedersen.VerifyingKey
-	CommitmentInfo constraint.Commitment // since the verifier doesn't input a constraint system, this needs to be provided here
+	CommitmentKey   pedersen.VerifyingKey
+	HasCommitment   bool  // TODO: Make CommitmentKey nullable instead
+	PublicCommitted []int // indexes of public committed variables
 }
 
 // Setup constructs the SRS
@@ -262,7 +263,8 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.CommitmentInfo = r1cs.CommitmentInfo // unfortunate but necessary
+	vk.HasCommitment = r1cs.CommitmentInfo.Is()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls24-317/setup.go
+++ b/backend/groth16/bls24-317/setup.go
@@ -264,7 +264,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls24-317/setup.go
+++ b/backend/groth16/bls24-317/setup.go
@@ -94,11 +94,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// get R1CS nb constraints, wires and public/private inputs
 	nbWires := r1cs.NbInternalVariables + r1cs.GetNbPublicVariables() + r1cs.GetNbSecretVariables()
-	nbPrivateCommittedWires := r1cs.CommitmentInfo.NbPrivateCommitted
+	nbPrivateCommittedWires := 0
+	if r1cs.HasCommitment() {
+		nbPrivateCommittedWires = r1cs.CommitmentInfo[0].NbPrivateCommitted
+	}
 	nbPublicWires := r1cs.GetNbPublicVariables()
 	nbPrivateWires := r1cs.GetNbSecretVariables() + r1cs.NbInternalVariables - nbPrivateCommittedWires
 
-	if r1cs.CommitmentInfo.Is() { // the commitment itself is defined by a hint so the prover considers it private
+	if r1cs.HasCommitment() { // the commitment itself is defined by a hint so the prover considers it private
 		nbPublicWires++  // but the verifier will need to inject the value itself so on the groth16
 		nbPrivateWires-- // level it must be considered public
 	}
@@ -151,11 +154,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vI, cI := 0, 0
-	privateCommitted := r1cs.CommitmentInfo.PrivateCommitted()
+	var privateCommitted []int
+	if r1cs.HasCommitment() {
+		privateCommitted = r1cs.CommitmentInfo[0].PrivateCommitted()
+	}
 
 	for i := range A {
 		isCommittedPrivate := cI < len(privateCommitted) && i == privateCommitted[cI]
-		isCommitment := r1cs.CommitmentInfo.Is() && i == r1cs.CommitmentInfo.CommitmentIndex
+		isCommitment := r1cs.HasCommitment() && i == r1cs.CommitmentInfo[0].CommitmentIndex
 		isPublic := i < r1cs.GetNbPublicVariables()
 
 		if isPublic || isCommittedPrivate || isCommitment {
@@ -263,8 +269,9 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
+	if vk.HasCommitment = r1cs.HasCommitment(); vk.HasCommitment {
+		vk.PublicCommitted = r1cs.CommitmentInfo[0].PublicCommitted()
+	}
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bls24-317/verify.go
+++ b/backend/groth16/bls24-317/verify.go
@@ -37,7 +37,7 @@ var (
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 	nbPublicVars := len(vk.G1.K)
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		nbPublicVars--
 	}
 	if len(publicWitness) != nbPublicVars-1 {
@@ -62,20 +62,20 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 		close(chDone)
 	}()
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 
 		if err := vk.CommitmentKey.Verify(proof.Commitment, proof.CommitmentPok); err != nil {
 			return err
 		}
 
-		publicCommitted := make([]*big.Int, vk.CommitmentInfo.NbPublicCommitted())
+		publicCommitted := make([]*big.Int, len(vk.PublicCommitted))
 		for i := range publicCommitted {
 			var b big.Int
-			publicWitness[vk.CommitmentInfo.Committed[i]-1].BigInt(&b)
+			publicWitness[vk.PublicCommitted[i]-1].BigInt(&b)
 			publicCommitted[i] = &b
 		}
 
-		if res, err := solveCommitmentWire(&vk.CommitmentInfo, &proof.Commitment, publicCommitted); err == nil {
+		if res, err := solveCommitmentWire(&proof.Commitment, publicCommitted); err == nil {
 			publicWitness = append(publicWitness, res)
 		}
 	}
@@ -87,7 +87,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 	}
 	kSum.AddMixed(&vk.G1.K[0])
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		kSum.AddMixed(&proof.Commitment)
 	}
 

--- a/backend/groth16/bn254/commitment.go
+++ b/backend/groth16/bn254/commitment.go
@@ -23,7 +23,7 @@ import (
 	"math/big"
 )
 
-func solveCommitmentWire(commitmentInfo *constraint.Commitment, commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
-	res, err := fr.Hash(commitmentInfo.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
+func solveCommitmentWire(commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
+	res, err := fr.Hash(constraint.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
 	return res[0], err
 }

--- a/backend/groth16/bn254/prove.go
+++ b/backend/groth16/bn254/prove.go
@@ -65,14 +65,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
 
-	if r1cs.CommitmentInfo.Is() {
-		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo.HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+	if r1cs.HasCommitment() {
+		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo[0].HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
 			// Perf-TODO: Converting these values to big.Int and back may be a performance bottleneck.
 			// If that is the case, figure out a way to feed the solution vector into this function
-			if len(in) != r1cs.CommitmentInfo.NbCommitted() { // TODO: Remove
+			if len(in) != r1cs.CommitmentInfo[0].NbCommitted() { // TODO: Remove
 				return fmt.Errorf("unexpected number of committed variables")
 			}
-			values := make([]fr.Element, r1cs.CommitmentInfo.NbPrivateCommitted)
+			values := make([]fr.Element, r1cs.CommitmentInfo[0].NbPrivateCommitted)
 			nbPublicCommitted := len(in) - len(values)
 			inPrivate := in[nbPublicCommitted:]
 			for i, inI := range inPrivate {
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo[0].NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))
@@ -202,8 +202,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			chKrs2Done <- err
 		}()
 
-		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
+		// filter the wire values if needed
+		_wireValues := wireValues
+		if r1cs.HasCommitment() {
+			_wireValues = filter(wireValues, r1cs.CommitmentInfo[0].PrivateToPublicGroth16())
+		}
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bn254/prove.go
+++ b/backend/groth16/bn254/prove.go
@@ -203,7 +203,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		}()
 
 		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublic())
+		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bn254/prove.go
+++ b/backend/groth16/bn254/prove.go
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&r1cs.CommitmentInfo, &proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))

--- a/backend/groth16/bn254/setup.go
+++ b/backend/groth16/bn254/setup.go
@@ -75,8 +75,9 @@ type VerifyingKey struct {
 	// e(α, β)
 	e curve.GT // not serialized
 
-	CommitmentKey  pedersen.VerifyingKey
-	CommitmentInfo constraint.Commitment // since the verifier doesn't input a constraint system, this needs to be provided here
+	CommitmentKey   pedersen.VerifyingKey
+	HasCommitment   bool  // TODO: Make CommitmentKey nullable instead
+	PublicCommitted []int // indexes of public committed variables
 }
 
 // Setup constructs the SRS
@@ -262,7 +263,8 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.CommitmentInfo = r1cs.CommitmentInfo // unfortunate but necessary
+	vk.HasCommitment = r1cs.CommitmentInfo.Is()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bn254/setup.go
+++ b/backend/groth16/bn254/setup.go
@@ -264,7 +264,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bn254/setup.go
+++ b/backend/groth16/bn254/setup.go
@@ -94,11 +94,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// get R1CS nb constraints, wires and public/private inputs
 	nbWires := r1cs.NbInternalVariables + r1cs.GetNbPublicVariables() + r1cs.GetNbSecretVariables()
-	nbPrivateCommittedWires := r1cs.CommitmentInfo.NbPrivateCommitted
+	nbPrivateCommittedWires := 0
+	if r1cs.HasCommitment() {
+		nbPrivateCommittedWires = r1cs.CommitmentInfo[0].NbPrivateCommitted
+	}
 	nbPublicWires := r1cs.GetNbPublicVariables()
 	nbPrivateWires := r1cs.GetNbSecretVariables() + r1cs.NbInternalVariables - nbPrivateCommittedWires
 
-	if r1cs.CommitmentInfo.Is() { // the commitment itself is defined by a hint so the prover considers it private
+	if r1cs.HasCommitment() { // the commitment itself is defined by a hint so the prover considers it private
 		nbPublicWires++  // but the verifier will need to inject the value itself so on the groth16
 		nbPrivateWires-- // level it must be considered public
 	}
@@ -151,11 +154,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vI, cI := 0, 0
-	privateCommitted := r1cs.CommitmentInfo.PrivateCommitted()
+	var privateCommitted []int
+	if r1cs.HasCommitment() {
+		privateCommitted = r1cs.CommitmentInfo[0].PrivateCommitted()
+	}
 
 	for i := range A {
 		isCommittedPrivate := cI < len(privateCommitted) && i == privateCommitted[cI]
-		isCommitment := r1cs.CommitmentInfo.Is() && i == r1cs.CommitmentInfo.CommitmentIndex
+		isCommitment := r1cs.HasCommitment() && i == r1cs.CommitmentInfo[0].CommitmentIndex
 		isPublic := i < r1cs.GetNbPublicVariables()
 
 		if isPublic || isCommittedPrivate || isCommitment {
@@ -263,8 +269,9 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
+	if vk.HasCommitment = r1cs.HasCommitment(); vk.HasCommitment {
+		vk.PublicCommitted = r1cs.CommitmentInfo[0].PublicCommitted()
+	}
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bn254/verify.go
+++ b/backend/groth16/bn254/verify.go
@@ -38,7 +38,7 @@ var (
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 	nbPublicVars := len(vk.G1.K)
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		nbPublicVars--
 	}
 	if len(publicWitness) != nbPublicVars-1 {
@@ -63,20 +63,20 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 		close(chDone)
 	}()
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 
 		if err := vk.CommitmentKey.Verify(proof.Commitment, proof.CommitmentPok); err != nil {
 			return err
 		}
 
-		publicCommitted := make([]*big.Int, vk.CommitmentInfo.NbPublicCommitted())
+		publicCommitted := make([]*big.Int, len(vk.PublicCommitted))
 		for i := range publicCommitted {
 			var b big.Int
-			publicWitness[vk.CommitmentInfo.Committed[i]-1].BigInt(&b)
+			publicWitness[vk.PublicCommitted[i]-1].BigInt(&b)
 			publicCommitted[i] = &b
 		}
 
-		if res, err := solveCommitmentWire(&vk.CommitmentInfo, &proof.Commitment, publicCommitted); err == nil {
+		if res, err := solveCommitmentWire(&proof.Commitment, publicCommitted); err == nil {
 			publicWitness = append(publicWitness, res)
 		}
 	}
@@ -88,7 +88,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 	}
 	kSum.AddMixed(&vk.G1.K[0])
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		kSum.AddMixed(&proof.Commitment)
 	}
 

--- a/backend/groth16/bw6-633/commitment.go
+++ b/backend/groth16/bw6-633/commitment.go
@@ -23,7 +23,7 @@ import (
 	"math/big"
 )
 
-func solveCommitmentWire(commitmentInfo *constraint.Commitment, commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
-	res, err := fr.Hash(commitmentInfo.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
+func solveCommitmentWire(commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
+	res, err := fr.Hash(constraint.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
 	return res[0], err
 }

--- a/backend/groth16/bw6-633/prove.go
+++ b/backend/groth16/bw6-633/prove.go
@@ -65,14 +65,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
 
-	if r1cs.CommitmentInfo.Is() {
-		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo.HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+	if r1cs.HasCommitment() {
+		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo[0].HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
 			// Perf-TODO: Converting these values to big.Int and back may be a performance bottleneck.
 			// If that is the case, figure out a way to feed the solution vector into this function
-			if len(in) != r1cs.CommitmentInfo.NbCommitted() { // TODO: Remove
+			if len(in) != r1cs.CommitmentInfo[0].NbCommitted() { // TODO: Remove
 				return fmt.Errorf("unexpected number of committed variables")
 			}
-			values := make([]fr.Element, r1cs.CommitmentInfo.NbPrivateCommitted)
+			values := make([]fr.Element, r1cs.CommitmentInfo[0].NbPrivateCommitted)
 			nbPublicCommitted := len(in) - len(values)
 			inPrivate := in[nbPublicCommitted:]
 			for i, inI := range inPrivate {
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo[0].NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))
@@ -202,8 +202,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			chKrs2Done <- err
 		}()
 
-		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
+		// filter the wire values if needed
+		_wireValues := wireValues
+		if r1cs.HasCommitment() {
+			_wireValues = filter(wireValues, r1cs.CommitmentInfo[0].PrivateToPublicGroth16())
+		}
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bw6-633/prove.go
+++ b/backend/groth16/bw6-633/prove.go
@@ -203,7 +203,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		}()
 
 		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublic())
+		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bw6-633/prove.go
+++ b/backend/groth16/bw6-633/prove.go
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&r1cs.CommitmentInfo, &proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))

--- a/backend/groth16/bw6-633/setup.go
+++ b/backend/groth16/bw6-633/setup.go
@@ -75,8 +75,9 @@ type VerifyingKey struct {
 	// e(α, β)
 	e curve.GT // not serialized
 
-	CommitmentKey  pedersen.VerifyingKey
-	CommitmentInfo constraint.Commitment // since the verifier doesn't input a constraint system, this needs to be provided here
+	CommitmentKey   pedersen.VerifyingKey
+	HasCommitment   bool  // TODO: Make CommitmentKey nullable instead
+	PublicCommitted []int // indexes of public committed variables
 }
 
 // Setup constructs the SRS
@@ -262,7 +263,8 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.CommitmentInfo = r1cs.CommitmentInfo // unfortunate but necessary
+	vk.HasCommitment = r1cs.CommitmentInfo.Is()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bw6-633/setup.go
+++ b/backend/groth16/bw6-633/setup.go
@@ -264,7 +264,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bw6-633/setup.go
+++ b/backend/groth16/bw6-633/setup.go
@@ -94,11 +94,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// get R1CS nb constraints, wires and public/private inputs
 	nbWires := r1cs.NbInternalVariables + r1cs.GetNbPublicVariables() + r1cs.GetNbSecretVariables()
-	nbPrivateCommittedWires := r1cs.CommitmentInfo.NbPrivateCommitted
+	nbPrivateCommittedWires := 0
+	if r1cs.HasCommitment() {
+		nbPrivateCommittedWires = r1cs.CommitmentInfo[0].NbPrivateCommitted
+	}
 	nbPublicWires := r1cs.GetNbPublicVariables()
 	nbPrivateWires := r1cs.GetNbSecretVariables() + r1cs.NbInternalVariables - nbPrivateCommittedWires
 
-	if r1cs.CommitmentInfo.Is() { // the commitment itself is defined by a hint so the prover considers it private
+	if r1cs.HasCommitment() { // the commitment itself is defined by a hint so the prover considers it private
 		nbPublicWires++  // but the verifier will need to inject the value itself so on the groth16
 		nbPrivateWires-- // level it must be considered public
 	}
@@ -151,11 +154,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vI, cI := 0, 0
-	privateCommitted := r1cs.CommitmentInfo.PrivateCommitted()
+	var privateCommitted []int
+	if r1cs.HasCommitment() {
+		privateCommitted = r1cs.CommitmentInfo[0].PrivateCommitted()
+	}
 
 	for i := range A {
 		isCommittedPrivate := cI < len(privateCommitted) && i == privateCommitted[cI]
-		isCommitment := r1cs.CommitmentInfo.Is() && i == r1cs.CommitmentInfo.CommitmentIndex
+		isCommitment := r1cs.HasCommitment() && i == r1cs.CommitmentInfo[0].CommitmentIndex
 		isPublic := i < r1cs.GetNbPublicVariables()
 
 		if isPublic || isCommittedPrivate || isCommitment {
@@ -263,8 +269,9 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
+	if vk.HasCommitment = r1cs.HasCommitment(); vk.HasCommitment {
+		vk.PublicCommitted = r1cs.CommitmentInfo[0].PublicCommitted()
+	}
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bw6-633/verify.go
+++ b/backend/groth16/bw6-633/verify.go
@@ -37,7 +37,7 @@ var (
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 	nbPublicVars := len(vk.G1.K)
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		nbPublicVars--
 	}
 	if len(publicWitness) != nbPublicVars-1 {
@@ -62,20 +62,20 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 		close(chDone)
 	}()
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 
 		if err := vk.CommitmentKey.Verify(proof.Commitment, proof.CommitmentPok); err != nil {
 			return err
 		}
 
-		publicCommitted := make([]*big.Int, vk.CommitmentInfo.NbPublicCommitted())
+		publicCommitted := make([]*big.Int, len(vk.PublicCommitted))
 		for i := range publicCommitted {
 			var b big.Int
-			publicWitness[vk.CommitmentInfo.Committed[i]-1].BigInt(&b)
+			publicWitness[vk.PublicCommitted[i]-1].BigInt(&b)
 			publicCommitted[i] = &b
 		}
 
-		if res, err := solveCommitmentWire(&vk.CommitmentInfo, &proof.Commitment, publicCommitted); err == nil {
+		if res, err := solveCommitmentWire(&proof.Commitment, publicCommitted); err == nil {
 			publicWitness = append(publicWitness, res)
 		}
 	}
@@ -87,7 +87,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 	}
 	kSum.AddMixed(&vk.G1.K[0])
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		kSum.AddMixed(&proof.Commitment)
 	}
 

--- a/backend/groth16/bw6-761/commitment.go
+++ b/backend/groth16/bw6-761/commitment.go
@@ -23,7 +23,7 @@ import (
 	"math/big"
 )
 
-func solveCommitmentWire(commitmentInfo *constraint.Commitment, commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
-	res, err := fr.Hash(commitmentInfo.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
+func solveCommitmentWire(commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
+	res, err := fr.Hash(constraint.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
 	return res[0], err
 }

--- a/backend/groth16/bw6-761/prove.go
+++ b/backend/groth16/bw6-761/prove.go
@@ -65,14 +65,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
 
-	if r1cs.CommitmentInfo.Is() {
-		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo.HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+	if r1cs.HasCommitment() {
+		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo[0].HintID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
 			// Perf-TODO: Converting these values to big.Int and back may be a performance bottleneck.
 			// If that is the case, figure out a way to feed the solution vector into this function
-			if len(in) != r1cs.CommitmentInfo.NbCommitted() { // TODO: Remove
+			if len(in) != r1cs.CommitmentInfo[0].NbCommitted() { // TODO: Remove
 				return fmt.Errorf("unexpected number of committed variables")
 			}
-			values := make([]fr.Element, r1cs.CommitmentInfo.NbPrivateCommitted)
+			values := make([]fr.Element, r1cs.CommitmentInfo[0].NbPrivateCommitted)
 			nbPublicCommitted := len(in) - len(values)
 			inPrivate := in[nbPublicCommitted:]
 			for i, inI := range inPrivate {
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo[0].NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))
@@ -202,8 +202,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			chKrs2Done <- err
 		}()
 
-		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
+		// filter the wire values if needed
+		_wireValues := wireValues
+		if r1cs.HasCommitment() {
+			_wireValues = filter(wireValues, r1cs.CommitmentInfo[0].PrivateToPublicGroth16())
+		}
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bw6-761/prove.go
+++ b/backend/groth16/bw6-761/prove.go
@@ -203,7 +203,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		}()
 
 		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublic())
+		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/backend/groth16/bw6-761/prove.go
+++ b/backend/groth16/bw6-761/prove.go
@@ -86,7 +86,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&r1cs.CommitmentInfo, &proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		}))

--- a/backend/groth16/bw6-761/setup.go
+++ b/backend/groth16/bw6-761/setup.go
@@ -75,8 +75,9 @@ type VerifyingKey struct {
 	// e(α, β)
 	e curve.GT // not serialized
 
-	CommitmentKey  pedersen.VerifyingKey
-	CommitmentInfo constraint.Commitment // since the verifier doesn't input a constraint system, this needs to be provided here
+	CommitmentKey   pedersen.VerifyingKey
+	HasCommitment   bool  // TODO: Make CommitmentKey nullable instead
+	PublicCommitted []int // indexes of public committed variables
 }
 
 // Setup constructs the SRS
@@ -262,7 +263,8 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.CommitmentInfo = r1cs.CommitmentInfo // unfortunate but necessary
+	vk.HasCommitment = r1cs.CommitmentInfo.Is()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bw6-761/setup.go
+++ b/backend/groth16/bw6-761/setup.go
@@ -264,7 +264,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bw6-761/setup.go
+++ b/backend/groth16/bw6-761/setup.go
@@ -94,11 +94,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// get R1CS nb constraints, wires and public/private inputs
 	nbWires := r1cs.NbInternalVariables + r1cs.GetNbPublicVariables() + r1cs.GetNbSecretVariables()
-	nbPrivateCommittedWires := r1cs.CommitmentInfo.NbPrivateCommitted
+	nbPrivateCommittedWires := 0
+	if r1cs.HasCommitment() {
+		nbPrivateCommittedWires = r1cs.CommitmentInfo[0].NbPrivateCommitted
+	}
 	nbPublicWires := r1cs.GetNbPublicVariables()
 	nbPrivateWires := r1cs.GetNbSecretVariables() + r1cs.NbInternalVariables - nbPrivateCommittedWires
 
-	if r1cs.CommitmentInfo.Is() { // the commitment itself is defined by a hint so the prover considers it private
+	if r1cs.HasCommitment() { // the commitment itself is defined by a hint so the prover considers it private
 		nbPublicWires++  // but the verifier will need to inject the value itself so on the groth16
 		nbPrivateWires-- // level it must be considered public
 	}
@@ -151,11 +154,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vI, cI := 0, 0
-	privateCommitted := r1cs.CommitmentInfo.PrivateCommitted()
+	var privateCommitted []int
+	if r1cs.HasCommitment() {
+		privateCommitted = r1cs.CommitmentInfo[0].PrivateCommitted()
+	}
 
 	for i := range A {
 		isCommittedPrivate := cI < len(privateCommitted) && i == privateCommitted[cI]
-		isCommitment := r1cs.CommitmentInfo.Is() && i == r1cs.CommitmentInfo.CommitmentIndex
+		isCommitment := r1cs.HasCommitment() && i == r1cs.CommitmentInfo[0].CommitmentIndex
 		isPublic := i < r1cs.GetNbPublicVariables()
 
 		if isPublic || isCommittedPrivate || isCommitment {
@@ -263,8 +269,9 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
+	if vk.HasCommitment = r1cs.HasCommitment(); vk.HasCommitment {
+		vk.PublicCommitted = r1cs.CommitmentInfo[0].PublicCommitted()
+	}
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/backend/groth16/bw6-761/verify.go
+++ b/backend/groth16/bw6-761/verify.go
@@ -37,7 +37,7 @@ var (
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 	nbPublicVars := len(vk.G1.K)
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		nbPublicVars--
 	}
 	if len(publicWitness) != nbPublicVars-1 {
@@ -62,20 +62,20 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 		close(chDone)
 	}()
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 
 		if err := vk.CommitmentKey.Verify(proof.Commitment, proof.CommitmentPok); err != nil {
 			return err
 		}
 
-		publicCommitted := make([]*big.Int, vk.CommitmentInfo.NbPublicCommitted())
+		publicCommitted := make([]*big.Int, len(vk.PublicCommitted))
 		for i := range publicCommitted {
 			var b big.Int
-			publicWitness[vk.CommitmentInfo.Committed[i]-1].BigInt(&b)
+			publicWitness[vk.PublicCommitted[i]-1].BigInt(&b)
 			publicCommitted[i] = &b
 		}
 
-		if res, err := solveCommitmentWire(&vk.CommitmentInfo, &proof.Commitment, publicCommitted); err == nil {
+		if res, err := solveCommitmentWire(&proof.Commitment, publicCommitted); err == nil {
 			publicWitness = append(publicWitness, res)
 		}
 	}
@@ -87,7 +87,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 	}
 	kSum.AddMixed(&vk.G1.K[0])
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		kSum.AddMixed(&proof.Commitment)
 	}
 

--- a/backend/plonk/bls12-377/setup.go
+++ b/backend/plonk/bls12-377/setup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/kzg"
+	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bls12-377"
 )
 
@@ -121,9 +122,7 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	if spr.CommitmentInfo.Is() {
-		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
-	}
+	vk.CommitmentConstraintIndexes = constraint.CommitmentIndexes(spr.CommitmentInfo)
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains
@@ -249,8 +248,10 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		j++
 	}
 
-	for _, committed := range spr.CommitmentInfo.Committed {
-		qcp[offset+committed].SetOne()
+	if len(spr.CommitmentInfo) != 0 {
+		for _, committed := range spr.CommitmentInfo[0].Committed {
+			qcp[offset+committed].SetOne()
+		}
 	}
 
 	lagReg := iop.Form{Basis: iop.Lagrange, Layout: iop.Regular}

--- a/backend/plonk/bls12-381/setup.go
+++ b/backend/plonk/bls12-381/setup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/kzg"
+	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bls12-381"
 )
 
@@ -121,9 +122,7 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	if spr.CommitmentInfo.Is() {
-		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
-	}
+	vk.CommitmentConstraintIndexes = constraint.CommitmentIndexes(spr.CommitmentInfo)
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains
@@ -249,8 +248,10 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		j++
 	}
 
-	for _, committed := range spr.CommitmentInfo.Committed {
-		qcp[offset+committed].SetOne()
+	if len(spr.CommitmentInfo) != 0 {
+		for _, committed := range spr.CommitmentInfo[0].Committed {
+			qcp[offset+committed].SetOne()
+		}
 	}
 
 	lagReg := iop.Form{Basis: iop.Lagrange, Layout: iop.Regular}

--- a/backend/plonk/bls24-315/setup.go
+++ b/backend/plonk/bls24-315/setup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/kzg"
+	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bls24-315"
 )
 
@@ -121,9 +122,7 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	if spr.CommitmentInfo.Is() {
-		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
-	}
+	vk.CommitmentConstraintIndexes = constraint.CommitmentIndexes(spr.CommitmentInfo)
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains
@@ -249,8 +248,10 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		j++
 	}
 
-	for _, committed := range spr.CommitmentInfo.Committed {
-		qcp[offset+committed].SetOne()
+	if len(spr.CommitmentInfo) != 0 {
+		for _, committed := range spr.CommitmentInfo[0].Committed {
+			qcp[offset+committed].SetOne()
+		}
 	}
 
 	lagReg := iop.Form{Basis: iop.Lagrange, Layout: iop.Regular}

--- a/backend/plonk/bls24-317/setup.go
+++ b/backend/plonk/bls24-317/setup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/kzg"
+	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bls24-317"
 )
 
@@ -121,9 +122,7 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	if spr.CommitmentInfo.Is() {
-		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
-	}
+	vk.CommitmentConstraintIndexes = constraint.CommitmentIndexes(spr.CommitmentInfo)
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains
@@ -249,8 +248,10 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		j++
 	}
 
-	for _, committed := range spr.CommitmentInfo.Committed {
-		qcp[offset+committed].SetOne()
+	if len(spr.CommitmentInfo) != 0 {
+		for _, committed := range spr.CommitmentInfo[0].Committed {
+			qcp[offset+committed].SetOne()
+		}
 	}
 
 	lagReg := iop.Form{Basis: iop.Lagrange, Layout: iop.Regular}

--- a/backend/plonk/bn254/setup.go
+++ b/backend/plonk/bn254/setup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/kzg"
+	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bn254"
 )
 
@@ -121,9 +122,7 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	if spr.CommitmentInfo.Is() {
-		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
-	}
+	vk.CommitmentConstraintIndexes = constraint.CommitmentIndexes(spr.CommitmentInfo)
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains
@@ -249,8 +248,10 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		j++
 	}
 
-	for _, committed := range spr.CommitmentInfo.Committed {
-		qcp[offset+committed].SetOne()
+	if len(spr.CommitmentInfo) != 0 {
+		for _, committed := range spr.CommitmentInfo[0].Committed {
+			qcp[offset+committed].SetOne()
+		}
 	}
 
 	lagReg := iop.Form{Basis: iop.Lagrange, Layout: iop.Regular}

--- a/backend/plonk/bn254/setup.go
+++ b/backend/plonk/bn254/setup.go
@@ -264,7 +264,7 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 
 }
 
-// commitTrace commits to every polynomials in the trace, and put
+// commitTrace commits to every polynomial in the trace, and put
 // the commitments int the verifying key.
 func commitTrace(trace *Trace, pk *ProvingKey) error {
 

--- a/backend/plonk/bn254/setup.go
+++ b/backend/plonk/bn254/setup.go
@@ -264,7 +264,7 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 
 }
 
-// commitTrace commits to every polynomial in the trace, and put
+// commitTrace commits to every polynomials in the trace, and put
 // the commitments int the verifying key.
 func commitTrace(trace *Trace, pk *ProvingKey) error {
 

--- a/backend/plonk/bw6-633/prove.go
+++ b/backend/plonk/bw6-633/prove.go
@@ -87,7 +87,7 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness witness.Witness, opts
 		wpi2iop       *iop.Polynomial // canonical
 		commitmentVal fr.Element      // TODO @Tabaie get rid of this
 	)
-	if spr.HasCommitment() {
+	if len(spr.CommitmentInfo) != 0 {
 		opt.SolverOpts = append(opt.SolverOpts, solver.OverrideHint(spr.CommitmentInfo[0].HintID, func(_ *big.Int, ins, outs []*big.Int) error {
 			pi2 := make([]fr.Element, pk.Domain[0].Cardinality)
 			offset := spr.GetNbPublicVariables()
@@ -133,7 +133,7 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness witness.Witness, opts
 	}
 	// TODO @gbotrel deal with that conversion lazily
 	var lcpi2iop *iop.Polynomial
-	if spr.HasCommitment() {
+	if len(spr.CommitmentInfo) != 0 {
 		lcpi2iop = wpi2iop.Clone(int(pk.Domain[1].Cardinality)).ToLagrangeCoset(&pk.Domain[1]) // lagrange coset form
 	} else {
 		coeffs := make([]fr.Element, pk.Domain[1].Cardinality)
@@ -188,7 +188,7 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness witness.Witness, opts
 		qkCompletedCanonical := make([]fr.Element, len(lqkcoef))
 		copy(qkCompletedCanonical, fw[:len(spr.Public)])
 		copy(qkCompletedCanonical[len(spr.Public):], lqkcoef[len(spr.Public):])
-		if spr.HasCommitment() {
+		if len(spr.CommitmentInfo) != 0 {
 			qkCompletedCanonical[spr.GetNbPublicVariables()+spr.CommitmentInfo[0].CommitmentIndex] = commitmentVal
 		}
 		pk.Domain[0].FFTInverse(qkCompletedCanonical, fft.DIF)

--- a/backend/plonk/bw6-633/prove.go
+++ b/backend/plonk/bw6-633/prove.go
@@ -87,18 +87,18 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness witness.Witness, opts
 		wpi2iop       *iop.Polynomial // canonical
 		commitmentVal fr.Element      // TODO @Tabaie get rid of this
 	)
-	if spr.CommitmentInfo.Is() {
-		opt.SolverOpts = append(opt.SolverOpts, solver.OverrideHint(spr.CommitmentInfo.HintID, func(_ *big.Int, ins, outs []*big.Int) error {
+	if spr.HasCommitment() {
+		opt.SolverOpts = append(opt.SolverOpts, solver.OverrideHint(spr.CommitmentInfo[0].HintID, func(_ *big.Int, ins, outs []*big.Int) error {
 			pi2 := make([]fr.Element, pk.Domain[0].Cardinality)
 			offset := spr.GetNbPublicVariables()
 			for i := range ins {
-				pi2[offset+spr.CommitmentInfo.Committed[i]].SetBigInt(ins[i])
+				pi2[offset+spr.CommitmentInfo[0].Committed[i]].SetBigInt(ins[i])
 			}
 			var (
 				err     error
 				hashRes []fr.Element
 			)
-			if _, err = pi2[offset+spr.CommitmentInfo.CommitmentIndex].SetRandom(); err != nil { // Commitment injection constraint has qcp = 0. Safe to use for blinding.
+			if _, err = pi2[offset+spr.CommitmentInfo[0].CommitmentIndex].SetRandom(); err != nil { // Commitment injection constraint has qcp = 0. Safe to use for blinding.
 				return err
 			}
 			if _, err = pi2[offset+spr.GetNbConstraints()-1].SetRandom(); err != nil { // Last constraint has qcp = 0. Safe to use for blinding
@@ -133,7 +133,7 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness witness.Witness, opts
 	}
 	// TODO @gbotrel deal with that conversion lazily
 	var lcpi2iop *iop.Polynomial
-	if spr.CommitmentInfo.Is() {
+	if spr.HasCommitment() {
 		lcpi2iop = wpi2iop.Clone(int(pk.Domain[1].Cardinality)).ToLagrangeCoset(&pk.Domain[1]) // lagrange coset form
 	} else {
 		coeffs := make([]fr.Element, pk.Domain[1].Cardinality)
@@ -188,8 +188,8 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness witness.Witness, opts
 		qkCompletedCanonical := make([]fr.Element, len(lqkcoef))
 		copy(qkCompletedCanonical, fw[:len(spr.Public)])
 		copy(qkCompletedCanonical[len(spr.Public):], lqkcoef[len(spr.Public):])
-		if spr.CommitmentInfo.Is() {
-			qkCompletedCanonical[spr.GetNbPublicVariables()+spr.CommitmentInfo.CommitmentIndex] = commitmentVal
+		if spr.HasCommitment() {
+			qkCompletedCanonical[spr.GetNbPublicVariables()+spr.CommitmentInfo[0].CommitmentIndex] = commitmentVal
 		}
 		pk.Domain[0].FFTInverse(qkCompletedCanonical, fft.DIF)
 		fft.BitReverse(qkCompletedCanonical)

--- a/backend/plonk/bw6-633/setup.go
+++ b/backend/plonk/bw6-633/setup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/kzg"
+	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bw6-633"
 )
 
@@ -121,9 +122,7 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	if spr.CommitmentInfo.Is() {
-		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
-	}
+	vk.CommitmentConstraintIndexes = constraint.CommitmentIndexes(spr.CommitmentInfo)
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains
@@ -249,8 +248,10 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		j++
 	}
 
-	for _, committed := range spr.CommitmentInfo.Committed {
-		qcp[offset+committed].SetOne()
+	if len(spr.CommitmentInfo) != 0 {
+		for _, committed := range spr.CommitmentInfo[0].Committed {
+			qcp[offset+committed].SetOne()
+		}
 	}
 
 	lagReg := iop.Form{Basis: iop.Lagrange, Layout: iop.Regular}

--- a/backend/plonk/bw6-761/setup.go
+++ b/backend/plonk/bw6-761/setup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/fft"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/kzg"
+	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/bw6-761"
 )
 
@@ -121,9 +122,7 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	if spr.CommitmentInfo.Is() {
-		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
-	}
+	vk.CommitmentConstraintIndexes = constraint.CommitmentIndexes(spr.CommitmentInfo)
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains
@@ -249,8 +248,10 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		j++
 	}
 
-	for _, committed := range spr.CommitmentInfo.Committed {
-		qcp[offset+committed].SetOne()
+	if len(spr.CommitmentInfo) != 0 {
+		for _, committed := range spr.CommitmentInfo[0].Committed {
+			qcp[offset+committed].SetOne()
+		}
 	}
 
 	lagReg := iop.Form{Basis: iop.Lagrange, Layout: iop.Regular}

--- a/constraint/commitment.go
+++ b/constraint/commitment.go
@@ -23,10 +23,6 @@ func (i *Commitment) NbCommitted() int {
 	return len(i.Committed)
 }
 
-func (i *Commitment) Is() bool {
-	return len(i.Committed) != 0
-}
-
 // NewCommitment initialize a Commitment object
 //   - committed are the sorted wireID to commit to (without duplicate)
 //   - nbPublicCommitted is the number of public inputs among the committed wireIDs

--- a/constraint/commitment.go
+++ b/constraint/commitment.go
@@ -9,11 +9,10 @@ import (
 const CommitmentDst = "bsb22-commitment"
 
 type Commitment struct {
-	Committed              []int // sorted list of id's of committed variables in groth16. in plonk, list of indexes of constraints defining committed values
-	NbPrivateCommitted     int
-	HintID                 solver.HintID // TODO @gbotrel we probably don't need that here
-	CommitmentIndex        int           // in groth16, CommitmentIndex is the wire index. in plonk, it's the constraint defining it
-	CommittedAndCommitment []int         // sorted list of id's of committed variables AND the commitment itself
+	Committed          []int // sorted list of id's of committed variables in groth16. in plonk, list of indexes of constraints defining committed values
+	NbPrivateCommitted int
+	HintID             solver.HintID // TODO @gbotrel we probably don't need that here
+	CommitmentIndex    int           // in groth16, CommitmentIndex is the wire index. in plonk, it's the constraint defining it
 }
 
 func (i *Commitment) NbPublicCommitted() int {
@@ -30,7 +29,7 @@ func (i *Commitment) Is() bool {
 
 // NewCommitment initialize a Commitment object
 //   - committed are the sorted wireID to commit to (without duplicate)
-//   - nbPublicCommited is the number of public inputs among the commited wireIDs
+//   - nbPublicCommitted is the number of public inputs among the committed wireIDs
 func NewCommitment(committed []int, nbPublicCommitted int) Commitment {
 	return Commitment{
 		Committed:          committed,
@@ -52,9 +51,13 @@ func SerializeCommitment(privateCommitment []byte, publicCommitted []*big.Int, f
 	return res
 }
 
-// PrivateToPublic returns indexes of variables which are private to the constraint system, but public to Groth16. That is, private committed variables and the commitment itself
-func (i *Commitment) PrivateToPublic() []int {
-	return i.CommittedAndCommitment[i.NbPublicCommitted():]
+// PrivateToPublicGroth16 returns indexes of variables which are private to the constraint system, but public to Groth16. That is, private committed variables and the commitment itself
+// TODO Perhaps move it elsewhere since it's specific to groth16
+func (i *Commitment) PrivateToPublicGroth16() []int {
+	res := make([]int, i.NbPrivateCommitted+1)
+	copy(res, i.PrivateCommitted())
+	res[i.NbPrivateCommitted] = i.CommitmentIndex
+	return res
 }
 
 func (i *Commitment) PrivateCommitted() []int {

--- a/constraint/commitment.go
+++ b/constraint/commitment.go
@@ -38,7 +38,7 @@ func NewCommitment(committed []int, nbPublicCommitted int) Commitment {
 	}
 }
 
-func (i *Commitment) SerializeCommitment(privateCommitment []byte, publicCommitted []*big.Int, fieldByteLen int) []byte {
+func SerializeCommitment(privateCommitment []byte, publicCommitted []*big.Int, fieldByteLen int) []byte {
 
 	res := make([]byte, len(privateCommitment)+len(publicCommitted)*fieldByteLen)
 	copy(res, privateCommitment)
@@ -59,4 +59,8 @@ func (i *Commitment) PrivateToPublic() []int {
 
 func (i *Commitment) PrivateCommitted() []int {
 	return i.Committed[i.NbPublicCommitted():]
+}
+
+func (i *Commitment) PublicCommitted() []int {
+	return i.Committed[:i.NbPublicCommitted()]
 }

--- a/constraint/commitment.go
+++ b/constraint/commitment.go
@@ -63,3 +63,11 @@ func (i *Commitment) PrivateCommitted() []int {
 func (i *Commitment) PublicCommitted() []int {
 	return i.Committed[:i.NbPublicCommitted()]
 }
+
+func CommitmentIndexes(commitments []Commitment) []uint64 {
+	res := make([]uint64, len(commitments))
+	for i := range res {
+		res[i] = uint64(commitments[i].CommitmentIndex)
+	}
+	return res
+}

--- a/constraint/commitment.go
+++ b/constraint/commitment.go
@@ -50,9 +50,6 @@ func SerializeCommitment(privateCommitment []byte, publicCommitted []*big.Int, f
 // PrivateToPublicGroth16 returns indexes of variables which are private to the constraint system, but public to Groth16. That is, private committed variables and the commitment itself
 // TODO Perhaps move it elsewhere since it's specific to groth16
 func (i *Commitment) PrivateToPublicGroth16() []int {
-	if !i.Is() {
-		return nil
-	}
 	res := make([]int, i.NbPrivateCommitted+1)
 	copy(res, i.PrivateCommitted())
 	res[i.NbPrivateCommitted] = i.CommitmentIndex

--- a/constraint/commitment.go
+++ b/constraint/commitment.go
@@ -54,6 +54,9 @@ func SerializeCommitment(privateCommitment []byte, publicCommitted []*big.Int, f
 // PrivateToPublicGroth16 returns indexes of variables which are private to the constraint system, but public to Groth16. That is, private committed variables and the commitment itself
 // TODO Perhaps move it elsewhere since it's specific to groth16
 func (i *Commitment) PrivateToPublicGroth16() []int {
+	if !i.Is() {
+		return nil
+	}
 	res := make([]int, i.NbPrivateCommitted+1)
 	copy(res, i.PrivateCommitted())
 	res[i.NbPrivateCommitted] = i.CommitmentIndex

--- a/constraint/core.go
+++ b/constraint/core.go
@@ -91,7 +91,7 @@ type System struct {
 	lbWireLevel []int    `cbor:"-"` // at which level we solve a wire. init at -1.
 	lbOutputs   []uint32 `cbor:"-"` // wire outputs for current constraint.
 
-	CommitmentInfo Commitment
+	CommitmentInfo []Commitment
 
 	genericHint BlueprintID
 }
@@ -249,12 +249,7 @@ func (system *System) AddSolverHint(f solver.Hint, input []LinearExpression, nbO
 }
 
 func (system *System) AddCommitment(c Commitment) error {
-	if system.CommitmentInfo.Is() {
-		return fmt.Errorf("currently only one commitment per circuit is supported")
-	}
-
-	system.CommitmentInfo = c
-
+	system.CommitmentInfo = append(system.CommitmentInfo, c)
 	return nil
 }
 
@@ -372,4 +367,8 @@ func (cs *System) GetR1CIterator() R1CIterator {
 
 func (cs *System) GetSparseR1CIterator() SparseR1CIterator {
 	return SparseR1CIterator{cs: cs}
+}
+
+func (cs *System) HasCommitment() bool {
+	return len(cs.CommitmentInfo) != 0
 }

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -48,6 +48,7 @@ type ConstraintSystem interface {
 	AddSolverHint(f solver.Hint, input []LinearExpression, nbOutput int) (internalVariables []int, err error)
 
 	AddCommitment(c Commitment) error
+	HasCommitment() bool // TODO: Erase once multi-commits are implemented in Groth16
 
 	AddLog(l LogEntry)
 

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -741,8 +741,6 @@ func (builder *builder) Commit(v ...frontend.Variable) (frontend.Variable, error
 
 	commitment.CommitmentIndex = (cVar.(expr.LinearExpression))[0].WireID()
 
-	// TODO @Tabaie Get rid of this field
-	commitment.CommittedAndCommitment = append(commitment.Committed, commitment.CommitmentIndex)
 	if commitment.CommitmentIndex <= commitment.Committed[len(commitment.Committed)-1] {
 		return nil, fmt.Errorf("commitment variable index smaller than some committed variable indices")
 	}

--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -676,6 +676,11 @@ func (builder *builder) Compiler() frontend.Compiler {
 }
 
 func (builder *builder) Commit(v ...frontend.Variable) (frontend.Variable, error) {
+
+	if builder.cs.HasCommitment() {
+		return nil, errors.New("multi-commits not available for groth16 - yet")
+	}
+
 	// we want to build a sorted slice of committed variables, without duplicates
 	// this is the same algorithm as builder.add(...); but we expect len(v) to be quite large.
 

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -573,7 +573,7 @@ func (builder *builder) Compiler() frontend.Compiler {
 func (builder *builder) Commit(v ...frontend.Variable) (frontend.Variable, error) {
 
 	if builder.cs.HasCommitment() {
-		return nil, errors.New("multi-commits not available for groth16 - yet")
+		return nil, errors.New("multi-commits not available for plonk - yet")
 	}
 
 	v = filterConstants(v) // TODO: @Tabaie Settle on a way to represent even constants; conventional hash?

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scs
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -570,6 +571,10 @@ func (builder *builder) Compiler() frontend.Compiler {
 }
 
 func (builder *builder) Commit(v ...frontend.Variable) (frontend.Variable, error) {
+
+	if builder.cs.HasCommitment() {
+		return nil, errors.New("multi-commits not available for groth16 - yet")
+	}
 
 	v = filterConstants(v) // TODO: @Tabaie Settle on a way to represent even constants; conventional hash?
 

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.commitment.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.commitment.go.tmpl
@@ -5,7 +5,7 @@ import (
     "math/big"
 )
 
-func solveCommitmentWire(commitmentInfo *constraint.Commitment, commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
-    res, err := fr.Hash(commitmentInfo.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
+func solveCommitmentWire(commitment *curve.G1Affine, publicCommitted []*big.Int) (fr.Element, error) {
+    res, err := fr.Hash(constraint.SerializeCommitment(commitment.Marshal(), publicCommitted, (fr.Bits-1)/8+1), []byte(constraint.CommitmentDst), 1)
     return res[0], err
 }

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -48,14 +48,14 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 
 	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
 
-	if r1cs.CommitmentInfo.Is() {
-		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo.HintID,func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+	if r1cs.HasCommitment() {
+		solverOpts = append(solverOpts, solver.OverrideHint(r1cs.CommitmentInfo[0].HintID,func(_ *big.Int, in []*big.Int, out []*big.Int) error {
 			// Perf-TODO: Converting these values to big.Int and back may be a performance bottleneck.
 			// If that is the case, figure out a way to feed the solution vector into this function
-			if len(in) != r1cs.CommitmentInfo.NbCommitted() { // TODO: Remove
+			if len(in) != r1cs.CommitmentInfo[0].NbCommitted() { // TODO: Remove
 				return fmt.Errorf("unexpected number of committed variables")
 			}
-			values := make([]fr.Element, r1cs.CommitmentInfo.NbPrivateCommitted)
+			values := make([]fr.Element, r1cs.CommitmentInfo[0].NbPrivateCommitted)
 			nbPublicCommitted := len(in) - len(values)
 			inPrivate := in[nbPublicCommitted:]
 			for i, inI := range inPrivate {
@@ -69,7 +69,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo[0].NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		} ))
@@ -185,8 +185,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			chKrs2Done <- err
 		}()
 
-		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
+		// filter the wire values if needed
+		_wireValues := wireValues
+		if r1cs.HasCommitment() {
+			_wireValues = filter(wireValues, r1cs.CommitmentInfo[0].PrivateToPublicGroth16())
+		}
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -69,7 +69,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 			}
 
 			var res fr.Element
-			res, err = solveCommitmentWire(&r1cs.CommitmentInfo, &proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
+			res, err = solveCommitmentWire(&proof.Commitment, in[:r1cs.CommitmentInfo.NbPublicCommitted()])
 			res.BigInt(out[0])
 			return err
 		} ))

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -186,7 +186,7 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		}()
 
 		// filter the wire values if needed;
-		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublic())
+		_wireValues := filter(wireValues, r1cs.CommitmentInfo.PrivateToPublicGroth16())
 
 		if _, err := krs.MultiExp(pk.G1.K, _wireValues[r1cs.GetNbPublicVariables():], ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
 			chKrsDone <- err

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -246,7 +246,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -57,8 +57,9 @@ type VerifyingKey struct {
 	// e(α, β)
 	e curve.GT // not serialized
 
-	CommitmentKey  pedersen.VerifyingKey
-	CommitmentInfo constraint.Commitment // since the verifier doesn't input a constraint system, this needs to be provided here
+	CommitmentKey   pedersen.VerifyingKey
+	HasCommitment   bool  // TODO: Make CommitmentKey nullable instead
+	PublicCommitted []int // indexes of public committed variables
 }
 
 // Setup constructs the SRS
@@ -244,7 +245,8 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.CommitmentInfo = r1cs.CommitmentInfo // unfortunate but necessary
+	vk.HasCommitment = r1cs.CommitmentInfo.Is()
+	vk.PublicCommitted = r1cs.CommitmentInfo.PrivateCommitted()
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -76,11 +76,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 
 	// get R1CS nb constraints, wires and public/private inputs
 	nbWires := r1cs.NbInternalVariables + r1cs.GetNbPublicVariables() + r1cs.GetNbSecretVariables()
-	nbPrivateCommittedWires := r1cs.CommitmentInfo.NbPrivateCommitted
+	nbPrivateCommittedWires := 0
+	if r1cs.HasCommitment() {
+		nbPrivateCommittedWires = r1cs.CommitmentInfo[0].NbPrivateCommitted
+	}
 	nbPublicWires := r1cs.GetNbPublicVariables()
 	nbPrivateWires := r1cs.GetNbSecretVariables() + r1cs.NbInternalVariables - nbPrivateCommittedWires
 
-	if r1cs.CommitmentInfo.Is() { // the commitment itself is defined by a hint so the prover considers it private
+	if r1cs.HasCommitment() { // the commitment itself is defined by a hint so the prover considers it private
 		nbPublicWires++  // but the verifier will need to inject the value itself so on the groth16
 		nbPrivateWires-- // level it must be considered public
 	}
@@ -133,11 +136,14 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 	}
 
 	vI, cI := 0, 0
-	privateCommitted := r1cs.CommitmentInfo.PrivateCommitted()
+	var privateCommitted []int
+	if r1cs.HasCommitment() {
+		privateCommitted = r1cs.CommitmentInfo[0].PrivateCommitted()
+	}
 
 	for i := range A {
 		isCommittedPrivate := cI < len(privateCommitted) && i == privateCommitted[cI]
-		isCommitment := r1cs.CommitmentInfo.Is() && i == r1cs.CommitmentInfo.CommitmentIndex
+		isCommitment := r1cs.HasCommitment() && i == r1cs.CommitmentInfo[0].CommitmentIndex
 		isPublic := i < r1cs.GetNbPublicVariables()
 
 		if isPublic || isCommittedPrivate || isCommitment {
@@ -245,8 +251,9 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		}
 	}
 
-	vk.HasCommitment = r1cs.CommitmentInfo.Is()
-	vk.PublicCommitted = r1cs.CommitmentInfo.PublicCommitted()
+	if vk.HasCommitment = r1cs.HasCommitment(); vk.HasCommitment {
+		vk.PublicCommitted = r1cs.CommitmentInfo[0].PublicCommitted()
+	}
 
 	// ---------------------------------------------------------------------------------------------
 	// G2 scalars

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.verify.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.verify.go.tmpl
@@ -22,7 +22,7 @@ var (
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 	nbPublicVars := len(vk.G1.K)
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		nbPublicVars--
 	}
 	if len(publicWitness) != nbPublicVars-1 {
@@ -47,20 +47,20 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 		close(chDone)
 	}()
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 
 		if err := vk.CommitmentKey.Verify(proof.Commitment, proof.CommitmentPok); err != nil {
 			return err
 		}
 
-		publicCommitted := make([]*big.Int, vk.CommitmentInfo.NbPublicCommitted())
+		publicCommitted := make([]*big.Int, len(vk.PublicCommitted))
 		for i := range publicCommitted {
 			var b big.Int
-			publicWitness[vk.CommitmentInfo.Committed[i]-1].BigInt(&b)
+			publicWitness[vk.PublicCommitted[i]-1].BigInt(&b)
 			publicCommitted[i] = &b
 		}
 
-		if res, err := solveCommitmentWire(&vk.CommitmentInfo, &proof.Commitment, publicCommitted); err == nil {
+		if res, err := solveCommitmentWire(&proof.Commitment, publicCommitted); err == nil {
 			publicWitness = append(publicWitness, res)
 		}
 	}
@@ -72,7 +72,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 	}
 	kSum.AddMixed(&vk.G1.K[0])
 
-	if vk.CommitmentInfo.Is() {
+	if vk.HasCommitment {
 		kSum.AddMixed(&proof.Commitment)
 	}
 	

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
@@ -65,18 +65,18 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness witness.Witness, opts
 		wpi2iop       *iop.Polynomial // canonical
 		commitmentVal fr.Element      // TODO @Tabaie get rid of this
 	)
-	if spr.CommitmentInfo.Is() {
-		opt.SolverOpts = append(opt.SolverOpts, solver.OverrideHint(spr.CommitmentInfo.HintID, func(_ *big.Int, ins, outs []*big.Int) error {
+	if len(spr.CommitmentInfo) != 0 {
+		opt.SolverOpts = append(opt.SolverOpts, solver.OverrideHint(spr.CommitmentInfo[0].HintID, func(_ *big.Int, ins, outs []*big.Int) error {
 			pi2 := make([]fr.Element, pk.Domain[0].Cardinality)
 			offset := spr.GetNbPublicVariables()
 			for i := range ins {
-				pi2[offset+spr.CommitmentInfo.Committed[i]].SetBigInt(ins[i])
+				pi2[offset+spr.CommitmentInfo[0].Committed[i]].SetBigInt(ins[i])
 			}
 			var (
 				err     error
 				hashRes []fr.Element
 			)
-			if _, err = pi2[offset+spr.CommitmentInfo.CommitmentIndex].SetRandom(); err != nil {	// Commitment injection constraint has qcp = 0. Safe to use for blinding.
+			if _, err = pi2[offset+spr.CommitmentInfo[0].CommitmentIndex].SetRandom(); err != nil {	// Commitment injection constraint has qcp = 0. Safe to use for blinding.
 				return err
 			}
 			if _, err = pi2[offset+spr.GetNbConstraints()-1].SetRandom(); err != nil { // Last constraint has qcp = 0. Safe to use for blinding
@@ -111,7 +111,7 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness witness.Witness, opts
 	}
 	// TODO @gbotrel deal with that conversion lazily
 	var lcpi2iop *iop.Polynomial
-	if spr.CommitmentInfo.Is() {
+	if len(spr.CommitmentInfo) != 0 {
 		lcpi2iop = wpi2iop.Clone(int(pk.Domain[1].Cardinality)).ToLagrangeCoset(&pk.Domain[1]) // lagrange coset form
 	} else {
 		coeffs := make([]fr.Element, pk.Domain[1].Cardinality)
@@ -168,8 +168,8 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness witness.Witness, opts
 		qkCompletedCanonical := make([]fr.Element, len(lqkcoef))
 		copy(qkCompletedCanonical, fw[:len(spr.Public)])
 		copy(qkCompletedCanonical[len(spr.Public):], lqkcoef[len(spr.Public):])
-		if spr.CommitmentInfo.Is() {
-			qkCompletedCanonical[spr.GetNbPublicVariables()+spr.CommitmentInfo.CommitmentIndex] = commitmentVal
+		if len(spr.CommitmentInfo) != 0 {
+			qkCompletedCanonical[spr.GetNbPublicVariables()+spr.CommitmentInfo[0].CommitmentIndex] = commitmentVal
 		}
 		pk.Domain[0].FFTInverse(qkCompletedCanonical, fft.DIF)
 		fft.BitReverse(qkCompletedCanonical)

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.setup.go.tmpl
@@ -6,6 +6,7 @@ import (
 	{{- template "import_backend_cs" . }}
 	"github.com/consensys/gnark-crypto/ecc/{{toLower .Curve}}/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/constraint"
 )
 
 // Trace stores a plonk trace as columns
@@ -103,9 +104,7 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	var pk ProvingKey
 	var vk VerifyingKey
 	pk.Vk = &vk
-	if spr.CommitmentInfo.Is() {
-		vk.CommitmentConstraintIndexes = []uint64{uint64(spr.CommitmentInfo.CommitmentIndex)}
-	}
+	vk.CommitmentConstraintIndexes = constraint.CommitmentIndexes(spr.CommitmentInfo)
 	// nbConstraints := len(spr.Constraints)
 
 	// step 0: set the fft domains
@@ -233,8 +232,10 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		j++
 	}
 
-	for _, committed := range spr.CommitmentInfo.Committed {
+	if len(spr.CommitmentInfo) != 0 {
+	for _, committed := range spr.CommitmentInfo[0].Committed {
 		qcp[offset+committed].SetOne()
+	}
 	}
 
 	lagReg := iop.Form{Basis: iop.Lagrange, Layout: iop.Regular}


### PR DESCRIPTION
This PR turns the commitment info in constraint system objects into arrays in anticipation of multi commits and reduces commitment info stored in Groth16 verifying keys to only what is needed by the verifier (the same was previously done for Plonk)