### PR TITLE
fix: fixed #761

### DIFF
--- a/backend/plonk/bn254/solidity.go
+++ b/backend/plonk/bn254/solidity.go
@@ -1227,8 +1227,10 @@ func (proof *Proof) MarshalSolidity() []byte {
 	// uint256[] selector_commit_api_at_zeta;
 	// uint256[] wire_committed_commitments;
 	if len(proof.Bsb22Commitments) > 0 {
-		tmp32 = proof.BatchedProof.ClaimedValues[7].Bytes()
-		res = append(res, tmp32[:]...)
+		for i := 0; i < len(proof.Bsb22Commitments); i++ {
+			tmp32 = proof.BatchedProof.ClaimedValues[7+i].Bytes()
+			res = append(res, tmp32[:]...)
+		}
 
 		for _, bc := range proof.Bsb22Commitments {
 			tmp64 = bc.RawBytes()


### PR DESCRIPTION
In the plonk verifier contract the proof is serialised like this:

`... || openings_bsb22_commitments || bsb22_commitments`

The `openings_bsb22_commitments` are in `proof.BatchedProof.ClaimedValues[7:]`, so far only proof.BatchedProof.ClaimedValues[7] was serialised