### PR TITLE
perf: a special case for mulacc

### DIFF
--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -55,28 +55,30 @@ func (builder *builder) Add(i1, i2 frontend.Variable, in ...frontend.Variable) f
 
 func (builder *builder) MulAcc(a, b, c frontend.Variable) frontend.Variable {
 
-	if a.(expr.Term).VID == b.(expr.Term).VID {
-		b, c = c, b
-	}
+	if aVar, ok := a.(expr.Term); ok {
+		if aVar.VID == b.(expr.Term).VID {
+			b, c = c, b
+		}
 
-	// special case for when a/c is constant
-	// let a = a' * α, b = b' * β, c = c' * α
-	// then a + b * c = a' * α + (b' * c') (β * α)
-	// thus qL = a', qR = 0, qM = b'c'
-	if a.(expr.Term).VID == c.(expr.Term).VID {
-		res := builder.newInternalVariable()
-		builder.addPlonkConstraint(sparseR1C{
-			xa:         a.(expr.Term).VID,
-			xb:         b.(expr.Term).VID,
-			xc:         res.VID,
-			qL:         a.(expr.Term).Coeff,
-			qR:         constraint.Element{},
-			qO:         builder.cs.Neg(builder.cs.One()),
-			qM:         builder.cs.Mul(b.(expr.Term).Coeff, c.(expr.Term).Coeff),
-			qC:         constraint.Element{},
-			commitment: 0,
-		})
-		return res
+		// special case for when a/c is constant
+		// let a = a' * α, b = b' * β, c = c' * α
+		// then a + b * c = a' * α + (b' * c') (β * α)
+		// thus qL = a', qR = 0, qM = b'c'
+		if aVar.VID == c.(expr.Term).VID {
+			res := builder.newInternalVariable()
+			builder.addPlonkConstraint(sparseR1C{
+				xa:         aVar.VID,
+				xb:         b.(expr.Term).VID,
+				xc:         res.VID,
+				qL:         aVar.Coeff,
+				qR:         constraint.Element{},
+				qO:         builder.cs.Neg(builder.cs.One()),
+				qM:         builder.cs.Mul(b.(expr.Term).Coeff, c.(expr.Term).Coeff),
+				qC:         constraint.Element{},
+				commitment: 0,
+			})
+			return res
+		}
 	}
 
 	// TODO can we do better here to limit allocations?

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -97,7 +97,7 @@ func (builder *builder) mulAccFastTrack(a, b, c frontend.Variable) frontend.Vari
 		xc:         res.VID,
 		qL:         aVar.Coeff,
 		qR:         constraint.Element{},
-		qO:         builder.cs.Neg(builder.cs.One()),
+		qO:         builder.tMinusOne,
 		qM:         builder.cs.Mul(bVar.Coeff, cVar.Coeff),
 		qC:         constraint.Element{},
 		commitment: 0,

--- a/frontend/cs/scs/api_test.go
+++ b/frontend/cs/scs/api_test.go
@@ -155,12 +155,12 @@ func TestExistDiv0(t *testing.T) {
 	_ = solution
 }
 
-type mulAccCircuit struct {
+type mulAccFastTrackCircuit struct {
 	A, B frontend.Variable
 	Res  frontend.Variable
 }
 
-func (c *mulAccCircuit) Define(api frontend.API) error {
+func (c *mulAccFastTrackCircuit) Define(api frontend.API) error {
 	r := api.MulAcc(api.Mul(c.A, 1), c.B, c.A)
 	api.AssertIsEqual(r, c.Res)
 	return nil
@@ -168,10 +168,10 @@ func (c *mulAccCircuit) Define(api frontend.API) error {
 
 func TestMulAccFastTrack(t *testing.T) {
 	assert := test.NewAssert(t)
-	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &mulAccCircuit{})
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &mulAccFastTrackCircuit{})
 	assert.NoError(err)
 	assert.Equal(2, ccs.GetNbConstraints())
-	w, err := frontend.NewWitness(&mulAccCircuit{
+	w, err := frontend.NewWitness(&mulAccFastTrackCircuit{
 		A: 11, B: 21,
 		Res: 242,
 	}, ecc.BN254.ScalarField())

--- a/frontend/cs/scs/api_test.go
+++ b/frontend/cs/scs/api_test.go
@@ -154,3 +154,29 @@ func TestExistDiv0(t *testing.T) {
 	assert.NoError(err)
 	_ = solution
 }
+
+type mulAccCircuit struct {
+	A, B frontend.Variable
+	Res  frontend.Variable
+}
+
+func (c *mulAccCircuit) Define(api frontend.API) error {
+	r := api.MulAcc(api.Mul(c.A, 1), c.B, c.A)
+	api.AssertIsEqual(r, c.Res)
+	return nil
+}
+
+func TestMulAccFastTrack(t *testing.T) {
+	assert := test.NewAssert(t)
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &mulAccCircuit{})
+	assert.NoError(err)
+	assert.Equal(2, ccs.GetNbConstraints())
+	w, err := frontend.NewWitness(&mulAccCircuit{
+		A: 11, B: 21,
+		Res: 242,
+	}, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	solution, err := ccs.Solve(w)
+	assert.NoError(err)
+	_ = solution
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Currently a `MulAcc` in Plonk always outputs two constraints. This PR saves one constraint for the special case of `a(b+1) = a + ab`.

## Type of change

<!-- Please delete options that are not relevant. -->

- Performance improvement

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- `TestMulAccFastTrack` in `frontend/cs/scs/api_test.go`

# How has this been benchmarked?

- The same test ensures that no more than one constraint is created.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

