### PR TITLE
Perf: Add-only emulated scalar multiplication

### DIFF
--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -511,14 +511,8 @@ func (c *Curve[B, S]) JointScalarMulBase(p *AffinePoint[B], s2, s1 *emulated.Ele
 		acc = c.double(acc)
 	}
 
-	// i = 0
-	tmp1 := c.add(res1, c.Neg(g))
-	res1 = c.Select(s1Bits[0], res1, tmp1)
-	tmp2 = c.add(res2, c.Neg(p))
-	res2 = c.Select(s2Bits[0], res2, tmp2)
-
 	// i = n-2
-	tmp1 = c.add(res1, &gm[n-2])
+	tmp1 := c.add(res1, &gm[n-2])
 	res1 = c.Select(s1Bits[n-2], tmp1, res1)
 	tmp2 = c.add(res2, acc)
 	res2 = c.Select(s2Bits[n-2], tmp2, res2)
@@ -528,6 +522,12 @@ func (c *Curve[B, S]) JointScalarMulBase(p *AffinePoint[B], s2, s1 *emulated.Ele
 	res1 = c.Select(s1Bits[n-1], tmp1, res1)
 	tmp2 = c.doubleAndAdd(acc, res2)
 	res2 = c.Select(s2Bits[n-1], tmp2, res2)
+
+	// i = 0
+	tmp1 = c.add(res1, c.Neg(g))
+	res1 = c.Select(s1Bits[0], res1, tmp1)
+	tmp2 = c.add(res2, c.Neg(p))
+	res2 = c.Select(s2Bits[0], res2, tmp2)
 
 	return c.add(res1, res2)
 }

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -363,19 +363,18 @@ func (c *Curve[B, S]) Lookup2(b0, b1 frontend.Variable, i0, i1, i2, i3 *AffinePo
 // (0,0) is not on the curve but we conventionally take it as the
 // neutral/infinity point as per the [EVM].
 //
-// It computes the standard little-endian variable-base double-and-add algorithm
-// [HMV04] (Algorithm 3.26).
+// It computes the right-to-left variable-base add-only algorithm ([Joye07], Alg.2).
 //
 // Since we use incomplete formulas for the addition law, we need to start with
-// a non-zero accumulator point (res). To do this, we skip the LSB (bit at
+// a non-zero accumulator point (R0). To do this, we skip the LSB (bit at
 // position 0) and proceed assuming it was 1. At the end, we conditionally
 // subtract the initial value (p) if LSB is 1. We also handle the bits at
-// positions 1, n-2 and n-1 outside of the loop to optimize the number of
+// positions 1 and n-1 outside of the loop to optimize the number of
 // constraints using [ELM03] (Section 3.1)
 //
 // [ELM03]: https://arxiv.org/pdf/math/0208038.pdf
-// [HMV04]: https://link.springer.com/book/10.1007/b97644
 // [EVM]: https://ethereum.github.io/yellowpaper/paper.pdf
+// [Joye07]: https://www.iacr.org/archive/ches2007/47270135/47270135.pdf
 func (c *Curve[B, S]) ScalarMul(p *AffinePoint[B], s *emulated.Element[S]) *AffinePoint[B] {
 
 	// if p=(0,0) we assign a dummy (0,1) to p and continue
@@ -389,35 +388,34 @@ func (c *Curve[B, S]) ScalarMul(p *AffinePoint[B], s *emulated.Element[S]) *Affi
 	n := st.Modulus().BitLen()
 
 	// i = 1
-	tmp := c.triple(p)
-	res := c.Select(sBits[1], tmp, p)
-	acc := c.add(tmp, p)
+	R := c.triple(p)
+	R0 := c.Select(sBits[1], R, p)
+	R1 := c.Select(sBits[1], p, R)
+	R2 := c.add(R0, R1)
 
-	for i := 2; i <= n-3; i++ {
-		tmp := c.add(res, acc)
-		res = c.Select(sBits[i], tmp, res)
-		acc = c.double(acc)
+	for i := 2; i < n-1; i++ {
+		R = c.Select(sBits[i], R0, R1)
+		R = c.add(R, R2)
+		R0 = c.Select(sBits[i], R, R0)
+		R1 = c.Select(sBits[i], R1, R)
+		R2 = c.add(R0, R1)
 	}
 
-	// i = n-2
-	tmp = c.add(res, acc)
-	res = c.Select(sBits[n-2], tmp, res)
-
 	// i = n-1
-	tmp = c.doubleAndAdd(acc, res)
-	res = c.Select(sBits[n-1], tmp, res)
+	R = c.Select(sBits[n-1], R0, R1)
+	R = c.add(R, R2)
+	R0 = c.Select(sBits[n-1], R, R0)
 
 	// i = 0
 	// we use AddUnified here instead of add so that when s=0, res=(0,0)
 	// because AddUnified(p, -p) = (0,0)
-	tmp = c.AddUnified(res, c.Neg(p))
-	res = c.Select(sBits[0], res, tmp)
+	R0 = c.Select(sBits[0], R0, c.AddUnified(R0, c.Neg(p)))
 
 	// if p=(0,0), return (0,0)
 	zero := c.baseApi.Zero()
-	res = c.Select(selector, &AffinePoint[B]{X: *zero, Y: *zero}, res)
+	R0 = c.Select(selector, &AffinePoint[B]{X: *zero, Y: *zero}, R0)
 
-	return res
+	return R0
 }
 
 // ScalarMulBase computes s * g and returns it, where g is the fixed generator.
@@ -428,12 +426,9 @@ func (c *Curve[B, S]) ScalarMul(p *AffinePoint[B], s *emulated.Element[S]) *Affi
 // neutral/infinity point as per the [EVM].
 //
 // It computes the standard little-endian fixed-base double-and-add algorithm
-// [HMV04] (Algorithm 3.26).
-//
-// The method proceeds similarly to ScalarMul but with the points [2^i]g
-// precomputed.  The bits at positions 1 and 2 are handled outside of the loop
-// to optimize the number of constraints using a Lookup2 with pre-computed
-// [3]g, [5]g and [7]g points.
+// [HMV04] (Algorithm 3.26), with the points [2^i]g precomputed.  The bits at
+// positions 1 and 2 are handled outside of the loop to optimize the number of
+// constraints using a Lookup2 with pre-computed [3]g, [5]g and [7]g points.
 //
 // [HMV04]: https://link.springer.com/book/10.1007/b97644
 // [EVM]: https://ethereum.github.io/yellowpaper/paper.pdf
@@ -467,6 +462,8 @@ func (c *Curve[B, S]) ScalarMulBase(s *emulated.Element[S]) *AffinePoint[B] {
 //
 // ⚠️   p must NOT be (0,0).
 // ⚠️   s1 and s2 must NOT be 0.
+//
+// It uses the logic from ScalarMul() for s1 * g and the logic from ScalarMulBase() for s2 * g.
 //
 // JointScalarMulBase is used to verify an ECDSA signature (r,s) on the
 // secp256k1 curve. In this case, p is a public key, s2=r/s and s1=hash/s.
@@ -545,58 +542,4 @@ func (c *Curve[B, S]) JointScalarMulBase(p *AffinePoint[B], s2, s1 *emulated.Ele
 	R0 = c.Select(s2Bits[0], R0, c.AddUnified(R0, c.Neg(p)))
 
 	return c.add(res1, R0)
-}
-
-// ScalarMulAddOnly computes s * p and returns it. It doesn't modify p nor s.
-// This function doesn't check that the p is on the curve. See AssertIsOnCurve.
-//
-// ✅ p can can be (0,0) and s can be 0.
-// (0,0) is not on the curve but we conventionally take it as the
-// neutral/infinity point as per the [EVM].
-//
-// It computes the right-to-left variable-base add-only algorithm ([Joye07], Alg.2).
-//
-// [EVM]: https://ethereum.github.io/yellowpaper/paper.pdf
-// [Joye07]: https://www.iacr.org/archive/ches2007/47270135/47270135.pdf
-func (c *Curve[B, S]) ScalarMulAddOnly(p *AffinePoint[B], s *emulated.Element[S]) *AffinePoint[B] {
-
-	// if p=(0,0) we assign a dummy (0,1) to p and continue
-	selector := c.api.And(c.baseApi.IsZero(&p.X), c.baseApi.IsZero(&p.Y))
-	one := c.baseApi.One()
-	p = c.Select(selector, &AffinePoint[B]{X: *one, Y: *one}, p)
-
-	var st S
-	sr := c.scalarApi.Reduce(s)
-	sBits := c.scalarApi.ToBits(sr)
-	n := st.Modulus().BitLen()
-
-	// i = 1
-	R := c.triple(p)
-	R0 := c.Select(sBits[1], R, p)
-	R1 := c.Select(sBits[1], p, R)
-	R2 := c.add(R0, R1)
-
-	for i := 2; i < n-1; i++ {
-		R = c.Select(sBits[i], R0, R1)
-		R = c.add(R, R2)
-		R0 = c.Select(sBits[i], R, R0)
-		R1 = c.Select(sBits[i], R1, R)
-		R2 = c.add(R0, R1)
-	}
-
-	// i = n-1
-	R = c.Select(sBits[n-1], R0, R1)
-	R = c.add(R, R2)
-	R0 = c.Select(sBits[n-1], R, R0)
-
-	// i = 0
-	// we use AddUnified here instead of add so that when s=0, res=(0,0)
-	// because AddUnified(p, -p) = (0,0)
-	R0 = c.Select(sBits[0], R0, c.AddUnified(R0, c.Neg(p)))
-
-	// if p=(0,0), return (0,0)
-	zero := c.baseApi.Zero()
-	R0 = c.Select(selector, &AffinePoint[B]{X: *zero, Y: *zero}, R0)
-
-	return R0
 }

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -558,7 +558,7 @@ func (c *Curve[B, S]) JointScalarMulBase(p *AffinePoint[B], s2, s1 *emulated.Ele
 //
 // [EVM]: https://ethereum.github.io/yellowpaper/paper.pdf
 // [Joye07]: https://www.iacr.org/archive/ches2007/47270135/47270135.pdf
-func (c *Curve[B, S]) ScalarMulAddOnly(api frontend.API, p *AffinePoint[B], s *emulated.Element[S]) *AffinePoint[B] {
+func (c *Curve[B, S]) ScalarMulAddOnly(p *AffinePoint[B], s *emulated.Element[S]) *AffinePoint[B] {
 
 	// if p=(0,0) we assign a dummy (0,1) to p and continue
 	selector := c.api.And(c.baseApi.IsZero(&p.X), c.baseApi.IsZero(&p.Y))

--- a/std/algebra/emulated/sw_emulated/point_test.go
+++ b/std/algebra/emulated/sw_emulated/point_test.go
@@ -617,65 +617,6 @@ func TestScalarMulEdgeCasesEdgeCases(t *testing.T) {
 	assert.NoError(err)
 }
 
-type ScalarMulAddOnlyEdgeCasesTest[T, S emulated.FieldParams] struct {
-	P, R AffinePoint[T]
-	S    emulated.Element[S]
-}
-
-func (c *ScalarMulAddOnlyEdgeCasesTest[T, S]) Define(api frontend.API) error {
-	cr, err := New[T, S](api, GetCurveParams[T]())
-	if err != nil {
-		return err
-	}
-	res := cr.ScalarMulAddOnly(&c.P, &c.S)
-	cr.AssertIsEqual(res, &c.R)
-	return nil
-}
-
-func TestScalarMulAddOnlyEdgeCasesEdgeCases(t *testing.T) {
-	assert := test.NewAssert(t)
-	var infinity bn254.G1Affine
-	_, _, g, _ := bn254.Generators()
-	var r fr_bn.Element
-	_, _ = r.SetRandom()
-	s := new(big.Int)
-	r.BigInt(s)
-	var S bn254.G1Affine
-	S.ScalarMultiplication(&g, s)
-
-	circuit := ScalarMulAddOnlyEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{}
-
-	// s * (0,0) == (0,0)
-	witness1 := ScalarMulAddOnlyEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{
-		S: emulated.ValueOf[emulated.BN254Fr](s),
-		P: AffinePoint[emulated.BN254Fp]{
-			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
-			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
-		},
-		R: AffinePoint[emulated.BN254Fp]{
-			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
-			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
-		},
-	}
-	err := test.IsSolved(&circuit, &witness1, testCurve.ScalarField())
-	assert.NoError(err)
-
-	// 0 * S == (0,0)
-	witness2 := ScalarMulAddOnlyEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{
-		S: emulated.ValueOf[emulated.BN254Fr](new(big.Int)),
-		P: AffinePoint[emulated.BN254Fp]{
-			X: emulated.ValueOf[emulated.BN254Fp](S.X),
-			Y: emulated.ValueOf[emulated.BN254Fp](S.Y),
-		},
-		R: AffinePoint[emulated.BN254Fp]{
-			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
-			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
-		},
-	}
-	err = test.IsSolved(&circuit, &witness2, testCurve.ScalarField())
-	assert.NoError(err)
-}
-
 type IsOnCurveTest[T, S emulated.FieldParams] struct {
 	Q AffinePoint[T]
 }
@@ -828,73 +769,6 @@ func TestJointScalarMulBase(t *testing.T) {
 		Q: AffinePoint[emulated.Secp256k1Fp]{
 			X: emulated.ValueOf[emulated.Secp256k1Fp](S.X),
 			Y: emulated.ValueOf[emulated.Secp256k1Fp](S.Y),
-		},
-	}
-	err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())
-	assert.NoError(err)
-}
-
-type ScalarMulAddOnlyTest[T, S emulated.FieldParams] struct {
-	P, Q AffinePoint[T]
-	S    emulated.Element[S]
-}
-
-func (c *ScalarMulAddOnlyTest[T, S]) Define(api frontend.API) error {
-	cr, err := New[T, S](api, GetCurveParams[T]())
-	if err != nil {
-		return err
-	}
-	res := cr.ScalarMulAddOnly(&c.P, &c.S)
-	cr.AssertIsEqual(res, &c.Q)
-	return nil
-}
-
-func TestScalarMulAddOnly(t *testing.T) {
-	assert := test.NewAssert(t)
-	_, g := secp256k1.Generators()
-	var r fr_secp.Element
-	_, _ = r.SetRandom()
-	s := new(big.Int)
-	r.BigInt(s)
-	var S secp256k1.G1Affine
-	S.ScalarMultiplication(&g, s)
-
-	circuit := ScalarMulAddOnlyTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{}
-	witness := ScalarMulAddOnlyTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
-		S: emulated.ValueOf[emulated.Secp256k1Fr](s),
-		P: AffinePoint[emulated.Secp256k1Fp]{
-			X: emulated.ValueOf[emulated.Secp256k1Fp](g.X),
-			Y: emulated.ValueOf[emulated.Secp256k1Fp](g.Y),
-		},
-		Q: AffinePoint[emulated.Secp256k1Fp]{
-			X: emulated.ValueOf[emulated.Secp256k1Fp](S.X),
-			Y: emulated.ValueOf[emulated.Secp256k1Fp](S.Y),
-		},
-	}
-	err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())
-	assert.NoError(err)
-}
-
-func TestScalarMulAddOnly2(t *testing.T) {
-	assert := test.NewAssert(t)
-	_, _, g, _ := bn254.Generators()
-	var r fr_secp.Element
-	_, _ = r.SetRandom()
-	s := new(big.Int)
-	r.BigInt(s)
-	var S bn254.G1Affine
-	S.ScalarMultiplication(&g, s)
-
-	circuit := ScalarMulAddOnlyTest[emulated.BN254Fp, emulated.BN254Fr]{}
-	witness := ScalarMulAddOnlyTest[emulated.BN254Fp, emulated.BN254Fr]{
-		S: emulated.ValueOf[emulated.BN254Fr](s),
-		P: AffinePoint[emulated.BN254Fp]{
-			X: emulated.ValueOf[emulated.BN254Fp](g.X),
-			Y: emulated.ValueOf[emulated.BN254Fp](g.Y),
-		},
-		Q: AffinePoint[emulated.BN254Fp]{
-			X: emulated.ValueOf[emulated.BN254Fp](S.X),
-			Y: emulated.ValueOf[emulated.BN254Fp](S.Y),
 		},
 	}
 	err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())

--- a/std/algebra/emulated/sw_emulated/point_test.go
+++ b/std/algebra/emulated/sw_emulated/point_test.go
@@ -627,7 +627,7 @@ func (c *ScalarMulAddOnlyEdgeCasesTest[T, S]) Define(api frontend.API) error {
 	if err != nil {
 		return err
 	}
-	res := cr.ScalarMulAddOnly(api, &c.P, &c.S)
+	res := cr.ScalarMulAddOnly(&c.P, &c.S)
 	cr.AssertIsEqual(res, &c.R)
 	return nil
 }
@@ -844,7 +844,7 @@ func (c *ScalarMulAddOnlyTest[T, S]) Define(api frontend.API) error {
 	if err != nil {
 		return err
 	}
-	res := cr.ScalarMulAddOnly(api, &c.P, &c.S)
+	res := cr.ScalarMulAddOnly(&c.P, &c.S)
 	cr.AssertIsEqual(res, &c.Q)
 	return nil
 }

--- a/std/algebra/emulated/sw_emulated/point_test.go
+++ b/std/algebra/emulated/sw_emulated/point_test.go
@@ -219,11 +219,11 @@ func TestDoubleAndAdd(t *testing.T) {
 	assert.NoError(err)
 }
 
-type AddUnifiedEdgeCases[T, S emulated.FieldParams] struct {
+type AddUnifiedEdgeCasesTest[T, S emulated.FieldParams] struct {
 	P, Q, R AffinePoint[T]
 }
 
-func (c *AddUnifiedEdgeCases[T, S]) Define(api frontend.API) error {
+func (c *AddUnifiedEdgeCasesTest[T, S]) Define(api frontend.API) error {
 	cr, err := New[T, S](api, GetCurveParams[T]())
 	if err != nil {
 		return err
@@ -245,10 +245,10 @@ func TestAddUnifiedEdgeCases(t *testing.T) {
 	S.ScalarMultiplication(&g, s)
 	Sn.Neg(&S)
 
-	circuit := AddUnifiedEdgeCases[emulated.BN254Fp, emulated.BN254Fr]{}
+	circuit := AddUnifiedEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{}
 
 	// (0,0) + (0,0) == (0,0)
-	witness1 := AddUnifiedEdgeCases[emulated.BN254Fp, emulated.BN254Fr]{
+	witness1 := AddUnifiedEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{
 		P: AffinePoint[emulated.BN254Fp]{
 			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
 			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
@@ -266,7 +266,7 @@ func TestAddUnifiedEdgeCases(t *testing.T) {
 	assert.NoError(err)
 
 	// S + (0,0) == S
-	witness2 := AddUnifiedEdgeCases[emulated.BN254Fp, emulated.BN254Fr]{
+	witness2 := AddUnifiedEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{
 		P: AffinePoint[emulated.BN254Fp]{
 			X: emulated.ValueOf[emulated.BN254Fp](S.X),
 			Y: emulated.ValueOf[emulated.BN254Fp](S.Y),
@@ -284,7 +284,7 @@ func TestAddUnifiedEdgeCases(t *testing.T) {
 	assert.NoError(err)
 
 	// (0,0) + S == S
-	witness3 := AddUnifiedEdgeCases[emulated.BN254Fp, emulated.BN254Fr]{
+	witness3 := AddUnifiedEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{
 		P: AffinePoint[emulated.BN254Fp]{
 			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
 			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
@@ -302,7 +302,7 @@ func TestAddUnifiedEdgeCases(t *testing.T) {
 	assert.NoError(err)
 
 	// S + (-S) == (0,0)
-	witness4 := AddUnifiedEdgeCases[emulated.BN254Fp, emulated.BN254Fr]{
+	witness4 := AddUnifiedEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{
 		P: AffinePoint[emulated.BN254Fp]{
 			X: emulated.ValueOf[emulated.BN254Fp](S.X),
 			Y: emulated.ValueOf[emulated.BN254Fp](S.Y),
@@ -320,7 +320,7 @@ func TestAddUnifiedEdgeCases(t *testing.T) {
 	assert.NoError(err)
 
 	// (-S) + S == (0,0)
-	witness5 := AddUnifiedEdgeCases[emulated.BN254Fp, emulated.BN254Fr]{
+	witness5 := AddUnifiedEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{
 		P: AffinePoint[emulated.BN254Fp]{
 			X: emulated.ValueOf[emulated.BN254Fp](Sn.X),
 			Y: emulated.ValueOf[emulated.BN254Fp](Sn.Y),
@@ -486,65 +486,6 @@ func TestScalarMul2(t *testing.T) {
 	assert.NoError(err)
 }
 
-type ScalarMulEdgeCases[T, S emulated.FieldParams] struct {
-	P, R AffinePoint[T]
-	S    emulated.Element[S]
-}
-
-func (c *ScalarMulEdgeCases[T, S]) Define(api frontend.API) error {
-	cr, err := New[T, S](api, GetCurveParams[T]())
-	if err != nil {
-		return err
-	}
-	res := cr.ScalarMul(&c.P, &c.S)
-	cr.AssertIsEqual(res, &c.R)
-	return nil
-}
-
-func TestScalarMulEdgeCasesEdgeCases(t *testing.T) {
-	assert := test.NewAssert(t)
-	var infinity bn254.G1Affine
-	_, _, g, _ := bn254.Generators()
-	var r fr_bn.Element
-	_, _ = r.SetRandom()
-	s := new(big.Int)
-	r.BigInt(s)
-	var S bn254.G1Affine
-	S.ScalarMultiplication(&g, s)
-
-	circuit := ScalarMulEdgeCases[emulated.BN254Fp, emulated.BN254Fr]{}
-
-	// s * (0,0) == (0,0)
-	witness1 := ScalarMulEdgeCases[emulated.BN254Fp, emulated.BN254Fr]{
-		S: emulated.ValueOf[emulated.BN254Fr](s),
-		P: AffinePoint[emulated.BN254Fp]{
-			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
-			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
-		},
-		R: AffinePoint[emulated.BN254Fp]{
-			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
-			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
-		},
-	}
-	err := test.IsSolved(&circuit, &witness1, testCurve.ScalarField())
-	assert.NoError(err)
-
-	// 0 * S == (0,0)
-	witness2 := ScalarMulEdgeCases[emulated.BN254Fp, emulated.BN254Fr]{
-		S: emulated.ValueOf[emulated.BN254Fr](new(big.Int)),
-		P: AffinePoint[emulated.BN254Fp]{
-			X: emulated.ValueOf[emulated.BN254Fp](S.X),
-			Y: emulated.ValueOf[emulated.BN254Fp](S.Y),
-		},
-		R: AffinePoint[emulated.BN254Fp]{
-			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
-			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
-		},
-	}
-	err = test.IsSolved(&circuit, &witness2, testCurve.ScalarField())
-	assert.NoError(err)
-}
-
 func TestScalarMul3(t *testing.T) {
 	assert := test.NewAssert(t)
 	var r fr_bls381.Element
@@ -614,6 +555,65 @@ func TestScalarMul5(t *testing.T) {
 		},
 	}
 	err = test.IsSolved(&circuit, &witness, testCurve.ScalarField())
+	assert.NoError(err)
+}
+
+type ScalarMulEdgeCasesTest[T, S emulated.FieldParams] struct {
+	P, R AffinePoint[T]
+	S    emulated.Element[S]
+}
+
+func (c *ScalarMulEdgeCasesTest[T, S]) Define(api frontend.API) error {
+	cr, err := New[T, S](api, GetCurveParams[T]())
+	if err != nil {
+		return err
+	}
+	res := cr.ScalarMul(&c.P, &c.S)
+	cr.AssertIsEqual(res, &c.R)
+	return nil
+}
+
+func TestScalarMulEdgeCasesEdgeCases(t *testing.T) {
+	assert := test.NewAssert(t)
+	var infinity bn254.G1Affine
+	_, _, g, _ := bn254.Generators()
+	var r fr_bn.Element
+	_, _ = r.SetRandom()
+	s := new(big.Int)
+	r.BigInt(s)
+	var S bn254.G1Affine
+	S.ScalarMultiplication(&g, s)
+
+	circuit := ScalarMulEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{}
+
+	// s * (0,0) == (0,0)
+	witness1 := ScalarMulEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{
+		S: emulated.ValueOf[emulated.BN254Fr](s),
+		P: AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
+		},
+		R: AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
+		},
+	}
+	err := test.IsSolved(&circuit, &witness1, testCurve.ScalarField())
+	assert.NoError(err)
+
+	// 0 * S == (0,0)
+	witness2 := ScalarMulEdgeCasesTest[emulated.BN254Fp, emulated.BN254Fr]{
+		S: emulated.ValueOf[emulated.BN254Fr](new(big.Int)),
+		P: AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](S.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](S.Y),
+		},
+		R: AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](infinity.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](infinity.Y),
+		},
+	}
+	err = test.IsSolved(&circuit, &witness2, testCurve.ScalarField())
 	assert.NoError(err)
 }
 
@@ -726,12 +726,12 @@ func TestIsOnCurve3(t *testing.T) {
 	assert.NoError(err)
 }
 
-type JointScalarMulBase[T, S emulated.FieldParams] struct {
+type JointScalarMulBaseTest[T, S emulated.FieldParams] struct {
 	P, Q   AffinePoint[T]
 	S1, S2 emulated.Element[S]
 }
 
-func (c *JointScalarMulBase[T, S]) Define(api frontend.API) error {
+func (c *JointScalarMulBaseTest[T, S]) Define(api frontend.API) error {
 	cr, err := New[T, S](api, GetCurveParams[T]())
 	if err != nil {
 		return err
@@ -758,8 +758,8 @@ func TestJointScalarMulBase(t *testing.T) {
 	var S secp256k1.G1Affine
 	S.FromJacobian(&Sj)
 
-	circuit := JointScalarMulBase[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{}
-	witness := JointScalarMulBase[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
+	circuit := JointScalarMulBaseTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{}
+	witness := JointScalarMulBaseTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
 		S1: emulated.ValueOf[emulated.Secp256k1Fr](s1),
 		S2: emulated.ValueOf[emulated.Secp256k1Fr](s2),
 		P: AffinePoint[emulated.Secp256k1Fp]{
@@ -769,6 +769,73 @@ func TestJointScalarMulBase(t *testing.T) {
 		Q: AffinePoint[emulated.Secp256k1Fp]{
 			X: emulated.ValueOf[emulated.Secp256k1Fp](S.X),
 			Y: emulated.ValueOf[emulated.Secp256k1Fp](S.Y),
+		},
+	}
+	err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())
+	assert.NoError(err)
+}
+
+type ScalarMulAddOnlyTest[T, S emulated.FieldParams] struct {
+	P, Q AffinePoint[T]
+	S    emulated.Element[S]
+}
+
+func (c *ScalarMulAddOnlyTest[T, S]) Define(api frontend.API) error {
+	cr, err := New[T, S](api, GetCurveParams[T]())
+	if err != nil {
+		return err
+	}
+	res := cr.ScalarMulAddOnly(api, &c.P, &c.S)
+	cr.AssertIsEqual(res, &c.Q)
+	return nil
+}
+
+func TestScalarMulAddOnly(t *testing.T) {
+	assert := test.NewAssert(t)
+	_, g := secp256k1.Generators()
+	var r fr_secp.Element
+	_, _ = r.SetRandom()
+	s := new(big.Int)
+	r.BigInt(s)
+	var S secp256k1.G1Affine
+	S.ScalarMultiplication(&g, s)
+
+	circuit := ScalarMulAddOnlyTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{}
+	witness := ScalarMulAddOnlyTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
+		S: emulated.ValueOf[emulated.Secp256k1Fr](s),
+		P: AffinePoint[emulated.Secp256k1Fp]{
+			X: emulated.ValueOf[emulated.Secp256k1Fp](g.X),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](g.Y),
+		},
+		Q: AffinePoint[emulated.Secp256k1Fp]{
+			X: emulated.ValueOf[emulated.Secp256k1Fp](S.X),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](S.Y),
+		},
+	}
+	err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())
+	assert.NoError(err)
+}
+
+func TestScalarMulAddOnly2(t *testing.T) {
+	assert := test.NewAssert(t)
+	_, _, g, _ := bn254.Generators()
+	var r fr_secp.Element
+	_, _ = r.SetRandom()
+	s := new(big.Int)
+	r.BigInt(s)
+	var S bn254.G1Affine
+	S.ScalarMultiplication(&g, s)
+
+	circuit := ScalarMulAddOnlyTest[emulated.BN254Fp, emulated.BN254Fr]{}
+	witness := ScalarMulAddOnlyTest[emulated.BN254Fp, emulated.BN254Fr]{
+		S: emulated.ValueOf[emulated.BN254Fr](s),
+		P: AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](g.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](g.Y),
+		},
+		Q: AffinePoint[emulated.BN254Fp]{
+			X: emulated.ValueOf[emulated.BN254Fp](S.X),
+			Y: emulated.ValueOf[emulated.BN254Fp](S.Y),
 		},
 	}
 	err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())

--- a/std/evmprecompiles/07-bnmul.go
+++ b/std/evmprecompiles/07-bnmul.go
@@ -15,6 +15,6 @@ func ECMul(api frontend.API, P *sw_emulated.AffinePoint[emulated.BN254Fp], u *em
 		panic(err)
 	}
 	// Check that P is on the curve (done in the zkEVM ⚠️ )
-	res := curve.ScalarMulAddOnly(P, u)
+	res := curve.ScalarMul(P, u)
 	return res
 }

--- a/std/evmprecompiles/07-bnmul.go
+++ b/std/evmprecompiles/07-bnmul.go
@@ -15,6 +15,6 @@ func ECMul(api frontend.API, P *sw_emulated.AffinePoint[emulated.BN254Fp], u *em
 		panic(err)
 	}
 	// Check that P is on the curve (done in the zkEVM ⚠️ )
-	res := curve.ScalarMul(P, u)
+	res := curve.ScalarMulAddOnly(api, P, u)
 	return res
 }

--- a/std/evmprecompiles/07-bnmul.go
+++ b/std/evmprecompiles/07-bnmul.go
@@ -15,6 +15,6 @@ func ECMul(api frontend.API, P *sw_emulated.AffinePoint[emulated.BN254Fp], u *em
 		panic(err)
 	}
 	// Check that P is on the curve (done in the zkEVM ⚠️ )
-	res := curve.ScalarMulAddOnly(api, P, u)
+	res := curve.ScalarMulAddOnly(P, u)
 	return res
 }


### PR DESCRIPTION
I was trying to have a `ScalarMul()` circuit with only additions and no doublings. Ultimately, I could make the circuit work with less constraints than the previous right-to-left double-and-add circuit. So I looked in the literature to check if it was previously known and I found that Marc Joye *of course* did it in 2007 😅
So this PR corresponds actually to Alg.2 of [[CHES:Joye07]](https://www.iacr.org/archive/ches2007/47270135/47270135.pdf) with some tweaks to make it work efficiently in-circuit: 
- select-logic with an additional register;
- isolate first iteration and use [[ELM02]](https://eprint.iacr.org/2002/112) `triple()` method;
- isolate last iteration and discard `R1` and `R2` computations.

Now when we use this new method in precompiles it saves:
- `ECRECOVER`: 
  - 17 609 r1cs
  - 111 590 scs
- `ECMUL`: 
  - 22 997 r1cs
  - 124 945 scs

P.S.: We can ditch the old `ScalarMul()` and replace it with the new `ScalarMulAddOnly()` once the PR is reviewed.

