### PR TITLE
feat: staticcall fails -> revert immediately instead of updating state_success

### DIFF
--- a/backend/plonk/bn254/solidity.go
+++ b/backend/plonk/bn254/solidity.go
@@ -1108,9 +1108,8 @@ contract PlonkVerifier {
         }
       }
 
-      // // dst <- [s]src
+      // dst <- [s]src
       function point_mul(dst,src,s, mPtr) {
-        // let mPtr := add(mload(0x40), state_last_mem)
         let state := mload(0x40)
         mstore(mPtr,mload(src))
         mstore(add(mPtr,0x20),mload(add(src,0x20)))
@@ -1123,7 +1122,6 @@ contract PlonkVerifier {
 
       // dst <- [s]src
       function point_mul_calldata(dst, src, s, mPtr) {
-        // let mPtr := add(mload(0x40), state_last_mem)
         let state := mload(0x40)
         mstore(mPtr, calldataload(src))
         mstore(add(mPtr, 0x20), calldataload(add(src, 0x20)))

--- a/backend/plonk/bn254/solidity.go
+++ b/backend/plonk/bn254/solidity.go
@@ -204,6 +204,15 @@ contract PlonkVerifier {
       success := mload(add(mem, state_success))
 
       // Beginning errors -------------------------------------------------
+      function error_ec_op() {
+        let ptError := mload(0x40)
+        mstore(ptError, error_string_id) // selector for function Error(string)
+        mstore(add(ptError, 0x4), 0x20)
+        mstore(add(ptError, 0x24), 0x12)
+        mstore(add(ptError, 0x44), "error ec operation")
+        revert(ptError, 0x64)
+      }
+
       function error_inputs_size() {
         let ptError := mload(0x40)
         mstore(ptError, error_string_id) // selector for function Error(string)
@@ -1076,45 +1085,53 @@ contract PlonkVerifier {
 
       // BEGINNING utils math functions -------------------------------------------------
       function point_add(dst, p, q, mPtr) {
-        // let mPtr := add(mload(0x40), state_last_mem)
         let state := mload(0x40)
         mstore(mPtr, mload(p))
         mstore(add(mPtr, 0x20), mload(add(p, 0x20)))
         mstore(add(mPtr, 0x40), mload(q))
         mstore(add(mPtr, 0x60), mload(add(q, 0x20)))
         let l_success := staticcall(gas(),6,mPtr,0x80,dst,0x40)
-        mstore(add(state, state_success), and(l_success,mload(add(state, state_success))))
+        if iszero(l_success) {
+          error_ec_op()
+        }
       }
 
       function point_add_calldata(dst, p, q, mPtr) {
-        // let mPtr := add(mload(0x40), state_last_mem)
         let state := mload(0x40)
         mstore(mPtr, mload(p))
         mstore(add(mPtr, 0x20), mload(add(p, 0x20)))
         mstore(add(mPtr, 0x40), calldataload(q))
         mstore(add(mPtr, 0x60), calldataload(add(q, 0x20)))
         let l_success := staticcall(gas(), 6, mPtr, 0x80, dst, 0x40)
-        mstore(add(state, state_success), and(l_success, mload(add(state, state_success))))
+        if iszero(l_success) {
+          error_ec_op()
+        }
       }
 
-      // dst <- [s]src
+      // // dst <- [s]src
       function point_mul(dst,src,s, mPtr) {
+        // let mPtr := add(mload(0x40), state_last_mem)
         let state := mload(0x40)
         mstore(mPtr,mload(src))
         mstore(add(mPtr,0x20),mload(add(src,0x20)))
         mstore(add(mPtr,0x40),s)
         let l_success := staticcall(gas(),7,mPtr,0x60,dst,0x40)
-        mstore(add(state, state_success), and(l_success,mload(add(state, state_success))))
+        if iszero(l_success) {
+          error_ec_op()
+        }
       }
 
       // dst <- [s]src
       function point_mul_calldata(dst, src, s, mPtr) {
+        // let mPtr := add(mload(0x40), state_last_mem)
         let state := mload(0x40)
         mstore(mPtr, calldataload(src))
         mstore(add(mPtr, 0x20), calldataload(add(src, 0x20)))
         mstore(add(mPtr, 0x40), s)
         let l_success := staticcall(gas(), 7, mPtr, 0x60, dst, 0x40)
-        mstore(add(state, state_success), and(l_success, mload(add(state, state_success))))
+        if iszero(l_success) {
+          error_ec_op()
+        }
       }
 
       // dst <- dst + [s]src (Elliptic curve)
@@ -1127,7 +1144,9 @@ contract PlonkVerifier {
         mstore(add(mPtr,0x40),mload(dst))
         mstore(add(mPtr,0x60),mload(add(dst,0x20)))
         l_success := and(l_success, staticcall(gas(),6,mPtr,0x80,dst, 0x40))
-        mstore(add(state, state_success), and(l_success,mload(add(state, state_success))))
+        if iszero(l_success) {
+          error_ec_op()
+        }
       }
 
       // dst <- dst + [s]src (Elliptic curve)
@@ -1140,7 +1159,9 @@ contract PlonkVerifier {
         mstore(add(mPtr, 0x40), mload(dst))
         mstore(add(mPtr, 0x60), mload(add(dst, 0x20)))
         l_success := and(l_success, staticcall(gas(), 6, mPtr, 0x80, dst, 0x40))
-        mstore(add(state, state_success), and(l_success, mload(add(state, state_success))))
+        if iszero(l_success) {
+          error_ec_op()
+        }
       }
 
       // dst <- dst + src (Fr) dst,src are addresses, s is a value


### PR DESCRIPTION
In order to not waste gas in gas of a failure, the math functions (ec_add, ec_mul, etc) revert immediately in case of failure.

Until now we updated the variable stored at `add(mload(0x40), add(mload(0x40), state_success)` and continued the execution until the end even in case of failure.

Now at `state_success` we store only the result of the actual checks related to the proof, which are
* the verification of the constraints at a random point
* the KZG openings