### PR TITLE
internal: util package to parse and verify AZTEC ignition ceremony

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ go.work
 go.work.sum
 
 examples/gbotrel/**
+
+# ignore cached SRS
+internal/ignition/cmd/data/**

--- a/internal/ignition/cmd/main.go
+++ b/internal/ignition/cmd/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/consensys/gnark/internal/ignition"
+)
+
+func main() {
+
+	// Example usage of the ignition package
+	config := ignition.Config{
+		BaseURL:  "https://aztec-ignition.s3.amazonaws.com/",
+		Ceremony: "TINY_TEST_7",
+		CacheDir: "./data",
+	}
+	if config.CacheDir != "" {
+		os.MkdirAll(config.CacheDir, os.ModePerm)
+	}
+
+	// 1. fetch manifest
+	log.Println("fetch manifest")
+	manifest, err := ignition.NewManifest(config)
+	if err != nil {
+		log.Fatal("when fetching manifest: ", err)
+	}
+
+	// sanity check
+	if len(manifest.Participants) <= 1 {
+		log.Fatal("not enough participants")
+	}
+
+	// 2. we read two contributions at a time, and check that the second one follows the first one
+	current, next := ignition.NewContribution(manifest.NumG1Points), ignition.NewContribution(manifest.NumG1Points)
+
+	log.Println("processing contributions 1 and 2")
+	if err := current.Get(manifest.Participants[0], config); err != nil {
+		log.Fatal("when fetching contribution 1: ", err)
+	}
+	if err := next.Get(manifest.Participants[1], config); err != nil {
+		log.Fatal("when fetching contribution 2: ", err)
+	}
+	if !next.Follows(&current) {
+		log.Fatal("contribution 2 does not follow contribution 1: ", err)
+	}
+	for i := 2; i < len(manifest.Participants); i++ {
+		log.Println("processing contribution ", i+1)
+		current, next = next, current
+		if err := next.Get(manifest.Participants[i], config); err != nil {
+			log.Fatal("when fetching contribution ", i+1, ": ", err)
+		}
+		if !next.Follows(&current) {
+			log.Fatal("contribution ", i+1, " does not follow contribution ", i, ": ", err)
+		}
+	}
+
+	log.Println("success ✅: all contributions are valid")
+}

--- a/internal/ignition/contribution.go
+++ b/internal/ignition/contribution.go
@@ -1,0 +1,203 @@
+package ignition
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"golang.org/x/crypto/blake2b"
+)
+
+// Contribution is a participant's contribution to the ceremony
+type Contribution struct {
+	G1 []bn254.G1Affine
+	G2 [2]bn254.G2Affine
+}
+
+// NewContribution allocates a new contribution
+func NewContribution(nbPoints int) Contribution {
+	var c Contribution
+	c.G1 = make([]bn254.G1Affine, nbPoints)
+	return c
+}
+
+// Get download or reads a contribution from a participant to the ceremony
+// The contribution validity is partially checked;
+// The G1 points are powers of Tau.
+// TODO we don't actually check the contribution against the signature of a known address (participant).
+func (c *Contribution) Get(participant Participant, config Config) error {
+	addr := strings.ToLower(participant.Address)
+
+	// read all transcripts
+	totalTranscripts := math.MaxInt
+	for i := 0; i < totalTranscripts; i++ {
+		file := fmt.Sprintf("%03d_%s/transcript%02d.dat", participant.Position, addr, i)
+
+		b, err := readOrDownload(config.ceremonyURL(), file, config)
+		if err != nil {
+			return err
+		}
+
+		// read the actual points from the bytes
+		tManifest := newTranscriptManifest(b)
+		totalTranscripts = int(tManifest.TotalTranscripts)
+		if totalTranscripts > 30 {
+			return errors.New("too many transcripts, that's suspicious")
+		}
+
+		// read G1 points
+		offset := 28
+		readG1Points(b[offset:], tManifest.NumG1Points, c.G1[tManifest.StartFrom:tManifest.StartFrom+tManifest.NumG1Points])
+		offset += int(tManifest.NumG1Points) * bn254.SizeOfG1AffineUncompressed
+
+		// read G2 point
+		if i == 0 {
+			readG2Points(b[offset:], &c.G2)
+			if !c.G2[0].IsInSubGroup() || !c.G2[1].IsInSubGroup() {
+				return errors.New("invalid G2 point: not in subgroup")
+			}
+			offset += bn254.SizeOfG2AffineUncompressed * 2
+		}
+
+		// The 'checksum' - a BLAKE2B hash of the rest of the file's data
+		checksum := blake2b.Sum512(b[:offset])
+		if !bytes.Equal(b[offset:offset+64], checksum[:]) {
+			return errors.New("invalid checksum")
+		}
+	}
+
+	var nbErrs uint64
+	execute(len(c.G1), func(start, end int) {
+		for i := start; i < end; i++ {
+			// to montgomery form
+			c.G1[i].X.Mul(&c.G1[i].X, &rSquare)
+			c.G1[i].Y.Mul(&c.G1[i].Y, &rSquare)
+
+			// check if the point is on the curve
+			if !c.G1[i].IsInSubGroup() {
+				atomic.AddUint64(&nbErrs, 1)
+				return
+			}
+		}
+	})
+	if nbErrs > 0 {
+		return errors.New("invalid point(s): some points are not on the curve or in the correct subgroup")
+	}
+	if !c.IsValid() {
+		return errors.New("invalid point(s): the contribution is not valid")
+	}
+	return nil
+}
+
+// Follows checks that a contribution is based on a known previous contribution.
+func (contribution *Contribution) Follows(previous *Contribution) bool {
+	// check that e1 = pair(g2gen, contribution.G1) == e2 = pair(contribution.G2, current.G1)
+	return sameRatio(contribution.G1[0], previous.G1[0], g2gen, contribution.G2[1])
+}
+
+// IsValid checks if the contribution is valid
+func (c *Contribution) IsValid() bool {
+	l1, l2 := linearCombinationG1(c.G1)
+	return sameRatio(l1, l2, c.G2[0], g2gen)
+}
+
+// utils functions; from gnark groth16 mpc
+
+// sameRatio checks that e(a₁, a₂) = e(b₁, b₂)
+func sameRatio(a1, b1 bn254.G1Affine, a2, b2 bn254.G2Affine) bool {
+	// we already know that a1, b1, a2, b2 are in the correct subgroup
+	// if !a1.IsInSubGroup() || !b1.IsInSubGroup() || !a2.IsInSubGroup() || !b2.IsInSubGroup() {
+	// 	panic("invalid point not in subgroup")
+	// }
+	var na2 bn254.G2Affine
+	na2.Neg(&a2)
+	res, err := bn254.PairingCheck(
+		[]bn254.G1Affine{a1, b1},
+		[]bn254.G2Affine{na2, b2})
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+// L1 = ∑ rᵢAᵢ, L2 = ∑ rᵢAᵢ₊₁ in G1
+func linearCombinationG1(A []bn254.G1Affine) (L1, L2 bn254.G1Affine) {
+	nc := runtime.NumCPU()
+	n := len(A)
+	r := make([]fr.Element, n-1)
+	for i := 0; i < n-1; i++ {
+		r[i].SetRandom()
+	}
+	chDone := make(chan struct{})
+	go func() {
+		L1.MultiExp(A[:n-1], r, ecc.MultiExpConfig{NbTasks: nc / 2})
+		close(chDone)
+	}()
+	L2.MultiExp(A[1:], r, ecc.MultiExpConfig{NbTasks: nc / 2})
+	<-chDone
+	return
+}
+
+// execute process in parallel the work function
+func execute(nbIterations int, work func(int, int), maxCpus ...int) {
+
+	nbTasks := runtime.NumCPU()
+	if len(maxCpus) == 1 {
+		nbTasks = maxCpus[0]
+		if nbTasks < 1 {
+			nbTasks = 1
+		} else if nbTasks > 512 {
+			nbTasks = 512
+		}
+	}
+
+	if nbTasks == 1 {
+		// no go routines
+		work(0, nbIterations)
+		return
+	}
+
+	nbIterationsPerCpus := nbIterations / nbTasks
+
+	// more CPUs than tasks: a CPU will work on exactly one iteration
+	if nbIterationsPerCpus < 1 {
+		nbIterationsPerCpus = 1
+		nbTasks = nbIterations
+	}
+
+	var wg sync.WaitGroup
+
+	extraTasks := nbIterations - (nbTasks * nbIterationsPerCpus)
+	extraTasksOffset := 0
+
+	for i := 0; i < nbTasks; i++ {
+		wg.Add(1)
+		_start := i*nbIterationsPerCpus + extraTasksOffset
+		_end := _start + nbIterationsPerCpus
+		if extraTasks > 0 {
+			_end++
+			extraTasks--
+			extraTasksOffset++
+		}
+		go func() {
+			work(_start, _end)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+var g2gen bn254.G2Affine
+
+func init() {
+	_, _, _, g2gen = bn254.Generators()
+}

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1,0 +1,34 @@
+// Package ignition is a package that provides helper functions to download, parse
+// and validate the AZTEC Ignition Ceremony data.
+// The specs are described here:
+//
+//	https://github.com/AztecProtocol/ignition-verification/blob/c333ec4775045139f86732abfbbd65728404ab7f/Transcript_spec.md
+//
+// The verification logic follows
+//
+//	https://github.com/AztecProtocol/ignition-verification
+package ignition
+
+import (
+	"net/url"
+	"path/filepath"
+)
+
+// Config specify from where to download the data and where to store it
+type Config struct {
+	BaseURL  string // "https://aztec-ignition.s3.amazonaws.com/"
+	Ceremony string // TINY_TEST_7
+	CacheDir string // if empty, files are not cached. Otherwise, they are stored in this directory
+}
+
+func (c *Config) ceremonyURL() string {
+	r, err := url.JoinPath(c.BaseURL, c.Ceremony)
+	if err != nil {
+		panic("invalid configuration")
+	}
+	return r
+}
+
+func (c *Config) cache() string {
+	return filepath.Join(c.CacheDir, c.Ceremony)
+}

--- a/internal/ignition/io.go
+++ b/internal/ignition/io.go
@@ -38,7 +38,9 @@ func readOrDownload(baseURL, file string, config Config) ([]byte, error) {
 	}
 	log.Println("download", baseURL, file)
 	// Send HTTP GET request to the URL
-	response, err := http.Get(baseURL)
+	// --> Potential HTTP request made with variable url
+	// this is for illustrative purposes only.
+	response, err := http.Get(baseURL) //#nosec G107
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ignition/io.go
+++ b/internal/ignition/io.go
@@ -1,0 +1,167 @@
+package ignition
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
+)
+
+// readOrDownload reads a file from disk if it exists, or downloads it from the URL if it doesn't.
+// It returns the file contents as a byte slice.
+// It also saves the file to disk if it was downloaded.
+func readOrDownload(baseURL, file string, config Config) ([]byte, error) {
+
+	if config.CacheDir != "" && fileExists(filepath.Join(config.cache(), file)) {
+		// reading from cache
+		file = filepath.Join(config.cache(), file)
+		log.Println("read", file)
+		f, err := os.Open(file)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		return io.ReadAll(f)
+	}
+
+	var buf bytes.Buffer
+	baseURL, err := url.JoinPath(baseURL, file)
+	if err != nil {
+		return nil, err
+	}
+	log.Println("download", baseURL, file)
+	// Send HTTP GET request to the URL
+	response, err := http.Get(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	var writer io.Writer
+	writer = &buf
+
+	// create the file
+	if config.CacheDir != "" {
+		file = filepath.Join(config.cache(), file)
+		dir := filepath.Dir(file)
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			return nil, err
+		}
+		f, err := os.Create(file)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		writer = io.MultiWriter(f, writer)
+	}
+
+	_, err = io.Copy(writer, response.Body)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+
+}
+
+func readG1Points(b []byte, nbPoints uint32, r []bn254.G1Affine) {
+	// per the specs:
+	// For big-integer numbers (g1, g2 coordinates),
+	// we describe each 256-bit field element as a uint64_t[4] array.
+	// The first entry is the least significant word of the field element. Each 'word' is written in big-endian form.
+	offset := 0
+	for i := 0; i < int(nbPoints); i++ {
+		// TODO we could parallelize that
+		data := b[offset : offset+fp.Bytes*2]
+
+		r[i].X[0] = binary.BigEndian.Uint64(data[0:8])
+		r[i].X[1] = binary.BigEndian.Uint64(data[8:16])
+		r[i].X[2] = binary.BigEndian.Uint64(data[16:24])
+		r[i].X[3] = binary.BigEndian.Uint64(data[24:32])
+		// p.X.Mul(&p.X, &rSquare) // to montgomery form
+
+		r[i].Y[0] = binary.BigEndian.Uint64(data[32:40])
+		r[i].Y[1] = binary.BigEndian.Uint64(data[40:48])
+		r[i].Y[2] = binary.BigEndian.Uint64(data[48:56])
+		r[i].Y[3] = binary.BigEndian.Uint64(data[56:64])
+		// p.Y.Mul(&p.Y, &rSquare) // to montgomery form
+
+		offset += fp.Bytes * 2
+	}
+}
+
+func readG2Points(data []byte, r *[2]bn254.G2Affine) {
+	_ = data[255]
+	// per the specs:
+	// For big-integer numbers (g1, g2 coordinates),
+	// we describe each 256-bit field element as a uint64_t[4] array.
+	// The first entry is the least significant word of the field element. Each 'word' is written in big-endian form.
+
+	r[0].X.A0[0] = binary.BigEndian.Uint64(data[0:8])
+	r[0].X.A0[1] = binary.BigEndian.Uint64(data[8:16])
+	r[0].X.A0[2] = binary.BigEndian.Uint64(data[16:24])
+	r[0].X.A0[3] = binary.BigEndian.Uint64(data[24:32])
+	r[0].X.A0.Mul(&r[0].X.A0, &rSquare) // to montgomery form
+
+	r[0].X.A1[0] = binary.BigEndian.Uint64(data[32:40])
+	r[0].X.A1[1] = binary.BigEndian.Uint64(data[40:48])
+	r[0].X.A1[2] = binary.BigEndian.Uint64(data[48:56])
+	r[0].X.A1[3] = binary.BigEndian.Uint64(data[56:64])
+	r[0].X.A1.Mul(&r[0].X.A1, &rSquare) // to montgomery form
+
+	r[0].Y.A0[0] = binary.BigEndian.Uint64(data[64:72])
+	r[0].Y.A0[1] = binary.BigEndian.Uint64(data[72:80])
+	r[0].Y.A0[2] = binary.BigEndian.Uint64(data[80:88])
+	r[0].Y.A0[3] = binary.BigEndian.Uint64(data[88:96])
+	r[0].Y.A0.Mul(&r[0].Y.A0, &rSquare) // to montgomery form
+
+	r[0].Y.A1[0] = binary.BigEndian.Uint64(data[96:104])
+	r[0].Y.A1[1] = binary.BigEndian.Uint64(data[104:112])
+	r[0].Y.A1[2] = binary.BigEndian.Uint64(data[112:120])
+	r[0].Y.A1[3] = binary.BigEndian.Uint64(data[120:128])
+	r[0].Y.A1.Mul(&r[0].Y.A1, &rSquare) // to montgomery form
+
+	r[1].X.A0[0] = binary.BigEndian.Uint64(data[128:136])
+	r[1].X.A0[1] = binary.BigEndian.Uint64(data[136:144])
+	r[1].X.A0[2] = binary.BigEndian.Uint64(data[144:152])
+	r[1].X.A0[3] = binary.BigEndian.Uint64(data[152:160])
+	r[1].X.A0.Mul(&r[1].X.A0, &rSquare) // to montgomery form
+
+	r[1].X.A1[0] = binary.BigEndian.Uint64(data[160:168])
+	r[1].X.A1[1] = binary.BigEndian.Uint64(data[168:176])
+	r[1].X.A1[2] = binary.BigEndian.Uint64(data[176:184])
+	r[1].X.A1[3] = binary.BigEndian.Uint64(data[184:192])
+	r[1].X.A1.Mul(&r[1].X.A1, &rSquare) // to montgomery form
+
+	r[1].Y.A0[0] = binary.BigEndian.Uint64(data[192:200])
+	r[1].Y.A0[1] = binary.BigEndian.Uint64(data[200:208])
+	r[1].Y.A0[2] = binary.BigEndian.Uint64(data[208:216])
+	r[1].Y.A0[3] = binary.BigEndian.Uint64(data[216:224])
+	r[1].Y.A0.Mul(&r[1].Y.A0, &rSquare) // to montgomery form
+
+	r[1].Y.A1[0] = binary.BigEndian.Uint64(data[224:232])
+	r[1].Y.A1[1] = binary.BigEndian.Uint64(data[232:240])
+	r[1].Y.A1[2] = binary.BigEndian.Uint64(data[240:248])
+	r[1].Y.A1[3] = binary.BigEndian.Uint64(data[248:256])
+	r[1].Y.A1.Mul(&r[1].Y.A1, &rSquare) // to montgomery form
+
+}
+
+// rSquare montgomery constant
+var rSquare = fp.Element{
+	17522657719365597833,
+	13107472804851548667,
+	5164255478447964150,
+	493319470278259999,
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return !os.IsNotExist(err)
+}

--- a/internal/ignition/manifest.go
+++ b/internal/ignition/manifest.go
@@ -1,0 +1,80 @@
+package ignition
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"time"
+)
+
+// NewManifest downloads and parses the manifest.json file
+func NewManifest(config Config) (Manifest, error) {
+	b, err := readOrDownload(config.ceremonyURL(), "manifest.json", config)
+	if err != nil {
+		return Manifest{}, err
+	}
+
+	var r Manifest
+	err = json.Unmarshal(b, &r)
+	if err != nil {
+		return Manifest{}, err
+	}
+
+	return r, nil
+}
+
+// transcriptManifest is 28 bytes of data with the following structure
+// byte index	description
+// 0-3	transcript number (starting from 0)
+// 4-7	total number of transcripts (should be 20)
+// 8-11	total number of G1 points in all transcripts (should be 100,000,000)
+// 12-15	total number of G2 points in all transcripts (should be 1)
+// 16-19	number of G1 points in this transcript (should be 5,000,000)
+// 20-23	number of G2 points in this transcript (2 for 1st transcript, 0 for the rest)
+// 24-27	'start-from', the index of the 1st G1 point in this transcript
+type transcriptManifest struct {
+	TranscriptNumber,
+	TotalTranscripts,
+	TotalG1Points,
+	TotalG2Points,
+	NumG1Points,
+	NumG2Points,
+	StartFrom uint32
+}
+
+func newTranscriptManifest(data []byte) transcriptManifest {
+	return transcriptManifest{
+		TranscriptNumber: binary.BigEndian.Uint32(data[:4]),
+		TotalTranscripts: binary.BigEndian.Uint32(data[4:8]),
+		TotalG1Points:    binary.BigEndian.Uint32(data[8:12]),
+		TotalG2Points:    binary.BigEndian.Uint32(data[12:16]),
+		NumG1Points:      binary.BigEndian.Uint32(data[16:20]),
+		NumG2Points:      binary.BigEndian.Uint32(data[20:24]),
+		StartFrom:        binary.BigEndian.Uint32(data[24:28]),
+	}
+}
+
+type Manifest struct {
+	Name                string        `json:"name"`
+	NumG1Points         int           `json:"numG1Points"`
+	NumG2Points         int           `json:"numG2Points"`
+	PointsPerTranscript int           `json:"pointsPerTranscript"`
+	RangeProofKmax      int           `json:"rangeProofKmax"`
+	RangeProofSize      int           `json:"rangeProofSize"`
+	RangeProofsPerFile  int           `json:"rangeProofsPerFile"`
+	Network             string        `json:"network"`
+	SelectBlock         int           `json:"selectBlock"`
+	StartTime           time.Time     `json:"startTime"`
+	CompletedAt         time.Time     `json:"completedAt"`
+	Participants        []Participant `json:"participants"`
+	Crs                 struct {
+		H  []string `json:"h"`
+		T2 []string `json:"t2"`
+	} `json:"crs"`
+}
+
+type Participant struct {
+	Address     string    `json:"address"`
+	Position    int       `json:"position"`
+	StartedAt   time.Time `json:"startedAt"`
+	CompletedAt time.Time `json:"completedAt"`
+}


### PR DESCRIPTION
To discuss, added it in gnark/internal for convenience, but maybe we should put that in a separate independent repo. 

Advantage of putting it here; the next step, having an API to pull a trusted setup from a web location would be more "discoverable" by gnark users. **Such a "trusted setup" would be usable for example for PlonK circuits using bn254**.

```
// Package ignition is a package that provides helper functions to download, parse
 // and validate the AZTEC Ignition Ceremony data.
 // The specs are described here:
 //
 //	https://github.com/AztecProtocol/ignition-verification/blob/c333ec4775045139f86732abfbbd65728404ab7f/Transcript_spec.md
 //
 // The verification logic follows
 //
 //	https://github.com/AztecProtocol/ignition-verification
 ```
