### PR TITLE
Perf: Improve MultiLin.Eval number of constraints

### DIFF
--- a/std/polynomial/polynomial.go
+++ b/std/polynomial/polynomial.go
@@ -18,7 +18,6 @@ func (m MultiLin) Evaluate(api frontend.API, at []frontend.Variable) frontend.Va
 	for len(_m) > 1 {
 		_m.fold(api, at[0])
 		_m = _m[:len(_m)/2]
-		//api.Println(_m...)
 		at = at[1:]
 	}
 

--- a/std/polynomial/polynomial_test.go
+++ b/std/polynomial/polynomial_test.go
@@ -5,6 +5,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/frontend/cs/scs"
 	"github.com/consensys/gnark/test"
 	"testing"
 )
@@ -203,4 +205,23 @@ func int64SliceToVariableSlice(slice []int64) []frontend.Variable {
 		res = append(res, v)
 	}
 	return res
+}
+
+func ExampleMultiLin_Evaluate() {
+	const logSize = 20
+	const size = 1 << logSize
+	m := MultiLin(make([]frontend.Variable, size))
+	e := MultiLin(make([]frontend.Variable, logSize))
+
+	cs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &evalMultiLinCircuit{M: m, At: e, Evaluation: 0})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("r1cs size:", cs.GetNbConstraints())
+
+	cs, err = frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &evalMultiLinCircuit{M: m, At: e, Evaluation: 0})
+	fmt.Println("scs size:", cs.GetNbConstraints())
+
+	// Output: r1cs size: 2100657
+	//scs size: 4194301
 }

--- a/std/polynomial/polynomial_test.go
+++ b/std/polynomial/polynomial_test.go
@@ -246,6 +246,9 @@ func ExampleMultiLin_Evaluate() {
 	fmt.Println("r1cs size:", cs.GetNbConstraints())
 
 	cs, err = frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &evalMultiLinCircuit{M: m, At: e, Evaluation: 0})
+	if err != nil {
+		panic(err)
+	}
 	fmt.Println("scs size:", cs.GetNbConstraints())
 
 	// Output: r1cs size: 1048576

--- a/std/polynomial/polynomial_test.go
+++ b/std/polynomial/polynomial_test.go
@@ -251,6 +251,6 @@ func ExampleMultiLin_Evaluate() {
 	}
 	fmt.Println("scs size:", cs.GetNbConstraints())
 
-	// Output: r1cs size: 1048576
-	//scs size: 3145726
+	// Output: r1cs size: 1048627
+	//scs size: 2097226
 }

--- a/std/polynomial/polynomial_test.go
+++ b/std/polynomial/polynomial_test.go
@@ -91,7 +91,7 @@ func (c *foldMultiLinCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func TestFoldTrivial(t *testing.T) {
+func TestFoldSmall(t *testing.T) {
 	test.NewAssert(t).SolvingSucceeded(
 		&foldMultiLinCircuit{M: make([]frontend.Variable, 4), Result: make([]frontend.Variable, 2)},
 		&foldMultiLinCircuit{M: []frontend.Variable{0, 1, 2, 3}, At: 2, Result: []frontend.Variable{4, 5}},
@@ -248,6 +248,6 @@ func ExampleMultiLin_Evaluate() {
 	cs, err = frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &evalMultiLinCircuit{M: m, At: e, Evaluation: 0})
 	fmt.Println("scs size:", cs.GetNbConstraints())
 
-	// Output: r1cs size: 2100657
-	//scs size: 4194301
+	// Output: r1cs size: 1048576
+	//scs size: 3145726
 }


### PR DESCRIPTION
Evaluation of large multilinear extensions is a major bottleneck in GKR verification. Currently the hypercube bases are evaluated at the requested point and the linear combination of these results with the corresponding hypercube values is taken. A massive reduction in the number of constraints can be achieved by performing successive foldings instead. For the 20-variable case we get
```
develop:
r1cs: 2100657 constraints
scs : 4194301 constraints

opt1 (successive fold):
r1cs: 1048576 constraints 49%
scs: 3145726 constraints 75%
```
a 25% improvement for SCS.

A second optimization defers scaling of folding operations which is corrected at the end. My experiments suggest that this starts paying off at around the $2^{16}$ size. It doesn't help with R1CS at all, but doesn't hurt significantly either. With SCS we see significant additional gains:

ops 1&2 (successive fold + defer scaling for large sizes):
```
r1cs: 1048627 constraints 50%
scs: 2097226 constraints 50%
```