### PR TITLE
backend: add ExportNeoGo for Groth-16 BLS12-381 curve

### DIFF
--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -88,6 +88,7 @@ type ProvingKey interface {
 // it's underlying implementation is strongly typed with the curve (see gnark/internal/backend)
 //
 // ExportSolidity is implemented for BN254 and will return an error with other curves
+// ExportNeoGo is implemented for BLS12-381 and will return an error with other curves
 type VerifyingKey interface {
 	groth16Object
 	gnarkio.UnsafeReaderFrom
@@ -104,6 +105,10 @@ type VerifyingKey interface {
 	// ExportSolidity writes a solidity Verifier contract from the VerifyingKey
 	// this will return an error if not supported on the CurveID()
 	ExportSolidity(w io.Writer) error
+
+	// ExportNeoGo writes a Go Verifier contract for Neo blockchain from the VerifyingKey
+	// this will return an error if not supported on the CurveID()
+	ExportNeoGo(w io.Writer) error
 
 	IsDifferent(interface{}) bool
 }

--- a/internal/backend/bls12-377/groth16/verify.go
+++ b/internal/backend/bls12-377/groth16/verify.go
@@ -19,13 +19,14 @@ package groth16
 import (
 	"errors"
 	"fmt"
+	"io"
+	"math/big"
+	"time"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark/logger"
-	"io"
-	"math/big"
-	"time"
 )
 
 var (
@@ -115,5 +116,10 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 // ExportSolidity not implemented for BLS12-377
 func (vk *VerifyingKey) ExportSolidity(w io.Writer) error {
+	return errors.New("not implemented")
+}
+
+// ExportNeoGo not implemented for BLS12-377
+func (vk *VerifyingKey) ExportNeoGo(w io.Writer) error {
 	return errors.New("not implemented")
 }

--- a/internal/backend/bls12-381/groth16/neogo.go
+++ b/internal/backend/bls12-381/groth16/neogo.go
@@ -1,0 +1,107 @@
+package groth16
+
+// neoGoTemplate is a Verifier smart contract template written in Go for Neo blockchain.
+// It contains a single `verifyProof` method that accepts a proof represented as three
+// BLS12-381 curve points and public witnesses required for verification
+// represented as a list of serialized 32-bytes field elements in the LE form.
+// The boolean result of `verifyProof` is either `true` (if the proof is
+// valid) or `false` (if the proof is invalid). The smart contract generated
+// from this template can be immediately compiled without any additional
+// changes using NeoGo compiler, deployed to the Neo chain and invoked. The
+// verification contract is circuit-specific, i.e. corresponds to a specific
+// single constraint system. Thus, every new circuit requires vew verification
+// contract to be generated and deployed to the chain.
+//
+// The contract template was not audited and is delivered "As Is" by the NeoGo developers.
+// Contract template source: https://github.com/nspcc-dev/neo-go/pull/3043 // TODO
+//
+// This is an experimental feature and gnark NeoGo generator as not been thoroughly tested.
+const neoGoTemplate = `// Package main contains verification smart contract that uses Neo BLS12-381
+// curves interoperability functionality to verify provided proof against provided
+// public witnesses using Groth-16 verification system. The contract contains a
+// single 'verifyProof'' method that accepts a proof represented as three BLS12-381
+// curve points and public witnesses required for verification represented as a
+// list of serialized 32-bytes field elements in the LE form. This contract is
+// circuit-specific and can not be used to verify other circuits.
+//
+// Use NeoGo smart contract compiler to compile this contract:
+// https://github.com/nspcc-dev/neo-go. You will need to create contract configuration
+// file and proper go.mod and go.sum files required for compilation. Please, refer
+// to the NeoGo ZKP example to see how to verify proves using this contract.
+package main
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/interop/native/crypto"
+	"github.com/nspcc-dev/neo-go/pkg/interop/util"
+)
+
+// A set of circuit-specific variables required for verification. Should be generated
+// using MPC process.
+var (
+	// G1 Affine point.
+	alpha = []byte{{ byteSliceToStr .G1.Alpha.Bytes }}
+	// G2 Affine point.
+	beta = []byte{{ byteSliceToStr .G2.Beta.Bytes }}
+	// G2 Affine point.
+	gamma = []byte{{ byteSliceToStr .G2.Gamma.Bytes }}
+	// G2 Affine point.
+	delta = []byte{{ byteSliceToStr .G2.Delta.Bytes }}
+	// A set of G1 Affine points.
+	ic = [][]byte{
+		{{- range $i := .G1.K }}
+		{{ byteSliceToStr $i.Bytes }},{{ end -}}
+	}
+)
+
+// VerifyProof verifies the given proof represented as three serialized compressed
+// BLS12-381 points against the public information represented as a list of
+// serialized 32-bytes field elements in the LE form. Verification process
+// follows the Groth-16 proving system and is taken from the
+// https://github.com/neo-project/neo/issues/2647#issuecomment-1002893109 without
+// any changes. Verification process checks the following equality:
+// A*B = alpha*beta + sum(pub_input[i]*(beta*u_i(x)+alpha*v_i(x)+w_i(x))/gamma)*gamma + C*delta
+func VerifyProof(a []byte, b []byte, c []byte, publicInput [][]byte) bool {
+	alphaPoint := crypto.Bls12381Deserialize(alpha)
+	betaPoint := crypto.Bls12381Deserialize(beta)
+	gammaPoint := crypto.Bls12381Deserialize(gamma)
+	deltaPoint := crypto.Bls12381Deserialize(delta)
+
+	aPoint := crypto.Bls12381Deserialize(a)
+	bPoint := crypto.Bls12381Deserialize(b)
+	cPoint := crypto.Bls12381Deserialize(c)
+
+	// Equation left1: A*B
+	lt := crypto.Bls12381Pairing(aPoint, bPoint)
+
+	// Equation right1: alpha*beta
+	rt1 := crypto.Bls12381Pairing(alphaPoint, betaPoint)
+
+	// Equation right2: sum(pub_input[i]*(beta*u_i(x)+alpha*v_i(x)+w_i(x))/gamma)*gamma
+	inputlen := len(publicInput)
+	iclen := len(ic)
+
+	if iclen != inputlen+1 {
+		panic("error: inputlen or iclen")
+	}
+	icPoints := make([]crypto.Bls12381Point, iclen)
+	for i := 0; i < iclen; i++ {
+		icPoints[i] = crypto.Bls12381Deserialize(ic[i])
+	}
+	acc := icPoints[0]
+	for i := 0; i < inputlen; i++ {
+		scalar := publicInput[i] // 32-bytes LE field element.
+		temp := crypto.Bls12381Mul(icPoints[i+1], scalar, false)
+		acc = crypto.Bls12381Add(acc, temp)
+	}
+	rt2 := crypto.Bls12381Pairing(acc, gammaPoint)
+
+	// Equation right3: C*delta
+	rt3 := crypto.Bls12381Pairing(cPoint, deltaPoint)
+
+	// Check equality.
+	t1 := crypto.Bls12381Add(rt1, rt2)
+	t2 := crypto.Bls12381Add(t1, rt3)
+
+	return util.Equals(lt, t2)
+}
+`

--- a/internal/backend/bls24-315/groth16/verify.go
+++ b/internal/backend/bls24-315/groth16/verify.go
@@ -19,13 +19,14 @@ package groth16
 import (
 	"errors"
 	"fmt"
+	"io"
+	"math/big"
+	"time"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-315"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark/logger"
-	"io"
-	"math/big"
-	"time"
 )
 
 var (
@@ -115,5 +116,10 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 // ExportSolidity not implemented for BLS24-315
 func (vk *VerifyingKey) ExportSolidity(w io.Writer) error {
+	return errors.New("not implemented")
+}
+
+// ExportNeoGo not implemented for BLS24-315
+func (vk *VerifyingKey) ExportNeoGo(w io.Writer) error {
 	return errors.New("not implemented")
 }

--- a/internal/backend/bls24-317/groth16/verify.go
+++ b/internal/backend/bls24-317/groth16/verify.go
@@ -19,13 +19,14 @@ package groth16
 import (
 	"errors"
 	"fmt"
+	"io"
+	"math/big"
+	"time"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-317"
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr"
 	"github.com/consensys/gnark/logger"
-	"io"
-	"math/big"
-	"time"
 )
 
 var (
@@ -115,5 +116,10 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 // ExportSolidity not implemented for BLS24-317
 func (vk *VerifyingKey) ExportSolidity(w io.Writer) error {
+	return errors.New("not implemented")
+}
+
+// ExportNeoGo not implemented for BLS24-317
+func (vk *VerifyingKey) ExportNeoGo(w io.Writer) error {
 	return errors.New("not implemented")
 }

--- a/internal/backend/bn254/groth16/verify.go
+++ b/internal/backend/bn254/groth16/verify.go
@@ -19,14 +19,15 @@ package groth16
 import (
 	"errors"
 	"fmt"
-	"github.com/consensys/gnark-crypto/ecc"
-	curve "github.com/consensys/gnark-crypto/ecc/bn254"
-	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
-	"github.com/consensys/gnark/logger"
 	"io"
 	"math/big"
 	"text/template"
 	"time"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	curve "github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/consensys/gnark/logger"
 )
 
 var (
@@ -134,4 +135,9 @@ func (vk *VerifyingKey) ExportSolidity(w io.Writer) error {
 
 	// execute template
 	return tmpl.Execute(w, vk)
+}
+
+// ExportNeoGo not implemented for BN254
+func (vk *VerifyingKey) ExportNeoGo(w io.Writer) error {
+	return errors.New("not implemented")
 }

--- a/internal/backend/bw6-633/groth16/verify.go
+++ b/internal/backend/bw6-633/groth16/verify.go
@@ -19,13 +19,14 @@ package groth16
 import (
 	"errors"
 	"fmt"
+	"io"
+	"math/big"
+	"time"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-633"
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr"
 	"github.com/consensys/gnark/logger"
-	"io"
-	"math/big"
-	"time"
 )
 
 var (
@@ -115,5 +116,10 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 // ExportSolidity not implemented for BW6-633
 func (vk *VerifyingKey) ExportSolidity(w io.Writer) error {
+	return errors.New("not implemented")
+}
+
+// ExportNeoGo not implemented for BW6-633
+func (vk *VerifyingKey) ExportNeoGo(w io.Writer) error {
 	return errors.New("not implemented")
 }

--- a/internal/backend/bw6-761/groth16/verify.go
+++ b/internal/backend/bw6-761/groth16/verify.go
@@ -19,13 +19,14 @@ package groth16
 import (
 	"errors"
 	"fmt"
+	"io"
+	"math/big"
+	"time"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-761"
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
 	"github.com/consensys/gnark/logger"
-	"io"
-	"math/big"
-	"time"
 )
 
 var (
@@ -115,5 +116,10 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector) error {
 
 // ExportSolidity not implemented for BW6-761
 func (vk *VerifyingKey) ExportSolidity(w io.Writer) error {
+	return errors.New("not implemented")
+}
+
+// ExportNeoGo not implemented for BW6-761
+func (vk *VerifyingKey) ExportNeoGo(w io.Writer) error {
 	return errors.New("not implemented")
 }


### PR DESCRIPTION
Hello, devs!

First of all, thank you for your amazing zk-SNARK packages! Currently [we](https://github.com/nspcc-dev/neo-go) are adapting them to create and verify Groth-16 BLS12-381 proofs on the [Neo blockchain](https://neo.org/).

#### PR motivation
We (as developers of Neo node implementation written in Go) are about to [add Groth-16 verification support for Neo smart contracts](https://github.com/nspcc-dev/neo-go/issues/2921) in the [upcoming 0.102.0 release](https://github.com/nspcc-dev/neo-go/milestone/66). We've successfully adapted your libraries to build an example circuit, generate proof for it and build/invoke Verifier Neo smart contract deployed to the Neo blockchain: https://github.com/nspcc-dev/neo-go/pull/3043/commits/5a19f81aff39486e2954a3b1fe95fa10c2045303. However, to create Verifier contract we have to retrieve paramters of `groth16.VerifyingKey` via its serialized representation (firstly use `vk.WriteTo(&buf)` and after that deserialise alpha, beta, gamma, delta and Kvks points from the resulted byte slice, take a look at the [lines](https://github.com/nspcc-dev/neo-go/pull/3043/commits/5a19f81aff39486e2954a3b1fe95fa10c2045303#diff-8cd55d7986f0824cccadfe87e1561c9a2b8590ec6bdbb30e7a60a2c94a05f45eR136-R142)). It's not very convenient, but at the same time we can't use `bls12-381`-specific `VerifyingKey` implementation and directly access these parameters since it's located under the `internal` subdirectory.

At the same time, I've noticed that exported `groth-16.VerifyingKey` interface has [`ExportSolidity` method](https://github.com/Consensys/gnark/blob/165b49ab88d69c97867a76e147e6fd41af138210/backend/groth16/groth16.go#L106) that is supported for BN254 and provides the ability to generate Solidity Verifier contract by `gnark` library itself.

It would be very helpful for Go smart contract developers of Neo ecosystem to have a similar `ExportToNeoGo` method which is defined for Groth-16 BLS12-381 curve and iss able to generate Go Verifier contract for Neo blockchain. It allows to reduce the number of steps needed to build Verifier contract for contract developers.

#### PR content
This PR contains a very initial implementation of `VerifyingKey.ExportToNeoGo` method that was successfully tested with end-to-end test (the idea of the test is same as for `ExportSolidity` test in https://github.com/Consensys/gnark-tests/blob/main/solidity/solidity_groth16_test.go). There's a large space for improvement in this PR, but if it's OK for you to add this API, then I'll finish it and fix all the review comments.

#### The question
Is there any chance that this new `VerifyingKey.ExportToNeoGo` API will be added to your library?

I'll appreciate any comments and opinions on this topic. Thank you for your time!