### PR TITLE
fix: init elements in arrays and slices if have init hook

### DIFF
--- a/frontend/schema/schema.go
+++ b/frontend/schema/schema.go
@@ -361,7 +361,11 @@ func parse(r []Field, input interface{}, target reflect.Type, parentFullName, pa
 			val := tValue.Index(j)
 			if val.CanAddr() && val.Addr().CanInterface() {
 				fqn := getFullName(parentFullName, strconv.Itoa(j), "")
-				subFields, err = parse(subFields, val.Addr().Interface(), target, fqn, fqn, parentTagName, parentVisibility, nbPublic, nbSecret)
+				ival := val.Addr().Interface()
+				if ih, hasInitHook := ival.(InitHook); hasInitHook {
+					ih.GnarkInitHook()
+				}
+				subFields, err = parse(subFields, ival, target, fqn, fqn, parentTagName, parentVisibility, nbPublic, nbSecret)
 				if err != nil {
 					return nil, err
 				}

--- a/frontend/schema/schema_test.go
+++ b/frontend/schema/schema_test.go
@@ -165,6 +165,31 @@ func TestSchemaInherit(t *testing.T) {
 	}
 }
 
+type initableVariable struct {
+	Val []variable
+}
+
+func (iv *initableVariable) GnarkInitHook() {
+	if iv.Val == nil {
+		iv.Val = make([]variable, 2)
+	}
+}
+
+type initableCircuit struct {
+	X [2]initableVariable
+	Y []initableVariable
+	Z initableVariable
+}
+
+func TestVariableInitHook(t *testing.T) {
+	assert := require.New(t)
+
+	witness := &initableCircuit{Y: make([]initableVariable, 2)}
+	s, err := New(witness, tVariable)
+	assert.NoError(err)
+	assert.Equal(s.NbSecret, 10) // X: 2*2, Y: 2*2, Z: 2
+}
+
 func BenchmarkLargeSchema(b *testing.B) {
 	const n1 = 1 << 12
 	const n2 = 1 << 12


### PR DESCRIPTION
Types in the circuit definition can implement `frontend.GnarkInitHook` interface. When a type implements this interface, then it knows how to initialise itself. This is useful for example in field emulation where we use it to allocate the limbs, allowing to correctly estimate the size of the native elements in the witness.

However, we currently didn't call the init hook when initable types were elements of arrays and slices. This PR implements calling init hooks both in `schema.Parse` and `schema.Walk`.

Fixes #680 and also a lot of "ignoring uninitialized slice" errors.