### PR TITLE
fix: plonk scs serialization issues

### DIFF
--- a/constraint/bls12-377/system.go
+++ b/constraint/bls12-377/system.go
@@ -367,6 +367,7 @@ func getTagSet() cbor.TagSet {
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CAdd{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CMul{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CBool{}))
+	addType(reflect.TypeOf(constraint.BlueprintLookupHint{}))
 	addType(reflect.TypeOf(constraint.Groth16Commitments{}))
 	addType(reflect.TypeOf(constraint.PlonkCommitments{}))
 

--- a/constraint/bls12-377/system.go
+++ b/constraint/bls12-377/system.go
@@ -159,8 +159,8 @@ func (cs *system) WriteTo(w io.Writer) (int64, error) {
 func (cs *system) ReadFrom(r io.Reader) (int64, error) {
 	ts := getTagSet()
 	dm, err := cbor.DecOptions{
-		MaxArrayElements: 134217728,
-		MaxMapPairs:      134217728,
+		MaxArrayElements: 2147483647,
+		MaxMapPairs:      2147483647,
 	}.DecModeWithTags(ts)
 
 	if err != nil {

--- a/constraint/bls12-381/system.go
+++ b/constraint/bls12-381/system.go
@@ -367,6 +367,7 @@ func getTagSet() cbor.TagSet {
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CAdd{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CMul{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CBool{}))
+	addType(reflect.TypeOf(constraint.BlueprintLookupHint{}))
 	addType(reflect.TypeOf(constraint.Groth16Commitments{}))
 	addType(reflect.TypeOf(constraint.PlonkCommitments{}))
 

--- a/constraint/bls12-381/system.go
+++ b/constraint/bls12-381/system.go
@@ -159,8 +159,8 @@ func (cs *system) WriteTo(w io.Writer) (int64, error) {
 func (cs *system) ReadFrom(r io.Reader) (int64, error) {
 	ts := getTagSet()
 	dm, err := cbor.DecOptions{
-		MaxArrayElements: 134217728,
-		MaxMapPairs:      134217728,
+		MaxArrayElements: 2147483647,
+		MaxMapPairs:      2147483647,
 	}.DecModeWithTags(ts)
 
 	if err != nil {

--- a/constraint/bls24-315/system.go
+++ b/constraint/bls24-315/system.go
@@ -367,6 +367,7 @@ func getTagSet() cbor.TagSet {
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CAdd{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CMul{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CBool{}))
+	addType(reflect.TypeOf(constraint.BlueprintLookupHint{}))
 	addType(reflect.TypeOf(constraint.Groth16Commitments{}))
 	addType(reflect.TypeOf(constraint.PlonkCommitments{}))
 

--- a/constraint/bls24-315/system.go
+++ b/constraint/bls24-315/system.go
@@ -159,8 +159,8 @@ func (cs *system) WriteTo(w io.Writer) (int64, error) {
 func (cs *system) ReadFrom(r io.Reader) (int64, error) {
 	ts := getTagSet()
 	dm, err := cbor.DecOptions{
-		MaxArrayElements: 134217728,
-		MaxMapPairs:      134217728,
+		MaxArrayElements: 2147483647,
+		MaxMapPairs:      2147483647,
 	}.DecModeWithTags(ts)
 
 	if err != nil {

--- a/constraint/bls24-317/system.go
+++ b/constraint/bls24-317/system.go
@@ -367,6 +367,7 @@ func getTagSet() cbor.TagSet {
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CAdd{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CMul{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CBool{}))
+	addType(reflect.TypeOf(constraint.BlueprintLookupHint{}))
 	addType(reflect.TypeOf(constraint.Groth16Commitments{}))
 	addType(reflect.TypeOf(constraint.PlonkCommitments{}))
 

--- a/constraint/bls24-317/system.go
+++ b/constraint/bls24-317/system.go
@@ -159,8 +159,8 @@ func (cs *system) WriteTo(w io.Writer) (int64, error) {
 func (cs *system) ReadFrom(r io.Reader) (int64, error) {
 	ts := getTagSet()
 	dm, err := cbor.DecOptions{
-		MaxArrayElements: 134217728,
-		MaxMapPairs:      134217728,
+		MaxArrayElements: 2147483647,
+		MaxMapPairs:      2147483647,
 	}.DecModeWithTags(ts)
 
 	if err != nil {

--- a/constraint/blueprint_logderivlookup.go
+++ b/constraint/blueprint_logderivlookup.go
@@ -1,10 +1,11 @@
-package logderivlookup
+package constraint
 
 import (
 	"fmt"
-
-	"github.com/consensys/gnark/constraint"
 )
+
+// TODO @gbotrel this shouldn't be there, but we need to figure out a clean way to serialize
+// blueprints
 
 // BlueprintLookupHint is a blueprint that facilitates the lookup of values in a table.
 // It is essentially a hint to the solver, but enables storing the table entries only once.
@@ -13,26 +14,11 @@ type BlueprintLookupHint struct {
 }
 
 // ensures BlueprintLookupHint implements the BlueprintSolvable interface
-var _ constraint.BlueprintSolvable = (*BlueprintLookupHint)(nil)
+var _ BlueprintSolvable = (*BlueprintLookupHint)(nil)
 
-// func lookupHint(_ *big.Int, in []*big.Int, out []*big.Int) error {
-// 	nbTable := len(in) - len(out)
-// 	for i := 0; i < len(in)-nbTable; i++ {
-// 		if !in[nbTable+i].IsInt64() {
-// 			return fmt.Errorf("lookup query not integer")
-// 		}
-// 		ptr := int(in[nbTable+i].Int64())
-// 		if ptr >= nbTable {
-// 			return fmt.Errorf("lookup query %d outside table size %d", ptr, nbTable)
-// 		}
-// 		out[i].Set(in[ptr])
-// 	}
-// 	return nil
-// }
-
-func (b *BlueprintLookupHint) Solve(s constraint.Solver, inst constraint.Instruction) error {
+func (b *BlueprintLookupHint) Solve(s Solver, inst Instruction) error {
 	nbEntries := int(inst.Calldata[1])
-	entries := make([]constraint.Element, nbEntries)
+	entries := make([]Element, nbEntries)
 
 	// read the static entries from the blueprint
 	// TODO @gbotrel cache that.
@@ -45,7 +31,7 @@ func (b *BlueprintLookupHint) Solve(s constraint.Solver, inst constraint.Instruc
 	nbInputs := int(inst.Calldata[2])
 
 	// read the inputs from the instruction
-	inputs := make([]constraint.Element, nbInputs)
+	inputs := make([]Element, nbInputs)
 	offset = 3
 	for i := 0; i < nbInputs; i++ {
 		inputs[i], delta = s.Read(inst.Calldata[offset:])
@@ -75,13 +61,13 @@ func (b *BlueprintLookupHint) NbConstraints() int {
 }
 
 // NbOutputs return the number of output wires this blueprint creates.
-func (b *BlueprintLookupHint) NbOutputs(inst constraint.Instruction) int {
+func (b *BlueprintLookupHint) NbOutputs(inst Instruction) int {
 	return int(inst.Calldata[2])
 }
 
 // Wires returns a function that walks the wires appearing in the blueprint.
 // This is used by the level builder to build a dependency graph between instructions.
-func (b *BlueprintLookupHint) WireWalker(inst constraint.Instruction) func(cb func(wire uint32)) {
+func (b *BlueprintLookupHint) WireWalker(inst Instruction) func(cb func(wire uint32)) {
 	return func(cb func(wire uint32)) {
 		// depend on the table UP to the number of entries at time of instruction creation.
 		nbEntries := int(inst.Calldata[1])
@@ -93,7 +79,7 @@ func (b *BlueprintLookupHint) WireWalker(inst constraint.Instruction) func(cb fu
 			n := int(b.EntriesCalldata[j])
 			j++
 			for k := 0; k < n; k++ {
-				t := constraint.Term{CID: b.EntriesCalldata[j], VID: b.EntriesCalldata[j+1]}
+				t := Term{CID: b.EntriesCalldata[j], VID: b.EntriesCalldata[j+1]}
 				if !t.IsConstant() {
 					cb(t.VID)
 				}
@@ -109,7 +95,7 @@ func (b *BlueprintLookupHint) WireWalker(inst constraint.Instruction) func(cb fu
 			n := int(inst.Calldata[j])
 			j++
 			for k := 0; k < n; k++ {
-				t := constraint.Term{CID: inst.Calldata[j], VID: inst.Calldata[j+1]}
+				t := Term{CID: inst.Calldata[j], VID: inst.Calldata[j+1]}
 				if !t.IsConstant() {
 					cb(t.VID)
 				}

--- a/constraint/bn254/system.go
+++ b/constraint/bn254/system.go
@@ -367,6 +367,7 @@ func getTagSet() cbor.TagSet {
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CAdd{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CMul{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CBool{}))
+	addType(reflect.TypeOf(constraint.BlueprintLookupHint{}))
 	addType(reflect.TypeOf(constraint.Groth16Commitments{}))
 	addType(reflect.TypeOf(constraint.PlonkCommitments{}))
 

--- a/constraint/bn254/system.go
+++ b/constraint/bn254/system.go
@@ -159,8 +159,8 @@ func (cs *system) WriteTo(w io.Writer) (int64, error) {
 func (cs *system) ReadFrom(r io.Reader) (int64, error) {
 	ts := getTagSet()
 	dm, err := cbor.DecOptions{
-		MaxArrayElements: 134217728,
-		MaxMapPairs:      134217728,
+		MaxArrayElements: 2147483647,
+		MaxMapPairs:      2147483647,
 	}.DecModeWithTags(ts)
 
 	if err != nil {

--- a/constraint/bw6-633/system.go
+++ b/constraint/bw6-633/system.go
@@ -367,6 +367,7 @@ func getTagSet() cbor.TagSet {
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CAdd{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CMul{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CBool{}))
+	addType(reflect.TypeOf(constraint.BlueprintLookupHint{}))
 	addType(reflect.TypeOf(constraint.Groth16Commitments{}))
 	addType(reflect.TypeOf(constraint.PlonkCommitments{}))
 

--- a/constraint/bw6-633/system.go
+++ b/constraint/bw6-633/system.go
@@ -159,8 +159,8 @@ func (cs *system) WriteTo(w io.Writer) (int64, error) {
 func (cs *system) ReadFrom(r io.Reader) (int64, error) {
 	ts := getTagSet()
 	dm, err := cbor.DecOptions{
-		MaxArrayElements: 134217728,
-		MaxMapPairs:      134217728,
+		MaxArrayElements: 2147483647,
+		MaxMapPairs:      2147483647,
 	}.DecModeWithTags(ts)
 
 	if err != nil {

--- a/constraint/bw6-761/system.go
+++ b/constraint/bw6-761/system.go
@@ -367,6 +367,7 @@ func getTagSet() cbor.TagSet {
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CAdd{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CMul{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CBool{}))
+	addType(reflect.TypeOf(constraint.BlueprintLookupHint{}))
 	addType(reflect.TypeOf(constraint.Groth16Commitments{}))
 	addType(reflect.TypeOf(constraint.PlonkCommitments{}))
 

--- a/constraint/bw6-761/system.go
+++ b/constraint/bw6-761/system.go
@@ -159,8 +159,8 @@ func (cs *system) WriteTo(w io.Writer) (int64, error) {
 func (cs *system) ReadFrom(r io.Reader) (int64, error) {
 	ts := getTagSet()
 	dm, err := cbor.DecOptions{
-		MaxArrayElements: 134217728,
-		MaxMapPairs:      134217728,
+		MaxArrayElements: 2147483647,
+		MaxMapPairs:      2147483647,
 	}.DecModeWithTags(ts)
 
 	if err != nil {

--- a/constraint/tinyfield/system.go
+++ b/constraint/tinyfield/system.go
@@ -367,6 +367,7 @@ func getTagSet() cbor.TagSet {
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CAdd{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CMul{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CBool{}))
+	addType(reflect.TypeOf(constraint.BlueprintLookupHint{}))
 	addType(reflect.TypeOf(constraint.Groth16Commitments{}))
 	addType(reflect.TypeOf(constraint.PlonkCommitments{}))
 

--- a/constraint/tinyfield/system.go
+++ b/constraint/tinyfield/system.go
@@ -159,8 +159,8 @@ func (cs *system) WriteTo(w io.Writer) (int64, error) {
 func (cs *system) ReadFrom(r io.Reader) (int64, error) {
 	ts := getTagSet()
 	dm, err := cbor.DecOptions{
-		MaxArrayElements: 134217728,
-		MaxMapPairs:      134217728,
+		MaxArrayElements: 2147483647,
+		MaxMapPairs:      2147483647,
 	}.DecModeWithTags(ts)
 
 	if err != nil {

--- a/internal/generator/backend/template/representations/system.go.tmpl
+++ b/internal/generator/backend/template/representations/system.go.tmpl
@@ -145,8 +145,8 @@ func (cs *system) WriteTo(w io.Writer) (int64, error) {
 func (cs *system) ReadFrom(r io.Reader) (int64, error) {
 	ts := getTagSet()
 	dm, err := cbor.DecOptions{
-		MaxArrayElements: 134217728,
-		MaxMapPairs:      134217728,
+		MaxArrayElements: 2147483647,
+		MaxMapPairs:      2147483647,
 	}.DecModeWithTags(ts)
 
 	if err != nil {

--- a/internal/generator/backend/template/representations/system.go.tmpl
+++ b/internal/generator/backend/template/representations/system.go.tmpl
@@ -364,6 +364,7 @@ func getTagSet() cbor.TagSet {
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CAdd{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CMul{}))
 	addType(reflect.TypeOf(constraint.BlueprintSparseR1CBool{}))
+	addType(reflect.TypeOf(constraint.BlueprintLookupHint{}))
 	addType(reflect.TypeOf(constraint.Groth16Commitments{}))
 	addType(reflect.TypeOf(constraint.PlonkCommitments{}))
 

--- a/std/lookup/logderivlookup/logderivlookup.go
+++ b/std/lookup/logderivlookup/logderivlookup.go
@@ -36,7 +36,7 @@ type Table struct {
 	// the blueprint stores the lookup table entries once
 	// such that each query only need to store the indexes to lookup
 	bID       constraint.BlueprintID
-	blueprint BlueprintLookupHint
+	blueprint constraint.BlueprintLookupHint
 }
 
 type result struct {


### PR DESCRIPTION
1. 
```
panic: error reading scs : cbor: exceeded max number of elements 134217728 for CBOR array
```
--> seems now we can do `2147483647` as max size, easy fix, lucky for us :) 

2. 
```
panic: cbor: cannot unmarshal map into Go struct field cs.system.Blueprints of type constraint.Blueprint
```

--> suspect this comes from `BlueprintLookupHint` 
We need to figure out a better way to serialize blueprints, this fix should do for now, but we need to re-serialize the circuits (cc @AlexandreBelling )