### PR TITLE
perf(2-chain/varScalarMul): use DoubleAndAdd to reduce #constraints

### DIFF
--- a/std/algebra/native/sw_bls12377/g1.go
+++ b/std/algebra/native/sw_bls12377/g1.go
@@ -300,20 +300,18 @@ func (P *G1Affine) varScalarMul(api frontend.API, Q G1Affine, s frontend.Variabl
 	// step value from [2] Acc (instead of conditionally adding step value to
 	// Acc):
 	//     Acc = [2] (Q + Φ(Q)) ± Q ± Φ(Q)
-	Acc.Double(api, Acc)
 	// only y coordinate differs for negation, select on that instead.
 	B.X = tableQ[0].X
 	B.Y = api.Select(s1bits[nbits-1], tableQ[1].Y, tableQ[0].Y)
-	Acc.AddAssign(api, B)
+	Acc.DoubleAndAdd(api, &Acc, &B)
 	B.X = tablePhiQ[0].X
 	B.Y = api.Select(s2bits[nbits-1], tablePhiQ[1].Y, tablePhiQ[0].Y)
 	Acc.AddAssign(api, B)
 
 	// second bit
-	Acc.Double(api, Acc)
 	B.X = tableQ[0].X
 	B.Y = api.Select(s1bits[nbits-2], tableQ[1].Y, tableQ[0].Y)
-	Acc.AddAssign(api, B)
+	Acc.DoubleAndAdd(api, &Acc, &B)
 	B.X = tablePhiQ[0].X
 	B.Y = api.Select(s2bits[nbits-2], tablePhiQ[1].Y, tablePhiQ[0].Y)
 	Acc.AddAssign(api, B)

--- a/std/algebra/native/sw_bls12377/g2.go
+++ b/std/algebra/native/sw_bls12377/g2.go
@@ -315,20 +315,18 @@ func (P *G2Affine) varScalarMul(api frontend.API, Q G2Affine, s frontend.Variabl
 	// step value from [2] Acc (instead of conditionally adding step value to
 	// Acc):
 	//     Acc = [2] (Q + Φ(Q)) ± Q ± Φ(Q)
-	Acc.Double(api, Acc)
 	// only y coordinate differs for negation, select on that instead.
 	B.X = tableQ[0].X
 	B.Y.Select(api, s1bits[nbits-1], tableQ[1].Y, tableQ[0].Y)
-	Acc.AddAssign(api, B)
+	Acc.DoubleAndAdd(api, &Acc, &B)
 	B.X = tablePhiQ[0].X
 	B.Y.Select(api, s2bits[nbits-1], tablePhiQ[1].Y, tablePhiQ[0].Y)
 	Acc.AddAssign(api, B)
 
 	// second bit
-	Acc.Double(api, Acc)
 	B.X = tableQ[0].X
 	B.Y.Select(api, s1bits[nbits-2], tableQ[1].Y, tableQ[0].Y)
-	Acc.AddAssign(api, B)
+	Acc.DoubleAndAdd(api, &Acc, &B)
 	B.X = tablePhiQ[0].X
 	B.Y.Select(api, s2bits[nbits-2], tablePhiQ[1].Y, tablePhiQ[0].Y)
 	Acc.AddAssign(api, B)


### PR DESCRIPTION
While looking into a question about emulated ScalarMul, I noticed we can further merge some `Double`+ `Add` into a `DoubleAndAdd` to reduce the number of constraints. Hence the tiny PR.

- Old
```
BenchmarkVarScalarMulG1
    g1_test.go:460: groth16 1548
BenchmarkVarScalarMulG1/plonk
    g1_test.go:471: plonk 3861
BenchmarkVarScalarMulG2
    g2_test.go:496: groth16 4250
BenchmarkVarScalarMulG2/plonk
    g2_test.go:507: plonk 12604
```
- New:
```
BenchmarkVarScalarMulG1
    g1_test.go:460: groth16 1544
BenchmarkVarScalarMulG1/plonk
    g1_test.go:471: plonk 3858
BenchmarkVarScalarMulG2
    g2_test.go:496: groth16 4240
BenchmarkVarScalarMulG2/plonk
    g2_test.go:507: plonk 12579
```