### PR TITLE
refactor: emulation parameters

### DIFF
--- a/std/math/emulated/emparams/emparams.go
+++ b/std/math/emulated/emparams/emparams.go
@@ -1,4 +1,4 @@
-// Package emulationparams contains emulation parameters for well known fields.
+// Package emparams contains emulation parameters for well known fields.
 //
 // We define some well-known parameters in this package for compatibility and
 // ease of use. When needing to use parameters not defined in this package it is
@@ -9,7 +9,7 @@
 //	func (SmallField) BitsPerLimb() uint { return 11 }
 //	func (SmallField) IsPrime() bool { return true }
 //	func (SmallField) Modulus() *big.Int { return big.NewInt(1032) }
-package emulationparams
+package emparams
 
 import (
 	"crypto/elliptic"

--- a/std/math/emulated/emulationparams/emulationparams.go
+++ b/std/math/emulated/emulationparams/emulationparams.go
@@ -144,6 +144,34 @@ type BLS12381Fr struct{ fourLimbPrimeField }
 
 func (fp BLS12381Fr) Modulus() *big.Int { return ecc.BLS12_381.ScalarField() }
 
+// P256Fp provides type parametrization for field emulation:
+//   - limbs: 4
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff (base 16)
+//	115792089210356248762697446949407573530086143415290314195533631308867097853951 (base 10)
+//
+// This is the base field of the P-256 (also SECP256r1) curve.
+type P256Fp struct{ fourLimbPrimeField }
+
+func (P256Fp) Modulus() *big.Int { return elliptic.P256().Params().P }
+
+// P256Fr provides type parametrization for field emulation:
+//   - limbs: 4
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551 (base 16)
+//	115792089210356248762697446949407573529996955224135760342422259061068512044369 (base 10)
+//
+// This is the base field of the P-256 (also SECP256r1) curve.
+type P256Fr struct{ fourLimbPrimeField }
+
+func (P256Fr) Modulus() *big.Int { return elliptic.P256().Params().N }
+
 // P384Fp provides type parametrization for field emulation:
 //   - limbs: 6
 //   - limb width: 64 bits

--- a/std/math/emulated/emulationparams/emulationparams.go
+++ b/std/math/emulated/emulationparams/emulationparams.go
@@ -1,0 +1,92 @@
+package emulationparams
+
+import (
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/field/goldilocks"
+)
+
+// Goldilocks provide type parametrization for emulated field on 1 limb of width 64bits
+// for modulus 0xffffffff00000001
+type Goldilocks struct{}
+
+func (fp Goldilocks) NbLimbs() uint     { return 1 }
+func (fp Goldilocks) BitsPerLimb() uint { return 64 }
+func (fp Goldilocks) IsPrime() bool     { return true }
+func (fp Goldilocks) Modulus() *big.Int { return goldilocks.Modulus() }
+
+// Secp256k1Fp provide type parametrization for emulated field on 4 limb of width 64bits
+// for modulus 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f.
+// This is the base field of secp256k1 curve
+type Secp256k1Fp struct{}
+
+func (fp Secp256k1Fp) NbLimbs() uint     { return 4 }
+func (fp Secp256k1Fp) BitsPerLimb() uint { return 64 }
+func (fp Secp256k1Fp) IsPrime() bool     { return true }
+func (fp Secp256k1Fp) Modulus() *big.Int { return ecc.SECP256K1.BaseField() }
+
+// Secp256k1Fr provides type parametrization for emulated field on 4 limbs of width 64bits
+// for modulus 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141.
+// This is the scalar field of secp256k1 curve.
+type Secp256k1Fr struct{}
+
+func (fp Secp256k1Fr) NbLimbs() uint     { return 4 }
+func (fp Secp256k1Fr) BitsPerLimb() uint { return 64 }
+func (fp Secp256k1Fr) IsPrime() bool     { return true }
+func (fp Secp256k1Fr) Modulus() *big.Int { return ecc.SECP256K1.ScalarField() }
+
+// BN254Fp provide type parametrization for emulated field on 4 limb of width
+// 64bits for modulus
+// 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47. This is
+// the base field of the BN254 curve.
+type BN254Fp struct{}
+
+func (fp BN254Fp) NbLimbs() uint     { return 4 }
+func (fp BN254Fp) BitsPerLimb() uint { return 64 }
+func (fp BN254Fp) IsPrime() bool     { return true }
+func (fp BN254Fp) Modulus() *big.Int { return ecc.BN254.BaseField() }
+
+// BN254Fr provides type parametrisation for emulated field on 4 limbs of width
+// 64bits for modulus
+// 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001. This is
+// the scalar field of the BN254 curve.
+type BN254Fr struct{}
+
+func (fp BN254Fr) NbLimbs() uint     { return 4 }
+func (fp BN254Fr) BitsPerLimb() uint { return 64 }
+func (fp BN254Fr) IsPrime() bool     { return true }
+func (fp BN254Fr) Modulus() *big.Int { return ecc.BN254.ScalarField() }
+
+// BLS12377Fp provide type parametrization for emulated field on 6 limb of width
+// 64bits for modulus
+// 0x1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001.
+// This is the base field of the BLS12-377 curve.
+type BLS12377Fp struct{}
+
+func (fp BLS12377Fp) NbLimbs() uint     { return 6 }
+func (fp BLS12377Fp) BitsPerLimb() uint { return 64 }
+func (fp BLS12377Fp) IsPrime() bool     { return true }
+func (fp BLS12377Fp) Modulus() *big.Int { return ecc.BLS12_377.BaseField() }
+
+// BLS12381Fp provide type parametrization for emulated field on 6 limb of width
+// 64bits for modulus
+// 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab.
+// This is the base field of the BLS12-381 curve.
+type BLS12381Fp struct{}
+
+func (fp BLS12381Fp) NbLimbs() uint     { return 6 }
+func (fp BLS12381Fp) BitsPerLimb() uint { return 64 }
+func (fp BLS12381Fp) IsPrime() bool     { return true }
+func (fp BLS12381Fp) Modulus() *big.Int { return ecc.BLS12_381.BaseField() }
+
+// BLS12381Fr provide type parametrization for emulated field on 4 limb of width
+// 64bits for modulus
+// 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001.
+// This is the scalar field of the BLS12-381 curve.
+type BLS12381Fr struct{}
+
+func (fp BLS12381Fr) NbLimbs() uint     { return 4 }
+func (fp BLS12381Fr) BitsPerLimb() uint { return 64 }
+func (fp BLS12381Fr) IsPrime() bool     { return true }
+func (fp BLS12381Fr) Modulus() *big.Int { return ecc.BLS12_381.ScalarField() }

--- a/std/math/emulated/emulationparams/emulationparams.go
+++ b/std/math/emulated/emulationparams/emulationparams.go
@@ -7,8 +7,14 @@ import (
 	"github.com/consensys/gnark-crypto/field/goldilocks"
 )
 
-// Goldilocks provide type parametrization for emulated field on 1 limb of width 64bits
-// for modulus 0xffffffff00000001
+// Goldilocks provides type parametrization for field emulation:
+//   - limbs: 1
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0xffffffff00000001 (base 16)
+//	18446744069414584321 (base 10)
 type Goldilocks struct{}
 
 func (fp Goldilocks) NbLimbs() uint     { return 1 }
@@ -16,9 +22,16 @@ func (fp Goldilocks) BitsPerLimb() uint { return 64 }
 func (fp Goldilocks) IsPrime() bool     { return true }
 func (fp Goldilocks) Modulus() *big.Int { return goldilocks.Modulus() }
 
-// Secp256k1Fp provide type parametrization for emulated field on 4 limb of width 64bits
-// for modulus 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f.
-// This is the base field of secp256k1 curve
+// Secp256k1Fp provides type parametrization for field emulation:
+//   - limbs: 4
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f (base 16)
+//	115792089237316195423570985008687907853269984665640564039457584007908834671663 (base 10)
+//
+// This is the base field of the SECP256k1 curve.
 type Secp256k1Fp struct{}
 
 func (fp Secp256k1Fp) NbLimbs() uint     { return 4 }
@@ -26,9 +39,16 @@ func (fp Secp256k1Fp) BitsPerLimb() uint { return 64 }
 func (fp Secp256k1Fp) IsPrime() bool     { return true }
 func (fp Secp256k1Fp) Modulus() *big.Int { return ecc.SECP256K1.BaseField() }
 
-// Secp256k1Fr provides type parametrization for emulated field on 4 limbs of width 64bits
-// for modulus 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141.
-// This is the scalar field of secp256k1 curve.
+// Secp256k1Fr provides type parametrization for field emulation:
+//   - limbs: 4
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141 (base 16)
+//	115792089237316195423570985008687907852837564279074904382605163141518161494337 (base 10)
+//
+// This is the scalar field of the SECP256k1 curve.
 type Secp256k1Fr struct{}
 
 func (fp Secp256k1Fr) NbLimbs() uint     { return 4 }
@@ -36,10 +56,16 @@ func (fp Secp256k1Fr) BitsPerLimb() uint { return 64 }
 func (fp Secp256k1Fr) IsPrime() bool     { return true }
 func (fp Secp256k1Fr) Modulus() *big.Int { return ecc.SECP256K1.ScalarField() }
 
-// BN254Fp provide type parametrization for emulated field on 4 limb of width
-// 64bits for modulus
-// 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47. This is
-// the base field of the BN254 curve.
+// BN254Fp provides type parametrization for field emulation:
+//   - limbs: 4
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47 (base 16)
+//	21888242871839275222246405745257275088696311157297823662689037894645226208583 (base 10)
+//
+// This is the base field of the BN254 curve.
 type BN254Fp struct{}
 
 func (fp BN254Fp) NbLimbs() uint     { return 4 }
@@ -47,10 +73,16 @@ func (fp BN254Fp) BitsPerLimb() uint { return 64 }
 func (fp BN254Fp) IsPrime() bool     { return true }
 func (fp BN254Fp) Modulus() *big.Int { return ecc.BN254.BaseField() }
 
-// BN254Fr provides type parametrisation for emulated field on 4 limbs of width
-// 64bits for modulus
-// 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001. This is
-// the scalar field of the BN254 curve.
+// BN254Fr provides type parametrization for field emulation:
+//   - limbs: 4
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001 (base 16)
+//	21888242871839275222246405745257275088548364400416034343698204186575808495617 (base 10)
+//
+// This is the scalar field of the BN254 curve.
 type BN254Fr struct{}
 
 func (fp BN254Fr) NbLimbs() uint     { return 4 }
@@ -58,9 +90,15 @@ func (fp BN254Fr) BitsPerLimb() uint { return 64 }
 func (fp BN254Fr) IsPrime() bool     { return true }
 func (fp BN254Fr) Modulus() *big.Int { return ecc.BN254.ScalarField() }
 
-// BLS12377Fp provide type parametrization for emulated field on 6 limb of width
-// 64bits for modulus
-// 0x1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001.
+// BLS12377Fp provides type parametrization for field emulation:
+//   - limbs: 6
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0x1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001 (base 16)
+//	258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 (base 10)
+//
 // This is the base field of the BLS12-377 curve.
 type BLS12377Fp struct{}
 
@@ -69,9 +107,15 @@ func (fp BLS12377Fp) BitsPerLimb() uint { return 64 }
 func (fp BLS12377Fp) IsPrime() bool     { return true }
 func (fp BLS12377Fp) Modulus() *big.Int { return ecc.BLS12_377.BaseField() }
 
-// BLS12381Fp provide type parametrization for emulated field on 6 limb of width
-// 64bits for modulus
-// 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab.
+// BLS12381Fp provides type parametrization for field emulation:
+//   - limbs: 6
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab (base 16)
+//	4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787 (base 10)
+//
 // This is the base field of the BLS12-381 curve.
 type BLS12381Fp struct{}
 
@@ -80,9 +124,15 @@ func (fp BLS12381Fp) BitsPerLimb() uint { return 64 }
 func (fp BLS12381Fp) IsPrime() bool     { return true }
 func (fp BLS12381Fp) Modulus() *big.Int { return ecc.BLS12_381.BaseField() }
 
-// BLS12381Fr provide type parametrization for emulated field on 4 limb of width
-// 64bits for modulus
-// 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001.
+// BLS12381Fr provides type parametrization for field emulation:
+//   - limbs: 4
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001 (base 16)
+//	52435875175126190479447740508185965837690552500527637822603658699938581184513 (base 10)
+//
 // This is the scalar field of the BLS12-381 curve.
 type BLS12381Fr struct{}
 

--- a/std/math/emulated/emulationparams/emulationparams.go
+++ b/std/math/emulated/emulationparams/emulationparams.go
@@ -1,3 +1,14 @@
+// Package emulationparams contains emulation parameters for well known fields.
+//
+// We define some well-known parameters in this package for compatibility and
+// ease of use. When needing to use parameters not defined in this package it is
+// sufficient to define a new type implementing [FieldParams]. For example, as:
+//
+//	type SmallField struct {}
+//	func (SmallField) NbLimbs() uint { return 1 }
+//	func (SmallField) BitsPerLimb() uint { return 11 }
+//	func (SmallField) IsPrime() bool { return true }
+//	func (SmallField) Modulus() *big.Int { return big.NewInt(1032) }
 package emulationparams
 
 import (

--- a/std/math/emulated/emulationparams/emulationparams.go
+++ b/std/math/emulated/emulationparams/emulationparams.go
@@ -12,6 +12,7 @@
 package emulationparams
 
 import (
+	"crypto/elliptic"
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -142,3 +143,31 @@ func (fp BLS12381Fp) Modulus() *big.Int { return ecc.BLS12_381.BaseField() }
 type BLS12381Fr struct{ fourLimbPrimeField }
 
 func (fp BLS12381Fr) Modulus() *big.Int { return ecc.BLS12_381.ScalarField() }
+
+// P384Fp provides type parametrization for field emulation:
+//   - limbs: 6
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff (base 16)
+//	39402006196394479212279040100143613805079739270465446667948293404245721771496870329047266088258938001861606973112319 (base 10)
+//
+// This is the base field of the P-384 (also SECP384r1) curve.
+type P384Fp struct{ sixLimbPrimeField }
+
+func (P384Fp) Modulus() *big.Int { return elliptic.P384().Params().P }
+
+// P384Fr provides type parametrization for field emulation:
+//   - limbs: 6
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973 (base 16)
+//	39402006196394479212279040100143613805079739270465446667946905279627659399113263569398956308152294913554433653942643 (base 10)
+//
+// This is the scalar field of the P-384 (also SECP384r1) curve.
+type P384Fr struct{ sixLimbPrimeField }
+
+func (P384Fr) Modulus() *big.Int { return elliptic.P384().Params().N }

--- a/std/math/emulated/emulationparams/emulationparams.go
+++ b/std/math/emulated/emulationparams/emulationparams.go
@@ -18,6 +18,18 @@ import (
 	"github.com/consensys/gnark-crypto/field/goldilocks"
 )
 
+type fourLimbPrimeField struct{}
+
+func (fourLimbPrimeField) NbLimbs() uint     { return 4 }
+func (fourLimbPrimeField) BitsPerLimb() uint { return 64 }
+func (fourLimbPrimeField) IsPrime() bool     { return true }
+
+type sixLimbPrimeField struct{}
+
+func (sixLimbPrimeField) NbLimbs() uint     { return 6 }
+func (sixLimbPrimeField) BitsPerLimb() uint { return 64 }
+func (sixLimbPrimeField) IsPrime() bool     { return true }
+
 // Goldilocks provides type parametrization for field emulation:
 //   - limbs: 1
 //   - limb width: 64 bits
@@ -43,11 +55,8 @@ func (fp Goldilocks) Modulus() *big.Int { return goldilocks.Modulus() }
 //	115792089237316195423570985008687907853269984665640564039457584007908834671663 (base 10)
 //
 // This is the base field of the SECP256k1 curve.
-type Secp256k1Fp struct{}
+type Secp256k1Fp struct{ fourLimbPrimeField }
 
-func (fp Secp256k1Fp) NbLimbs() uint     { return 4 }
-func (fp Secp256k1Fp) BitsPerLimb() uint { return 64 }
-func (fp Secp256k1Fp) IsPrime() bool     { return true }
 func (fp Secp256k1Fp) Modulus() *big.Int { return ecc.SECP256K1.BaseField() }
 
 // Secp256k1Fr provides type parametrization for field emulation:
@@ -60,11 +69,8 @@ func (fp Secp256k1Fp) Modulus() *big.Int { return ecc.SECP256K1.BaseField() }
 //	115792089237316195423570985008687907852837564279074904382605163141518161494337 (base 10)
 //
 // This is the scalar field of the SECP256k1 curve.
-type Secp256k1Fr struct{}
+type Secp256k1Fr struct{ fourLimbPrimeField }
 
-func (fp Secp256k1Fr) NbLimbs() uint     { return 4 }
-func (fp Secp256k1Fr) BitsPerLimb() uint { return 64 }
-func (fp Secp256k1Fr) IsPrime() bool     { return true }
 func (fp Secp256k1Fr) Modulus() *big.Int { return ecc.SECP256K1.ScalarField() }
 
 // BN254Fp provides type parametrization for field emulation:
@@ -77,11 +83,8 @@ func (fp Secp256k1Fr) Modulus() *big.Int { return ecc.SECP256K1.ScalarField() }
 //	21888242871839275222246405745257275088696311157297823662689037894645226208583 (base 10)
 //
 // This is the base field of the BN254 curve.
-type BN254Fp struct{}
+type BN254Fp struct{ fourLimbPrimeField }
 
-func (fp BN254Fp) NbLimbs() uint     { return 4 }
-func (fp BN254Fp) BitsPerLimb() uint { return 64 }
-func (fp BN254Fp) IsPrime() bool     { return true }
 func (fp BN254Fp) Modulus() *big.Int { return ecc.BN254.BaseField() }
 
 // BN254Fr provides type parametrization for field emulation:
@@ -94,11 +97,8 @@ func (fp BN254Fp) Modulus() *big.Int { return ecc.BN254.BaseField() }
 //	21888242871839275222246405745257275088548364400416034343698204186575808495617 (base 10)
 //
 // This is the scalar field of the BN254 curve.
-type BN254Fr struct{}
+type BN254Fr struct{ fourLimbPrimeField }
 
-func (fp BN254Fr) NbLimbs() uint     { return 4 }
-func (fp BN254Fr) BitsPerLimb() uint { return 64 }
-func (fp BN254Fr) IsPrime() bool     { return true }
 func (fp BN254Fr) Modulus() *big.Int { return ecc.BN254.ScalarField() }
 
 // BLS12377Fp provides type parametrization for field emulation:
@@ -111,11 +111,8 @@ func (fp BN254Fr) Modulus() *big.Int { return ecc.BN254.ScalarField() }
 //	258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177 (base 10)
 //
 // This is the base field of the BLS12-377 curve.
-type BLS12377Fp struct{}
+type BLS12377Fp struct{ sixLimbPrimeField }
 
-func (fp BLS12377Fp) NbLimbs() uint     { return 6 }
-func (fp BLS12377Fp) BitsPerLimb() uint { return 64 }
-func (fp BLS12377Fp) IsPrime() bool     { return true }
 func (fp BLS12377Fp) Modulus() *big.Int { return ecc.BLS12_377.BaseField() }
 
 // BLS12381Fp provides type parametrization for field emulation:
@@ -128,11 +125,8 @@ func (fp BLS12377Fp) Modulus() *big.Int { return ecc.BLS12_377.BaseField() }
 //	4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787 (base 10)
 //
 // This is the base field of the BLS12-381 curve.
-type BLS12381Fp struct{}
+type BLS12381Fp struct{ sixLimbPrimeField }
 
-func (fp BLS12381Fp) NbLimbs() uint     { return 6 }
-func (fp BLS12381Fp) BitsPerLimb() uint { return 64 }
-func (fp BLS12381Fp) IsPrime() bool     { return true }
 func (fp BLS12381Fp) Modulus() *big.Int { return ecc.BLS12_381.BaseField() }
 
 // BLS12381Fr provides type parametrization for field emulation:
@@ -145,9 +139,6 @@ func (fp BLS12381Fp) Modulus() *big.Int { return ecc.BLS12_381.BaseField() }
 //	52435875175126190479447740508185965837690552500527637822603658699938581184513 (base 10)
 //
 // This is the scalar field of the BLS12-381 curve.
-type BLS12381Fr struct{}
+type BLS12381Fr struct{ fourLimbPrimeField }
 
-func (fp BLS12381Fr) NbLimbs() uint     { return 4 }
-func (fp BLS12381Fr) BitsPerLimb() uint { return 64 }
-func (fp BLS12381Fr) IsPrime() bool     { return true }
 func (fp BLS12381Fr) Modulus() *big.Int { return ecc.BLS12_381.ScalarField() }

--- a/std/math/emulated/params.go
+++ b/std/math/emulated/params.go
@@ -15,14 +15,6 @@ type FieldParams interface {
 	Modulus() *big.Int // returns modulus. Do not modify.
 }
 
-var (
-	qSecp256k1, rSecp256k1 *big.Int
-)
-func init() {
-	qSecp256k1, _ = new(big.Int).SetString("fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f", 16)
-	rSecp256k1, _ = new(big.Int).SetString("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16)
-}
-
 // Goldilocks provide type parametrization for emulated field on 1 limb of width 64bits
 // for modulus 0xffffffff00000001
 type Goldilocks struct{}
@@ -40,7 +32,7 @@ type Secp256k1Fp struct{}
 func (fp Secp256k1Fp) NbLimbs() uint     { return 4 }
 func (fp Secp256k1Fp) BitsPerLimb() uint { return 64 }
 func (fp Secp256k1Fp) IsPrime() bool     { return true }
-func (fp Secp256k1Fp) Modulus() *big.Int { return qSecp256k1 }
+func (fp Secp256k1Fp) Modulus() *big.Int { return ecc.SECP256K1.BaseField() }
 
 // Secp256k1Fr provides type parametrization for emulated field on 4 limbs of width 64bits
 // for modulus 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141.
@@ -50,7 +42,7 @@ type Secp256k1Fr struct{}
 func (fp Secp256k1Fr) NbLimbs() uint     { return 4 }
 func (fp Secp256k1Fr) BitsPerLimb() uint { return 64 }
 func (fp Secp256k1Fr) IsPrime() bool     { return true }
-func (fp Secp256k1Fr) Modulus() *big.Int { return rSecp256k1 }
+func (fp Secp256k1Fr) Modulus() *big.Int { return ecc.SECP256K1.ScalarField() }
 
 // BN254Fp provide type parametrization for emulated field on 4 limb of width
 // 64bits for modulus

--- a/std/math/emulated/params.go
+++ b/std/math/emulated/params.go
@@ -3,8 +3,7 @@ package emulated
 import (
 	"math/big"
 
-	"github.com/consensys/gnark-crypto/ecc"
-	"github.com/consensys/gnark-crypto/field/goldilocks"
+	"github.com/consensys/gnark/std/math/emulated/emulationparams"
 )
 
 // FieldParams describes the emulated field characteristics
@@ -15,86 +14,11 @@ type FieldParams interface {
 	Modulus() *big.Int // returns modulus. Do not modify.
 }
 
-// Goldilocks provide type parametrization for emulated field on 1 limb of width 64bits
-// for modulus 0xffffffff00000001
-type Goldilocks struct{}
-
-func (fp Goldilocks) NbLimbs() uint     { return 1 }
-func (fp Goldilocks) BitsPerLimb() uint { return 64 }
-func (fp Goldilocks) IsPrime() bool     { return true }
-func (fp Goldilocks) Modulus() *big.Int { return goldilocks.Modulus() }
-
-// Secp256k1Fp provide type parametrization for emulated field on 4 limb of width 64bits
-// for modulus 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f.
-// This is the base field of secp256k1 curve
-type Secp256k1Fp struct{}
-
-func (fp Secp256k1Fp) NbLimbs() uint     { return 4 }
-func (fp Secp256k1Fp) BitsPerLimb() uint { return 64 }
-func (fp Secp256k1Fp) IsPrime() bool     { return true }
-func (fp Secp256k1Fp) Modulus() *big.Int { return ecc.SECP256K1.BaseField() }
-
-// Secp256k1Fr provides type parametrization for emulated field on 4 limbs of width 64bits
-// for modulus 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141.
-// This is the scalar field of secp256k1 curve.
-type Secp256k1Fr struct{}
-
-func (fp Secp256k1Fr) NbLimbs() uint     { return 4 }
-func (fp Secp256k1Fr) BitsPerLimb() uint { return 64 }
-func (fp Secp256k1Fr) IsPrime() bool     { return true }
-func (fp Secp256k1Fr) Modulus() *big.Int { return ecc.SECP256K1.ScalarField() }
-
-// BN254Fp provide type parametrization for emulated field on 4 limb of width
-// 64bits for modulus
-// 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47. This is
-// the base field of the BN254 curve.
-type BN254Fp struct{}
-
-func (fp BN254Fp) NbLimbs() uint     { return 4 }
-func (fp BN254Fp) BitsPerLimb() uint { return 64 }
-func (fp BN254Fp) IsPrime() bool     { return true }
-func (fp BN254Fp) Modulus() *big.Int { return ecc.BN254.BaseField() }
-
-// BN254Fr provides type parametrisation for emulated field on 4 limbs of width
-// 64bits for modulus
-// 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001. This is
-// the scalar field of the BN254 curve.
-type BN254Fr struct{}
-
-func (fp BN254Fr) NbLimbs() uint     { return 4 }
-func (fp BN254Fr) BitsPerLimb() uint { return 64 }
-func (fp BN254Fr) IsPrime() bool     { return true }
-func (fp BN254Fr) Modulus() *big.Int { return ecc.BN254.ScalarField() }
-
-// BLS12377Fp provide type parametrization for emulated field on 6 limb of width
-// 64bits for modulus
-// 0x1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001.
-// This is the base field of the BLS12-377 curve.
-type BLS12377Fp struct{}
-
-func (fp BLS12377Fp) NbLimbs() uint     { return 6 }
-func (fp BLS12377Fp) BitsPerLimb() uint { return 64 }
-func (fp BLS12377Fp) IsPrime() bool     { return true }
-func (fp BLS12377Fp) Modulus() *big.Int { return ecc.BLS12_377.BaseField() }
-
-// BLS12381Fp provide type parametrization for emulated field on 6 limb of width
-// 64bits for modulus
-// 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab.
-// This is the base field of the BLS12-381 curve.
-type BLS12381Fp struct{}
-
-func (fp BLS12381Fp) NbLimbs() uint     { return 6 }
-func (fp BLS12381Fp) BitsPerLimb() uint { return 64 }
-func (fp BLS12381Fp) IsPrime() bool     { return true }
-func (fp BLS12381Fp) Modulus() *big.Int { return ecc.BLS12_381.BaseField() }
-
-// BLS12381Fr provide type parametrization for emulated field on 4 limb of width
-// 64bits for modulus
-// 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001.
-// This is the scalar field of the BLS12-381 curve.
-type BLS12381Fr struct{}
-
-func (fp BLS12381Fr) NbLimbs() uint     { return 4 }
-func (fp BLS12381Fr) BitsPerLimb() uint { return 64 }
-func (fp BLS12381Fr) IsPrime() bool     { return true }
-func (fp BLS12381Fr) Modulus() *big.Int { return ecc.BLS12_381.ScalarField() }
+type Goldilocks = emulationparams.Goldilocks
+type Secp256k1Fp = emulationparams.Secp256k1Fp
+type Secp256k1Fr = emulationparams.Secp256k1Fr
+type BN254Fp = emulationparams.BN254Fp
+type BN254Fr = emulationparams.BN254Fr
+type BLS12377Fp = emulationparams.BLS12377Fp
+type BLS12381Fp = emulationparams.BLS12381Fp
+type BLS12381Fr = emulationparams.BLS12381Fr

--- a/std/math/emulated/params.go
+++ b/std/math/emulated/params.go
@@ -15,8 +15,8 @@ import (
 //   - [BN254Fp] and [BN254Fr]
 //   - [BLS12377Fp]
 //   - [BLS12381Fp] and [BLS12381Fr]
-//
-// Any new parameters will be included in [emparams] package, not here.
+//   - [P256Fp] and [P256Fr]
+//   - [P384Fp] and [P384Fr]
 type FieldParams interface {
 	NbLimbs() uint     // number of limbs to represent field element
 	BitsPerLimb() uint // number of bits per limb. Top limb may contain less than limbSize bits.
@@ -24,11 +24,17 @@ type FieldParams interface {
 	Modulus() *big.Int // returns modulus. Do not modify.
 }
 
-type Goldilocks = emparams.Goldilocks
-type Secp256k1Fp = emparams.Secp256k1Fp
-type Secp256k1Fr = emparams.Secp256k1Fr
-type BN254Fp = emparams.BN254Fp
-type BN254Fr = emparams.BN254Fr
-type BLS12377Fp = emparams.BLS12377Fp
-type BLS12381Fp = emparams.BLS12381Fp
-type BLS12381Fr = emparams.BLS12381Fr
+type (
+	Goldilocks  = emparams.Goldilocks
+	Secp256k1Fp = emparams.Secp256k1Fp
+	Secp256k1Fr = emparams.Secp256k1Fr
+	BN254Fp     = emparams.BN254Fp
+	BN254Fr     = emparams.BN254Fr
+	BLS12377Fp  = emparams.BLS12377Fp
+	BLS12381Fp  = emparams.BLS12381Fp
+	BLS12381Fr  = emparams.BLS12381Fr
+	P256Fp      = emparams.P256Fp
+	P256Fr      = emparams.P256Fr
+	P384Fp      = emparams.P384Fp
+	P384Fr      = emparams.P384Fr
+)

--- a/std/math/emulated/params.go
+++ b/std/math/emulated/params.go
@@ -3,11 +3,11 @@ package emulated
 import (
 	"math/big"
 
-	"github.com/consensys/gnark/std/math/emulated/emulationparams"
+	"github.com/consensys/gnark/std/math/emulated/emparams"
 )
 
 // FieldParams describes the emulated field characteristics. For a list of
-// included built-in emulation params refer to the [emulationparams] package.
+// included built-in emulation params refer to the [emparams] package.
 // For backwards compatibility, the current package contains the following
 // parameters:
 //   - [Goldilocks]
@@ -16,7 +16,7 @@ import (
 //   - [BLS12377Fp]
 //   - [BLS12381Fp] and [BLS12381Fr]
 //
-// Any new parameters will be included in [emulationparams] package, not here.
+// Any new parameters will be included in [emparams] package, not here.
 type FieldParams interface {
 	NbLimbs() uint     // number of limbs to represent field element
 	BitsPerLimb() uint // number of bits per limb. Top limb may contain less than limbSize bits.
@@ -24,11 +24,11 @@ type FieldParams interface {
 	Modulus() *big.Int // returns modulus. Do not modify.
 }
 
-type Goldilocks = emulationparams.Goldilocks
-type Secp256k1Fp = emulationparams.Secp256k1Fp
-type Secp256k1Fr = emulationparams.Secp256k1Fr
-type BN254Fp = emulationparams.BN254Fp
-type BN254Fr = emulationparams.BN254Fr
-type BLS12377Fp = emulationparams.BLS12377Fp
-type BLS12381Fp = emulationparams.BLS12381Fp
-type BLS12381Fr = emulationparams.BLS12381Fr
+type Goldilocks = emparams.Goldilocks
+type Secp256k1Fp = emparams.Secp256k1Fp
+type Secp256k1Fr = emparams.Secp256k1Fr
+type BN254Fp = emparams.BN254Fp
+type BN254Fr = emparams.BN254Fr
+type BLS12377Fp = emparams.BLS12377Fp
+type BLS12381Fp = emparams.BLS12381Fp
+type BLS12381Fr = emparams.BLS12381Fr

--- a/std/math/emulated/params.go
+++ b/std/math/emulated/params.go
@@ -6,7 +6,17 @@ import (
 	"github.com/consensys/gnark/std/math/emulated/emulationparams"
 )
 
-// FieldParams describes the emulated field characteristics
+// FieldParams describes the emulated field characteristics. For a list of
+// included built-in emulation params refer to the [emulationparams] package.
+// For backwards compatibility, the current package contains the following
+// parameters:
+//   - [Goldilocks]
+//   - [Secp256k1Fp] and [Secp256k1Fr]
+//   - [BN254Fp] and [BN254Fr]
+//   - [BLS12377Fp]
+//   - [BLS12381Fp] and [BLS12381Fr]
+//
+// Any new parameters will be included in [emulationparams] package, not here.
 type FieldParams interface {
 	NbLimbs() uint     // number of limbs to represent field element
 	BitsPerLimb() uint // number of bits per limb. Top limb may contain less than limbSize bits.

--- a/std/math/emulated/params.go
+++ b/std/math/emulated/params.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/field/goldilocks"
 )
 
 // FieldParams describes the emulated field characteristics
@@ -16,13 +17,10 @@ type FieldParams interface {
 
 var (
 	qSecp256k1, rSecp256k1 *big.Int
-	qGoldilocks            *big.Int
 )
-
 func init() {
 	qSecp256k1, _ = new(big.Int).SetString("fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f", 16)
 	rSecp256k1, _ = new(big.Int).SetString("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16)
-	qGoldilocks, _ = new(big.Int).SetString("ffffffff00000001", 16)
 }
 
 // Goldilocks provide type parametrization for emulated field on 1 limb of width 64bits
@@ -32,7 +30,7 @@ type Goldilocks struct{}
 func (fp Goldilocks) NbLimbs() uint     { return 1 }
 func (fp Goldilocks) BitsPerLimb() uint { return 64 }
 func (fp Goldilocks) IsPrime() bool     { return true }
-func (fp Goldilocks) Modulus() *big.Int { return qGoldilocks }
+func (fp Goldilocks) Modulus() *big.Int { return goldilocks.Modulus() }
 
 // Secp256k1Fp provide type parametrization for emulated field on 4 limb of width 64bits
 // for modulus 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f.


### PR DESCRIPTION
I was implementing ECDSA verification over P-384 and meanwhile saw a few things to improve:
* for Goldilocks field use the modulus from gnark-crypto instead of hardcoding. Makes easier to review when there is only a single definition.
* same for secp256k1 base and scalar fields. Previously weren't available in gnark-crypto but now is, so makes more sense to refer.
* moved emulation parameters into new package to decrease the number of implemented types and methods there. This hopefully makes it easier for the users to find the methods they are actually interested in. I enforce type aliases for existing parameters not to break any existing code.
* structured the type descriptions for types which implement FieldParams. Now everything is bullet pointed and modulus is in separate code-block for easier copying.
* added types which define 4 and 6 limbs. Then use type embedding for actual parameter implementations to minimise code overlap and possible errors.
* Added P-256 and P-384 parameters. This is preparatory work to add P-256 and P-384 parameters in emulated short weierstrass arithmetic for allowing verifying the P-256/P-384 ECDSA signatures in-chain.