### PR TITLE
Adds ground work for custom blueprints. Fixes #660

### DIFF
--- a/constraint/bls12-377/coeff.go
+++ b/constraint/bls12-377/coeff.go
@@ -182,3 +182,11 @@ func (engine *field) String(a constraint.Element) string {
 	e := (*fr.Element)(a[:])
 	return e.String()
 }
+
+func (engine *field) Uint64(a constraint.Element) (uint64, bool) {
+	e := (*fr.Element)(a[:])
+	if !e.IsUint64() {
+		return 0, false
+	}
+	return e.Uint64(), true
+}

--- a/constraint/bls12-377/solver.go
+++ b/constraint/bls12-377/solver.go
@@ -376,7 +376,7 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.Instruction, scratch *scratch) error {
+func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
 	blueprint := solver.Blueprints[inst.BlueprintID]
 	calldata := solver.GetCallData(inst)

--- a/constraint/bls12-377/solver.go
+++ b/constraint/bls12-377/solver.go
@@ -133,15 +133,15 @@ func (s *solver) set(id int, value fr.Element) {
 }
 
 // computeTerm computes coeff*variable
-// TODO @gbotrel check if t is a Constant only
 func (s *solver) computeTerm(t constraint.Term) fr.Element {
 	cID, vID := t.CoeffID(), t.WireID()
-	if cID != 0 && !s.solved[vID] {
-		panic("computing a term with an unsolved wire")
-	}
 
 	if t.IsConstant() {
 		return s.Coefficients[cID]
+	}
+
+	if cID != 0 && !s.solved[vID] {
+		panic("computing a term with an unsolved wire")
 	}
 
 	switch cID {
@@ -390,14 +390,14 @@ func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratc
 			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
-	} else if solver.Type == constraint.SystemSparseR1CS {
-		// blueprint declared "I know how to solve this."
-		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, inst); err != nil {
-				return solver.wrapErrWithDebugInfo(cID, err)
-			}
-			return nil
+	}
+
+	// blueprint declared "I know how to solve this."
+	if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
+		if err := bc.Solve(solver, inst); err != nil {
+			return solver.wrapErrWithDebugInfo(cID, err)
 		}
+		return nil
 	}
 
 	// blueprint encodes a hint, we execute.

--- a/constraint/bls12-377/solver.go
+++ b/constraint/bls12-377/solver.go
@@ -358,7 +358,7 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
-		return s.GetValue(calldata[0], calldata[1]), 2
+		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element
 	n := int(calldata[0])

--- a/constraint/bls12-377/solver.go
+++ b/constraint/bls12-377/solver.go
@@ -376,10 +376,10 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
+func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
-	blueprint := solver.Blueprints[inst.BlueprintID]
-	calldata := solver.GetCallData(inst)
+	blueprint := solver.Blueprints[pi.BlueprintID]
+	inst := pi.Unpack(&solver.System)
 	cID := inst.ConstraintOffset // here we have 1 constraint in the instruction only
 
 	if solver.Type == constraint.SystemR1CS {
@@ -387,13 +387,13 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 			// TODO @gbotrel we use the solveR1C method for now, having user-defined
 			// blueprint for R1CS would require constraint.Solver interface to add methods
 			// to set a,b,c since it's more efficient to compute these while we solve.
-			bc.DecompressR1C(&scratch.tR1C, calldata)
+			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
 	} else if solver.Type == constraint.SystemSparseR1CS {
 		// blueprint declared "I know how to solve this."
 		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, calldata); err != nil {
+			if err := bc.Solve(solver, inst); err != nil {
 				return solver.wrapErrWithDebugInfo(cID, err)
 			}
 			return nil
@@ -403,7 +403,7 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 	// blueprint encodes a hint, we execute.
 	// TODO @gbotrel may be worth it to move hint logic in blueprint "solve"
 	if bc, ok := blueprint.(constraint.BlueprintHint); ok {
-		bc.DecompressHint(&scratch.tHint, calldata)
+		bc.DecompressHint(&scratch.tHint, inst)
 		return solver.solveWithHint(&scratch.tHint)
 	}
 

--- a/constraint/bls12-377/solver.go
+++ b/constraint/bls12-377/solver.go
@@ -358,6 +358,9 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
+		if calldata[0] != 1 {
+			panic("invalid calldata")
+		}
 		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element

--- a/constraint/bls12-377/system.go
+++ b/constraint/bls12-377/system.go
@@ -121,7 +121,7 @@ func (cs *system) GetR1Cs() []constraint.R1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintR1C); ok {
 			var r1c constraint.R1C
-			bc.DecompressR1C(&r1c, cs.GetCallData(inst))
+			bc.DecompressR1C(&r1c, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, r1c)
 		} else {
 			panic("not implemented")
@@ -196,8 +196,7 @@ func (cs *system) GetSparseR1Cs() []constraint.SparseR1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
 			var sparseR1C constraint.SparseR1C
-			calldata := cs.CallData[inst.StartCallData : inst.StartCallData+uint64(blueprint.NbInputs())]
-			bc.DecompressSparseR1C(&sparseR1C, calldata)
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, sparseR1C)
 		} else {
 			panic("not implemented")
@@ -234,7 +233,7 @@ func evaluateLROSmallDomain(cs *system, solution []fr.Element) ([]fr.Element, []
 	for _, inst := range cs.Instructions {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
-			bc.DecompressSparseR1C(&sparseR1C, cs.GetCallData(inst))
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 
 			l[offset+j] = solution[sparseR1C.XA]
 			r[offset+j] = solution[sparseR1C.XB]

--- a/constraint/bls12-381/coeff.go
+++ b/constraint/bls12-381/coeff.go
@@ -182,3 +182,11 @@ func (engine *field) String(a constraint.Element) string {
 	e := (*fr.Element)(a[:])
 	return e.String()
 }
+
+func (engine *field) Uint64(a constraint.Element) (uint64, bool) {
+	e := (*fr.Element)(a[:])
+	if !e.IsUint64() {
+		return 0, false
+	}
+	return e.Uint64(), true
+}

--- a/constraint/bls12-381/solver.go
+++ b/constraint/bls12-381/solver.go
@@ -376,7 +376,7 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.Instruction, scratch *scratch) error {
+func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
 	blueprint := solver.Blueprints[inst.BlueprintID]
 	calldata := solver.GetCallData(inst)

--- a/constraint/bls12-381/solver.go
+++ b/constraint/bls12-381/solver.go
@@ -133,15 +133,15 @@ func (s *solver) set(id int, value fr.Element) {
 }
 
 // computeTerm computes coeff*variable
-// TODO @gbotrel check if t is a Constant only
 func (s *solver) computeTerm(t constraint.Term) fr.Element {
 	cID, vID := t.CoeffID(), t.WireID()
-	if cID != 0 && !s.solved[vID] {
-		panic("computing a term with an unsolved wire")
-	}
 
 	if t.IsConstant() {
 		return s.Coefficients[cID]
+	}
+
+	if cID != 0 && !s.solved[vID] {
+		panic("computing a term with an unsolved wire")
 	}
 
 	switch cID {
@@ -390,14 +390,14 @@ func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratc
 			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
-	} else if solver.Type == constraint.SystemSparseR1CS {
-		// blueprint declared "I know how to solve this."
-		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, inst); err != nil {
-				return solver.wrapErrWithDebugInfo(cID, err)
-			}
-			return nil
+	}
+
+	// blueprint declared "I know how to solve this."
+	if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
+		if err := bc.Solve(solver, inst); err != nil {
+			return solver.wrapErrWithDebugInfo(cID, err)
 		}
+		return nil
 	}
 
 	// blueprint encodes a hint, we execute.

--- a/constraint/bls12-381/solver.go
+++ b/constraint/bls12-381/solver.go
@@ -358,7 +358,7 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
-		return s.GetValue(calldata[0], calldata[1]), 2
+		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element
 	n := int(calldata[0])

--- a/constraint/bls12-381/solver.go
+++ b/constraint/bls12-381/solver.go
@@ -376,10 +376,10 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
+func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
-	blueprint := solver.Blueprints[inst.BlueprintID]
-	calldata := solver.GetCallData(inst)
+	blueprint := solver.Blueprints[pi.BlueprintID]
+	inst := pi.Unpack(&solver.System)
 	cID := inst.ConstraintOffset // here we have 1 constraint in the instruction only
 
 	if solver.Type == constraint.SystemR1CS {
@@ -387,13 +387,13 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 			// TODO @gbotrel we use the solveR1C method for now, having user-defined
 			// blueprint for R1CS would require constraint.Solver interface to add methods
 			// to set a,b,c since it's more efficient to compute these while we solve.
-			bc.DecompressR1C(&scratch.tR1C, calldata)
+			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
 	} else if solver.Type == constraint.SystemSparseR1CS {
 		// blueprint declared "I know how to solve this."
 		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, calldata); err != nil {
+			if err := bc.Solve(solver, inst); err != nil {
 				return solver.wrapErrWithDebugInfo(cID, err)
 			}
 			return nil
@@ -403,7 +403,7 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 	// blueprint encodes a hint, we execute.
 	// TODO @gbotrel may be worth it to move hint logic in blueprint "solve"
 	if bc, ok := blueprint.(constraint.BlueprintHint); ok {
-		bc.DecompressHint(&scratch.tHint, calldata)
+		bc.DecompressHint(&scratch.tHint, inst)
 		return solver.solveWithHint(&scratch.tHint)
 	}
 

--- a/constraint/bls12-381/solver.go
+++ b/constraint/bls12-381/solver.go
@@ -358,6 +358,9 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
+		if calldata[0] != 1 {
+			panic("invalid calldata")
+		}
 		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element

--- a/constraint/bls12-381/system.go
+++ b/constraint/bls12-381/system.go
@@ -121,7 +121,7 @@ func (cs *system) GetR1Cs() []constraint.R1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintR1C); ok {
 			var r1c constraint.R1C
-			bc.DecompressR1C(&r1c, cs.GetCallData(inst))
+			bc.DecompressR1C(&r1c, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, r1c)
 		} else {
 			panic("not implemented")
@@ -196,8 +196,7 @@ func (cs *system) GetSparseR1Cs() []constraint.SparseR1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
 			var sparseR1C constraint.SparseR1C
-			calldata := cs.CallData[inst.StartCallData : inst.StartCallData+uint64(blueprint.NbInputs())]
-			bc.DecompressSparseR1C(&sparseR1C, calldata)
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, sparseR1C)
 		} else {
 			panic("not implemented")
@@ -234,7 +233,7 @@ func evaluateLROSmallDomain(cs *system, solution []fr.Element) ([]fr.Element, []
 	for _, inst := range cs.Instructions {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
-			bc.DecompressSparseR1C(&sparseR1C, cs.GetCallData(inst))
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 
 			l[offset+j] = solution[sparseR1C.XA]
 			r[offset+j] = solution[sparseR1C.XB]

--- a/constraint/bls24-315/coeff.go
+++ b/constraint/bls24-315/coeff.go
@@ -182,3 +182,11 @@ func (engine *field) String(a constraint.Element) string {
 	e := (*fr.Element)(a[:])
 	return e.String()
 }
+
+func (engine *field) Uint64(a constraint.Element) (uint64, bool) {
+	e := (*fr.Element)(a[:])
+	if !e.IsUint64() {
+		return 0, false
+	}
+	return e.Uint64(), true
+}

--- a/constraint/bls24-315/solver.go
+++ b/constraint/bls24-315/solver.go
@@ -376,7 +376,7 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.Instruction, scratch *scratch) error {
+func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
 	blueprint := solver.Blueprints[inst.BlueprintID]
 	calldata := solver.GetCallData(inst)

--- a/constraint/bls24-315/solver.go
+++ b/constraint/bls24-315/solver.go
@@ -133,15 +133,15 @@ func (s *solver) set(id int, value fr.Element) {
 }
 
 // computeTerm computes coeff*variable
-// TODO @gbotrel check if t is a Constant only
 func (s *solver) computeTerm(t constraint.Term) fr.Element {
 	cID, vID := t.CoeffID(), t.WireID()
-	if cID != 0 && !s.solved[vID] {
-		panic("computing a term with an unsolved wire")
-	}
 
 	if t.IsConstant() {
 		return s.Coefficients[cID]
+	}
+
+	if cID != 0 && !s.solved[vID] {
+		panic("computing a term with an unsolved wire")
 	}
 
 	switch cID {
@@ -390,14 +390,14 @@ func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratc
 			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
-	} else if solver.Type == constraint.SystemSparseR1CS {
-		// blueprint declared "I know how to solve this."
-		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, inst); err != nil {
-				return solver.wrapErrWithDebugInfo(cID, err)
-			}
-			return nil
+	}
+
+	// blueprint declared "I know how to solve this."
+	if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
+		if err := bc.Solve(solver, inst); err != nil {
+			return solver.wrapErrWithDebugInfo(cID, err)
 		}
+		return nil
 	}
 
 	// blueprint encodes a hint, we execute.

--- a/constraint/bls24-315/solver.go
+++ b/constraint/bls24-315/solver.go
@@ -358,7 +358,7 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
-		return s.GetValue(calldata[0], calldata[1]), 2
+		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element
 	n := int(calldata[0])

--- a/constraint/bls24-315/solver.go
+++ b/constraint/bls24-315/solver.go
@@ -376,10 +376,10 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
+func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
-	blueprint := solver.Blueprints[inst.BlueprintID]
-	calldata := solver.GetCallData(inst)
+	blueprint := solver.Blueprints[pi.BlueprintID]
+	inst := pi.Unpack(&solver.System)
 	cID := inst.ConstraintOffset // here we have 1 constraint in the instruction only
 
 	if solver.Type == constraint.SystemR1CS {
@@ -387,13 +387,13 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 			// TODO @gbotrel we use the solveR1C method for now, having user-defined
 			// blueprint for R1CS would require constraint.Solver interface to add methods
 			// to set a,b,c since it's more efficient to compute these while we solve.
-			bc.DecompressR1C(&scratch.tR1C, calldata)
+			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
 	} else if solver.Type == constraint.SystemSparseR1CS {
 		// blueprint declared "I know how to solve this."
 		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, calldata); err != nil {
+			if err := bc.Solve(solver, inst); err != nil {
 				return solver.wrapErrWithDebugInfo(cID, err)
 			}
 			return nil
@@ -403,7 +403,7 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 	// blueprint encodes a hint, we execute.
 	// TODO @gbotrel may be worth it to move hint logic in blueprint "solve"
 	if bc, ok := blueprint.(constraint.BlueprintHint); ok {
-		bc.DecompressHint(&scratch.tHint, calldata)
+		bc.DecompressHint(&scratch.tHint, inst)
 		return solver.solveWithHint(&scratch.tHint)
 	}
 

--- a/constraint/bls24-315/solver.go
+++ b/constraint/bls24-315/solver.go
@@ -358,6 +358,9 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
+		if calldata[0] != 1 {
+			panic("invalid calldata")
+		}
 		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element

--- a/constraint/bls24-315/system.go
+++ b/constraint/bls24-315/system.go
@@ -121,7 +121,7 @@ func (cs *system) GetR1Cs() []constraint.R1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintR1C); ok {
 			var r1c constraint.R1C
-			bc.DecompressR1C(&r1c, cs.GetCallData(inst))
+			bc.DecompressR1C(&r1c, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, r1c)
 		} else {
 			panic("not implemented")
@@ -196,8 +196,7 @@ func (cs *system) GetSparseR1Cs() []constraint.SparseR1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
 			var sparseR1C constraint.SparseR1C
-			calldata := cs.CallData[inst.StartCallData : inst.StartCallData+uint64(blueprint.NbInputs())]
-			bc.DecompressSparseR1C(&sparseR1C, calldata)
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, sparseR1C)
 		} else {
 			panic("not implemented")
@@ -234,7 +233,7 @@ func evaluateLROSmallDomain(cs *system, solution []fr.Element) ([]fr.Element, []
 	for _, inst := range cs.Instructions {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
-			bc.DecompressSparseR1C(&sparseR1C, cs.GetCallData(inst))
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 
 			l[offset+j] = solution[sparseR1C.XA]
 			r[offset+j] = solution[sparseR1C.XB]

--- a/constraint/bls24-317/coeff.go
+++ b/constraint/bls24-317/coeff.go
@@ -182,3 +182,11 @@ func (engine *field) String(a constraint.Element) string {
 	e := (*fr.Element)(a[:])
 	return e.String()
 }
+
+func (engine *field) Uint64(a constraint.Element) (uint64, bool) {
+	e := (*fr.Element)(a[:])
+	if !e.IsUint64() {
+		return 0, false
+	}
+	return e.Uint64(), true
+}

--- a/constraint/bls24-317/solver.go
+++ b/constraint/bls24-317/solver.go
@@ -376,7 +376,7 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.Instruction, scratch *scratch) error {
+func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
 	blueprint := solver.Blueprints[inst.BlueprintID]
 	calldata := solver.GetCallData(inst)

--- a/constraint/bls24-317/solver.go
+++ b/constraint/bls24-317/solver.go
@@ -133,15 +133,15 @@ func (s *solver) set(id int, value fr.Element) {
 }
 
 // computeTerm computes coeff*variable
-// TODO @gbotrel check if t is a Constant only
 func (s *solver) computeTerm(t constraint.Term) fr.Element {
 	cID, vID := t.CoeffID(), t.WireID()
-	if cID != 0 && !s.solved[vID] {
-		panic("computing a term with an unsolved wire")
-	}
 
 	if t.IsConstant() {
 		return s.Coefficients[cID]
+	}
+
+	if cID != 0 && !s.solved[vID] {
+		panic("computing a term with an unsolved wire")
 	}
 
 	switch cID {
@@ -390,14 +390,14 @@ func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratc
 			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
-	} else if solver.Type == constraint.SystemSparseR1CS {
-		// blueprint declared "I know how to solve this."
-		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, inst); err != nil {
-				return solver.wrapErrWithDebugInfo(cID, err)
-			}
-			return nil
+	}
+
+	// blueprint declared "I know how to solve this."
+	if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
+		if err := bc.Solve(solver, inst); err != nil {
+			return solver.wrapErrWithDebugInfo(cID, err)
 		}
+		return nil
 	}
 
 	// blueprint encodes a hint, we execute.

--- a/constraint/bls24-317/solver.go
+++ b/constraint/bls24-317/solver.go
@@ -358,7 +358,7 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
-		return s.GetValue(calldata[0], calldata[1]), 2
+		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element
 	n := int(calldata[0])

--- a/constraint/bls24-317/solver.go
+++ b/constraint/bls24-317/solver.go
@@ -376,10 +376,10 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
+func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
-	blueprint := solver.Blueprints[inst.BlueprintID]
-	calldata := solver.GetCallData(inst)
+	blueprint := solver.Blueprints[pi.BlueprintID]
+	inst := pi.Unpack(&solver.System)
 	cID := inst.ConstraintOffset // here we have 1 constraint in the instruction only
 
 	if solver.Type == constraint.SystemR1CS {
@@ -387,13 +387,13 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 			// TODO @gbotrel we use the solveR1C method for now, having user-defined
 			// blueprint for R1CS would require constraint.Solver interface to add methods
 			// to set a,b,c since it's more efficient to compute these while we solve.
-			bc.DecompressR1C(&scratch.tR1C, calldata)
+			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
 	} else if solver.Type == constraint.SystemSparseR1CS {
 		// blueprint declared "I know how to solve this."
 		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, calldata); err != nil {
+			if err := bc.Solve(solver, inst); err != nil {
 				return solver.wrapErrWithDebugInfo(cID, err)
 			}
 			return nil
@@ -403,7 +403,7 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 	// blueprint encodes a hint, we execute.
 	// TODO @gbotrel may be worth it to move hint logic in blueprint "solve"
 	if bc, ok := blueprint.(constraint.BlueprintHint); ok {
-		bc.DecompressHint(&scratch.tHint, calldata)
+		bc.DecompressHint(&scratch.tHint, inst)
 		return solver.solveWithHint(&scratch.tHint)
 	}
 

--- a/constraint/bls24-317/solver.go
+++ b/constraint/bls24-317/solver.go
@@ -358,6 +358,9 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
+		if calldata[0] != 1 {
+			panic("invalid calldata")
+		}
 		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element

--- a/constraint/bls24-317/system.go
+++ b/constraint/bls24-317/system.go
@@ -121,7 +121,7 @@ func (cs *system) GetR1Cs() []constraint.R1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintR1C); ok {
 			var r1c constraint.R1C
-			bc.DecompressR1C(&r1c, cs.GetCallData(inst))
+			bc.DecompressR1C(&r1c, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, r1c)
 		} else {
 			panic("not implemented")
@@ -196,8 +196,7 @@ func (cs *system) GetSparseR1Cs() []constraint.SparseR1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
 			var sparseR1C constraint.SparseR1C
-			calldata := cs.CallData[inst.StartCallData : inst.StartCallData+uint64(blueprint.NbInputs())]
-			bc.DecompressSparseR1C(&sparseR1C, calldata)
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, sparseR1C)
 		} else {
 			panic("not implemented")
@@ -234,7 +233,7 @@ func evaluateLROSmallDomain(cs *system, solution []fr.Element) ([]fr.Element, []
 	for _, inst := range cs.Instructions {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
-			bc.DecompressSparseR1C(&sparseR1C, cs.GetCallData(inst))
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 
 			l[offset+j] = solution[sparseR1C.XA]
 			r[offset+j] = solution[sparseR1C.XB]

--- a/constraint/blueprint.go
+++ b/constraint/blueprint.go
@@ -33,25 +33,25 @@ type Solver interface {
 // BlueprintSolvable represents a blueprint that knows how to solve itself.
 type BlueprintSolvable interface {
 	// Solve may return an error if the decoded constraint / calldata is unsolvable.
-	Solve(s Solver, calldata []uint32) error
+	Solve(s Solver, instruction Instruction) error
 }
 
 // BlueprintR1C indicates that the blueprint and associated calldata encodes a R1C
 type BlueprintR1C interface {
 	CompressR1C(c *R1C) []uint32
-	DecompressR1C(into *R1C, calldata []uint32)
+	DecompressR1C(into *R1C, instruction Instruction)
 }
 
 // BlueprintSparseR1C indicates that the blueprint and associated calldata encodes a SparseR1C.
 type BlueprintSparseR1C interface {
 	CompressSparseR1C(c *SparseR1C) []uint32
-	DecompressSparseR1C(into *SparseR1C, calldata []uint32)
+	DecompressSparseR1C(into *SparseR1C, instruction Instruction)
 }
 
 // BlueprintHint indicates that the blueprint and associated calldata encodes a hint.
 type BlueprintHint interface {
 	CompressHint(HintMapping) []uint32
-	DecompressHint(h *HintMapping, calldata []uint32)
+	DecompressHint(h *HintMapping, instruction Instruction)
 }
 
 // Compressable represent an object that knows how to encode itself as a []uint32.

--- a/constraint/blueprint.go
+++ b/constraint/blueprint.go
@@ -68,6 +68,6 @@ type BlueprintHint interface {
 
 // Compressable represent an object that knows how to encode itself as a []uint32.
 type Compressable interface {
-	// CompressLE interprets the objects as a LinearExpression and encodes it as a []uint32.
-	CompressLE(to *[]uint32)
+	// Compress interprets the objects as a LinearExpression and encodes it as a []uint32.
+	Compress(to *[]uint32)
 }

--- a/constraint/blueprint.go
+++ b/constraint/blueprint.go
@@ -49,3 +49,13 @@ type BlueprintHint interface {
 	CompressHint(HintMapping) []uint32
 	DecompressHint(h *HintMapping, calldata []uint32)
 }
+
+// Compressable represent an object that knows how to encode itself as a []uint32.
+type Compressable interface {
+	Compress(to *[]uint32)
+}
+
+// Decompressable represent an object that knows how to decode itself into a []uint32.
+type Decompressable interface {
+	Decompress(in []uint32)
+}

--- a/constraint/blueprint.go
+++ b/constraint/blueprint.go
@@ -7,13 +7,20 @@ type BlueprintID uint32
 // constraints or instructions, and specify for the solving (or zksnark setup) part how to
 // "decompress" and optionally "solve" the associated wires.
 type Blueprint interface {
-	// NbInputs return the number of calldata input this blueprint expects.
+	// CalldataSize return the number of calldata input this blueprint expects.
 	// If this is unknown at compile time, implementation must return -1 and store
 	// the actual number of inputs in the first index of the calldata.
-	NbInputs() int
+	CalldataSize() int
 
 	// NbConstraints return the number of constraints this blueprint creates.
 	NbConstraints() int
+
+	// NbOutputs return the number of output wires this blueprint creates.
+	NbOutputs() int
+
+	// Wires returns a function that walks the wires appearing in the blueprint.
+	// This is used by the level builder to build a dependency graph between instructions.
+	Wires(inst Instruction) func(cb func(wire uint32))
 }
 
 // Solver represents the state of a constraint system solver at runtime. Blueprint can interact

--- a/constraint/blueprint.go
+++ b/constraint/blueprint.go
@@ -24,6 +24,10 @@ type Solver interface {
 	GetCoeff(cID uint32) Element
 	SetValue(vID uint32, f Element)
 	IsSolved(vID uint32) bool
+
+	// Read interprets input calldata as either a LinearExpression (if R1CS) or a Term (if Plonkish),
+	// evaluates it and return the result and the number of uint32 word read.
+	Read(calldata []uint32) (Element, int)
 }
 
 // BlueprintSolvable represents a blueprint that knows how to solve itself.
@@ -57,5 +61,5 @@ type Compressable interface {
 
 // Decompressable represent an object that knows how to decode itself into a []uint32.
 type Decompressable interface {
-	Decompress(in []uint32)
+	Decompress(in []uint32) int // returns number of uint32 read.
 }

--- a/constraint/blueprint.go
+++ b/constraint/blueprint.go
@@ -27,12 +27,13 @@ type Blueprint interface {
 // with this object to perform run time logic, solve constraints and assign values in the solution.
 type Solver interface {
 	Field
+
 	GetValue(cID, vID uint32) Element
 	GetCoeff(cID uint32) Element
 	SetValue(vID uint32, f Element)
 	IsSolved(vID uint32) bool
 
-	// Read interprets input calldata as either a LinearExpression (if R1CS) or a Term (if Plonkish),
+	// Read interprets input calldata as a LinearExpression,
 	// evaluates it and return the result and the number of uint32 word read.
 	Read(calldata []uint32) (Element, int)
 }

--- a/constraint/blueprint.go
+++ b/constraint/blueprint.go
@@ -18,9 +18,9 @@ type Blueprint interface {
 	// NbOutputs return the number of output wires this blueprint creates.
 	NbOutputs(inst Instruction) int
 
-	// Wires returns a function that walks the wires appearing in the blueprint.
+	// WireWalker returns a function that walks the wires appearing in the blueprint.
 	// This is used by the level builder to build a dependency graph between instructions.
-	Wires(inst Instruction) func(cb func(wire uint32))
+	WireWalker(inst Instruction) func(cb func(wire uint32))
 }
 
 // Solver represents the state of a constraint system solver at runtime. Blueprint can interact

--- a/constraint/blueprint.go
+++ b/constraint/blueprint.go
@@ -16,7 +16,7 @@ type Blueprint interface {
 	NbConstraints() int
 
 	// NbOutputs return the number of output wires this blueprint creates.
-	NbOutputs() int
+	NbOutputs(inst Instruction) int
 
 	// Wires returns a function that walks the wires appearing in the blueprint.
 	// This is used by the level builder to build a dependency graph between instructions.
@@ -39,34 +39,34 @@ type Solver interface {
 
 // BlueprintSolvable represents a blueprint that knows how to solve itself.
 type BlueprintSolvable interface {
+	Blueprint
 	// Solve may return an error if the decoded constraint / calldata is unsolvable.
 	Solve(s Solver, instruction Instruction) error
 }
 
 // BlueprintR1C indicates that the blueprint and associated calldata encodes a R1C
 type BlueprintR1C interface {
+	Blueprint
 	CompressR1C(c *R1C) []uint32
 	DecompressR1C(into *R1C, instruction Instruction)
 }
 
 // BlueprintSparseR1C indicates that the blueprint and associated calldata encodes a SparseR1C.
 type BlueprintSparseR1C interface {
+	Blueprint
 	CompressSparseR1C(c *SparseR1C) []uint32
 	DecompressSparseR1C(into *SparseR1C, instruction Instruction)
 }
 
 // BlueprintHint indicates that the blueprint and associated calldata encodes a hint.
 type BlueprintHint interface {
+	Blueprint
 	CompressHint(HintMapping) []uint32
 	DecompressHint(h *HintMapping, instruction Instruction)
 }
 
 // Compressable represent an object that knows how to encode itself as a []uint32.
 type Compressable interface {
-	Compress(to *[]uint32)
-}
-
-// Decompressable represent an object that knows how to decode itself into a []uint32.
-type Decompressable interface {
-	Decompress(in []uint32) int // returns number of uint32 read.
+	// CompressLE interprets the objects as a LinearExpression and encodes it as a []uint32.
+	CompressLE(to *[]uint32)
 }

--- a/constraint/blueprint_hint.go
+++ b/constraint/blueprint_hint.go
@@ -76,7 +76,7 @@ func (b *BlueprintGenericHint) NbOutputs(inst Instruction) int {
 	return 0
 }
 
-func (b *BlueprintGenericHint) Wires(inst Instruction) func(cb func(wire uint32)) {
+func (b *BlueprintGenericHint) WireWalker(inst Instruction) func(cb func(wire uint32)) {
 	return func(cb func(wire uint32)) {
 		lenInputs := int(inst.Calldata[2])
 		j := 3

--- a/constraint/blueprint_hint.go
+++ b/constraint/blueprint_hint.go
@@ -4,10 +4,10 @@ import "github.com/consensys/gnark/constraint/solver"
 
 type BlueprintGenericHint struct{}
 
-func (b *BlueprintGenericHint) DecompressHint(h *HintMapping, calldata []uint32) {
+func (b *BlueprintGenericHint) DecompressHint(h *HintMapping, inst Instruction) {
 	// ignore first call data == nbInputs
-	h.HintID = solver.HintID(calldata[1])
-	lenInputs := int(calldata[2])
+	h.HintID = solver.HintID(inst.Calldata[1])
+	lenInputs := int(inst.Calldata[2])
 	if cap(h.Inputs) >= lenInputs {
 		h.Inputs = h.Inputs[:lenInputs]
 	} else {
@@ -16,7 +16,7 @@ func (b *BlueprintGenericHint) DecompressHint(h *HintMapping, calldata []uint32)
 
 	j := 3
 	for i := 0; i < lenInputs; i++ {
-		n := int(calldata[j]) // len of linear expr
+		n := int(inst.Calldata[j]) // len of linear expr
 		j++
 		if cap(h.Inputs[i]) >= n {
 			h.Inputs[i] = h.Inputs[i][:0]
@@ -24,12 +24,12 @@ func (b *BlueprintGenericHint) DecompressHint(h *HintMapping, calldata []uint32)
 			h.Inputs[i] = make(LinearExpression, 0, n)
 		}
 		for k := 0; k < n; k++ {
-			h.Inputs[i] = append(h.Inputs[i], Term{CID: calldata[j], VID: calldata[j+1]})
+			h.Inputs[i] = append(h.Inputs[i], Term{CID: inst.Calldata[j], VID: inst.Calldata[j+1]})
 			j += 2
 		}
 	}
-	h.OutputRange.Start = calldata[j]
-	h.OutputRange.End = calldata[j+1]
+	h.OutputRange.Start = inst.Calldata[j]
+	h.OutputRange.End = inst.Calldata[j+1]
 }
 
 func (b *BlueprintGenericHint) CompressHint(h HintMapping) []uint32 {

--- a/constraint/blueprint_hint.go
+++ b/constraint/blueprint_hint.go
@@ -1,6 +1,8 @@
 package constraint
 
-import "github.com/consensys/gnark/constraint/solver"
+import (
+	"github.com/consensys/gnark/constraint/solver"
+)
 
 type BlueprintGenericHint struct{}
 
@@ -63,9 +65,35 @@ func (b *BlueprintGenericHint) CompressHint(h HintMapping) []uint32 {
 	return r
 }
 
-func (b *BlueprintGenericHint) NbInputs() int {
+func (b *BlueprintGenericHint) CalldataSize() int {
 	return -1
 }
 func (b *BlueprintGenericHint) NbConstraints() int {
 	return 0
+}
+
+func (b *BlueprintGenericHint) NbOutputs() int {
+	return 0
+}
+
+func (b *BlueprintGenericHint) Wires(inst Instruction) func(cb func(wire uint32)) {
+	return func(cb func(wire uint32)) {
+		lenInputs := int(inst.Calldata[2])
+		j := 3
+		for i := 0; i < lenInputs; i++ {
+			n := int(inst.Calldata[j]) // len of linear expr
+			j++
+
+			for k := 0; k < n; k++ {
+				t := Term{CID: inst.Calldata[j], VID: inst.Calldata[j+1]}
+				if !t.IsConstant() {
+					cb(t.VID)
+				}
+				j += 2
+			}
+		}
+		for k := inst.Calldata[j]; k < inst.Calldata[j+1]; k++ {
+			cb(k)
+		}
+	}
 }

--- a/constraint/blueprint_hint.go
+++ b/constraint/blueprint_hint.go
@@ -72,7 +72,7 @@ func (b *BlueprintGenericHint) NbConstraints() int {
 	return 0
 }
 
-func (b *BlueprintGenericHint) NbOutputs() int {
+func (b *BlueprintGenericHint) NbOutputs(inst Instruction) int {
 	return 0
 }
 

--- a/constraint/blueprint_r1cs.go
+++ b/constraint/blueprint_r1cs.go
@@ -13,7 +13,7 @@ func (b *BlueprintGenericR1C) CalldataSize() int {
 func (b *BlueprintGenericR1C) NbConstraints() int {
 	return 1
 }
-func (b *BlueprintGenericR1C) NbOutputs() int {
+func (b *BlueprintGenericR1C) NbOutputs(inst Instruction) int {
 	return 0
 }
 

--- a/constraint/blueprint_r1cs.go
+++ b/constraint/blueprint_r1cs.go
@@ -32,7 +32,7 @@ func (b *BlueprintGenericR1C) CompressR1C(c *R1C) []uint32 {
 	return r
 }
 
-func (b *BlueprintGenericR1C) DecompressR1C(c *R1C, calldata []uint32) {
+func (b *BlueprintGenericR1C) DecompressR1C(c *R1C, inst Instruction) {
 	copySlice := func(slice *LinearExpression, expectedLen, idx int) {
 		if cap(*slice) >= expectedLen {
 			(*slice) = (*slice)[:expectedLen]
@@ -40,16 +40,16 @@ func (b *BlueprintGenericR1C) DecompressR1C(c *R1C, calldata []uint32) {
 			(*slice) = make(LinearExpression, expectedLen, expectedLen*2)
 		}
 		for k := 0; k < expectedLen; k++ {
-			(*slice)[k].CID = calldata[idx]
+			(*slice)[k].CID = inst.Calldata[idx]
 			idx++
-			(*slice)[k].VID = calldata[idx]
+			(*slice)[k].VID = inst.Calldata[idx]
 			idx++
 		}
 	}
 
-	lenL := int(calldata[1])
-	lenR := int(calldata[2])
-	lenO := int(calldata[3])
+	lenL := int(inst.Calldata[1])
+	lenR := int(inst.Calldata[2])
+	lenO := int(inst.Calldata[3])
 
 	const offset = 4
 	copySlice(&c.L, lenL, offset)

--- a/constraint/blueprint_r1cs.go
+++ b/constraint/blueprint_r1cs.go
@@ -60,7 +60,7 @@ func (b *BlueprintGenericR1C) DecompressR1C(c *R1C, inst Instruction) {
 	copySlice(&c.O, lenO, offset+2*(lenL+lenR))
 }
 
-func (b *BlueprintGenericR1C) Wires(inst Instruction) func(cb func(wire uint32)) {
+func (b *BlueprintGenericR1C) WireWalker(inst Instruction) func(cb func(wire uint32)) {
 	return func(cb func(wire uint32)) {
 		lenL := int(inst.Calldata[1])
 		lenR := int(inst.Calldata[2])

--- a/constraint/blueprint_r1cs.go
+++ b/constraint/blueprint_r1cs.go
@@ -6,12 +6,15 @@ package constraint
 //	L * R == 0
 type BlueprintGenericR1C struct{}
 
-func (b *BlueprintGenericR1C) NbInputs() int {
+func (b *BlueprintGenericR1C) CalldataSize() int {
 	// size of linear expressions are unknown.
 	return -1
 }
 func (b *BlueprintGenericR1C) NbConstraints() int {
 	return 1
+}
+func (b *BlueprintGenericR1C) NbOutputs() int {
+	return 0
 }
 
 func (b *BlueprintGenericR1C) CompressR1C(c *R1C) []uint32 {
@@ -55,6 +58,27 @@ func (b *BlueprintGenericR1C) DecompressR1C(c *R1C, inst Instruction) {
 	copySlice(&c.L, lenL, offset)
 	copySlice(&c.R, lenR, offset+2*lenL)
 	copySlice(&c.O, lenO, offset+2*(lenL+lenR))
+}
+
+func (b *BlueprintGenericR1C) Wires(inst Instruction) func(cb func(wire uint32)) {
+	return func(cb func(wire uint32)) {
+		lenL := int(inst.Calldata[1])
+		lenR := int(inst.Calldata[2])
+		lenO := int(inst.Calldata[3])
+
+		appendWires := func(expectedLen, idx int) {
+			for k := 0; k < expectedLen; k++ {
+				idx++
+				cb(inst.Calldata[idx])
+				idx++
+			}
+		}
+
+		const offset = 4
+		appendWires(lenL, offset)
+		appendWires(lenR, offset+2*lenL)
+		appendWires(lenO, offset+2*(lenL+lenR))
+	}
 }
 
 // since frontend is single threaded, to avoid allocating slices at each compress call

--- a/constraint/blueprint_scs.go
+++ b/constraint/blueprint_scs.go
@@ -37,23 +37,23 @@ func (b *BlueprintGenericSparseR1C) CompressSparseR1C(c *SparseR1C) []uint32 {
 	return bufSCS[:]
 }
 
-func (b *BlueprintGenericSparseR1C) DecompressSparseR1C(c *SparseR1C, calldata []uint32) {
+func (b *BlueprintGenericSparseR1C) DecompressSparseR1C(c *SparseR1C, inst Instruction) {
 	c.Clear()
 
-	c.XA = calldata[0]
-	c.XB = calldata[1]
-	c.XC = calldata[2]
-	c.QL = calldata[3]
-	c.QR = calldata[4]
-	c.QO = calldata[5]
-	c.QM = calldata[6]
-	c.QC = calldata[7]
-	c.Commitment = CommitmentConstraint(calldata[8])
+	c.XA = inst.Calldata[0]
+	c.XB = inst.Calldata[1]
+	c.XC = inst.Calldata[2]
+	c.QL = inst.Calldata[3]
+	c.QR = inst.Calldata[4]
+	c.QO = inst.Calldata[5]
+	c.QM = inst.Calldata[6]
+	c.QC = inst.Calldata[7]
+	c.Commitment = CommitmentConstraint(inst.Calldata[8])
 }
 
-func (b *BlueprintGenericSparseR1C) Solve(s Solver, calldata []uint32) error {
+func (b *BlueprintGenericSparseR1C) Solve(s Solver, inst Instruction) error {
 	var c SparseR1C
-	b.DecompressSparseR1C(&c, calldata)
+	b.DecompressSparseR1C(&c, inst)
 	if c.Commitment != NOT {
 		// a constraint of the form f_L - PI_2 = 0 or f_L = Comm.
 		// these are there for enforcing the correctness of the commitment and can be skipped in solving time
@@ -174,24 +174,24 @@ func (b *BlueprintSparseR1CMul) CompressSparseR1C(c *SparseR1C) []uint32 {
 	return bufSCS[:4]
 }
 
-func (b *BlueprintSparseR1CMul) Solve(s Solver, calldata []uint32) error {
+func (b *BlueprintSparseR1CMul) Solve(s Solver, inst Instruction) error {
 	// qM⋅(xaxb)  == xc
-	m0 := s.GetValue(calldata[3], calldata[0])
-	m1 := s.GetValue(CoeffIdOne, calldata[1])
+	m0 := s.GetValue(inst.Calldata[3], inst.Calldata[0])
+	m1 := s.GetValue(CoeffIdOne, inst.Calldata[1])
 
 	m0 = s.Mul(m0, m1)
 
-	s.SetValue(calldata[2], m0)
+	s.SetValue(inst.Calldata[2], m0)
 	return nil
 }
 
-func (b *BlueprintSparseR1CMul) DecompressSparseR1C(c *SparseR1C, calldata []uint32) {
+func (b *BlueprintSparseR1CMul) DecompressSparseR1C(c *SparseR1C, inst Instruction) {
 	c.Clear()
-	c.XA = calldata[0]
-	c.XB = calldata[1]
-	c.XC = calldata[2]
+	c.XA = inst.Calldata[0]
+	c.XB = inst.Calldata[1]
+	c.XC = inst.Calldata[2]
 	c.QO = CoeffIdMinusOne
-	c.QM = calldata[3]
+	c.QM = inst.Calldata[3]
 }
 
 // BlueprintSparseR1CAdd implements Blueprint, BlueprintSolvable and BlueprintSparseR1C.
@@ -217,28 +217,28 @@ func (b *BlueprintSparseR1CAdd) CompressSparseR1C(c *SparseR1C) []uint32 {
 	return bufSCS[:6]
 }
 
-func (blueprint *BlueprintSparseR1CAdd) Solve(s Solver, calldata []uint32) error {
+func (blueprint *BlueprintSparseR1CAdd) Solve(s Solver, inst Instruction) error {
 	// a + b + k == c
-	a := s.GetValue(calldata[3], calldata[0])
-	b := s.GetValue(calldata[4], calldata[1])
-	k := s.GetCoeff(calldata[5])
+	a := s.GetValue(inst.Calldata[3], inst.Calldata[0])
+	b := s.GetValue(inst.Calldata[4], inst.Calldata[1])
+	k := s.GetCoeff(inst.Calldata[5])
 
 	a = s.Add(a, b)
 	a = s.Add(a, k)
 
-	s.SetValue(calldata[2], a)
+	s.SetValue(inst.Calldata[2], a)
 	return nil
 }
 
-func (b *BlueprintSparseR1CAdd) DecompressSparseR1C(c *SparseR1C, calldata []uint32) {
+func (b *BlueprintSparseR1CAdd) DecompressSparseR1C(c *SparseR1C, inst Instruction) {
 	c.Clear()
-	c.XA = calldata[0]
-	c.XB = calldata[1]
-	c.XC = calldata[2]
-	c.QL = calldata[3]
-	c.QR = calldata[4]
+	c.XA = inst.Calldata[0]
+	c.XB = inst.Calldata[1]
+	c.XC = inst.Calldata[2]
+	c.QL = inst.Calldata[3]
+	c.QR = inst.Calldata[4]
 	c.QO = CoeffIdMinusOne
-	c.QC = calldata[5]
+	c.QC = inst.Calldata[5]
 }
 
 // BlueprintSparseR1CBool implements Blueprint, BlueprintSolvable and BlueprintSparseR1C.
@@ -262,11 +262,11 @@ func (b *BlueprintSparseR1CBool) CompressSparseR1C(c *SparseR1C) []uint32 {
 	return bufSCS[:3]
 }
 
-func (blueprint *BlueprintSparseR1CBool) Solve(s Solver, calldata []uint32) error {
+func (blueprint *BlueprintSparseR1CBool) Solve(s Solver, inst Instruction) error {
 	// all wires are already solved, we just check the constraint.
-	v1 := s.GetValue(calldata[1], calldata[0])
-	v2 := s.GetValue(calldata[2], calldata[0])
-	v := s.GetValue(CoeffIdOne, calldata[0])
+	v1 := s.GetValue(inst.Calldata[1], inst.Calldata[0])
+	v2 := s.GetValue(inst.Calldata[2], inst.Calldata[0])
+	v := s.GetValue(CoeffIdOne, inst.Calldata[0])
 	v = s.Mul(v, v2)
 	v = s.Add(v1, v)
 	if !v.IsZero() {
@@ -275,12 +275,12 @@ func (blueprint *BlueprintSparseR1CBool) Solve(s Solver, calldata []uint32) erro
 	return nil
 }
 
-func (b *BlueprintSparseR1CBool) DecompressSparseR1C(c *SparseR1C, calldata []uint32) {
+func (b *BlueprintSparseR1CBool) DecompressSparseR1C(c *SparseR1C, inst Instruction) {
 	c.Clear()
-	c.XA = calldata[0]
+	c.XA = inst.Calldata[0]
 	c.XB = c.XA
-	c.QL = calldata[1]
-	c.QM = calldata[2]
+	c.QL = inst.Calldata[1]
+	c.QM = inst.Calldata[2]
 }
 
 // since frontend is single threaded, to avoid allocating slices at each compress call

--- a/constraint/blueprint_scs.go
+++ b/constraint/blueprint_scs.go
@@ -28,7 +28,7 @@ func (b *BlueprintGenericSparseR1C) NbOutputs(inst Instruction) int {
 	return 0
 }
 
-func (b *BlueprintGenericSparseR1C) Wires(inst Instruction) func(cb func(wire uint32)) {
+func (b *BlueprintGenericSparseR1C) WireWalker(inst Instruction) func(cb func(wire uint32)) {
 	return func(cb func(wire uint32)) {
 		cb(inst.Calldata[0]) // xa
 		cb(inst.Calldata[1]) // xb
@@ -181,7 +181,7 @@ func (b *BlueprintSparseR1CMul) NbOutputs(inst Instruction) int {
 	return 0
 }
 
-func (b *BlueprintSparseR1CMul) Wires(inst Instruction) func(cb func(wire uint32)) {
+func (b *BlueprintSparseR1CMul) WireWalker(inst Instruction) func(cb func(wire uint32)) {
 	return func(cb func(wire uint32)) {
 		cb(inst.Calldata[0]) // xa
 		cb(inst.Calldata[1]) // xb
@@ -233,7 +233,7 @@ func (b *BlueprintSparseR1CAdd) NbOutputs(inst Instruction) int {
 	return 0
 }
 
-func (b *BlueprintSparseR1CAdd) Wires(inst Instruction) func(cb func(wire uint32)) {
+func (b *BlueprintSparseR1CAdd) WireWalker(inst Instruction) func(cb func(wire uint32)) {
 	return func(cb func(wire uint32)) {
 		cb(inst.Calldata[0]) // xa
 		cb(inst.Calldata[1]) // xb
@@ -292,7 +292,7 @@ func (b *BlueprintSparseR1CBool) NbOutputs(inst Instruction) int {
 	return 0
 }
 
-func (b *BlueprintSparseR1CBool) Wires(inst Instruction) func(cb func(wire uint32)) {
+func (b *BlueprintSparseR1CBool) WireWalker(inst Instruction) func(cb func(wire uint32)) {
 	return func(cb func(wire uint32)) {
 		cb(inst.Calldata[0]) // xa
 	}

--- a/constraint/blueprint_scs.go
+++ b/constraint/blueprint_scs.go
@@ -24,7 +24,7 @@ func (b *BlueprintGenericSparseR1C) NbConstraints() int {
 	return 1
 }
 
-func (b *BlueprintGenericSparseR1C) NbOutputs() int {
+func (b *BlueprintGenericSparseR1C) NbOutputs(inst Instruction) int {
 	return 0
 }
 
@@ -177,7 +177,7 @@ func (b *BlueprintSparseR1CMul) CalldataSize() int {
 func (b *BlueprintSparseR1CMul) NbConstraints() int {
 	return 1
 }
-func (b *BlueprintSparseR1CMul) NbOutputs() int {
+func (b *BlueprintSparseR1CMul) NbOutputs(inst Instruction) int {
 	return 0
 }
 
@@ -229,7 +229,7 @@ func (b *BlueprintSparseR1CAdd) CalldataSize() int {
 func (b *BlueprintSparseR1CAdd) NbConstraints() int {
 	return 1
 }
-func (b *BlueprintSparseR1CAdd) NbOutputs() int {
+func (b *BlueprintSparseR1CAdd) NbOutputs(inst Instruction) int {
 	return 0
 }
 
@@ -288,7 +288,7 @@ func (b *BlueprintSparseR1CBool) CalldataSize() int {
 func (b *BlueprintSparseR1CBool) NbConstraints() int {
 	return 1
 }
-func (b *BlueprintSparseR1CBool) NbOutputs() int {
+func (b *BlueprintSparseR1CBool) NbOutputs(inst Instruction) int {
 	return 0
 }
 

--- a/constraint/blueprint_scs.go
+++ b/constraint/blueprint_scs.go
@@ -17,11 +17,23 @@ var (
 type BlueprintGenericSparseR1C struct {
 }
 
-func (b *BlueprintGenericSparseR1C) NbInputs() int {
+func (b *BlueprintGenericSparseR1C) CalldataSize() int {
 	return 9 // number of fields in SparseR1C
 }
 func (b *BlueprintGenericSparseR1C) NbConstraints() int {
 	return 1
+}
+
+func (b *BlueprintGenericSparseR1C) NbOutputs() int {
+	return 0
+}
+
+func (b *BlueprintGenericSparseR1C) Wires(inst Instruction) func(cb func(wire uint32)) {
+	return func(cb func(wire uint32)) {
+		cb(inst.Calldata[0]) // xa
+		cb(inst.Calldata[1]) // xb
+		cb(inst.Calldata[2]) // xc
+	}
 }
 
 func (b *BlueprintGenericSparseR1C) CompressSparseR1C(c *SparseR1C) []uint32 {
@@ -159,11 +171,22 @@ func (b *BlueprintGenericSparseR1C) checkConstraint(c *SparseR1C, s Solver) erro
 //	qM⋅(xaxb)  == xc
 type BlueprintSparseR1CMul struct{}
 
-func (b *BlueprintSparseR1CMul) NbInputs() int {
+func (b *BlueprintSparseR1CMul) CalldataSize() int {
 	return 4
 }
 func (b *BlueprintSparseR1CMul) NbConstraints() int {
 	return 1
+}
+func (b *BlueprintSparseR1CMul) NbOutputs() int {
+	return 0
+}
+
+func (b *BlueprintSparseR1CMul) Wires(inst Instruction) func(cb func(wire uint32)) {
+	return func(cb func(wire uint32)) {
+		cb(inst.Calldata[0]) // xa
+		cb(inst.Calldata[1]) // xb
+		cb(inst.Calldata[2]) // xc
+	}
 }
 
 func (b *BlueprintSparseR1CMul) CompressSparseR1C(c *SparseR1C) []uint32 {
@@ -200,11 +223,22 @@ func (b *BlueprintSparseR1CMul) DecompressSparseR1C(c *SparseR1C, inst Instructi
 //	qL⋅xa + qR⋅xb + qC == xc
 type BlueprintSparseR1CAdd struct{}
 
-func (b *BlueprintSparseR1CAdd) NbInputs() int {
+func (b *BlueprintSparseR1CAdd) CalldataSize() int {
 	return 6
 }
 func (b *BlueprintSparseR1CAdd) NbConstraints() int {
 	return 1
+}
+func (b *BlueprintSparseR1CAdd) NbOutputs() int {
+	return 0
+}
+
+func (b *BlueprintSparseR1CAdd) Wires(inst Instruction) func(cb func(wire uint32)) {
+	return func(cb func(wire uint32)) {
+		cb(inst.Calldata[0]) // xa
+		cb(inst.Calldata[1]) // xb
+		cb(inst.Calldata[2]) // xc
+	}
 }
 
 func (b *BlueprintSparseR1CAdd) CompressSparseR1C(c *SparseR1C) []uint32 {
@@ -248,11 +282,20 @@ func (b *BlueprintSparseR1CAdd) DecompressSparseR1C(c *SparseR1C, inst Instructi
 //	that is v + -v*v == 0
 type BlueprintSparseR1CBool struct{}
 
-func (b *BlueprintSparseR1CBool) NbInputs() int {
+func (b *BlueprintSparseR1CBool) CalldataSize() int {
 	return 3
 }
 func (b *BlueprintSparseR1CBool) NbConstraints() int {
 	return 1
+}
+func (b *BlueprintSparseR1CBool) NbOutputs() int {
+	return 0
+}
+
+func (b *BlueprintSparseR1CBool) Wires(inst Instruction) func(cb func(wire uint32)) {
+	return func(cb func(wire uint32)) {
+		cb(inst.Calldata[0]) // xa
+	}
 }
 
 func (b *BlueprintSparseR1CBool) CompressSparseR1C(c *SparseR1C) []uint32 {

--- a/constraint/bn254/coeff.go
+++ b/constraint/bn254/coeff.go
@@ -182,3 +182,11 @@ func (engine *field) String(a constraint.Element) string {
 	e := (*fr.Element)(a[:])
 	return e.String()
 }
+
+func (engine *field) Uint64(a constraint.Element) (uint64, bool) {
+	e := (*fr.Element)(a[:])
+	if !e.IsUint64() {
+		return 0, false
+	}
+	return e.Uint64(), true
+}

--- a/constraint/bn254/solver.go
+++ b/constraint/bn254/solver.go
@@ -376,7 +376,7 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.Instruction, scratch *scratch) error {
+func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
 	blueprint := solver.Blueprints[inst.BlueprintID]
 	calldata := solver.GetCallData(inst)

--- a/constraint/bn254/solver.go
+++ b/constraint/bn254/solver.go
@@ -133,15 +133,15 @@ func (s *solver) set(id int, value fr.Element) {
 }
 
 // computeTerm computes coeff*variable
-// TODO @gbotrel check if t is a Constant only
 func (s *solver) computeTerm(t constraint.Term) fr.Element {
 	cID, vID := t.CoeffID(), t.WireID()
-	if cID != 0 && !s.solved[vID] {
-		panic("computing a term with an unsolved wire")
-	}
 
 	if t.IsConstant() {
 		return s.Coefficients[cID]
+	}
+
+	if cID != 0 && !s.solved[vID] {
+		panic("computing a term with an unsolved wire")
 	}
 
 	switch cID {
@@ -390,14 +390,14 @@ func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratc
 			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
-	} else if solver.Type == constraint.SystemSparseR1CS {
-		// blueprint declared "I know how to solve this."
-		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, inst); err != nil {
-				return solver.wrapErrWithDebugInfo(cID, err)
-			}
-			return nil
+	}
+
+	// blueprint declared "I know how to solve this."
+	if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
+		if err := bc.Solve(solver, inst); err != nil {
+			return solver.wrapErrWithDebugInfo(cID, err)
 		}
+		return nil
 	}
 
 	// blueprint encodes a hint, we execute.

--- a/constraint/bn254/solver.go
+++ b/constraint/bn254/solver.go
@@ -358,7 +358,7 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
-		return s.GetValue(calldata[0], calldata[1]), 2
+		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element
 	n := int(calldata[0])

--- a/constraint/bn254/solver.go
+++ b/constraint/bn254/solver.go
@@ -376,10 +376,10 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
+func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
-	blueprint := solver.Blueprints[inst.BlueprintID]
-	calldata := solver.GetCallData(inst)
+	blueprint := solver.Blueprints[pi.BlueprintID]
+	inst := pi.Unpack(&solver.System)
 	cID := inst.ConstraintOffset // here we have 1 constraint in the instruction only
 
 	if solver.Type == constraint.SystemR1CS {
@@ -387,13 +387,13 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 			// TODO @gbotrel we use the solveR1C method for now, having user-defined
 			// blueprint for R1CS would require constraint.Solver interface to add methods
 			// to set a,b,c since it's more efficient to compute these while we solve.
-			bc.DecompressR1C(&scratch.tR1C, calldata)
+			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
 	} else if solver.Type == constraint.SystemSparseR1CS {
 		// blueprint declared "I know how to solve this."
 		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, calldata); err != nil {
+			if err := bc.Solve(solver, inst); err != nil {
 				return solver.wrapErrWithDebugInfo(cID, err)
 			}
 			return nil
@@ -403,7 +403,7 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 	// blueprint encodes a hint, we execute.
 	// TODO @gbotrel may be worth it to move hint logic in blueprint "solve"
 	if bc, ok := blueprint.(constraint.BlueprintHint); ok {
-		bc.DecompressHint(&scratch.tHint, calldata)
+		bc.DecompressHint(&scratch.tHint, inst)
 		return solver.solveWithHint(&scratch.tHint)
 	}
 

--- a/constraint/bn254/solver.go
+++ b/constraint/bn254/solver.go
@@ -358,6 +358,9 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
+		if calldata[0] != 1 {
+			panic("invalid calldata")
+		}
 		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element

--- a/constraint/bn254/system.go
+++ b/constraint/bn254/system.go
@@ -121,7 +121,7 @@ func (cs *system) GetR1Cs() []constraint.R1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintR1C); ok {
 			var r1c constraint.R1C
-			bc.DecompressR1C(&r1c, cs.GetCallData(inst))
+			bc.DecompressR1C(&r1c, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, r1c)
 		} else {
 			panic("not implemented")
@@ -196,8 +196,7 @@ func (cs *system) GetSparseR1Cs() []constraint.SparseR1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
 			var sparseR1C constraint.SparseR1C
-			calldata := cs.CallData[inst.StartCallData : inst.StartCallData+uint64(blueprint.NbInputs())]
-			bc.DecompressSparseR1C(&sparseR1C, calldata)
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, sparseR1C)
 		} else {
 			panic("not implemented")
@@ -234,7 +233,7 @@ func evaluateLROSmallDomain(cs *system, solution []fr.Element) ([]fr.Element, []
 	for _, inst := range cs.Instructions {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
-			bc.DecompressSparseR1C(&sparseR1C, cs.GetCallData(inst))
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 
 			l[offset+j] = solution[sparseR1C.XA]
 			r[offset+j] = solution[sparseR1C.XB]

--- a/constraint/bw6-633/coeff.go
+++ b/constraint/bw6-633/coeff.go
@@ -182,3 +182,11 @@ func (engine *field) String(a constraint.Element) string {
 	e := (*fr.Element)(a[:])
 	return e.String()
 }
+
+func (engine *field) Uint64(a constraint.Element) (uint64, bool) {
+	e := (*fr.Element)(a[:])
+	if !e.IsUint64() {
+		return 0, false
+	}
+	return e.Uint64(), true
+}

--- a/constraint/bw6-633/solver.go
+++ b/constraint/bw6-633/solver.go
@@ -376,7 +376,7 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.Instruction, scratch *scratch) error {
+func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
 	blueprint := solver.Blueprints[inst.BlueprintID]
 	calldata := solver.GetCallData(inst)

--- a/constraint/bw6-633/solver.go
+++ b/constraint/bw6-633/solver.go
@@ -133,15 +133,15 @@ func (s *solver) set(id int, value fr.Element) {
 }
 
 // computeTerm computes coeff*variable
-// TODO @gbotrel check if t is a Constant only
 func (s *solver) computeTerm(t constraint.Term) fr.Element {
 	cID, vID := t.CoeffID(), t.WireID()
-	if cID != 0 && !s.solved[vID] {
-		panic("computing a term with an unsolved wire")
-	}
 
 	if t.IsConstant() {
 		return s.Coefficients[cID]
+	}
+
+	if cID != 0 && !s.solved[vID] {
+		panic("computing a term with an unsolved wire")
 	}
 
 	switch cID {
@@ -390,14 +390,14 @@ func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratc
 			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
-	} else if solver.Type == constraint.SystemSparseR1CS {
-		// blueprint declared "I know how to solve this."
-		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, inst); err != nil {
-				return solver.wrapErrWithDebugInfo(cID, err)
-			}
-			return nil
+	}
+
+	// blueprint declared "I know how to solve this."
+	if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
+		if err := bc.Solve(solver, inst); err != nil {
+			return solver.wrapErrWithDebugInfo(cID, err)
 		}
+		return nil
 	}
 
 	// blueprint encodes a hint, we execute.

--- a/constraint/bw6-633/solver.go
+++ b/constraint/bw6-633/solver.go
@@ -358,7 +358,7 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
-		return s.GetValue(calldata[0], calldata[1]), 2
+		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element
 	n := int(calldata[0])

--- a/constraint/bw6-633/solver.go
+++ b/constraint/bw6-633/solver.go
@@ -376,10 +376,10 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
+func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
-	blueprint := solver.Blueprints[inst.BlueprintID]
-	calldata := solver.GetCallData(inst)
+	blueprint := solver.Blueprints[pi.BlueprintID]
+	inst := pi.Unpack(&solver.System)
 	cID := inst.ConstraintOffset // here we have 1 constraint in the instruction only
 
 	if solver.Type == constraint.SystemR1CS {
@@ -387,13 +387,13 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 			// TODO @gbotrel we use the solveR1C method for now, having user-defined
 			// blueprint for R1CS would require constraint.Solver interface to add methods
 			// to set a,b,c since it's more efficient to compute these while we solve.
-			bc.DecompressR1C(&scratch.tR1C, calldata)
+			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
 	} else if solver.Type == constraint.SystemSparseR1CS {
 		// blueprint declared "I know how to solve this."
 		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, calldata); err != nil {
+			if err := bc.Solve(solver, inst); err != nil {
 				return solver.wrapErrWithDebugInfo(cID, err)
 			}
 			return nil
@@ -403,7 +403,7 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 	// blueprint encodes a hint, we execute.
 	// TODO @gbotrel may be worth it to move hint logic in blueprint "solve"
 	if bc, ok := blueprint.(constraint.BlueprintHint); ok {
-		bc.DecompressHint(&scratch.tHint, calldata)
+		bc.DecompressHint(&scratch.tHint, inst)
 		return solver.solveWithHint(&scratch.tHint)
 	}
 

--- a/constraint/bw6-633/solver.go
+++ b/constraint/bw6-633/solver.go
@@ -358,6 +358,9 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
+		if calldata[0] != 1 {
+			panic("invalid calldata")
+		}
 		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element

--- a/constraint/bw6-633/system.go
+++ b/constraint/bw6-633/system.go
@@ -121,7 +121,7 @@ func (cs *system) GetR1Cs() []constraint.R1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintR1C); ok {
 			var r1c constraint.R1C
-			bc.DecompressR1C(&r1c, cs.GetCallData(inst))
+			bc.DecompressR1C(&r1c, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, r1c)
 		} else {
 			panic("not implemented")
@@ -196,8 +196,7 @@ func (cs *system) GetSparseR1Cs() []constraint.SparseR1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
 			var sparseR1C constraint.SparseR1C
-			calldata := cs.CallData[inst.StartCallData : inst.StartCallData+uint64(blueprint.NbInputs())]
-			bc.DecompressSparseR1C(&sparseR1C, calldata)
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, sparseR1C)
 		} else {
 			panic("not implemented")
@@ -234,7 +233,7 @@ func evaluateLROSmallDomain(cs *system, solution []fr.Element) ([]fr.Element, []
 	for _, inst := range cs.Instructions {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
-			bc.DecompressSparseR1C(&sparseR1C, cs.GetCallData(inst))
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 
 			l[offset+j] = solution[sparseR1C.XA]
 			r[offset+j] = solution[sparseR1C.XB]

--- a/constraint/bw6-761/coeff.go
+++ b/constraint/bw6-761/coeff.go
@@ -182,3 +182,11 @@ func (engine *field) String(a constraint.Element) string {
 	e := (*fr.Element)(a[:])
 	return e.String()
 }
+
+func (engine *field) Uint64(a constraint.Element) (uint64, bool) {
+	e := (*fr.Element)(a[:])
+	if !e.IsUint64() {
+		return 0, false
+	}
+	return e.Uint64(), true
+}

--- a/constraint/bw6-761/solver.go
+++ b/constraint/bw6-761/solver.go
@@ -376,7 +376,7 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.Instruction, scratch *scratch) error {
+func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
 	blueprint := solver.Blueprints[inst.BlueprintID]
 	calldata := solver.GetCallData(inst)

--- a/constraint/bw6-761/solver.go
+++ b/constraint/bw6-761/solver.go
@@ -133,15 +133,15 @@ func (s *solver) set(id int, value fr.Element) {
 }
 
 // computeTerm computes coeff*variable
-// TODO @gbotrel check if t is a Constant only
 func (s *solver) computeTerm(t constraint.Term) fr.Element {
 	cID, vID := t.CoeffID(), t.WireID()
-	if cID != 0 && !s.solved[vID] {
-		panic("computing a term with an unsolved wire")
-	}
 
 	if t.IsConstant() {
 		return s.Coefficients[cID]
+	}
+
+	if cID != 0 && !s.solved[vID] {
+		panic("computing a term with an unsolved wire")
 	}
 
 	switch cID {
@@ -390,14 +390,14 @@ func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratc
 			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
-	} else if solver.Type == constraint.SystemSparseR1CS {
-		// blueprint declared "I know how to solve this."
-		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, inst); err != nil {
-				return solver.wrapErrWithDebugInfo(cID, err)
-			}
-			return nil
+	}
+
+	// blueprint declared "I know how to solve this."
+	if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
+		if err := bc.Solve(solver, inst); err != nil {
+			return solver.wrapErrWithDebugInfo(cID, err)
 		}
+		return nil
 	}
 
 	// blueprint encodes a hint, we execute.

--- a/constraint/bw6-761/solver.go
+++ b/constraint/bw6-761/solver.go
@@ -358,7 +358,7 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
-		return s.GetValue(calldata[0], calldata[1]), 2
+		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element
 	n := int(calldata[0])

--- a/constraint/bw6-761/solver.go
+++ b/constraint/bw6-761/solver.go
@@ -376,10 +376,10 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
+func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
-	blueprint := solver.Blueprints[inst.BlueprintID]
-	calldata := solver.GetCallData(inst)
+	blueprint := solver.Blueprints[pi.BlueprintID]
+	inst := pi.Unpack(&solver.System)
 	cID := inst.ConstraintOffset // here we have 1 constraint in the instruction only
 
 	if solver.Type == constraint.SystemR1CS {
@@ -387,13 +387,13 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 			// TODO @gbotrel we use the solveR1C method for now, having user-defined
 			// blueprint for R1CS would require constraint.Solver interface to add methods
 			// to set a,b,c since it's more efficient to compute these while we solve.
-			bc.DecompressR1C(&scratch.tR1C, calldata)
+			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
 	} else if solver.Type == constraint.SystemSparseR1CS {
 		// blueprint declared "I know how to solve this."
 		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, calldata); err != nil {
+			if err := bc.Solve(solver, inst); err != nil {
 				return solver.wrapErrWithDebugInfo(cID, err)
 			}
 			return nil
@@ -403,7 +403,7 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 	// blueprint encodes a hint, we execute.
 	// TODO @gbotrel may be worth it to move hint logic in blueprint "solve"
 	if bc, ok := blueprint.(constraint.BlueprintHint); ok {
-		bc.DecompressHint(&scratch.tHint, calldata)
+		bc.DecompressHint(&scratch.tHint, inst)
 		return solver.solveWithHint(&scratch.tHint)
 	}
 

--- a/constraint/bw6-761/solver.go
+++ b/constraint/bw6-761/solver.go
@@ -358,6 +358,9 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
+		if calldata[0] != 1 {
+			panic("invalid calldata")
+		}
 		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element

--- a/constraint/bw6-761/system.go
+++ b/constraint/bw6-761/system.go
@@ -121,7 +121,7 @@ func (cs *system) GetR1Cs() []constraint.R1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintR1C); ok {
 			var r1c constraint.R1C
-			bc.DecompressR1C(&r1c, cs.GetCallData(inst))
+			bc.DecompressR1C(&r1c, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, r1c)
 		} else {
 			panic("not implemented")
@@ -196,8 +196,7 @@ func (cs *system) GetSparseR1Cs() []constraint.SparseR1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
 			var sparseR1C constraint.SparseR1C
-			calldata := cs.CallData[inst.StartCallData : inst.StartCallData+uint64(blueprint.NbInputs())]
-			bc.DecompressSparseR1C(&sparseR1C, calldata)
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, sparseR1C)
 		} else {
 			panic("not implemented")
@@ -234,7 +233,7 @@ func evaluateLROSmallDomain(cs *system, solution []fr.Element) ([]fr.Element, []
 	for _, inst := range cs.Instructions {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
-			bc.DecompressSparseR1C(&sparseR1C, cs.GetCallData(inst))
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 
 			l[offset+j] = solution[sparseR1C.XA]
 			r[offset+j] = solution[sparseR1C.XB]

--- a/constraint/core.go
+++ b/constraint/core.go
@@ -357,17 +357,17 @@ func (cs *System) AddInstruction(bID BlueprintID, calldata []uint32) []uint32 {
 
 	// add the output wires
 	inst := pi.Unpack(cs)
+	nbOutputs := blueprint.NbOutputs(inst)
 	var wires []uint32
-	for i := 0; i < blueprint.NbOutputs(inst); i++ {
+	for i := 0; i < nbOutputs; i++ {
 		wires = append(wires, uint32(cs.AddInternalVariable()))
 	}
 
 	// add the instruction
 	cs.Instructions = append(cs.Instructions, pi)
 
-	walker := blueprint.Wires(inst)
 	// update the instruction dependency tree
-	cs.updateLevel(len(cs.Instructions)-1, walker)
+	cs.updateLevel(len(cs.Instructions)-1, blueprint.WireWalker(inst))
 
 	return wires
 }

--- a/constraint/core.go
+++ b/constraint/core.go
@@ -34,7 +34,10 @@ type PackedInstruction struct {
 	// multiple constraints.
 	ConstraintOffset uint32
 
-	// WireOffset stores the starting internal wire ID of this instruction.
+	// WireOffset stores the starting internal wire ID of this instruction. Blueprints may use this
+	// and refer to output wires by their offset.
+	// For example, if a blueprint declared 5 outputs, the first output wire will be WireOffset,
+	// the last one WireOffset+4.
 	WireOffset uint32
 
 	// The constraint system stores a single []uint32 calldata slice. StartCallData

--- a/constraint/core.go
+++ b/constraint/core.go
@@ -317,18 +317,6 @@ func (system *System) VariableToString(vID int) string {
 	return fmt.Sprintf("v%d", vID) // TODO @gbotrel  vs strconv.Itoa.
 }
 
-// GetCallData re-slice the constraint system full calldata slice with the portion
-// related to the instruction. This does not copy and caller should not modify.
-func (cs *System) GetCallData(instruction PackedInstruction) []uint32 {
-	blueprint := cs.Blueprints[instruction.BlueprintID]
-	nbInputs := blueprint.NbInputs()
-	if nbInputs < 0 {
-		// by convention, we store nbInputs < 0 for non-static input length.
-		nbInputs = int(cs.CallData[instruction.StartCallData])
-	}
-	return cs.CallData[instruction.StartCallData : instruction.StartCallData+uint64(nbInputs)]
-}
-
 func (cs *System) AddR1C(c R1C, bID BlueprintID) int {
 	profile.RecordConstraint()
 

--- a/constraint/field.go
+++ b/constraint/field.go
@@ -26,4 +26,5 @@ type Field interface {
 	One() Element
 	IsOne(Element) bool
 	String(Element) string
+	Uint64(Element) (uint64, bool)
 }

--- a/constraint/field.go
+++ b/constraint/field.go
@@ -1,6 +1,7 @@
 package constraint
 
 import (
+	"encoding/binary"
 	"math/big"
 )
 
@@ -12,6 +13,28 @@ type Element [6]uint64
 // IsZero returns true if coefficient == 0
 func (z *Element) IsZero() bool {
 	return (z[5] | z[4] | z[3] | z[2] | z[1] | z[0]) == 0
+}
+
+// Bytes return the Element as a big-endian byte slice
+func (z *Element) Bytes() [48]byte {
+	var b [48]byte
+	binary.BigEndian.PutUint64(b[40:48], z[0])
+	binary.BigEndian.PutUint64(b[32:40], z[1])
+	binary.BigEndian.PutUint64(b[24:32], z[2])
+	binary.BigEndian.PutUint64(b[16:24], z[3])
+	binary.BigEndian.PutUint64(b[8:16], z[4])
+	binary.BigEndian.PutUint64(b[0:8], z[5])
+	return b
+}
+
+// SetBytes sets the Element from a big-endian byte slice
+func (z *Element) SetBytes(b [48]byte) {
+	z[0] = binary.BigEndian.Uint64(b[40:48])
+	z[1] = binary.BigEndian.Uint64(b[32:40])
+	z[2] = binary.BigEndian.Uint64(b[24:32])
+	z[3] = binary.BigEndian.Uint64(b[16:24])
+	z[4] = binary.BigEndian.Uint64(b[8:16])
+	z[5] = binary.BigEndian.Uint64(b[0:8])
 }
 
 // Field capability to perform arithmetic on Coeff

--- a/constraint/hint.go
+++ b/constraint/hint.go
@@ -12,36 +12,3 @@ type HintMapping struct {
 		Start, End uint32
 	}
 }
-
-// WireIterator implements constraint.Iterable
-// returns all the wires referenced by the hint.
-func (h *HintMapping) WireIterator() func() int {
-	curr := 0
-	n := 0
-	for i := 0; i < len(h.Inputs); i++ {
-		n += len(h.Inputs[i])
-	}
-	inputs := getBuffer(n)
-	for i := 0; i < len(h.Inputs); i++ {
-		for j := 0; j < len(h.Inputs[i]); j++ {
-			term := h.Inputs[i][j]
-			if term.IsConstant() {
-				continue
-			}
-			inputs = append(inputs, term.VID)
-		}
-	}
-	lenOutputs := int(h.OutputRange.End - h.OutputRange.Start)
-
-	return func() int {
-		if curr < lenOutputs {
-			curr++
-			return int(h.OutputRange.Start) + curr - 1
-		}
-		if curr < lenOutputs+len(inputs) {
-			curr++
-			return int(inputs[curr-1-lenOutputs])
-		}
-		return -1
-	}
-}

--- a/constraint/level_builder.go
+++ b/constraint/level_builder.go
@@ -8,14 +8,13 @@ package constraint
 //
 // We build a graph of dependency; we say that a wire is solved at a level l
 // --> l = max(level_of_dependencies(wire)) + 1
-func (system *System) updateLevel(iID int, c Iterable) {
+func (system *System) updateLevel(iID int, walkWires func(cb func(wire uint32))) {
 	level := -1
-	wireIterator := c.WireIterator()
 
-	for wID := wireIterator(); wID != -1; wID = wireIterator() {
-		// iterate over all wires of the instruction
-		system.processWire(uint32(wID), &level)
-	}
+	// process all wires of the instruction
+	walkWires(func(wire uint32) {
+		system.processWire(wire, &level)
+	})
 
 	// level =  max(dependencies) + 1
 	level++

--- a/constraint/linear_expression.go
+++ b/constraint/linear_expression.go
@@ -30,22 +30,7 @@ func (l LinearExpression) String(r Resolver) string {
 	return sbb.String()
 }
 
-// implements constraint.Compressable
-
-// func (l *LinearExpression) Decompress(in []uint32) int {
-// 	n := int(in[0])
-// 	*l = make(LinearExpression, n)
-// 	j := 1
-// 	for i := 0; i < n; i++ {
-// 		(*l)[i].CID = in[j]
-// 		j++
-// 		(*l)[i].VID = in[j]
-// 		j++
-// 	}
-// 	return j - 1
-// }
-
-func (l LinearExpression) CompressLE(to *[]uint32) {
+func (l LinearExpression) Compress(to *[]uint32) {
 	(*to) = append((*to), uint32(len(l)))
 	for i := 0; i < len(l); i++ {
 		(*to) = append((*to), l[i].CID, l[i].VID)

--- a/constraint/linear_expression.go
+++ b/constraint/linear_expression.go
@@ -32,20 +32,20 @@ func (l LinearExpression) String(r Resolver) string {
 
 // implements constraint.Compressable
 
-func (l *LinearExpression) Decompress(in []uint32) int {
-	n := int(in[0])
-	*l = make(LinearExpression, n)
-	j := 1
-	for i := 0; i < n; i++ {
-		(*l)[i].CID = in[j]
-		j++
-		(*l)[i].VID = in[j]
-		j++
-	}
-	return j - 1
-}
+// func (l *LinearExpression) Decompress(in []uint32) int {
+// 	n := int(in[0])
+// 	*l = make(LinearExpression, n)
+// 	j := 1
+// 	for i := 0; i < n; i++ {
+// 		(*l)[i].CID = in[j]
+// 		j++
+// 		(*l)[i].VID = in[j]
+// 		j++
+// 	}
+// 	return j - 1
+// }
 
-func (l LinearExpression) Compress(to *[]uint32) {
+func (l LinearExpression) CompressLE(to *[]uint32) {
 	(*to) = append((*to), uint32(len(l)))
 	for i := 0; i < len(l); i++ {
 		(*to) = append((*to), l[i].CID, l[i].VID)

--- a/constraint/linear_expression.go
+++ b/constraint/linear_expression.go
@@ -51,15 +51,3 @@ func (l LinearExpression) Compress(to *[]uint32) {
 		(*to) = append((*to), l[i].CID, l[i].VID)
 	}
 }
-
-// implements constraint.Iterable
-func (l LinearExpression) WireIterator() (next func() int) {
-	curr := 0
-	return func() int {
-		if curr < len(l) {
-			curr++
-			return int(l[curr-1].VID)
-		}
-		return -1
-	}
-}

--- a/constraint/linear_expression.go
+++ b/constraint/linear_expression.go
@@ -29,3 +29,24 @@ func (l LinearExpression) String(r Resolver) string {
 	sbb.WriteLinearExpression(l)
 	return sbb.String()
 }
+
+// implements constraint.Compressable
+
+func (l *LinearExpression) Decompress(in []uint32) {
+	n := int(in[0])
+	*l = make(LinearExpression, n)
+	j := 1
+	for i := 0; i < n; i++ {
+		(*l)[i].CID = in[j]
+		j++
+		(*l)[i].VID = in[j]
+		j++
+	}
+}
+
+func (l LinearExpression) Compress(to *[]uint32) {
+	(*to) = append((*to), uint32(len(l)))
+	for i := 0; i < len(l); i++ {
+		(*to) = append((*to), l[i].CID, l[i].VID)
+	}
+}

--- a/constraint/linear_expression.go
+++ b/constraint/linear_expression.go
@@ -32,7 +32,7 @@ func (l LinearExpression) String(r Resolver) string {
 
 // implements constraint.Compressable
 
-func (l *LinearExpression) Decompress(in []uint32) {
+func (l *LinearExpression) Decompress(in []uint32) int {
 	n := int(in[0])
 	*l = make(LinearExpression, n)
 	j := 1
@@ -42,11 +42,24 @@ func (l *LinearExpression) Decompress(in []uint32) {
 		(*l)[i].VID = in[j]
 		j++
 	}
+	return j - 1
 }
 
 func (l LinearExpression) Compress(to *[]uint32) {
 	(*to) = append((*to), uint32(len(l)))
 	for i := 0; i < len(l); i++ {
 		(*to) = append((*to), l[i].CID, l[i].VID)
+	}
+}
+
+// implements constraint.Iterable
+func (l LinearExpression) WireIterator() (next func() int) {
+	curr := 0
+	return func() int {
+		if curr < len(l) {
+			curr++
+			return int(l[curr-1].VID)
+		}
+		return -1
 	}
 }

--- a/constraint/r1cs.go
+++ b/constraint/r1cs.go
@@ -151,26 +151,6 @@ type R1C struct {
 	L, R, O LinearExpression
 }
 
-// WireIterator implements constraint.Iterable
-func (r1c *R1C) WireIterator() func() int {
-	curr := 0
-	return func() int {
-		if curr < len(r1c.L) {
-			curr++
-			return r1c.L[curr-1].WireID()
-		}
-		if curr < len(r1c.L)+len(r1c.R) {
-			curr++
-			return r1c.R[curr-1-len(r1c.L)].WireID()
-		}
-		if curr < len(r1c.L)+len(r1c.R)+len(r1c.O) {
-			curr++
-			return r1c.O[curr-1-len(r1c.L)-len(r1c.R)].WireID()
-		}
-		return -1
-	}
-}
-
 // String formats a R1C as L⋅R == O
 func (r1c *R1C) String(r Resolver) string {
 	sbb := NewStringBuilder(r)

--- a/constraint/r1cs.go
+++ b/constraint/r1cs.go
@@ -47,7 +47,7 @@ func (it *R1CIterator) Next() *R1C {
 	it.n++
 	blueprint := it.cs.Blueprints[inst.BlueprintID]
 	if bc, ok := blueprint.(BlueprintR1C); ok {
-		bc.DecompressR1C(&it.R1C, it.cs.GetCallData(inst))
+		bc.DecompressR1C(&it.R1C, inst.Unpack(it.cs))
 		return &it.R1C
 	}
 	return it.Next()

--- a/constraint/r1cs_sparse.go
+++ b/constraint/r1cs_sparse.go
@@ -150,25 +150,6 @@ func (c *SparseR1C) Clear() {
 	*c = SparseR1C{}
 }
 
-// WireIterator implements constraint.Iterable
-func (c *SparseR1C) WireIterator() func() int {
-	curr := 0
-	return func() int {
-		switch curr {
-		case 0:
-			curr++
-			return int(c.XA)
-		case 1:
-			curr++
-			return int(c.XB)
-		case 2:
-			curr++
-			return int(c.XC)
-		}
-		return -1
-	}
-}
-
 // String formats the constraint as qL⋅xa + qR⋅xb + qO⋅xc + qM⋅(xaxb) + qC == 0
 func (c *SparseR1C) String(r Resolver) string {
 	sbb := NewStringBuilder(r)

--- a/constraint/r1cs_sparse.go
+++ b/constraint/r1cs_sparse.go
@@ -46,7 +46,7 @@ func (it *SparseR1CIterator) Next() *SparseR1C {
 	it.n++
 	blueprint := it.cs.Blueprints[inst.BlueprintID]
 	if bc, ok := blueprint.(BlueprintSparseR1C); ok {
-		bc.DecompressSparseR1C(&it.SparseR1C, it.cs.GetCallData(inst))
+		bc.DecompressSparseR1C(&it.SparseR1C, inst.Unpack(it.cs))
 		return &it.SparseR1C
 	}
 	return it.Next()

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -80,19 +80,6 @@ type CustomizableSystem interface {
 	// AddBlueprint registers the given blueprint and returns its id. This should be called only once per blueprint.
 	AddBlueprint(b Blueprint) BlueprintID
 
-	AddInstruction(bID BlueprintID, calldata []uint32, c Iterable)
+	// AddInstruction adds an instruction to the system and returns a list of created wires.
+	AddInstruction(bID BlueprintID, calldata []uint32) []uint32
 }
-
-type Iterable interface {
-	// WireIterator returns a new iterator to iterate over the wires of the implementer (usually, a constraint)
-	// Call to next() returns the next wireID of the Iterable object and -1 when iteration is over.
-	//
-	// For example a R1C constraint with L, R, O linear expressions, each of size 2, calling several times
-	// 		next := r1c.WireIterator();
-	// 		for wID := next(); wID != -1; wID = next() {}
-	//		// will return in order L[0],L[1],R[0],R[1],O[0],O[1],-1
-	WireIterator() (next func() int)
-}
-
-var _ Iterable = &SparseR1C{}
-var _ Iterable = &R1C{}

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -74,10 +74,6 @@ type ConstraintSystem interface {
 	GetInstruction(int) Instruction
 
 	GetCoefficient(i int) Element
-
-	// GetCallData re-slice the constraint system full calldata slice with the portion
-	// related to the instruction. This does not copy and caller should not modify.
-	GetCallData(instruction PackedInstruction) []uint32
 }
 
 type CustomizableSystem interface {

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -71,13 +71,13 @@ type ConstraintSystem interface {
 	// This is experimental.
 	CheckUnconstrainedWires() error
 
-	GetInstruction(int) Instruction
+	GetInstruction(int) PackedInstruction
 
 	GetCoefficient(i int) Element
 
 	// GetCallData re-slice the constraint system full calldata slice with the portion
 	// related to the instruction. This does not copy and caller should not modify.
-	GetCallData(instruction Instruction) []uint32
+	GetCallData(instruction PackedInstruction) []uint32
 }
 
 type CustomizableSystem interface {

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -71,7 +71,7 @@ type ConstraintSystem interface {
 	// This is experimental.
 	CheckUnconstrainedWires() error
 
-	GetInstruction(int) PackedInstruction
+	GetInstruction(int) Instruction
 
 	GetCoefficient(i int) Element
 

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -80,6 +80,7 @@ type CustomizableSystem interface {
 	// AddBlueprint registers the given blueprint and returns its id. This should be called only once per blueprint.
 	AddBlueprint(b Blueprint) BlueprintID
 
-	// AddInstruction adds an instruction to the system and returns a list of created wires.
+	// AddInstruction adds an instruction to the system and returns a list of created wires
+	// if the blueprint declared any outputs.
 	AddInstruction(bID BlueprintID, calldata []uint32) []uint32
 }

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -14,6 +14,7 @@ type ConstraintSystem interface {
 	io.ReaderFrom
 	Field
 	Resolver
+	CustomizableSystem
 
 	// IsSolved returns nil if given witness solves the constraint system and error otherwise
 	// Deprecated: use _, err := Solve(...) instead
@@ -70,9 +71,6 @@ type ConstraintSystem interface {
 	// This is experimental.
 	CheckUnconstrainedWires() error
 
-	// AddBlueprint registers the given blueprint and returns its id. This should be called only once per blueprint.
-	AddBlueprint(b Blueprint) BlueprintID
-
 	GetInstruction(int) Instruction
 
 	GetCoefficient(i int) Element
@@ -80,6 +78,13 @@ type ConstraintSystem interface {
 	// GetCallData re-slice the constraint system full calldata slice with the portion
 	// related to the instruction. This does not copy and caller should not modify.
 	GetCallData(instruction Instruction) []uint32
+}
+
+type CustomizableSystem interface {
+	// AddBlueprint registers the given blueprint and returns its id. This should be called only once per blueprint.
+	AddBlueprint(b Blueprint) BlueprintID
+
+	AddInstruction(bID BlueprintID, calldata []uint32, c Iterable)
 }
 
 type Iterable interface {

--- a/constraint/term.go
+++ b/constraint/term.go
@@ -65,15 +65,3 @@ func (t *Term) Decompress(in []uint32) int {
 func (t Term) Compress(to *[]uint32) {
 	(*to) = append((*to), t.CID, t.VID)
 }
-
-// implements constraint.Iterable
-func (t Term) WireIterator() (next func() int) {
-	curr := 0
-	return func() int {
-		curr++
-		if curr == 1 {
-			return int(t.VID)
-		}
-		return -1
-	}
-}

--- a/constraint/term.go
+++ b/constraint/term.go
@@ -56,12 +56,6 @@ func (t Term) String(r Resolver) string {
 
 // implements constraint.Compressable
 
-func (t *Term) Decompress(in []uint32) int {
-	t.CID = in[0]
-	t.VID = in[1]
-	return 2
-}
-
-func (t Term) Compress(to *[]uint32) {
-	(*to) = append((*to), t.CID, t.VID)
+func (t Term) CompressLE(to *[]uint32) {
+	(*to) = append((*to), 1, t.CID, t.VID)
 }

--- a/constraint/term.go
+++ b/constraint/term.go
@@ -53,3 +53,14 @@ func (t Term) String(r Resolver) string {
 	sbb.WriteTerm(t)
 	return sbb.String()
 }
+
+// implements constraint.Compressable
+
+func (t *Term) Decompress(in []uint32) {
+	t.CID = in[0]
+	t.VID = in[1]
+}
+
+func (t Term) Compress(to *[]uint32) {
+	(*to) = append((*to), t.CID, t.VID)
+}

--- a/constraint/term.go
+++ b/constraint/term.go
@@ -56,11 +56,24 @@ func (t Term) String(r Resolver) string {
 
 // implements constraint.Compressable
 
-func (t *Term) Decompress(in []uint32) {
+func (t *Term) Decompress(in []uint32) int {
 	t.CID = in[0]
 	t.VID = in[1]
+	return 2
 }
 
 func (t Term) Compress(to *[]uint32) {
 	(*to) = append((*to), t.CID, t.VID)
+}
+
+// implements constraint.Iterable
+func (t Term) WireIterator() (next func() int) {
+	curr := 0
+	return func() int {
+		curr++
+		if curr == 1 {
+			return int(t.VID)
+		}
+		return -1
+	}
 }

--- a/constraint/term.go
+++ b/constraint/term.go
@@ -56,9 +56,9 @@ func (t Term) String(r Resolver) string {
 
 // implements constraint.Compressable
 
-// CompressLE compresses the term into a slice of uint32 words.
+// Compress compresses the term into a slice of uint32 words.
 // For compatibility with test engine and LinearExpression, the term is encoded as:
 // 1, CID, VID (i.e a LinearExpression with a single term)
-func (t Term) CompressLE(to *[]uint32) {
+func (t Term) Compress(to *[]uint32) {
 	(*to) = append((*to), 1, t.CID, t.VID)
 }

--- a/constraint/term.go
+++ b/constraint/term.go
@@ -56,6 +56,9 @@ func (t Term) String(r Resolver) string {
 
 // implements constraint.Compressable
 
+// CompressLE compresses the term into a slice of uint32 words.
+// For compatibility with test engine and LinearExpression, the term is encoded as:
+// 1, CID, VID (i.e a LinearExpression with a single term)
 func (t Term) CompressLE(to *[]uint32) {
 	(*to) = append((*to), 1, t.CID, t.VID)
 }

--- a/constraint/tinyfield/coeff.go
+++ b/constraint/tinyfield/coeff.go
@@ -182,3 +182,11 @@ func (engine *field) String(a constraint.Element) string {
 	e := (*fr.Element)(a[:])
 	return e.String()
 }
+
+func (engine *field) Uint64(a constraint.Element) (uint64, bool) {
+	e := (*fr.Element)(a[:])
+	if !e.IsUint64() {
+		return 0, false
+	}
+	return e.Uint64(), true
+}

--- a/constraint/tinyfield/solver.go
+++ b/constraint/tinyfield/solver.go
@@ -376,7 +376,7 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.Instruction, scratch *scratch) error {
+func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
 	blueprint := solver.Blueprints[inst.BlueprintID]
 	calldata := solver.GetCallData(inst)

--- a/constraint/tinyfield/solver.go
+++ b/constraint/tinyfield/solver.go
@@ -133,15 +133,15 @@ func (s *solver) set(id int, value fr.Element) {
 }
 
 // computeTerm computes coeff*variable
-// TODO @gbotrel check if t is a Constant only
 func (s *solver) computeTerm(t constraint.Term) fr.Element {
 	cID, vID := t.CoeffID(), t.WireID()
-	if cID != 0 && !s.solved[vID] {
-		panic("computing a term with an unsolved wire")
-	}
 
 	if t.IsConstant() {
 		return s.Coefficients[cID]
+	}
+
+	if cID != 0 && !s.solved[vID] {
+		panic("computing a term with an unsolved wire")
 	}
 
 	switch cID {
@@ -390,14 +390,14 @@ func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratc
 			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
-	} else if solver.Type == constraint.SystemSparseR1CS {
-		// blueprint declared "I know how to solve this."
-		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, inst); err != nil {
-				return solver.wrapErrWithDebugInfo(cID, err)
-			}
-			return nil
+	}
+
+	// blueprint declared "I know how to solve this."
+	if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
+		if err := bc.Solve(solver, inst); err != nil {
+			return solver.wrapErrWithDebugInfo(cID, err)
 		}
+		return nil
 	}
 
 	// blueprint encodes a hint, we execute.

--- a/constraint/tinyfield/solver.go
+++ b/constraint/tinyfield/solver.go
@@ -358,7 +358,7 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
-		return s.GetValue(calldata[0], calldata[1]), 2
+		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element
 	n := int(calldata[0])

--- a/constraint/tinyfield/solver.go
+++ b/constraint/tinyfield/solver.go
@@ -376,10 +376,10 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
+func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
-	blueprint := solver.Blueprints[inst.BlueprintID]
-	calldata := solver.GetCallData(inst)
+	blueprint := solver.Blueprints[pi.BlueprintID]
+	inst := pi.Unpack(&solver.System)
 	cID := inst.ConstraintOffset // here we have 1 constraint in the instruction only
 
 	if solver.Type == constraint.SystemR1CS {
@@ -387,13 +387,13 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 			// TODO @gbotrel we use the solveR1C method for now, having user-defined
 			// blueprint for R1CS would require constraint.Solver interface to add methods
 			// to set a,b,c since it's more efficient to compute these while we solve.
-			bc.DecompressR1C(&scratch.tR1C, calldata)
+			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
 	} else if solver.Type == constraint.SystemSparseR1CS {
 		// blueprint declared "I know how to solve this."
 		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, calldata); err != nil {
+			if err := bc.Solve(solver, inst); err != nil {
 				return solver.wrapErrWithDebugInfo(cID, err)
 			}
 			return nil
@@ -403,7 +403,7 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 	// blueprint encodes a hint, we execute.
 	// TODO @gbotrel may be worth it to move hint logic in blueprint "solve"
 	if bc, ok := blueprint.(constraint.BlueprintHint); ok {
-		bc.DecompressHint(&scratch.tHint, calldata)
+		bc.DecompressHint(&scratch.tHint, inst)
 		return solver.solveWithHint(&scratch.tHint)
 	}
 

--- a/constraint/tinyfield/solver.go
+++ b/constraint/tinyfield/solver.go
@@ -358,6 +358,9 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
+		if calldata[0] != 1 {
+			panic("invalid calldata")
+		}
 		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element

--- a/constraint/tinyfield/system.go
+++ b/constraint/tinyfield/system.go
@@ -121,7 +121,7 @@ func (cs *system) GetR1Cs() []constraint.R1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintR1C); ok {
 			var r1c constraint.R1C
-			bc.DecompressR1C(&r1c, cs.GetCallData(inst))
+			bc.DecompressR1C(&r1c, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, r1c)
 		} else {
 			panic("not implemented")
@@ -196,8 +196,7 @@ func (cs *system) GetSparseR1Cs() []constraint.SparseR1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
 			var sparseR1C constraint.SparseR1C
-			calldata := cs.CallData[inst.StartCallData : inst.StartCallData+uint64(blueprint.NbInputs())]
-			bc.DecompressSparseR1C(&sparseR1C, calldata)
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 			toReturn = append(toReturn, sparseR1C)
 		} else {
 			panic("not implemented")
@@ -234,7 +233,7 @@ func evaluateLROSmallDomain(cs *system, solution []fr.Element) ([]fr.Element, []
 	for _, inst := range cs.Instructions {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
-			bc.DecompressSparseR1C(&sparseR1C, cs.GetCallData(inst))
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 
 			l[offset+j] = solution[sparseR1C.XA]
 			r[offset+j] = solution[sparseR1C.XB]

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -99,6 +99,9 @@ type Rangechecker interface {
 }
 
 // CanonicalVariable represents a variable that's encoded in a constraint system specific way.
+// For example a R1CS builder may represent this as a constraint.LinearExpression,
+// a PLONK builder --> constraint.Term
+// and the test/Engine --> ~*big.Int.
 type CanonicalVariable interface {
 	constraint.Compressable
 }

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -57,6 +57,7 @@ type Compiler interface {
 	Defer(cb func(api API) error)
 
 	// InternalVariable returns the internal variable associated with the given wireID
+	// ! Experimental: use in conjunction with constraint.CustomizableSystem
 	InternalVariable(wireID uint32) Variable
 
 	// ToCanonicalVariable converts a frontend.Variable to a constraint system specific Variable

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -101,7 +101,6 @@ type Rangechecker interface {
 // CanonicalVariable represents a variable that's encoded in a constraint system specific way.
 type CanonicalVariable interface {
 	constraint.Compressable
-	constraint.Iterable
 }
 
 type RRVariable interface {

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -56,9 +56,8 @@ type Compiler interface {
 	// operations etc. Unlike Go defer, it is not locally scoped.
 	Defer(cb func(api API) error)
 
-	// AddInternalVariable adds and returns an internal variable.
-	// ! Experimental: use in conjunction with constraint.CustomizableSystem
-	AddInternalVariable() RRVariable
+	// InternalVariable returns the internal variable associated with the given wireID
+	InternalVariable(wireID uint32) Variable
 
 	// ToCanonicalVariable converts a frontend.Variable to a constraint system specific Variable
 	// ! Experimental: use in conjunction with constraint.CustomizableSystem
@@ -101,8 +100,4 @@ type Rangechecker interface {
 // CanonicalVariable represents a variable that's encoded in a constraint system specific way.
 type CanonicalVariable interface {
 	constraint.Compressable
-}
-
-type RRVariable interface {
-	RRVariableID() uint32
 }

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -12,6 +12,8 @@ type NewBuilder func(*big.Int, CompileConfig) (Builder, error)
 
 // Compiler represents a constraint system compiler
 type Compiler interface {
+	constraint.CustomizableSystem
+
 	// MarkBoolean sets (but do not constraint!) v to be boolean
 	// This is useful in scenarios where a variable is known to be boolean through a constraint
 	// that is not api.AssertIsBoolean. If v is a constant, this is a no-op.
@@ -53,6 +55,14 @@ type Compiler interface {
 	// allows for the circuits to register callbacks which finalize batching
 	// operations etc. Unlike Go defer, it is not locally scoped.
 	Defer(cb func(api API) error)
+
+	// AddInternalVariable adds and returns an internal variable.
+	// ! Experimental: use in conjunction with constraint.CustomizableSystem
+	AddInternalVariable() CanonicalVariable
+
+	// ToCanonicalVariable converts a frontend.Variable to a constraint system specific Variable
+	// ! Experimental: use in conjunction with constraint.CustomizableSystem
+	ToCanonicalVariable(Variable) CanonicalVariable
 }
 
 // Builder represents a constraint system builder
@@ -86,4 +96,9 @@ type Committer interface {
 type Rangechecker interface {
 	// Check checks that the given variable v has bit-length bits.
 	Check(v Variable, bits int)
+}
+
+// CanonicalVariable represents a variable that's encoded in a constraint system specific way.
+type CanonicalVariable interface {
+	constraint.Compressable
 }

--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -58,7 +58,7 @@ type Compiler interface {
 
 	// AddInternalVariable adds and returns an internal variable.
 	// ! Experimental: use in conjunction with constraint.CustomizableSystem
-	AddInternalVariable() CanonicalVariable
+	AddInternalVariable() RRVariable
 
 	// ToCanonicalVariable converts a frontend.Variable to a constraint system specific Variable
 	// ! Experimental: use in conjunction with constraint.CustomizableSystem
@@ -101,4 +101,9 @@ type Rangechecker interface {
 // CanonicalVariable represents a variable that's encoded in a constraint system specific way.
 type CanonicalVariable interface {
 	constraint.Compressable
+	constraint.Iterable
+}
+
+type RRVariable interface {
+	RRVariableID() uint32
 }

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -483,11 +483,8 @@ func (builder *builder) AddBlueprint(b constraint.Blueprint) constraint.Blueprin
 	return builder.cs.AddBlueprint(b)
 }
 
-// AddInternalVariable adds and returns an internal variable.
-// ! Experimental: use in conjunction with constraint.CustomizableSystem
-func (builder *builder) AddInternalVariable() frontend.RRVariable {
-	return builder.newInternalVariable()
-	// return builder.getLinearExpression(v)
+func (builder *builder) InternalVariable(wireID uint32) frontend.Variable {
+	return expr.NewLinearExpression(int(wireID), builder.tOne)
 }
 
 // ToCanonicalVariable converts a frontend.Variable to a constraint system specific Variable

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -472,3 +472,34 @@ func (builder *builder) Defer(cb func(frontend.API) error) {
 func (*builder) FrontendType() frontendtype.Type {
 	return frontendtype.R1CS
 }
+
+// AddInstruction is used to add custom instructions to the constraint system.
+func (builder *builder) AddInstruction(bID constraint.BlueprintID, calldata []uint32, c constraint.Iterable) {
+	builder.cs.AddInstruction(bID, calldata, c)
+}
+
+// AddBlueprint adds a custom blueprint to the constraint system.
+func (builder *builder) AddBlueprint(b constraint.Blueprint) constraint.BlueprintID {
+	return builder.cs.AddBlueprint(b)
+}
+
+// AddInternalVariable adds and returns an internal variable.
+// ! Experimental: use in conjunction with constraint.CustomizableSystem
+func (builder *builder) AddInternalVariable() frontend.CanonicalVariable {
+	v := builder.newInternalVariable()
+	return builder.getLinearExpression(v)
+}
+
+// ToCanonicalVariable converts a frontend.Variable to a constraint system specific Variable
+// ! Experimental: use in conjunction with constraint.CustomizableSystem
+func (builder *builder) ToCanonicalVariable(in frontend.Variable) frontend.CanonicalVariable {
+	if t, ok := in.(expr.LinearExpression); ok {
+		assertIsSet(t)
+		return builder.getLinearExpression(t)
+	} else {
+		c := builder.cs.FromInterface(in)
+		term := builder.cs.MakeTerm(c, 0)
+		term.MarkConstant()
+		return constraint.LinearExpression{term}
+	}
+}

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -474,8 +474,8 @@ func (*builder) FrontendType() frontendtype.Type {
 }
 
 // AddInstruction is used to add custom instructions to the constraint system.
-func (builder *builder) AddInstruction(bID constraint.BlueprintID, calldata []uint32, c constraint.Iterable) {
-	builder.cs.AddInstruction(bID, calldata, c)
+func (builder *builder) AddInstruction(bID constraint.BlueprintID, calldata []uint32) []uint32 {
+	return builder.cs.AddInstruction(bID, calldata)
 }
 
 // AddBlueprint adds a custom blueprint to the constraint system.

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -485,9 +485,9 @@ func (builder *builder) AddBlueprint(b constraint.Blueprint) constraint.Blueprin
 
 // AddInternalVariable adds and returns an internal variable.
 // ! Experimental: use in conjunction with constraint.CustomizableSystem
-func (builder *builder) AddInternalVariable() frontend.CanonicalVariable {
-	v := builder.newInternalVariable()
-	return builder.getLinearExpression(v)
+func (builder *builder) AddInternalVariable() frontend.RRVariable {
+	return builder.newInternalVariable()
+	// return builder.getLinearExpression(v)
 }
 
 // ToCanonicalVariable converts a frontend.Variable to a constraint system specific Variable

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -478,7 +478,7 @@ func (builder *builder) addConstraintExist(a, b expr.Term, k constraint.Element)
 		inst := builder.cs.GetInstruction(iID)
 		// we know the blueprint we added it.
 		blueprint := constraint.BlueprintSparseR1CAdd{}
-		blueprint.DecompressSparseR1C(&c, builder.cs.GetCallData(inst))
+		blueprint.DecompressSparseR1C(&c, inst)
 
 		// qO == -1
 		if a.WireID() == int(c.XB) {
@@ -566,7 +566,7 @@ func (builder *builder) mulConstraintExist(a, b expr.Term) (expr.Term, bool) {
 		inst := builder.cs.GetInstruction(iID)
 		// we know the blueprint we added it.
 		blueprint := constraint.BlueprintSparseR1CMul{}
-		blueprint.DecompressSparseR1C(&c, builder.cs.GetCallData(inst))
+		blueprint.DecompressSparseR1C(&c, inst)
 
 		// qO == -1
 

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -663,11 +663,8 @@ func (builder *builder) AddBlueprint(b constraint.Blueprint) constraint.Blueprin
 	return builder.cs.AddBlueprint(b)
 }
 
-// AddInternalVariable adds and returns an internal variable.
-// ! Experimental: use in conjunction with constraint.CustomizableSystem
-func (builder *builder) AddInternalVariable() frontend.RRVariable {
-	return builder.newInternalVariable()
-	// return builder.cs.MakeTerm(v.Coeff, v.VID)
+func (builder *builder) InternalVariable(wireID uint32) frontend.Variable {
+	return expr.NewTerm(int(wireID), builder.tOne)
 }
 
 // ToCanonicalVariable converts a frontend.Variable to a constraint system specific Variable

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -654,8 +654,8 @@ func (builder *builder) Defer(cb func(frontend.API) error) {
 }
 
 // AddInstruction is used to add custom instructions to the constraint system.
-func (builder *builder) AddInstruction(bID constraint.BlueprintID, calldata []uint32, c constraint.Iterable) {
-	builder.cs.AddInstruction(bID, calldata, c)
+func (builder *builder) AddInstruction(bID constraint.BlueprintID, calldata []uint32) []uint32 {
+	return builder.cs.AddInstruction(bID, calldata)
 }
 
 // AddBlueprint adds a custom blueprint to the constraint system.

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -652,3 +652,34 @@ func (builder *builder) newDebugInfo(errName string, in ...interface{}) constrai
 func (builder *builder) Defer(cb func(frontend.API) error) {
 	circuitdefer.Put(builder, cb)
 }
+
+// AddInstruction is used to add custom instructions to the constraint system.
+func (builder *builder) AddInstruction(bID constraint.BlueprintID, calldata []uint32, c constraint.Iterable) {
+	builder.cs.AddInstruction(bID, calldata, c)
+}
+
+// AddBlueprint adds a custom blueprint to the constraint system.
+func (builder *builder) AddBlueprint(b constraint.Blueprint) constraint.BlueprintID {
+	return builder.cs.AddBlueprint(b)
+}
+
+// AddInternalVariable adds and returns an internal variable.
+// ! Experimental: use in conjunction with constraint.CustomizableSystem
+func (builder *builder) AddInternalVariable() frontend.CanonicalVariable {
+	v := builder.newInternalVariable()
+	return builder.cs.MakeTerm(v.Coeff, v.VID)
+}
+
+// ToCanonicalVariable converts a frontend.Variable to a constraint system specific Variable
+// ! Experimental: use in conjunction with constraint.CustomizableSystem
+func (builder *builder) ToCanonicalVariable(v frontend.Variable) frontend.CanonicalVariable {
+	switch t := v.(type) {
+	case expr.Term:
+		return builder.cs.MakeTerm(t.Coeff, t.VID)
+	default:
+		c := builder.cs.FromInterface(v)
+		term := builder.cs.MakeTerm(c, 0)
+		term.MarkConstant()
+		return term
+	}
+}

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -665,9 +665,9 @@ func (builder *builder) AddBlueprint(b constraint.Blueprint) constraint.Blueprin
 
 // AddInternalVariable adds and returns an internal variable.
 // ! Experimental: use in conjunction with constraint.CustomizableSystem
-func (builder *builder) AddInternalVariable() frontend.CanonicalVariable {
-	v := builder.newInternalVariable()
-	return builder.cs.MakeTerm(v.Coeff, v.VID)
+func (builder *builder) AddInternalVariable() frontend.RRVariable {
+	return builder.newInternalVariable()
+	// return builder.cs.MakeTerm(v.Coeff, v.VID)
 }
 
 // ToCanonicalVariable converts a frontend.Variable to a constraint system specific Variable

--- a/frontend/internal/expr/linear_expression.go
+++ b/frontend/internal/expr/linear_expression.go
@@ -61,10 +61,3 @@ func (l LinearExpression) HashCode() uint64 {
 	}
 	return h
 }
-
-func (l LinearExpression) RRVariableID() uint32 {
-	if len(l) != 1 {
-		panic("here tmp refactor")
-	}
-	return uint32(l[0].VID)
-}

--- a/frontend/internal/expr/linear_expression.go
+++ b/frontend/internal/expr/linear_expression.go
@@ -4,43 +4,17 @@ import (
 	"github.com/consensys/gnark/constraint"
 )
 
-// TODO @gbotrel --> storing a UUID in the linear expressions would enable better perf
-// in the frontend -> check a linear expression is boolean, or has been converted to a
-// "backend" constraint.LinearExpresion ... and avoid duplicating work would be interesting.
-
 type LinearExpression []Term
-
-func (l LinearExpression) Clone() LinearExpression {
-	res := make(LinearExpression, len(l))
-	copy(res, l)
-	return res
-}
 
 // NewLinearExpression helper to initialize a linear expression with one term
 func NewLinearExpression(vID int, cID constraint.Element) LinearExpression {
 	return LinearExpression{Term{Coeff: cID, VID: vID}}
 }
 
-func NewTerm(vID int, cID constraint.Element) Term {
-	return Term{Coeff: cID, VID: vID}
-}
-
-type Term struct {
-	VID   int
-	Coeff constraint.Element
-}
-
-func (t *Term) SetCoeff(c constraint.Element) {
-	t.Coeff = c
-}
-
-// TODO @gbotrel make that return a uint32
-func (t Term) WireID() int {
-	return t.VID
-}
-
-func (t Term) HashCode() uint64 {
-	return t.Coeff[0]*29 + uint64(t.VID<<12)
+func (l LinearExpression) Clone() LinearExpression {
+	res := make(LinearExpression, len(l))
+	copy(res, l)
+	return res
 }
 
 // Len return the length of the Variable (implements Sort interface)

--- a/frontend/internal/expr/linear_expression.go
+++ b/frontend/internal/expr/linear_expression.go
@@ -61,3 +61,10 @@ func (l LinearExpression) HashCode() uint64 {
 	}
 	return h
 }
+
+func (l LinearExpression) RRVariableID() uint32 {
+	if len(l) != 1 {
+		panic("here tmp refactor")
+	}
+	return uint32(l[0].VID)
+}

--- a/frontend/internal/expr/term.go
+++ b/frontend/internal/expr/term.go
@@ -1,0 +1,25 @@
+package expr
+
+import "github.com/consensys/gnark/constraint"
+
+type Term struct {
+	VID   int
+	Coeff constraint.Element
+}
+
+func NewTerm(vID int, cID constraint.Element) Term {
+	return Term{Coeff: cID, VID: vID}
+}
+
+func (t *Term) SetCoeff(c constraint.Element) {
+	t.Coeff = c
+}
+
+// TODO @gbotrel make that return a uint32
+func (t Term) WireID() int {
+	return t.VID
+}
+
+func (t Term) HashCode() uint64 {
+	return t.Coeff[0]*29 + uint64(t.VID<<12)
+}

--- a/frontend/internal/expr/term.go
+++ b/frontend/internal/expr/term.go
@@ -23,7 +23,3 @@ func (t Term) WireID() int {
 func (t Term) HashCode() uint64 {
 	return t.Coeff[0]*29 + uint64(t.VID<<12)
 }
-
-func (t Term) RRVariableID() uint32 {
-	return uint32(t.VID)
-}

--- a/frontend/internal/expr/term.go
+++ b/frontend/internal/expr/term.go
@@ -23,3 +23,7 @@ func (t Term) WireID() int {
 func (t Term) HashCode() uint64 {
 	return t.Coeff[0]*29 + uint64(t.VID<<12)
 }
+
+func (t Term) RRVariableID() uint32 {
+	return uint32(t.VID)
+}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-test/deep v1.1.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,6 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
-github.com/consensys/gnark-crypto v0.10.1-0.20230408232650-7fda2542de4d h1:TJ2dYEdgx8dVt4Jv/ftodldmVkQK3R4ntCGyo1u0v3U=
-github.com/consensys/gnark-crypto v0.10.1-0.20230408232650-7fda2542de4d/go.mod h1:Iq/P3HHl0ElSjsg2E1gsMwhAyxnxoKK5nVyZKd+/KhU=
-github.com/consensys/gnark-crypto v0.10.1-0.20230420025556-eaeb6db64ed7 h1:5OAqdipDbuXlHzpJY2xDjef1jn4gkdOpf4zRQB6WPaU=
-github.com/consensys/gnark-crypto v0.10.1-0.20230420025556-eaeb6db64ed7/go.mod h1:Iq/P3HHl0ElSjsg2E1gsMwhAyxnxoKK5nVyZKd+/KhU=
 github.com/consensys/gnark-crypto v0.10.1-0.20230420183752-ed3709c81831 h1:2y5CcR1Ww4wJxCZX4psdiIqdaNb7Kd4WM8YfPqQb6yY=
 github.com/consensys/gnark-crypto v0.10.1-0.20230420183752-ed3709c81831/go.mod h1:Iq/P3HHl0ElSjsg2E1gsMwhAyxnxoKK5nVyZKd+/KhU=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
@@ -17,8 +13,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
-github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
-github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/internal/generator/backend/template/representations/coeff.go.tmpl
+++ b/internal/generator/backend/template/representations/coeff.go.tmpl
@@ -166,3 +166,11 @@ func (engine *field) String(a constraint.Element) string {
 	e := (*fr.Element)(a[:])
 	return e.String()
 }
+
+func (engine *field) Uint64(a constraint.Element) (uint64, bool) {
+	e := (*fr.Element)(a[:])
+	if !e.IsUint64() {
+		return 0, false
+	}
+	return e.Uint64(), true
+}

--- a/internal/generator/backend/template/representations/solver.go.tmpl
+++ b/internal/generator/backend/template/representations/solver.go.tmpl
@@ -369,7 +369,7 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.Instruction, scratch *scratch) error {
+func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
 	blueprint := solver.Blueprints[inst.BlueprintID]
 	calldata := solver.GetCallData(inst)

--- a/internal/generator/backend/template/representations/solver.go.tmpl
+++ b/internal/generator/backend/template/representations/solver.go.tmpl
@@ -369,10 +369,10 @@ func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 
 // processInstruction decodes the instruction and execute blueprint-defined logic.
 // an instruction can encode a hint, a custom constraint or a generic constraint.
-func (solver *solver) processInstruction(inst constraint.PackedInstruction, scratch *scratch) error {
+func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratch *scratch) error {
 	// fetch the blueprint
-	blueprint := solver.Blueprints[inst.BlueprintID]
-	calldata := solver.GetCallData(inst)
+	blueprint := solver.Blueprints[pi.BlueprintID]
+	inst := pi.Unpack(&solver.System)
 	cID := inst.ConstraintOffset // here we have 1 constraint in the instruction only
 
 	if solver.Type == constraint.SystemR1CS {
@@ -380,13 +380,13 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 			// TODO @gbotrel we use the solveR1C method for now, having user-defined
 			// blueprint for R1CS would require constraint.Solver interface to add methods
 			// to set a,b,c since it's more efficient to compute these while we solve.
-			bc.DecompressR1C(&scratch.tR1C, calldata)
+			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
 	} else if solver.Type == constraint.SystemSparseR1CS {
 		// blueprint declared "I know how to solve this."
 		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, calldata); err != nil {
+			if err := bc.Solve(solver, inst); err != nil {
 				return solver.wrapErrWithDebugInfo(cID, err)
 			}
 			return nil
@@ -396,7 +396,7 @@ func (solver *solver) processInstruction(inst constraint.PackedInstruction, scra
 	// blueprint encodes a hint, we execute.
 	// TODO @gbotrel may be worth it to move hint logic in blueprint "solve"
 	if bc, ok := blueprint.(constraint.BlueprintHint); ok {
-		bc.DecompressHint(&scratch.tHint, calldata)
+		bc.DecompressHint(&scratch.tHint,inst)
 		return solver.solveWithHint(&scratch.tHint)
 	}
 

--- a/internal/generator/backend/template/representations/solver.go.tmpl
+++ b/internal/generator/backend/template/representations/solver.go.tmpl
@@ -124,6 +124,11 @@ func (s *solver) computeTerm(t constraint.Term) fr.Element {
 	if cID != 0 && !s.solved[vID] {
 		panic("computing a term with an unsolved wire")
 	}
+
+	if t.IsConstant() {
+		return s.Coefficients[cID]
+	}
+
 	switch cID {
 	case constraint.CoeffIdZero:
 		return fr.Element{}
@@ -149,6 +154,11 @@ func (s *solver) computeTerm(t constraint.Term) fr.Element {
 func (s *solver) accumulateInto(t constraint.Term, r *fr.Element) {
 	cID := t.CoeffID()
 	vID := t.WireID()
+
+	if t.IsConstant() {
+		r.Add(r, &s.Coefficients[cID])
+		return
+	}
 
 	switch cID {
 	case constraint.CoeffIdZero:
@@ -335,6 +345,25 @@ func (s *solver) IsSolved(vID uint32) bool {
 	return s.solved[vID]
 }
 
+// Read interprets input calldata as either a LinearExpression (if R1CS) or a Term (if Plonkish),
+// evaluates it and return the result and the number of uint32 word read.
+func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
+	if s.Type == constraint.SystemSparseR1CS {
+		return s.GetValue(calldata[0], calldata[1]), 2
+	}
+	var r fr.Element
+	n := int(calldata[0])
+	j := 1
+	for k:= 0; k < n; k++ {
+		// we read k Terms
+		s.accumulateInto(constraint.Term{CID:calldata[j],VID: calldata[j+1]} , &r)
+		j+=2
+	}
+
+	var ret constraint.Element
+	copy(ret[:], r[:])
+	return ret, j
+}
 
 
 

--- a/internal/generator/backend/template/representations/solver.go.tmpl
+++ b/internal/generator/backend/template/representations/solver.go.tmpl
@@ -349,6 +349,9 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
+		if calldata[0] != 1 {
+			panic("invalid calldata")
+		}
 		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element

--- a/internal/generator/backend/template/representations/solver.go.tmpl
+++ b/internal/generator/backend/template/representations/solver.go.tmpl
@@ -349,7 +349,7 @@ func (s *solver) IsSolved(vID uint32) bool {
 // evaluates it and return the result and the number of uint32 word read.
 func (s *solver) Read(calldata []uint32) (constraint.Element, int) {
 	if s.Type == constraint.SystemSparseR1CS {
-		return s.GetValue(calldata[0], calldata[1]), 2
+		return s.GetValue(calldata[1], calldata[2]), 3
 	}
 	var r fr.Element
 	n := int(calldata[0])

--- a/internal/generator/backend/template/representations/solver.go.tmpl
+++ b/internal/generator/backend/template/representations/solver.go.tmpl
@@ -118,15 +118,15 @@ func (s *solver) set(id int, value fr.Element) {
 
 
 // computeTerm computes coeff*variable
-// TODO @gbotrel check if t is a Constant only
 func (s *solver) computeTerm(t constraint.Term) fr.Element {
 	cID, vID := t.CoeffID(), t.WireID()
-	if cID != 0 && !s.solved[vID] {
-		panic("computing a term with an unsolved wire")
-	}
 
 	if t.IsConstant() {
 		return s.Coefficients[cID]
+	}
+
+	if cID != 0 && !s.solved[vID] {
+		panic("computing a term with an unsolved wire")
 	}
 
 	switch cID {
@@ -383,14 +383,14 @@ func (solver *solver) processInstruction(pi constraint.PackedInstruction, scratc
 			bc.DecompressR1C(&scratch.tR1C, inst)
 			return solver.solveR1C(cID, &scratch.tR1C)
 		}
-	} else if solver.Type == constraint.SystemSparseR1CS {
-		// blueprint declared "I know how to solve this."
-		if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
-			if err := bc.Solve(solver, inst); err != nil {
-				return solver.wrapErrWithDebugInfo(cID, err)
-			}
-			return nil
+	} 
+
+	// blueprint declared "I know how to solve this."
+	if bc, ok := blueprint.(constraint.BlueprintSolvable); ok {
+		if err := bc.Solve(solver, inst); err != nil {
+			return solver.wrapErrWithDebugInfo(cID, err)
 		}
+		return nil
 	}
 
 	// blueprint encodes a hint, we execute.

--- a/internal/generator/backend/template/representations/system.go.tmpl
+++ b/internal/generator/backend/template/representations/system.go.tmpl
@@ -107,7 +107,7 @@ func (cs *system) GetR1Cs() []constraint.R1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintR1C); ok {
 			var r1c constraint.R1C
-			bc.DecompressR1C(&r1c, cs.GetCallData(inst))	
+			bc.DecompressR1C(&r1c, inst.Unpack(&cs.System))	
 			toReturn = append(toReturn, r1c)
 		} else {
 			panic("not implemented")
@@ -185,8 +185,7 @@ func (cs *system) GetSparseR1Cs() []constraint.SparseR1C {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
 			var sparseR1C constraint.SparseR1C
-			calldata := cs.CallData[inst.StartCallData:inst.StartCallData+uint64(blueprint.NbInputs())]
-			bc.DecompressSparseR1C(&sparseR1C, calldata)	
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))	
 			toReturn = append(toReturn, sparseR1C)	 
 		} else {
 			panic("not implemented")
@@ -226,7 +225,7 @@ func evaluateLROSmallDomain(cs *system, solution []fr.Element) ([]fr.Element, []
 	for _, inst := range cs.Instructions {
 		blueprint := cs.Blueprints[inst.BlueprintID]
 		if bc, ok := blueprint.(constraint.BlueprintSparseR1C); ok {
-			bc.DecompressSparseR1C(&sparseR1C, cs.GetCallData(inst))
+			bc.DecompressSparseR1C(&sparseR1C, inst.Unpack(&cs.System))
 
 			l[offset+j] = solution[sparseR1C.XA]
 			r[offset+j] = solution[sparseR1C.XB]

--- a/std/hints.go
+++ b/std/hints.go
@@ -8,7 +8,6 @@ import (
 	"github.com/consensys/gnark/std/algebra/native/sw_bls24315"
 	"github.com/consensys/gnark/std/evmprecompiles"
 	"github.com/consensys/gnark/std/internal/logderivarg"
-	"github.com/consensys/gnark/std/lookup/logderivlookup"
 	"github.com/consensys/gnark/std/math/bits"
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/std/rangecheck"
@@ -40,5 +39,4 @@ func registerHints() {
 	solver.RegisterHint(rangecheck.GetHints()...)
 	solver.RegisterHint(evmprecompiles.GetHints()...)
 	solver.RegisterHint(logderivarg.GetHints()...)
-	solver.RegisterHint(logderivlookup.GetHints()...)
 }

--- a/std/lookup/logderivlookup/blueprint.go
+++ b/std/lookup/logderivlookup/blueprint.go
@@ -1,0 +1,125 @@
+package logderivlookup
+
+import (
+	"fmt"
+
+	"github.com/consensys/gnark/constraint"
+)
+
+// BlueprintLookupHint is a blueprint that facilitates the lookup of values in a table.
+// It is essentially a hint to the solver, but enables storing the table entries only once.
+type BlueprintLookupHint struct {
+	EntriesCalldata []uint32
+}
+
+// ensures BlueprintLookupHint implements the BlueprintSolvable interface
+var _ constraint.BlueprintSolvable = (*BlueprintLookupHint)(nil)
+
+// func lookupHint(_ *big.Int, in []*big.Int, out []*big.Int) error {
+// 	nbTable := len(in) - len(out)
+// 	for i := 0; i < len(in)-nbTable; i++ {
+// 		if !in[nbTable+i].IsInt64() {
+// 			return fmt.Errorf("lookup query not integer")
+// 		}
+// 		ptr := int(in[nbTable+i].Int64())
+// 		if ptr >= nbTable {
+// 			return fmt.Errorf("lookup query %d outside table size %d", ptr, nbTable)
+// 		}
+// 		out[i].Set(in[ptr])
+// 	}
+// 	return nil
+// }
+
+func (b *BlueprintLookupHint) Solve(s constraint.Solver, inst constraint.Instruction) error {
+	nbEntries := int(inst.Calldata[1])
+	entries := make([]constraint.Element, nbEntries)
+
+	// read the static entries from the blueprint
+	// TODO @gbotrel cache that.
+	offset, delta := 0, 0
+	for i := 0; i < nbEntries; i++ {
+		entries[i], delta = s.Read(b.EntriesCalldata[offset:])
+		offset += delta
+	}
+
+	nbInputs := int(inst.Calldata[2])
+
+	// read the inputs from the instruction
+	inputs := make([]constraint.Element, nbInputs)
+	offset, delta = 3, 0
+	for i := 0; i < nbInputs; i++ {
+		inputs[i], delta = s.Read(inst.Calldata[offset:])
+		offset += delta
+	}
+
+	// set the outputs
+	nbOutputs := nbInputs
+
+	for i := 0; i < nbOutputs; i++ {
+		idx, isUint64 := s.Uint64(inputs[i])
+		if !isUint64 || idx >= uint64(len(entries)) {
+			return fmt.Errorf("lookup query too large")
+		}
+		// we set the output wire to the value of the entry
+		s.SetValue(uint32(i+int(inst.WireOffset)), entries[idx])
+	}
+	return nil
+}
+
+func (b *BlueprintLookupHint) CalldataSize() int {
+	// variable size
+	return -1
+}
+func (b *BlueprintLookupHint) NbConstraints() int {
+	return 0
+}
+
+// NbOutputs return the number of output wires this blueprint creates.
+func (b *BlueprintLookupHint) NbOutputs(inst constraint.Instruction) int {
+	return int(inst.Calldata[2])
+}
+
+// Wires returns a function that walks the wires appearing in the blueprint.
+// This is used by the level builder to build a dependency graph between instructions.
+func (b *BlueprintLookupHint) WireWalker(inst constraint.Instruction) func(cb func(wire uint32)) {
+	return func(cb func(wire uint32)) {
+		// depend on the table UP to the number of entries at time of instruction creation.
+		nbEntries := int(inst.Calldata[1])
+
+		// invoke the callback on each wire appearing in the table
+		j := 0
+		for i := 0; i < nbEntries; i++ {
+			// first we have the length of the linear expression
+			n := int(b.EntriesCalldata[j])
+			j++
+			for k := 0; k < n; k++ {
+				t := constraint.Term{CID: b.EntriesCalldata[j], VID: b.EntriesCalldata[j+1]}
+				if !t.IsConstant() {
+					cb(t.VID)
+				}
+				j += 2
+			}
+		}
+
+		// invoke the callback on each wire appearing in the inputs
+		nbInputs := int(inst.Calldata[2])
+		j = 3
+		for i := 0; i < nbInputs; i++ {
+			// first we have the length of the linear expression
+			n := int(inst.Calldata[j])
+			j++
+			for k := 0; k < n; k++ {
+				t := constraint.Term{CID: inst.Calldata[j], VID: inst.Calldata[j+1]}
+				if !t.IsConstant() {
+					cb(t.VID)
+				}
+				j += 2
+			}
+		}
+
+		// finally we have the outputs
+		for i := 0; i < nbInputs; i++ {
+			cb(uint32(i + int(inst.WireOffset)))
+		}
+	}
+}

--- a/std/lookup/logderivlookup/blueprint.go
+++ b/std/lookup/logderivlookup/blueprint.go
@@ -46,7 +46,7 @@ func (b *BlueprintLookupHint) Solve(s constraint.Solver, inst constraint.Instruc
 
 	// read the inputs from the instruction
 	inputs := make([]constraint.Element, nbInputs)
-	offset, delta = 3, 0
+	offset = 3
 	for i := 0; i < nbInputs; i++ {
 		inputs[i], delta = s.Read(inst.Calldata[offset:])
 		offset += delta

--- a/std/lookup/logderivlookup/logderivlookup.go
+++ b/std/lookup/logderivlookup/logderivlookup.go
@@ -65,7 +65,7 @@ func (t *Table) Insert(val frontend.Variable) (index int) {
 
 	// each time we insert a new entry, we update the blueprint
 	v := t.api.Compiler().ToCanonicalVariable(val)
-	v.CompressLE(&t.blueprint.EntriesCalldata)
+	v.Compress(&t.blueprint.EntriesCalldata)
 
 	return len(t.entries) - 1
 }
@@ -103,7 +103,7 @@ func (t *Table) performLookup(inds []frontend.Variable) []frontend.Variable {
 	// encode inputs
 	for _, in := range inds {
 		v := compiler.ToCanonicalVariable(in)
-		v.CompressLE(&calldata)
+		v.Compress(&calldata)
 	}
 
 	// by convention, first calldata is len of inputs

--- a/std/lookup/logderivlookup/logderivlookup.go
+++ b/std/lookup/logderivlookup/logderivlookup.go
@@ -19,21 +19,10 @@
 package logderivlookup
 
 import (
-	"fmt"
-
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/internal/logderivarg"
 )
-
-// func init() {
-// 	solver.RegisterHint(GetHints()...)
-// }
-
-// // GetHints returns all hints used in the package.
-// func GetHints() []solver.Hint {
-// 	return []solver.Hint{lookupHint}
-// }
 
 // Table holds all the entries and queries.
 type Table struct {
@@ -43,6 +32,9 @@ type Table struct {
 	immutable bool
 	results   []result
 
+	// each table has a unique blueprint
+	// the blueprint stores the lookup table entries once
+	// such that each query only need to store the indexes to lookup
 	bID       constraint.BlueprintID
 	blueprint BlueprintLookupHint
 }
@@ -57,6 +49,8 @@ type result struct {
 func New(api frontend.API) *Table {
 	t := &Table{api: api}
 	api.Compiler().Defer(t.commit)
+
+	// each table has a unique blueprint
 	t.bID = api.Compiler().AddBlueprint(&t.blueprint)
 	return t
 }
@@ -69,7 +63,7 @@ func (t *Table) Insert(val frontend.Variable) (index int) {
 	}
 	t.entries = append(t.entries, val)
 
-	// 1. update the blueprint with the entry
+	// each time we insert a new entry, we update the blueprint
 	v := t.api.Compiler().ToCanonicalVariable(val)
 	v.CompressLE(&t.blueprint.EntriesCalldata)
 
@@ -90,20 +84,16 @@ func (t *Table) Lookup(inds ...frontend.Variable) (vals []frontend.Variable) {
 	if len(t.entries) == 0 {
 		panic("looking up from empty table")
 	}
-	return t.callLookupHint(inds)
+	return t.performLookup(inds)
 }
 
-func (t *Table) callLookupHint(inds []frontend.Variable) []frontend.Variable {
-	// we encode the "call to the lookup hint"
-	// as a blueprint.
-	//
-	// the entry table is stored only once in the blueprint object itself.
-	// the calldata slice is:
-	// 0. len(calldata) --> blueprint convention.
-	// 1. len(entries) --> can change overtime so we keep an offset here
-	// 2. len(inputs)
-	// 3. calldata(inputs)
-	// 4. output range --> the wire ids of the resulting variables
+// performLookup performs the lookup and returns the resulting variables.
+// underneath, it does use the blueprint to encode the lookup hint.
+func (t *Table) performLookup(inds []frontend.Variable) []frontend.Variable {
+	// to build the instruction, we need to first encode its dependency as a calldata []uint32 slice.
+	// * calldata[0] is the length of the calldata,
+	// * calldata[1] is the number of entries in the table we consider.
+	// * calldata[2] is the number of queries (which is the number of indices we are looking up and the number of outputs we expect)
 	compiler := t.api.Compiler()
 
 	calldata := make([]uint32, 3, 3+len(inds)*2+2)
@@ -123,18 +113,22 @@ func (t *Table) callLookupHint(inds []frontend.Variable) []frontend.Variable {
 	// such that at solving time the blueprint can properly execute the lookup logic.
 	outputs := compiler.AddInstruction(t.bID, calldata)
 
+	// sanity check
 	if len(outputs) != len(inds) {
 		panic("sanity check")
 	}
 
-	res := make([]frontend.Variable, len(inds))
-	results := make([]result, len(inds))
+	// we need to return the variables corresponding to the outputs
+	internalVariables := make([]frontend.Variable, len(inds))
+	lookupResult := make([]result, len(inds))
+
+	// we need to store the result of the lookup in the table
 	for i := range inds {
-		res[i] = compiler.InternalVariable(outputs[i])
-		results[i] = result{ind: inds[i], val: res[i]}
+		internalVariables[i] = compiler.InternalVariable(outputs[i])
+		lookupResult[i] = result{ind: inds[i], val: internalVariables[i]}
 	}
-	t.results = append(t.results, results...)
-	return res
+	t.results = append(t.results, lookupResult...)
+	return internalVariables
 }
 
 func (t *Table) entryTable() [][]frontend.Variable {
@@ -155,119 +149,4 @@ func (t *Table) resultsTable() [][]frontend.Variable {
 
 func (t *Table) commit(api frontend.API) error {
 	return logderivarg.Build(api, t.entryTable(), t.resultsTable())
-}
-
-// func lookupHint(_ *big.Int, in []*big.Int, out []*big.Int) error {
-// 	nbTable := len(in) - len(out)
-// 	for i := 0; i < len(in)-nbTable; i++ {
-// 		if !in[nbTable+i].IsInt64() {
-// 			return fmt.Errorf("lookup query not integer")
-// 		}
-// 		ptr := int(in[nbTable+i].Int64())
-// 		if ptr >= nbTable {
-// 			return fmt.Errorf("lookup query %d outside table size %d", ptr, nbTable)
-// 		}
-// 		out[i].Set(in[ptr])
-// 	}
-// 	return nil
-// }
-
-type BlueprintLookupHint struct {
-	// store the table
-	EntriesCalldata []uint32
-}
-
-func (b *BlueprintLookupHint) Solve(s constraint.Solver, inst constraint.Instruction) error {
-	nbEntries := int(inst.Calldata[1])
-	entries := make([]constraint.Element, nbEntries)
-
-	// read the entries
-	// TODO cache that.
-	offset, delta := 0, 0
-	for i := 0; i < nbEntries; i++ {
-		entries[i], delta = s.Read(b.EntriesCalldata[offset:])
-		offset += delta
-	}
-
-	nbInputs := int(inst.Calldata[2])
-
-	// read the inputs
-	inputs := make([]constraint.Element, nbInputs)
-	offset, delta = 3, 0
-	for i := 0; i < nbInputs; i++ {
-		inputs[i], delta = s.Read(inst.Calldata[offset:])
-		offset += delta
-	}
-
-	// read the outputs
-	nbOutputs := nbInputs
-
-	for i := 0; i < nbOutputs; i++ {
-		ptr := inputs[i]
-		idx, isUint64 := s.Uint64(ptr)
-		if !isUint64 {
-			return fmt.Errorf("lookup query not integer")
-		}
-		if idx >= uint64(len(entries)) {
-			return fmt.Errorf("idx too large")
-		}
-		s.SetValue(uint32(i+int(inst.WireOffset)), entries[idx])
-	}
-	return nil
-}
-
-func (b *BlueprintLookupHint) CalldataSize() int {
-	return -1
-}
-func (b *BlueprintLookupHint) NbConstraints() int {
-	return 0
-}
-
-// NbOutputs return the number of output wires this blueprint creates.
-func (b *BlueprintLookupHint) NbOutputs(inst constraint.Instruction) int {
-	return int(inst.Calldata[2])
-}
-
-// Wires returns a function that walks the wires appearing in the blueprint.
-// This is used by the level builder to build a dependency graph between instructions.
-func (b *BlueprintLookupHint) Wires(inst constraint.Instruction) func(cb func(wire uint32)) {
-	return func(cb func(wire uint32)) {
-		// depend on the table UP to the number of entries at time of instruction creation.
-		nbEntries := int(inst.Calldata[1])
-
-		j := 0
-		for i := 0; i < nbEntries; i++ {
-			// first we have the length of the linear expression
-			n := int(b.EntriesCalldata[j])
-			j++
-			for k := 0; k < n; k++ {
-				t := constraint.Term{CID: b.EntriesCalldata[j], VID: b.EntriesCalldata[j+1]}
-				if !t.IsConstant() {
-					cb(t.VID)
-				}
-				j += 2
-			}
-		}
-
-		// then we have the inputs
-		nbInputs := int(inst.Calldata[2])
-		j = 3
-		for i := 0; i < nbInputs; i++ {
-			// first we have the length of the linear expression
-			n := int(inst.Calldata[j])
-			j++
-			for k := 0; k < n; k++ {
-				t := constraint.Term{CID: inst.Calldata[j], VID: inst.Calldata[j+1]}
-				if !t.IsConstant() {
-					cb(t.VID)
-				}
-				j += 2
-			}
-		}
-
-		// finally we have the outputs
-		for i := 0; i < nbInputs; i++ {
-			cb(uint32(i + int(inst.WireOffset)))
-		}
-	}
 }

--- a/std/lookup/logderivlookup/logderivlookup_test.go
+++ b/std/lookup/logderivlookup/logderivlookup_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/test"
 )
 
@@ -45,7 +45,17 @@ func TestLookup(t *testing.T) {
 		witness.Queries[i] = q
 		witness.Expected[i] = new(big.Int).Set(witness.Entries[q.Int64()].(*big.Int))
 	}
-	assert.ProverSucceeded(&LookupCircuit{}, &witness,
-		test.WithCurves(ecc.BN254),
-		test.WithBackends(backend.GROTH16, backend.PLONK))
+
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &LookupCircuit{})
+	assert.NoError(err)
+
+	w, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+
+	_, err = ccs.Solve(w)
+	assert.NoError(err)
+
+	// assert.ProverSucceeded(&LookupCircuit{}, &witness,
+	// 	test.WithCurves(ecc.BN254),
+	// 	test.WithBackends(backend.GROTH16, backend.PLONK))
 }

--- a/std/lookup/logderivlookup/logderivlookup_test.go
+++ b/std/lookup/logderivlookup/logderivlookup_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/frontend/cs/scs"
 	"github.com/consensys/gnark/test"
 )
 
@@ -46,7 +47,7 @@ func TestLookup(t *testing.T) {
 		witness.Expected[i] = new(big.Int).Set(witness.Entries[q.Int64()].(*big.Int))
 	}
 
-	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &LookupCircuit{})
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &LookupCircuit{})
 	assert.NoError(err)
 
 	w, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
@@ -55,7 +56,10 @@ func TestLookup(t *testing.T) {
 	_, err = ccs.Solve(w)
 	assert.NoError(err)
 
-	// assert.ProverSucceeded(&LookupCircuit{}, &witness,
-	// 	test.WithCurves(ecc.BN254),
-	// 	test.WithBackends(backend.GROTH16, backend.PLONK))
+	err = test.IsSolved(&LookupCircuit{}, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+
+	assert.ProverSucceeded(&LookupCircuit{}, &witness,
+		test.WithCurves(ecc.BN254),
+		test.WithBackends(backend.GROTH16, backend.PLONK))
 }

--- a/test/blueprint_solver.go
+++ b/test/blueprint_solver.go
@@ -128,7 +128,7 @@ type wrappedBigInt struct {
 	*big.Int
 }
 
-func (w wrappedBigInt) CompressLE(to *[]uint32) {
+func (w wrappedBigInt) Compress(to *[]uint32) {
 	// convert to Element.
 	e := bigIntToElement(w.Int)
 

--- a/test/blueprint_solver.go
+++ b/test/blueprint_solver.go
@@ -4,8 +4,11 @@ import (
 	"math/big"
 
 	"github.com/consensys/gnark/constraint"
+	"github.com/consensys/gnark/internal/utils"
 )
 
+// blueprintSolver is a constraint.Solver that can be used to test a circuit
+// it is a separate type to avoid method collisions with the engine.
 type blueprintSolver struct {
 	internalVariables []*big.Int
 	q                 *big.Int
@@ -13,18 +16,21 @@ type blueprintSolver struct {
 
 // implements constraint.Solver
 
+func (s *blueprintSolver) SetValue(vID uint32, f constraint.Element) {
+	if int(vID) > len(s.internalVariables) {
+		panic("out of bounds")
+	}
+	v := s.ToBigInt(f)
+	s.internalVariables[vID].Set(v)
+}
+
 func (s *blueprintSolver) GetValue(cID, vID uint32) constraint.Element {
 	panic("not implemented in test.Engine")
 }
 func (s *blueprintSolver) GetCoeff(cID uint32) constraint.Element {
 	panic("not implemented in test.Engine")
 }
-func (s *blueprintSolver) SetValue(vID uint32, f constraint.Element) {
-	if int(vID) < len(s.internalVariables) {
-		v := s.ToBigInt(f)
-		s.internalVariables[vID].Set(v)
-	}
-}
+
 func (s *blueprintSolver) IsSolved(vID uint32) bool {
 	panic("not implemented in test.Engine")
 }
@@ -32,7 +38,8 @@ func (s *blueprintSolver) IsSolved(vID uint32) bool {
 // implements constraint.Field
 
 func (s *blueprintSolver) FromInterface(i interface{}) constraint.Element {
-	panic("not implemented in test.Engine")
+	b := utils.FromInterface(i)
+	return s.toElement(&b)
 }
 
 func (s *blueprintSolver) ToBigInt(f constraint.Element) *big.Int {
@@ -42,19 +49,29 @@ func (s *blueprintSolver) ToBigInt(f constraint.Element) *big.Int {
 	return r
 }
 func (s *blueprintSolver) Mul(a, b constraint.Element) constraint.Element {
-	panic("not implemented in test.Engine")
+	ba, bb := s.ToBigInt(a), s.ToBigInt(b)
+	ba.Mul(ba, bb).Mod(ba, s.q)
+	return s.toElement(ba)
 }
 func (s *blueprintSolver) Add(a, b constraint.Element) constraint.Element {
-	panic("not implemented in test.Engine")
+	ba, bb := s.ToBigInt(a), s.ToBigInt(b)
+	ba.Add(ba, bb).Mod(ba, s.q)
+	return s.toElement(ba)
 }
 func (s *blueprintSolver) Sub(a, b constraint.Element) constraint.Element {
-	panic("not implemented in test.Engine")
+	ba, bb := s.ToBigInt(a), s.ToBigInt(b)
+	ba.Sub(ba, bb).Mod(ba, s.q)
+	return s.toElement(ba)
 }
 func (s *blueprintSolver) Neg(a constraint.Element) constraint.Element {
-	panic("not implemented in test.Engine")
+	ba := s.ToBigInt(a)
+	ba.Neg(ba).Mod(ba, s.q)
+	return s.toElement(ba)
 }
 func (s *blueprintSolver) Inverse(a constraint.Element) (constraint.Element, bool) {
-	panic("not implemented in test.Engine")
+	ba := s.ToBigInt(a)
+	r := ba.ModInverse(ba, s.q)
+	return s.toElement(ba), r != nil
 }
 func (s *blueprintSolver) One() constraint.Element {
 	b := new(big.Int).SetUint64(1)
@@ -76,11 +93,20 @@ func (s *blueprintSolver) Uint64(a constraint.Element) (uint64, bool) {
 }
 
 func (s *blueprintSolver) Read(calldata []uint32) (constraint.Element, int) {
-	b, n := decodeUint32SliceToBigInt(calldata)
-	return s.toElement(b), n
+	// We encoded big.Int as constraint.Element on 12 uint32 words.
+	var r constraint.Element
+	for i := 0; i < len(r); i++ {
+		index := i * 2
+		r[i] = uint64(calldata[index])<<32 | uint64(calldata[index+1])
+	}
+	return r, len(r) * 2
 }
 
 func (s *blueprintSolver) toElement(b *big.Int) constraint.Element {
+	return bigIntToElement(b)
+}
+
+func bigIntToElement(b *big.Int) constraint.Element {
 	if b.Sign() == -1 {
 		panic("negative value")
 	}
@@ -95,5 +121,20 @@ func (s *blueprintSolver) toElement(b *big.Int) constraint.Element {
 	r.SetBytes(paddedBytes)
 
 	return r
+}
 
+// wrappedBigInt is a wrapper around big.Int to implement the frontend.CanonicalVariable interface
+type wrappedBigInt struct {
+	*big.Int
+}
+
+func (w wrappedBigInt) CompressLE(to *[]uint32) {
+	// convert to Element.
+	e := bigIntToElement(w.Int)
+
+	// append the uint32 words to the slice
+	for i := 0; i < len(e); i++ {
+		*to = append(*to, uint32(e[i]>>32))
+		*to = append(*to, uint32(e[i]&0xffffffff))
+	}
 }

--- a/test/blueprint_solver_test.go
+++ b/test/blueprint_solver_test.go
@@ -16,7 +16,7 @@ func TestBigIntToElement(t *testing.T) {
 	s := blueprintSolver{q: ecc.BN254.ScalarField()}
 	b := big.NewInt(0)
 	for i := 0; i < 50; i++ {
-		b.Rand(rand.New(rand.NewSource(time.Now().Unix())), s.q)
+		b.Rand(rand.New(rand.NewSource(time.Now().Unix())), s.q) //#nosec G404 -- This is a false positive
 		e := s.toElement(b)
 		b2 := s.ToBigInt(e)
 		if b.Cmp(b2) != 0 {
@@ -35,8 +35,8 @@ func TestBigIntToUint32Slice(t *testing.T) {
 	b2 := big.NewInt(0)
 
 	for i := 0; i < 50; i++ {
-		b1.Rand(rand.New(rand.NewSource(time.Now().Unix())), s.q)
-		b2.Rand(rand.New(rand.NewSource(time.Now().Unix())), s.q)
+		b1.Rand(rand.New(rand.NewSource(time.Now().Unix())), s.q) //#nosec G404 -- This is a false positive
+		b2.Rand(rand.New(rand.NewSource(time.Now().Unix())), s.q) //#nosec G404 -- This is a false positive
 		wb1 := wrappedBigInt{b1}
 		wb2 := wrappedBigInt{b2}
 		var to []uint32

--- a/test/blueprint_solver_test.go
+++ b/test/blueprint_solver_test.go
@@ -40,8 +40,8 @@ func TestBigIntToUint32Slice(t *testing.T) {
 		wb1 := wrappedBigInt{b1}
 		wb2 := wrappedBigInt{b2}
 		var to []uint32
-		wb1.CompressLE(&to)
-		wb2.CompressLE(&to)
+		wb1.Compress(&to)
+		wb2.Compress(&to)
 
 		if len(to) != 24 {
 			t.Fatal("wrong length: expected 2*len of constraint.Element (uint32 words)")

--- a/test/blueprint_solver_test.go
+++ b/test/blueprint_solver_test.go
@@ -1,0 +1,64 @@
+package test
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/consensys/gnark-crypto/ecc"
+)
+
+func TestBigIntToElement(t *testing.T) {
+	t.Parallel()
+	// sample a random big.Int, convert it to an element, and back
+	// to a big.Int, and check that it's the same
+	s := blueprintSolver{q: ecc.BN254.ScalarField()}
+	b := big.NewInt(0)
+	for i := 0; i < 50; i++ {
+		b.Rand(rand.New(rand.NewSource(time.Now().Unix())), s.q)
+		e := s.toElement(b)
+		b2 := s.ToBigInt(e)
+		if b.Cmp(b2) != 0 {
+			t.Fatal("b != b2")
+		}
+	}
+
+}
+
+func TestBigIntToUint32Slice(t *testing.T) {
+	t.Parallel()
+	// sample a random big.Int, write it to a uint32 slice, and back
+	// to a big.Int, and check that it's the same
+	s := blueprintSolver{q: ecc.BN254.ScalarField()}
+	b1 := big.NewInt(0)
+	b2 := big.NewInt(0)
+
+	for i := 0; i < 50; i++ {
+		b1.Rand(rand.New(rand.NewSource(time.Now().Unix())), s.q)
+		b2.Rand(rand.New(rand.NewSource(time.Now().Unix())), s.q)
+		wb1 := wrappedBigInt{b1}
+		wb2 := wrappedBigInt{b2}
+		var to []uint32
+		wb1.CompressLE(&to)
+		wb2.CompressLE(&to)
+
+		if len(to) != 24 {
+			t.Fatal("wrong length: expected 2*len of constraint.Element (uint32 words)")
+		}
+
+		e1, n := s.Read(to)
+		if n != 12 {
+			t.Fatal("wrong length: expected 1 len of constraint.Element (uint32 words)")
+		}
+		e2, n := s.Read(to[n:])
+		if n != 12 {
+			t.Fatal("wrong length: expected 1 len of constraint.Element (uint32 words)")
+		}
+		rb1, rb2 := s.ToBigInt(e1), s.ToBigInt(e2)
+		if rb1.Cmp(b1) != 0 || rb2.Cmp(b2) != 0 {
+			t.Fatal("rb1 != b1 || rb2 != b2")
+		}
+	}
+
+}

--- a/test/engine.go
+++ b/test/engine.go
@@ -630,8 +630,9 @@ func (e *engine) Defer(cb func(frontend.API) error) {
 }
 
 // AddInstruction is used to add custom instructions to the constraint system.
-func (e *engine) AddInstruction(bID constraint.BlueprintID, calldata []uint32, c constraint.Iterable) {
+func (e *engine) AddInstruction(bID constraint.BlueprintID, calldata []uint32) []uint32 {
 	// blueprint := e.blueprints[bID].(constraint.s
+	return nil
 }
 
 // AddBlueprint adds a custom blueprint to the constraint system.

--- a/test/engine.go
+++ b/test/engine.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/debug"
 	"github.com/consensys/gnark/frontend/schema"
@@ -53,6 +54,7 @@ type engine struct {
 	// mHintsFunctions map[hint.ID]hintFunction
 	constVars bool
 	kvstore.Store
+	blueprints []constraint.Blueprint
 }
 
 // TestEngineOption defines an option for the test engine.
@@ -607,4 +609,26 @@ func (e *engine) Commit(v ...frontend.Variable) (frontend.Variable, error) {
 
 func (e *engine) Defer(cb func(frontend.API) error) {
 	circuitdefer.Put(e, cb)
+}
+
+// AddInstruction is used to add custom instructions to the constraint system.
+func (e *engine) AddInstruction(bID constraint.BlueprintID, calldata []uint32, c constraint.Iterable) {
+	// blueprint := e.blueprints[bID].(constraint.s
+}
+
+// AddBlueprint adds a custom blueprint to the constraint system.
+func (e *engine) AddBlueprint(b constraint.Blueprint) constraint.BlueprintID {
+	if _, ok := b.(constraint.BlueprintSolvable); !ok {
+		panic("unsupported blueprint in test engine")
+	}
+	e.blueprints = append(e.blueprints, b)
+	return constraint.BlueprintID(len(e.blueprints) - 1)
+}
+
+func (e *engine) AddInternalVariable() frontend.CanonicalVariable {
+	panic("not implemented")
+}
+
+func (e *engine) ToCanonicalVariable(in frontend.Variable) frontend.CanonicalVariable {
+	panic("not implemented")
 }

--- a/test/engine.go
+++ b/test/engine.go
@@ -54,7 +54,25 @@ type engine struct {
 	// mHintsFunctions map[hint.ID]hintFunction
 	constVars bool
 	kvstore.Store
-	blueprints []constraint.Blueprint
+	blueprints        []constraint.Blueprint
+	internalVariables []internalVariable
+}
+
+type internalVariable int
+
+func (v internalVariable) Compress(to *[]uint32) {
+	*to = append(*to, uint32(v))
+}
+
+func (v internalVariable) WireIterator() (next func() int) {
+	curr := 0
+	return func() int {
+		curr++
+		if curr == 1 {
+			return int(v)
+		}
+		return -1
+	}
 }
 
 // TestEngineOption defines an option for the test engine.
@@ -625,8 +643,11 @@ func (e *engine) AddBlueprint(b constraint.Blueprint) constraint.BlueprintID {
 	return constraint.BlueprintID(len(e.blueprints) - 1)
 }
 
-func (e *engine) AddInternalVariable() frontend.CanonicalVariable {
+func (e *engine) AddInternalVariable() frontend.RRVariable {
 	panic("not implemented")
+	// v := internalVariable(len(e.internalVariables))
+	// e.internalVariables = append(e.internalVariables, v)
+	// return v
 }
 
 func (e *engine) ToCanonicalVariable(in frontend.Variable) frontend.CanonicalVariable {

--- a/test/solver.go
+++ b/test/solver.go
@@ -1,0 +1,99 @@
+package test
+
+import (
+	"math/big"
+
+	"github.com/consensys/gnark/constraint"
+)
+
+type blueprintSolver struct {
+	internalVariables []*big.Int
+	q                 *big.Int
+}
+
+// implements constraint.Solver
+
+func (s *blueprintSolver) GetValue(cID, vID uint32) constraint.Element {
+	panic("not implemented in test.Engine")
+}
+func (s *blueprintSolver) GetCoeff(cID uint32) constraint.Element {
+	panic("not implemented in test.Engine")
+}
+func (s *blueprintSolver) SetValue(vID uint32, f constraint.Element) {
+	if int(vID) < len(s.internalVariables) {
+		v := s.ToBigInt(f)
+		s.internalVariables[vID].Set(v)
+	}
+}
+func (s *blueprintSolver) IsSolved(vID uint32) bool {
+	panic("not implemented in test.Engine")
+}
+
+// implements constraint.Field
+
+func (s *blueprintSolver) FromInterface(i interface{}) constraint.Element {
+	panic("not implemented in test.Engine")
+}
+
+func (s *blueprintSolver) ToBigInt(f constraint.Element) *big.Int {
+	r := new(big.Int)
+	fBytes := f.Bytes()
+	r.SetBytes(fBytes[:])
+	return r
+}
+func (s *blueprintSolver) Mul(a, b constraint.Element) constraint.Element {
+	panic("not implemented in test.Engine")
+}
+func (s *blueprintSolver) Add(a, b constraint.Element) constraint.Element {
+	panic("not implemented in test.Engine")
+}
+func (s *blueprintSolver) Sub(a, b constraint.Element) constraint.Element {
+	panic("not implemented in test.Engine")
+}
+func (s *blueprintSolver) Neg(a constraint.Element) constraint.Element {
+	panic("not implemented in test.Engine")
+}
+func (s *blueprintSolver) Inverse(a constraint.Element) (constraint.Element, bool) {
+	panic("not implemented in test.Engine")
+}
+func (s *blueprintSolver) One() constraint.Element {
+	b := new(big.Int).SetUint64(1)
+	return s.toElement(b)
+}
+func (s *blueprintSolver) IsOne(a constraint.Element) bool {
+	b := s.ToBigInt(a)
+	return b.IsUint64() && b.Uint64() == 1
+}
+
+func (s *blueprintSolver) String(a constraint.Element) string {
+	b := s.ToBigInt(a)
+	return b.String()
+}
+
+func (s *blueprintSolver) Uint64(a constraint.Element) (uint64, bool) {
+	b := s.ToBigInt(a)
+	return b.Uint64(), b.IsUint64()
+}
+
+func (s *blueprintSolver) Read(calldata []uint32) (constraint.Element, int) {
+	b, n := decodeUint32SliceToBigInt(calldata)
+	return s.toElement(b), n
+}
+
+func (s *blueprintSolver) toElement(b *big.Int) constraint.Element {
+	if b.Sign() == -1 {
+		panic("negative value")
+	}
+	bytes := b.Bytes()
+	if len(bytes) > 48 {
+		panic("value too big")
+	}
+	var paddedBytes [48]byte
+	copy(paddedBytes[48-len(bytes):], bytes[:])
+
+	var r constraint.Element
+	r.SetBytes(paddedBytes)
+
+	return r
+
+}


### PR DESCRIPTION
Fixes #660  .

High level idea of this PR; replace the lookup hint, with a "custom blueprint". The blueprint is functionally similar to a hint, in the sense that it does not add constraint, and indicates to the solver how to solve some wires at run time. 

However, the blueprint can have a state; in particular here, it encodes the lookup entries only once, such that additional query calls on the table do not incur a significant memory overhead. 

There are couple of perf adjustment to do (like caching the evaluation of the table in the solver and decrease overall memory allocs) but not urgent / will be in separate PR.

* The `test/Engine` also now implements `constraint.Solver` (partially) to support custom blueprints.
* This PR also kills the `WireIterator` and adds a simpler `WireWalker`; blueprint calls a callback with each wire that appears in an instruction.


## Benchmarks

 In particular, against `develop` for a circuit with 1000 lookups and a table with 130k entries, the size of the serialized constraint systems:

```
plonkish: -88.66%
r1cs: -93.41%
```



```
benchmark                                old ns/op      new ns/op      delta
BenchmarkCircuitTest/compile_scs-10      2936793375     803487125      -72.64%
BenchmarkCircuitTest/solve_scs-10        2854547292     665826250      -76.67%
BenchmarkCircuitTest/compile_r1cs-10     4438137000     1018271167     -77.06%
BenchmarkCircuitTest/solve_r1cs-10       3463089250     436040819      -87.41%

benchmark                                old allocs     new allocs     delta
BenchmarkCircuitTest/compile_scs-10      6787375        7583678        +11.73%
BenchmarkCircuitTest/solve_scs-10        2457896        1191280        -51.53%
BenchmarkCircuitTest/compile_r1cs-10     139058391      8515117        -93.88%
BenchmarkCircuitTest/solve_r1cs-10       4113213        1191315        -71.04%

benchmark                                old bytes       new bytes      delta
BenchmarkCircuitTest/compile_scs-10      10727280448     863376192      -91.95%
BenchmarkCircuitTest/solve_scs-10        1360056376      6508774600     +378.57%
BenchmarkCircuitTest/compile_r1cs-10     16213037632     2016655336     -87.56%
BenchmarkCircuitTest/solve_r1cs-10       1432770664      6445375594     +349.85%
``` 

