### PR TITLE
Perf: save some negations in emulated pairings

### DIFF
--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -347,7 +347,6 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 		// So, 1/y is well defined for all points P's.
 		yInv[k] = pr.curveF.Inverse(&P[k].Y)
 		xNegOverY[k] = pr.curveF.MulMod(&P[k].X, yInv[k])
-		xNegOverY[k] = pr.curveF.MulMod(&P[k].X, yInv[k])
 		xNegOverY[k] = pr.curveF.Neg(xNegOverY[k])
 	}
 

--- a/std/algebra/native/sw_bls12377/pairing.go
+++ b/std/algebra/native/sw_bls12377/pairing.go
@@ -53,13 +53,14 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 	var l1, l2 lineEvaluation
 	Qacc := make([]G2Affine, n)
 	yInv := make([]frontend.Variable, n)
-	xOverY := make([]frontend.Variable, n)
+	xNegOverY := make([]frontend.Variable, n)
 	for k := 0; k < n; k++ {
 		Qacc[k] = Q[k]
 		// x=0x1ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000000
 		// TODO: point P=(x,0) should be ruled out
 		yInv[k] = api.DivUnchecked(1, P[k].Y)
-		xOverY[k] = api.Mul(P[k].X, yInv[k])
+		xNegOverY[k] = api.Mul(P[k].X, yInv[k])
+		xNegOverY[k] = api.Neg(xNegOverY[k])
 	}
 
 	// Compute ∏ᵢ { fᵢ_{x₀,Q}(P) }
@@ -70,7 +71,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 	// (assign line to res)
 	Qacc[0], l1 = doubleStep(api, &Qacc[0])
 	// line evaluation at P[0]
-	res.C1.B0.MulByFp(api, l1.R0, xOverY[0])
+	res.C1.B0.MulByFp(api, l1.R0, xNegOverY[0])
 	res.C1.B1.MulByFp(api, l1.R1, yInv[0])
 
 	if n >= 2 {
@@ -79,7 +80,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 		Qacc[1], l1 = doubleStep(api, &Qacc[1])
 
 		// line evaluation at P[1]
-		l1.R0.MulByFp(api, l1.R0, xOverY[1])
+		l1.R0.MulByFp(api, l1.R0, xNegOverY[1])
 		l1.R1.MulByFp(api, l1.R1, yInv[1])
 
 		// ℓ × res
@@ -98,7 +99,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 		Qacc[2], l1 = doubleStep(api, &Qacc[2])
 
 		// line evaluation at P[1]
-		l1.R0.MulByFp(api, l1.R0, xOverY[2])
+		l1.R0.MulByFp(api, l1.R0, xNegOverY[2])
 		l1.R1.MulByFp(api, l1.R1, yInv[2])
 
 		// ℓ × res
@@ -110,7 +111,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 			Qacc[k], l1 = doubleStep(api, &Qacc[k])
 
 			// line evaluation at P[k]
-			l1.R0.MulByFp(api, l1.R0, xOverY[k])
+			l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 			l1.R1.MulByFp(api, l1.R1, yInv[k])
 
 			// ℓ × res
@@ -123,7 +124,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 	// Qacc[0] ← 2Qacc[0] and l1 the tangent ℓ passing 2Qacc[0]
 	Qacc[0], l1 = doubleStep(api, &Qacc[0])
 	// line evaluation at P[0]
-	l1.R0.MulByFp(api, l1.R0, xOverY[0])
+	l1.R0.MulByFp(api, l1.R0, xNegOverY[0])
 	l1.R1.MulByFp(api, l1.R1, yInv[0])
 
 	if n == 1 {
@@ -148,7 +149,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 		Qacc[k], l1 = doubleStep(api, &Qacc[k])
 
 		// line evaluation at P[k]
-		l1.R0.MulByFp(api, l1.R0, xOverY[k])
+		l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 		l1.R1.MulByFp(api, l1.R1, yInv[k])
 
 		// ℓ × res
@@ -166,7 +167,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 				Qacc[k], l1 = doubleStep(api, &Qacc[k])
 
 				// line evaluation at P[k]
-				l1.R0.MulByFp(api, l1.R0, xOverY[k])
+				l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 				l1.R1.MulByFp(api, l1.R1, yInv[k])
 
 				// ℓ × res
@@ -182,9 +183,9 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 			Qacc[k], l1, l2 = doubleAndAddStep(api, &Qacc[k], &Q[k])
 
 			// lines evaluation at P[k]
-			l1.R0.MulByFp(api, l1.R0, xOverY[k])
+			l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 			l1.R1.MulByFp(api, l1.R1, yInv[k])
-			l2.R0.MulByFp(api, l2.R0, xOverY[k])
+			l2.R0.MulByFp(api, l2.R0, xNegOverY[k])
 			l2.R1.MulByFp(api, l2.R1, yInv[k])
 
 			// ℓ × ℓ
@@ -201,9 +202,9 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 		// l2 line through Qacc[k]+Q[k] and Qacc[k]
 		l1, l2 = linesCompute(api, &Qacc[k], &Q[k])
 
-		l1.R0.MulByFp(api, l1.R0, xOverY[k])
+		l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 		l1.R1.MulByFp(api, l1.R1, yInv[k])
-		l2.R0.MulByFp(api, l2.R0, xOverY[k])
+		l2.R0.MulByFp(api, l2.R0, xNegOverY[k])
 		l2.R1.MulByFp(api, l2.R1, yInv[k])
 
 		// ℓ × ℓ
@@ -293,7 +294,7 @@ func doubleAndAddStep(api frontend.API, p1, p2 *G2Affine) (G2Affine, lineEvaluat
 		// omit y3 computation
 
 		// compute line1
-	line1.R0.Neg(api, l1)
+	line1.R0 = l1
 	line1.R1.Mul(api, l1, p1.X).Sub(api, line1.R1, p1.Y)
 
 	// compute lambda2 = -lambda1-2*y1/(x3-x1)
@@ -316,7 +317,7 @@ func doubleAndAddStep(api frontend.API, p1, p2 *G2Affine) (G2Affine, lineEvaluat
 	p.Y = y4
 
 	// compute line2
-	line2.R0.Neg(api, l2)
+	line2.R0 = l2
 	line2.R1.Mul(api, l2, p1.X).Sub(api, line2.R1, p1.Y)
 
 	return p, line1, line2
@@ -348,7 +349,7 @@ func doubleStep(api frontend.API, p1 *G2Affine) (G2Affine, lineEvaluation) {
 	p.X = xr
 	p.Y = yr
 
-	line.R0.Neg(api, l)
+	line.R0 = l
 	line.R1.Mul(api, l, p1.X).Sub(api, line.R1, p1.Y)
 
 	return p, line
@@ -371,10 +372,9 @@ func linesCompute(api frontend.API, p1, p2 *G2Affine) (lineEvaluation, lineEvalu
 		Sub(api, x3, p1.X).
 		Sub(api, x3, p2.X)
 
-		// omit y3 computation
-
-		// compute line1
-	line1.R0.Neg(api, l1)
+	// omit y3 computation
+	// compute line1
+	line1.R0 = l1
 	line1.R1.Mul(api, l1, p1.X).Sub(api, line1.R1, p1.Y)
 
 	// compute lambda2 = -lambda1-2*y1/(x3-x1)
@@ -384,7 +384,7 @@ func linesCompute(api frontend.API, p1, p2 *G2Affine) (lineEvaluation, lineEvalu
 	l2.Add(api, l2, l1).Neg(api, l2)
 
 	// compute line2
-	line2.R0.Neg(api, l2)
+	line2.R0 = l2
 	line2.R1.Mul(api, l2, p1.X).Sub(api, line2.R1, p1.Y)
 
 	return line1, line2

--- a/std/algebra/native/sw_bls12377/pairing_test.go
+++ b/std/algebra/native/sw_bls12377/pairing_test.go
@@ -24,7 +24,6 @@ import (
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/std/algebra/native/fields_bls12377"
 	"github.com/consensys/gnark/test"
 )
@@ -196,23 +195,4 @@ func mustbeEq(api frontend.API, fp12 fields_bls12377.E12, e12 *bls12377.GT) {
 	api.AssertIsEqual(fp12.C1.B1.A1, e12.C1.B1.A1)
 	api.AssertIsEqual(fp12.C1.B2.A0, e12.C1.B2.A0)
 	api.AssertIsEqual(fp12.C1.B2.A1, e12.C1.B2.A1)
-}
-
-// bench
-func BenchmarkPairing(b *testing.B) {
-	var c pairingBLS377
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		ccsBench, _ = frontend.Compile(ecc.BW6_761.ScalarField(), r1cs.NewBuilder, &c)
-	}
-	b.Log("groth16", ccsBench.GetNbConstraints())
-}
-
-func BenchmarkTriplePairing(b *testing.B) {
-	var c triplePairingBLS377
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		ccsBench, _ = frontend.Compile(ecc.BW6_761.ScalarField(), r1cs.NewBuilder, &c)
-	}
-	b.Log("groth16", ccsBench.GetNbConstraints())
 }

--- a/std/algebra/native/sw_bls24315/pairing.go
+++ b/std/algebra/native/sw_bls24315/pairing.go
@@ -57,13 +57,14 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 	Qacc := make([]G2Affine, n)
 	Qneg := make([]G2Affine, n)
 	yInv := make([]frontend.Variable, n)
-	xOverY := make([]frontend.Variable, n)
+	xNegOverY := make([]frontend.Variable, n)
 	for k := 0; k < n; k++ {
 		Qacc[k] = Q[k]
 		Qneg[k].Neg(api, Q[k])
 		// TODO: point P=(x,O) should be ruled out
 		yInv[k] = api.DivUnchecked(1, P[k].Y)
-		xOverY[k] = api.Mul(P[k].X, yInv[k])
+		xNegOverY[k] = api.Mul(P[k].X, yInv[k])
+		xNegOverY[k] = api.Neg(xNegOverY[k])
 	}
 
 	// Compute ∏ᵢ { fᵢ_{x₀,Q}(P) }
@@ -73,7 +74,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 	// k = 0, separately to avoid MulBy034 (res × ℓ)
 	// (assign line to res)
 	Qacc[0], l1 = doubleStep(api, &Qacc[0])
-	res.D1.C0.MulByFp(api, l1.R0, xOverY[0])
+	res.D1.C0.MulByFp(api, l1.R0, xNegOverY[0])
 	res.D1.C1.MulByFp(api, l1.R1, yInv[0])
 
 	if n >= 2 {
@@ -82,7 +83,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 		Qacc[1], l1 = doubleStep(api, &Qacc[1])
 
 		// line evaluation at P[1]
-		l1.R0.MulByFp(api, l1.R0, xOverY[1])
+		l1.R0.MulByFp(api, l1.R0, xNegOverY[1])
 		l1.R1.MulByFp(api, l1.R1, yInv[1])
 
 		// ℓ × res
@@ -102,7 +103,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 			Qacc[k], l1 = doubleStep(api, &Qacc[k])
 
 			// line evaluation at P[k]
-			l1.R0.MulByFp(api, l1.R0, xOverY[k])
+			l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 			l1.R1.MulByFp(api, l1.R1, yInv[k])
 
 			// ℓ × res
@@ -124,7 +125,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 		l2 = lineCompute(api, &Qacc[k], &Qneg[k])
 
 		// line evaluation at P[k]
-		l2.R0.MulByFp(api, l2.R0, xOverY[k])
+		l2.R0.MulByFp(api, l2.R0, xNegOverY[k])
 		l2.R1.MulByFp(api, l2.R1, yInv[k])
 
 		// Qacc[k] ← Qacc[k]+Q[k] and
@@ -132,7 +133,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 		Qacc[k], l1 = addStep(api, &Qacc[k], &Q[k])
 
 		// line evaluation at P[k]
-		l1.R0.MulByFp(api, l1.R0, xOverY[k])
+		l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 		l1.R1.MulByFp(api, l1.R1, yInv[k])
 
 		// ℓ × res
@@ -153,7 +154,7 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 				Qacc[k], l1 = doubleStep(api, &Qacc[k])
 
 				// line evaluation at P[k]
-				l1.R0.MulByFp(api, l1.R0, xOverY[k])
+				l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 				l1.R1.MulByFp(api, l1.R1, yInv[k])
 
 				// ℓ × res
@@ -167,14 +168,14 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 				Qacc[k], l1, l2 = doubleAndAddStep(api, &Qacc[k], &Q[k])
 
 				// line evaluation at P[k]
-				l1.R0.MulByFp(api, l1.R0, xOverY[k])
+				l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 				l1.R1.MulByFp(api, l1.R1, yInv[k])
 
 				// ℓ × res
 				res.MulBy034(api, l1.R0, l1.R1)
 
 				// line evaluation at P[k]
-				l2.R0.MulByFp(api, l2.R0, xOverY[k])
+				l2.R0.MulByFp(api, l2.R0, xNegOverY[k])
 				l2.R1.MulByFp(api, l2.R1, yInv[k])
 
 				// ℓ × res
@@ -188,14 +189,14 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 				Qacc[k], l1, l2 = doubleAndAddStep(api, &Qacc[k], &Qneg[k])
 
 				// line evaluation at P[k]
-				l1.R0.MulByFp(api, l1.R0, xOverY[k])
+				l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 				l1.R1.MulByFp(api, l1.R1, yInv[k])
 
 				// ℓ × res
 				res.MulBy034(api, l1.R0, l1.R1)
 
 				// line evaluation at P[k]
-				l2.R0.MulByFp(api, l2.R0, xOverY[k])
+				l2.R0.MulByFp(api, l2.R0, xNegOverY[k])
 				l2.R1.MulByFp(api, l2.R1, yInv[k])
 
 				// ℓ × res
@@ -214,14 +215,14 @@ func MillerLoop(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 		l1, l2 = linesCompute(api, &Qacc[k], &Qneg[k])
 
 		// line evaluation at P[k]
-		l1.R0.MulByFp(api, l1.R0, xOverY[k])
+		l1.R0.MulByFp(api, l1.R0, xNegOverY[k])
 		l1.R1.MulByFp(api, l1.R1, yInv[k])
 
 		// ℓ × res
 		res.MulBy034(api, l1.R0, l1.R1)
 
 		// line evaluation at P[k]
-		l2.R0.MulByFp(api, l2.R0, xOverY[k])
+		l2.R0.MulByFp(api, l2.R0, xNegOverY[k])
 		l2.R1.MulByFp(api, l2.R1, yInv[k])
 
 		// ℓ × res
@@ -317,7 +318,7 @@ func doubleAndAddStep(api frontend.API, p1, p2 *G2Affine) (G2Affine, lineEvaluat
 		// omit y3 computation
 
 		// compute line1
-	line1.R0.Neg(api, l1)
+	line1.R0 = l1
 	line1.R1.Mul(api, l1, p1.X).Sub(api, line1.R1, p1.Y)
 
 	// compute lambda2 = -lambda1-2*y1/(x3-x1)
@@ -340,7 +341,7 @@ func doubleAndAddStep(api frontend.API, p1, p2 *G2Affine) (G2Affine, lineEvaluat
 	p.Y = y4
 
 	// compute line2
-	line2.R0.Neg(api, l2)
+	line2.R0 = l2
 	line2.R1.Mul(api, l2, p1.X).Sub(api, line2.R1, p1.Y)
 
 	return p, line1, line2
@@ -372,7 +373,7 @@ func doubleStep(api frontend.API, p1 *G2Affine) (G2Affine, lineEvaluation) {
 	p.X = xr
 	p.Y = yr
 
-	line.R0.Neg(api, l)
+	line.R0 = l
 	line.R1.Mul(api, l, p1.X).Sub(api, line.R1, p1.Y)
 
 	return p, line
@@ -404,7 +405,7 @@ func addStep(api frontend.API, p1, p2 *G2Affine) (G2Affine, lineEvaluation) {
 	res.Y = yr
 
 	var line lineEvaluation
-	line.R0.Neg(api, λ)
+	line.R0 = λ
 	line.R1.Mul(api, λ, p1.X)
 	line.R1.Sub(api, line.R1, p1.Y)
 
@@ -428,10 +429,9 @@ func linesCompute(api frontend.API, p1, p2 *G2Affine) (lineEvaluation, lineEvalu
 		Sub(api, x3, p1.X).
 		Sub(api, x3, p2.X)
 
-		// omit y3 computation
-
-		// compute line1
-	line1.R0.Neg(api, l1)
+	// omit y3 computation
+	// compute line1
+	line1.R0 = l1
 	line1.R1.Mul(api, l1, p1.X).Sub(api, line1.R1, p1.Y)
 
 	// compute lambda2 = -lambda1-2*y1/(x3-x1)
@@ -441,7 +441,7 @@ func linesCompute(api frontend.API, p1, p2 *G2Affine) (lineEvaluation, lineEvalu
 	l2.Add(api, l2, l1).Neg(api, l2)
 
 	// compute line2
-	line2.R0.Neg(api, l2)
+	line2.R0 = l2
 	line2.R1.Mul(api, l2, p1.X).Sub(api, line2.R1, p1.Y)
 
 	return line1, line2
@@ -458,7 +458,7 @@ func lineCompute(api frontend.API, p1, p2 *G2Affine) lineEvaluation {
 	λ.DivUnchecked(api, qypy, qxpx)
 
 	var line lineEvaluation
-	line.R0.Neg(api, λ)
+	line.R0 = λ
 	line.R1.Mul(api, λ, p1.X)
 	line.R1.Sub(api, line.R1, p1.Y)
 

--- a/std/algebra/native/sw_bls24315/pairing_test.go
+++ b/std/algebra/native/sw_bls24315/pairing_test.go
@@ -24,7 +24,6 @@ import (
 	bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315"
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/std/algebra/native/fields_bls24315"
 	"github.com/consensys/gnark/test"
 )
@@ -209,17 +208,4 @@ func mustbeEq(api frontend.API, fp24 fields_bls24315.E24, e24 *bls24315.GT) {
 	api.AssertIsEqual(fp24.D1.C2.B0.A1, e24.D1.C2.B0.A1)
 	api.AssertIsEqual(fp24.D1.C2.B1.A0, e24.D1.C2.B1.A0)
 	api.AssertIsEqual(fp24.D1.C2.B1.A1, e24.D1.C2.B1.A1)
-}
-
-// bench
-func BenchmarkPairing(b *testing.B) {
-	var c pairingBLS24315
-	ccsBench, _ = frontend.Compile(ecc.BW6_633.ScalarField(), r1cs.NewBuilder, &c)
-	b.Log("groth16", ccsBench.GetNbConstraints())
-}
-
-func BenchmarkTriplePairing(b *testing.B) {
-	var c triplePairingBLS24315
-	ccsBench, _ = frontend.Compile(ecc.BW6_633.ScalarField(), r1cs.NewBuilder, &c)
-	b.Log("groth16", ccsBench.GetNbConstraints())
 }


### PR DESCRIPTION
# Description

@feltroidprime pointed out this morning that pre-computing `-x/y` in emulated pairings would save lines negations at each double/add step in the Miller loop. While it shouldn't in native fields, the idea is interesting for emulated fields. I tried this for 2-chains and emulated BN254 and BLS12-381:
- For 2-chains it does not save anything for both Groth16 and Plonk, as expected.
- For emulated pairings however, the results are a bit weird because of how field emulation works (@ivokub any explanation?): 
  - For BLS12-381, it does not save anything in Groth16.
  - For BN254, we lose -385 constraints in Groth16.
 
However this PR is worth it for Plonk because the addition gates are not free. We save 5960 constraints for BLS12-381 and 2896 for BN254. I applied the changes to 2-chains as well, to homogenise the implementations in native and emulated packages.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce.

- [x] Test suite for native and emulated packages.

# How has this been benchmarked?

Benchmarks on fixed and variable input pairings of different sizes (1 to 10).

- [x] Benchmark, on Macbook air M1

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

