### PR TITLE
Perf/pairing add0

### DIFF
--- a/std/algebra/emulated/fields_bn254/e12_pairing.go
+++ b/std/algebra/emulated/fields_bn254/e12_pairing.go
@@ -69,6 +69,37 @@ func (e Ext12) ExptTorus(x *E6) *E6 {
 	return z
 }
 
+// Square034 squares an E12 sparse element of the form
+//
+//	E12{
+//		C0: E6{B0: 1, B1: 0, B2: 0},
+//		C1: E6{B0: c3, B1: c4, B2: 0},
+//	}
+func (e *Ext12) Square034(x *E12) *E12 {
+	var c0, c2, c3 E6
+	var z E12
+
+	c0.B0 = *e.Ext2.Sub(&x.C0.B0, &x.C1.B0)
+	c0.B1 = *e.Ext2.Neg(&x.C1.B1)
+	c0.B2 = *e.Ext2.Zero()
+
+	c3.B0 = x.C0.B0
+	c3.B1 = *e.Ext2.Neg(&x.C1.B0)
+	c3.B2 = *e.Ext2.Neg(&x.C1.B1)
+
+	c2 = *e.Mul0By01(&x.C0.B0, &x.C1.B0, &x.C1.B1)
+	c3 = *e.MulBy01(&c3, &c0.B0, &c0.B1)
+	c3 = *e.Ext6.Add(&c3, &c2)
+	z.C1.B0 = *e.Ext2.Add(&c2.B0, &c2.B0)
+	z.C1.B1 = *e.Ext2.Add(&c2.B1, &c2.B1)
+
+	z.C0.B0 = c3.B0
+	z.C0.B1 = *e.Ext2.Add(&c3.B1, &c2.B0)
+	z.C0.B2 = *e.Ext2.Add(&c3.B2, &c2.B1)
+
+	return &z
+}
+
 // MulBy034 multiplies z by an E12 sparse element of the form
 //
 //	E12{

--- a/std/algebra/emulated/fields_bn254/e12_pairing.go
+++ b/std/algebra/emulated/fields_bn254/e12_pairing.go
@@ -76,20 +76,27 @@ func (e Ext12) ExptTorus(x *E6) *E6 {
 //		C1: E6{B0: c3, B1: c4, B2: 0},
 //	}
 func (e *Ext12) Square034(x *E12) *E12 {
-	var c0, c2, c3 E6
-	var z E12
+	c0 := E6{
+		B0: *e.Ext2.Sub(&x.C0.B0, &x.C1.B0),
+		B1: *e.Ext2.Neg(&x.C1.B1),
+		B2: *e.Ext2.Zero(),
+	}
 
-	c0.B0 = *e.Ext2.Sub(&x.C0.B0, &x.C1.B0)
-	c0.B1 = *e.Ext2.Neg(&x.C1.B1)
-	c0.B2 = *e.Ext2.Zero()
+	c3 := E6{
+		B0: x.C0.B0,
+		B1: *e.Ext2.Neg(&x.C1.B0),
+		B2: *e.Ext2.Neg(&x.C1.B1),
+	}
 
-	c3.B0 = x.C0.B0
-	c3.B1 = *e.Ext2.Neg(&x.C1.B0)
-	c3.B2 = *e.Ext2.Neg(&x.C1.B1)
-
-	c2 = *e.Mul0By01(&x.C0.B0, &x.C1.B0, &x.C1.B1)
+	c2 := E6{
+		B0: x.C1.B0,
+		B1: x.C1.B1,
+		B2: *e.Ext2.Zero(),
+	}
 	c3 = *e.MulBy01(&c3, &c0.B0, &c0.B1)
 	c3 = *e.Ext6.Add(&c3, &c2)
+
+	var z E12
 	z.C1.B0 = *e.Ext2.Add(&c2.B0, &c2.B0)
 	z.C1.B1 = *e.Ext2.Add(&c2.B1, &c2.B1)
 

--- a/std/algebra/emulated/fields_bn254/e6.go
+++ b/std/algebra/emulated/fields_bn254/e6.go
@@ -249,6 +249,35 @@ func (e Ext6) Mul01By01(c0, c1, d0, d1 *E2) *E6 {
 	}
 }
 
+// Mul0By01 multiplies two E6 sparse element of the form:
+//
+//	E6{
+//		B0: c0,
+//		B1: 0,
+//		B2: 0,
+//	}
+//
+// and
+//
+//	E6{
+//		B0: b0,
+//		B1: b1,
+//		B2: 0,
+//	}
+func (e *Ext6) Mul0By01(a0, b0, b1 *E2) *E6 {
+
+	t0 := e.Ext2.Mul(a0, b0)
+	c1 := e.Ext2.Add(b0, b1)
+	c1 = e.Ext2.Mul(c1, a0)
+	c1 = e.Ext2.Sub(c1, t0)
+
+	return &E6{
+		B0: *t0,
+		B1: *c1,
+		B2: *e.Ext2.Zero(),
+	}
+}
+
 func (e Ext6) MulByNonResidue(x *E6) *E6 {
 	z2, z1, z0 := &x.B1, &x.B0, &x.B2
 	z0 = e.Ext2.MulByNonResidue(z0)

--- a/std/algebra/emulated/fields_bn254/e6.go
+++ b/std/algebra/emulated/fields_bn254/e6.go
@@ -249,35 +249,6 @@ func (e Ext6) Mul01By01(c0, c1, d0, d1 *E2) *E6 {
 	}
 }
 
-// Mul0By01 multiplies two E6 sparse element of the form:
-//
-//	E6{
-//		B0: c0,
-//		B1: 0,
-//		B2: 0,
-//	}
-//
-// and
-//
-//	E6{
-//		B0: b0,
-//		B1: b1,
-//		B2: 0,
-//	}
-func (e *Ext6) Mul0By01(a0, b0, b1 *E2) *E6 {
-
-	t0 := e.Ext2.Mul(a0, b0)
-	c1 := e.Ext2.Add(b0, b1)
-	c1 = e.Ext2.Mul(c1, a0)
-	c1 = e.Ext2.Sub(c1, t0)
-
-	return &E6{
-		B0: *t0,
-		B1: *c1,
-		B2: *e.Ext2.Zero(),
-	}
-}
-
 func (e Ext6) MulByNonResidue(x *E6) *E6 {
 	z2, z1, z0 := &x.B1, &x.B0, &x.B2
 	z0 = e.Ext2.MulByNonResidue(z0)

--- a/std/algebra/native/fields_bls12377/e12_pairing.go
+++ b/std/algebra/native/fields_bls12377/e12_pairing.go
@@ -2,6 +2,30 @@ package fields_bls12377
 
 import "github.com/consensys/gnark/frontend"
 
+// Square034 squares a sparse element in Fp12
+func (e *E12) Square034(api frontend.API, x E12) *E12 {
+	var c0, c2, c3 E6
+
+	c0.B0.Sub(api, x.C0.B0, x.C1.B0)
+	c0.B1.Neg(api, x.C1.B1)
+	c0.B2 = E2{0, 0}
+
+	c3.B0 = x.C0.B0
+	c3.B1.Neg(api, x.C1.B0)
+	c3.B2.Neg(api, x.C1.B1)
+
+	c2.Mul0By01(api, x.C0.B0, x.C1.B0, x.C1.B1)
+	c3.MulBy01(api, c0.B0, c0.B1).Add(api, c3, c2)
+	e.C1.B0.Add(api, c2.B0, c2.B0)
+	e.C1.B1.Add(api, c2.B1, c2.B1)
+
+	e.C0.B0 = c3.B0
+	e.C0.B1.Add(api, c3.B1, c2.B0)
+	e.C0.B2.Add(api, c3.B2, c2.B1)
+
+	return e
+}
+
 // MulBy034 multiplication by sparse element
 func (e *E12) MulBy034(api frontend.API, c3, c4 E2) *E12 {
 

--- a/std/algebra/native/fields_bls12377/e6.go
+++ b/std/algebra/native/fields_bls12377/e6.go
@@ -122,6 +122,21 @@ func (e *E6) Mul(api frontend.API, e1, e2 E6) *E6 {
 	return e
 }
 
+func (e *E6) Mul0By01(api frontend.API, a0, b0, b1 E2) *E6 {
+
+	var t0, c1 E2
+
+	t0.Mul(api, a0, b0)
+	c1.Add(api, b0, b1)
+	c1.Mul(api, c1, a0).Sub(api, c1, t0)
+
+	e.B0 = t0
+	e.B1 = c1
+	e.B2 = E2{0, 0}
+
+	return e
+}
+
 // MulByFp2 creates a fp6elmt from fp elmts
 // icube is the imaginary elmt to the cube
 func (e *E6) MulByFp2(api frontend.API, e1 E6, e2 E2) *E6 {

--- a/std/algebra/native/fields_bls24315/e12.go
+++ b/std/algebra/native/fields_bls24315/e12.go
@@ -353,6 +353,21 @@ func (e *E12) MulBy01(api frontend.API, c0, c1 E4) *E12 {
 	return e
 }
 
+func (e *E12) Mul0By01(api frontend.API, a0, b0, b1 E4) *E12 {
+
+	var t0, c1 E4
+
+	t0.Mul(api, a0, b0)
+	c1.Add(api, b0, b1)
+	c1.Mul(api, c1, a0).Sub(api, c1, t0)
+
+	e.C0 = t0
+	e.C1 = c1
+	e.C2 = E4{E2{0, 0}, E2{0, 0}}
+
+	return e
+}
+
 // Assign a value to self (witness assignment)
 func (e *E12) Assign(a *bls24315.E12) {
 	e.C0.Assign(&a.C0)

--- a/std/algebra/native/fields_bls24315/e24_pairing.go
+++ b/std/algebra/native/fields_bls24315/e24_pairing.go
@@ -2,6 +2,30 @@ package fields_bls24315
 
 import "github.com/consensys/gnark/frontend"
 
+// Square034 squares a sparse element in Fp24
+func (e *E24) Square034(api frontend.API, x E24) *E24 {
+	var c0, c2, c3 E12
+
+	c0.C0.Sub(api, x.D0.C0, x.D1.C0)
+	c0.C1.Neg(api, x.D1.C1)
+	c0.C2 = E4{E2{0, 0}, E2{0, 0}}
+
+	c3.C0 = x.D0.C0
+	c3.C1.Neg(api, x.D1.C0)
+	c3.C2.Neg(api, x.D1.C1)
+
+	c2.Mul0By01(api, x.D0.C0, x.D1.C0, x.D1.C1)
+	c3.MulBy01(api, c0.C0, c0.C1).Add(api, c3, c2)
+	e.D1.C0.Add(api, c2.C0, c2.C0)
+	e.D1.C1.Add(api, c2.C1, c2.C1)
+
+	e.D0.C0 = c3.C0
+	e.D0.C1.Add(api, c3.C1, c2.C0)
+	e.D0.C2.Add(api, c3.C2, c2.C1)
+
+	return e
+}
+
 // MulBy034 multiplication by sparse element
 func (e *E24) MulBy034(api frontend.API, c3, c4 E4) *E24 {
 

--- a/std/algebra/native/sw_bls12377/pairing.go
+++ b/std/algebra/native/sw_bls12377/pairing.go
@@ -118,7 +118,28 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 		}
 	}
 
-	for i := 61; i >= 1; i-- {
+	// i = 61, separately to avoid a full E12 Square
+	if n == 1 {
+		res.Square034(api, res)
+
+	} else {
+		res.Square(api, res)
+
+	}
+
+	for k := 0; k < n; k++ {
+		// Qacc[k] ← 2Qacc[k] and l1 the tangent ℓ passing 2Qacc[k]
+		Qacc[k], l1 = doubleStep(api, &Qacc[k])
+
+		// line evaluation at P[k]
+		l1.R0.MulByFp(api, l1.R0, xOverY[k])
+		l1.R1.MulByFp(api, l1.R1, yInv[k])
+
+		// ℓ × res
+		res.MulBy034(api, l1.R0, l1.R1)
+	}
+
+	for i := 60; i >= 1; i-- {
 		// mutualize the square among n Miller loops
 		// (∏ᵢfᵢ)²
 		res.Square(api, res)

--- a/std/algebra/native/sw_bls12377/pairing.go
+++ b/std/algebra/native/sw_bls12377/pairing.go
@@ -118,16 +118,32 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 		}
 	}
 
-	// i = 61, separately to avoid a full E12 Square
+	// i = 61, separately to use a special E12 Square
+	// k = 0
+	// Qacc[0] ← 2Qacc[0] and l1 the tangent ℓ passing 2Qacc[0]
+	Qacc[0], l1 = doubleStep(api, &Qacc[0])
+	// line evaluation at P[0]
+	l1.R0.MulByFp(api, l1.R0, xOverY[0])
+	l1.R1.MulByFp(api, l1.R1, yInv[0])
+
 	if n == 1 {
 		res.Square034(api, res)
+		prodLines[0] = res.C0.B0
+		prodLines[1] = res.C0.B1
+		prodLines[2] = res.C0.B2
+		prodLines[3] = res.C1.B0
+		prodLines[4] = res.C1.B1
+		// ℓ × res
+		res = *fields_bls12377.Mul01234By034(api, prodLines, l1.R0, l1.R1)
 
 	} else {
 		res.Square(api, res)
+		// ℓ × res
+		res.MulBy034(api, l1.R0, l1.R1)
 
 	}
 
-	for k := 0; k < n; k++ {
+	for k := 1; k < n; k++ {
 		// Qacc[k] ← 2Qacc[k] and l1 the tangent ℓ passing 2Qacc[k]
 		Qacc[k], l1 = doubleStep(api, &Qacc[k])
 
@@ -407,7 +423,20 @@ func MillerLoopFixedQ(api frontend.API, P G1Affine) (GT, error) {
 	res.C1.B0.MulByFp(api, precomputedLines[0][62], xOverY)
 	res.C1.B1.MulByFp(api, precomputedLines[1][62], yInv)
 
-	for i := 61; i >= 0; i-- {
+	// i = 61, separately to use a special E12 Square
+	res.Square034(api, res)
+	prodLines[0] = res.C0.B0
+	prodLines[1] = res.C0.B1
+	prodLines[2] = res.C0.B2
+	prodLines[3] = res.C1.B0
+	prodLines[4] = res.C1.B1
+	// line evaluation at P
+	l1.R0.MulByFp(api, precomputedLines[0][61], xOverY)
+	l1.R1.MulByFp(api, precomputedLines[1][61], yInv)
+	// ℓ × res
+	res = *fields_bls12377.Mul01234By034(api, prodLines, l1.R0, l1.R1)
+
+	for i := 60; i >= 0; i-- {
 		// mutualize the square among n Miller loops
 		// (∏ᵢfᵢ)²
 		res.Square(api, res)

--- a/std/algebra/native/sw_bls24315/pairing.go
+++ b/std/algebra/native/sw_bls24315/pairing.go
@@ -113,7 +113,12 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 	// i = 30, separately to avoid a doubleStep
 	// (at this point Qacc = 2Q, so 2Qacc-Q=3Q is equivalent to Qacc+Q=3Q
 	// this means doubleAndAddStep is equivalent to addStep here)
-	res.Square(api, res)
+	if n == 1 {
+		res.Square034(api, res)
+	} else {
+		res.Square(api, res)
+
+	}
 	for k := 0; k < n; k++ {
 		// l2 the line passing Qacc[k] and -Q
 		l2 = lineCompute(api, &Qacc[k], &Qneg[k])
@@ -504,7 +509,31 @@ func MillerLoopFixedQ(api frontend.API, P G1Affine) (GT, error) {
 		fields_bls24315.E4{B0: precomputedLines[2][31], B1: precomputedLines[3][31]},
 		yInv)
 
-	for i := 30; i >= 0; i-- {
+	// i = 30
+	res.Square034(api, res)
+	// line evaluation at P
+	l1.R0.MulByFp(api,
+		fields_bls24315.E4{B0: precomputedLines[0][30], B1: precomputedLines[1][30]},
+		xOverY)
+	l1.R1.MulByFp(api,
+		fields_bls24315.E4{B0: precomputedLines[2][30], B1: precomputedLines[3][30]},
+		yInv)
+
+	// ℓ × res
+	res.MulBy034(api, l1.R0, l1.R1)
+
+	// line evaluation at P
+	l2.R0.MulByFp(api,
+		fields_bls24315.E4{B0: precomputedLines[4][30], B1: precomputedLines[5][30]},
+		xOverY)
+	l2.R1.MulByFp(api,
+		fields_bls24315.E4{B0: precomputedLines[6][30], B1: precomputedLines[7][30]},
+		yInv)
+
+	// ℓ × res
+	res.MulBy034(api, l2.R0, l2.R1)
+
+	for i := 29; i >= 0; i-- {
 		// mutualize the square among n Miller loops
 		// (∏ᵢfᵢ)²
 		res.Square(api, res)


### PR DESCRIPTION
PR #763 triggered some unnecessary additions by 0 in pairing circuits (for 2-chains). It also happens for emulated pairings but it's hidden by how field emulation works. @ivokub tracked these occurrences and suggested to handle them in the pairing algorithm. These happen at the second iteration of the Miller loop. In fact, at this point, for a single pairing, the accumulator is a sparse element in Fpk (it's actually just the assigned line). So in this PR instead of calling the plain `Square`  function we implement a special `Square034` that takes into account this sparsity. The benefit is not huge but still, e.g.:

*PLONK bench of emulated BN254 pairing in a BN254 circuit:*
```
old: 8075956 scs
new: 8066505 scs
diff: 9451 scs
```