### PR TITLE
fix: emulated ToBits

### DIFF
--- a/std/math/emulated/field_binary.go
+++ b/std/math/emulated/field_binary.go
@@ -14,7 +14,6 @@ func (f *Field[T]) ToBits(a *Element[T]) []frontend.Variable {
 	f.enforceWidthConditional(a)
 	ba, aConst := f.constantValue(a)
 	if aConst {
-		ba.Mod(ba, f.fParams.Modulus())
 		res := make([]frontend.Variable, f.fParams.BitsPerLimb()*f.fParams.NbLimbs())
 		for i := range res {
 			res[i] = ba.Bit(i)


### PR DESCRIPTION
We modreduced when the input was constant, but did not when it was a variable. For ECDSA we assert against the modulus which was constant and modreduced.

Need to apply to plonk branch.