### PR TITLE
refactor: compactify commitment tests

### DIFF
--- a/backend/groth16/bls12-377/setup.go
+++ b/backend/groth16/bls12-377/setup.go
@@ -655,7 +655,7 @@ func (pk *ProvingKey) NbG2() int {
 	return 2 + len(pk.G2.B)
 }
 
-// bitRerverse permutation as in fft.BitReverse , but with []curve.G1Affine
+// bitReverse permutation as in fft.BitReverse , but with []curve.G1Affine
 func bitReverse(a []curve.G1Affine) {
 	n := uint(len(a))
 	nn := uint(bits.UintSize - bits.TrailingZeros(n))

--- a/backend/groth16/bls12-381/setup.go
+++ b/backend/groth16/bls12-381/setup.go
@@ -655,7 +655,7 @@ func (pk *ProvingKey) NbG2() int {
 	return 2 + len(pk.G2.B)
 }
 
-// bitRerverse permutation as in fft.BitReverse , but with []curve.G1Affine
+// bitReverse permutation as in fft.BitReverse , but with []curve.G1Affine
 func bitReverse(a []curve.G1Affine) {
 	n := uint(len(a))
 	nn := uint(bits.UintSize - bits.TrailingZeros(n))

--- a/backend/groth16/bls24-315/setup.go
+++ b/backend/groth16/bls24-315/setup.go
@@ -655,7 +655,7 @@ func (pk *ProvingKey) NbG2() int {
 	return 2 + len(pk.G2.B)
 }
 
-// bitRerverse permutation as in fft.BitReverse , but with []curve.G1Affine
+// bitReverse permutation as in fft.BitReverse , but with []curve.G1Affine
 func bitReverse(a []curve.G1Affine) {
 	n := uint(len(a))
 	nn := uint(bits.UintSize - bits.TrailingZeros(n))

--- a/backend/groth16/bls24-317/setup.go
+++ b/backend/groth16/bls24-317/setup.go
@@ -655,7 +655,7 @@ func (pk *ProvingKey) NbG2() int {
 	return 2 + len(pk.G2.B)
 }
 
-// bitRerverse permutation as in fft.BitReverse , but with []curve.G1Affine
+// bitReverse permutation as in fft.BitReverse , but with []curve.G1Affine
 func bitReverse(a []curve.G1Affine) {
 	n := uint(len(a))
 	nn := uint(bits.UintSize - bits.TrailingZeros(n))

--- a/backend/groth16/bn254/setup.go
+++ b/backend/groth16/bn254/setup.go
@@ -655,7 +655,7 @@ func (pk *ProvingKey) NbG2() int {
 	return 2 + len(pk.G2.B)
 }
 
-// bitRerverse permutation as in fft.BitReverse , but with []curve.G1Affine
+// bitReverse permutation as in fft.BitReverse , but with []curve.G1Affine
 func bitReverse(a []curve.G1Affine) {
 	n := uint(len(a))
 	nn := uint(bits.UintSize - bits.TrailingZeros(n))

--- a/backend/groth16/bw6-633/setup.go
+++ b/backend/groth16/bw6-633/setup.go
@@ -655,7 +655,7 @@ func (pk *ProvingKey) NbG2() int {
 	return 2 + len(pk.G2.B)
 }
 
-// bitRerverse permutation as in fft.BitReverse , but with []curve.G1Affine
+// bitReverse permutation as in fft.BitReverse , but with []curve.G1Affine
 func bitReverse(a []curve.G1Affine) {
 	n := uint(len(a))
 	nn := uint(bits.UintSize - bits.TrailingZeros(n))

--- a/backend/groth16/bw6-761/setup.go
+++ b/backend/groth16/bw6-761/setup.go
@@ -655,7 +655,7 @@ func (pk *ProvingKey) NbG2() int {
 	return 2 + len(pk.G2.B)
 }
 
-// bitRerverse permutation as in fft.BitReverse , but with []curve.G1Affine
+// bitReverse permutation as in fft.BitReverse , but with []curve.G1Affine
 func bitReverse(a []curve.G1Affine) {
 	n := uint(len(a))
 	nn := uint(bits.UintSize - bits.TrailingZeros(n))

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -638,7 +638,7 @@ func (pk *ProvingKey) NbG2() int {
 	return 2 + len(pk.G2.B)
 }
 
-// bitRerverse permutation as in fft.BitReverse , but with []curve.G1Affine
+// bitReverse permutation as in fft.BitReverse , but with []curve.G1Affine
 func bitReverse(a []curve.G1Affine) {
 	n := uint(len(a))
 	nn := uint(bits.UintSize - bits.TrailingZeros(n))


### PR DESCRIPTION
More compact tests for commitments (one test method iterating over prepared circuits) similar to elsewhere in the repo