### PR TITLE
chore: avoid nonnative dereferences

### DIFF
--- a/std/algebra/emulated/fields_bls12381/e12_pairing.go
+++ b/std/algebra/emulated/fields_bls12381/e12_pairing.go
@@ -80,8 +80,7 @@ func (e Ext12) ExptTorus(x *E6) *E6 {
 //	}
 func (e *Ext12) MulBy014(z *E12, c0, c1 *E2) *E12 {
 
-	a := z.C0
-	a = *e.MulBy01(&a, c0, c1)
+	a := e.MulBy01(&z.C0, c0, c1)
 
 	var b E6
 	// Mul by E6{0, 1, 0}
@@ -94,10 +93,10 @@ func (e *Ext12) MulBy014(z *E12, c0, c1 *E2) *E12 {
 
 	zC1 := e.Ext6.Add(&z.C1, &z.C0)
 	zC1 = e.Ext6.MulBy01(zC1, c0, d)
-	zC1 = e.Ext6.Sub(zC1, &a)
+	zC1 = e.Ext6.Sub(zC1, a)
 	zC1 = e.Ext6.Sub(zC1, &b)
 	zC0 := e.Ext6.MulByNonResidue(&b)
-	zC0 = e.Ext6.Add(zC0, &a)
+	zC0 = e.Ext6.Add(zC0, a)
 
 	return &E12{
 		C0: *zC0,
@@ -118,7 +117,7 @@ func (e *Ext12) MulBy014(z *E12, c0, c1 *E2) *E12 {
 //		C0: E6{B0: d0, B1: d1, B2: 0},
 //		C1: E6{B0: 0, B1: 1, B2: 0},
 //	}
-func (e Ext12) Mul014By014(d0, d1, c0, c1 *E2) *[5]E2 {
+func (e Ext12) Mul014By014(d0, d1, c0, c1 *E2) [5]*E2 {
 	one := e.Ext2.One()
 	x0 := e.Ext2.Mul(c0, d0)
 	x1 := e.Ext2.Mul(c1, d1)
@@ -141,7 +140,7 @@ func (e Ext12) Mul014By014(d0, d1, c0, c1 *E2) *[5]E2 {
 	zC0B0 := e.Ext2.NonResidue()
 	zC0B0 = e.Ext2.Add(zC0B0, x0)
 
-	return &[5]E2{*zC0B0, *x01, *x1, *x04, *x14}
+	return [5]*E2{zC0B0, x01, x1, x04, x14}
 }
 
 // MulBy01245 multiplies z by an E12 sparse element of the form
@@ -150,14 +149,14 @@ func (e Ext12) Mul014By014(d0, d1, c0, c1 *E2) *[5]E2 {
 //		C0: E6{B0: c0, B1: c1, B2: c2},
 //		C1: E6{B0: 0, B1: c4, B2: c5},
 //	}
-func (e *Ext12) MulBy01245(z *E12, x *[5]E2) *E12 {
-	c0 := &E6{B0: x[0], B1: x[1], B2: x[2]}
-	c1 := &E6{B0: *e.Ext2.Zero(), B1: x[3], B2: x[4]}
+func (e *Ext12) MulBy01245(z *E12, x [5]*E2) *E12 {
+	c0 := &E6{B0: *x[0], B1: *x[1], B2: *x[2]}
+	c1 := &E6{B0: *e.Ext2.Zero(), B1: *x[3], B2: *x[4]}
 	a := e.Ext6.Add(&z.C0, &z.C1)
 	b := e.Ext6.Add(c0, c1)
 	a = e.Ext6.Mul(a, b)
 	b = e.Ext6.Mul(&z.C0, c0)
-	c := e.Ext6.MulBy12(&z.C1, &x[3], &x[4])
+	c := e.Ext6.MulBy12(&z.C1, x[3], x[4])
 	z1 := e.Ext6.Sub(a, b)
 	z1 = e.Ext6.Sub(z1, c)
 	z0 := e.Ext6.MulByNonResidue(c)

--- a/std/algebra/emulated/fields_bn254/e12_pairing.go
+++ b/std/algebra/emulated/fields_bn254/e12_pairing.go
@@ -82,7 +82,7 @@ func (e *Ext12) Square034(x *E12) *E12 {
 		B2: *e.Ext2.Zero(),
 	}
 
-	c3 := E6{
+	c3 := &E6{
 		B0: x.C0.B0,
 		B1: *e.Ext2.Neg(&x.C1.B0),
 		B2: *e.Ext2.Neg(&x.C1.B1),
@@ -93,8 +93,8 @@ func (e *Ext12) Square034(x *E12) *E12 {
 		B1: x.C1.B1,
 		B2: *e.Ext2.Zero(),
 	}
-	c3 = *e.MulBy01(&c3, &c0.B0, &c0.B1)
-	c3 = *e.Ext6.Add(&c3, &c2)
+	c3 = e.MulBy01(c3, &c0.B0, &c0.B1)
+	c3 = e.Ext6.Add(c3, &c2)
 
 	var z E12
 	z.C1.B0 = *e.Ext2.Add(&c2.B0, &c2.B0)
@@ -116,16 +116,15 @@ func (e *Ext12) Square034(x *E12) *E12 {
 func (e *Ext12) MulBy034(z *E12, c3, c4 *E2) *E12 {
 
 	a := z.C0
-	b := z.C1
-	b = *e.MulBy01(&b, c3, c4)
+	b := e.MulBy01(&z.C1, c3, c4)
 	c3 = e.Ext2.Add(e.Ext2.One(), c3)
 	d := e.Ext6.Add(&z.C0, &z.C1)
 	d = e.MulBy01(d, c3, c4)
 
-	zC1 := e.Ext6.Add(&a, &b)
+	zC1 := e.Ext6.Add(&a, b)
 	zC1 = e.Ext6.Neg(zC1)
 	zC1 = e.Ext6.Add(zC1, d)
-	zC0 := e.Ext6.MulByNonResidue(&b)
+	zC0 := e.Ext6.MulByNonResidue(b)
 	zC0 = e.Ext6.Add(zC0, &a)
 
 	return &E12{
@@ -147,7 +146,7 @@ func (e *Ext12) MulBy034(z *E12, c3, c4 *E2) *E12 {
 //		C0: E6{B0: 1, B1: 0, B2: 0},
 //		C1: E6{B0: d3, B1: d4, B2: 0},
 //	}
-func (e *Ext12) Mul034By034(d3, d4, c3, c4 *E2) *[5]E2 {
+func (e *Ext12) Mul034By034(d3, d4, c3, c4 *E2) [5]*E2 {
 	x3 := e.Ext2.Mul(c3, d3)
 	x4 := e.Ext2.Mul(c4, d4)
 	x04 := e.Ext2.Add(c4, d4)
@@ -165,7 +164,7 @@ func (e *Ext12) Mul034By034(d3, d4, c3, c4 *E2) *[5]E2 {
 	zC1B0 := x03
 	zC1B1 := x04
 
-	return &[5]E2{*zC0B0, *zC0B1, *zC0B2, *zC1B0, *zC1B1}
+	return [5]*E2{zC0B0, zC0B1, zC0B2, zC1B0, zC1B1}
 }
 
 // MulBy01234 multiplies z by an E12 sparse element of the form
@@ -174,14 +173,14 @@ func (e *Ext12) Mul034By034(d3, d4, c3, c4 *E2) *[5]E2 {
 //		C0: E6{B0: c0, B1: c1, B2: c2},
 //		C1: E6{B0: c3, B1: c4, B2: 0},
 //	}
-func (e *Ext12) MulBy01234(z *E12, x *[5]E2) *E12 {
-	c0 := &E6{B0: x[0], B1: x[1], B2: x[2]}
-	c1 := &E6{B0: x[3], B1: x[4], B2: *e.Ext2.Zero()}
+func (e *Ext12) MulBy01234(z *E12, x [5]*E2) *E12 {
+	c0 := &E6{B0: *x[0], B1: *x[1], B2: *x[2]}
+	c1 := &E6{B0: *x[3], B1: *x[4], B2: *e.Ext2.Zero()}
 	a := e.Ext6.Add(&z.C0, &z.C1)
 	b := e.Ext6.Add(c0, c1)
 	a = e.Ext6.Mul(a, b)
 	b = e.Ext6.Mul(&z.C0, c0)
-	c := e.Ext6.MulBy01(&z.C1, &x[3], &x[4])
+	c := e.Ext6.MulBy01(&z.C1, x[3], x[4])
 	z1 := e.Ext6.Sub(a, b)
 	z1 = e.Ext6.Sub(z1, c)
 	z0 := e.Ext6.MulByNonResidue(c)
@@ -205,13 +204,13 @@ func (e *Ext12) MulBy01234(z *E12, x *[5]E2) *E12 {
 //		C0: E6{B0: 1, B1: 0, B2: 0},
 //		C1: E6{B0: z3, B1: z4, B2: 0},
 //	}
-func (e *Ext12) Mul01234By034(x *[5]E2, z3, z4 *E2) *E12 {
-	c0 := &E6{B0: x[0], B1: x[1], B2: x[2]}
-	c1 := &E6{B0: x[3], B1: x[4], B2: *e.Ext2.Zero()}
+func (e *Ext12) Mul01234By034(x [5]*E2, z3, z4 *E2) *E12 {
+	c0 := &E6{B0: *x[0], B1: *x[1], B2: *x[2]}
+	c1 := &E6{B0: *x[3], B1: *x[4], B2: *e.Ext2.Zero()}
 	a := e.Ext6.Add(e.Ext6.One(), &E6{B0: *z3, B1: *z4, B2: *e.Ext2.Zero()})
 	b := e.Ext6.Add(c0, c1)
 	a = e.Ext6.Mul(a, b)
-	c := e.Ext6.Mul01By01(z3, z4, &x[3], &x[4])
+	c := e.Ext6.Mul01By01(z3, z4, x[3], x[4])
 	z1 := e.Ext6.Sub(a, c0)
 	z1 = e.Ext6.Sub(z1, c)
 	z0 := e.Ext6.MulByNonResidue(c)
@@ -263,7 +262,11 @@ func (e Ext12) DecompressTorus(y *E6) *E12 {
 // N.B.: we use MulTorus in the final exponentiation throughout y1 ≠ -y2 always.
 func (e Ext12) MulTorus(y1, y2 *E6) *E6 {
 	n := e.Ext6.Mul(y1, y2)
-	n.B1 = *e.Ext2.Add(&n.B1, e.Ext2.One())
+	n = &E6{
+		B0: n.B0,
+		B1: *e.Ext2.Add(&n.B1, e.Ext2.One()),
+		B2: n.B2,
+	}
 	d := e.Ext6.Add(y1, y2)
 	y3 := e.Ext6.DivUnchecked(n, d)
 	return y3

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -151,7 +151,10 @@ func (pr Pairing) finalExponentiation(e *GTEl, unsafe bool) *GTEl {
 		// the case, the result is 1 in the torus. We assign a dummy value (1) to e.C1
 		// and proceed further.
 		selector1 = pr.Ext6.IsZero(&e.C1)
-		e.C1 = *pr.Ext6.Select(selector1, _dummy, &e.C1)
+		e = &fields_bn254.E12{
+			C0: e.C0,
+			C1: *pr.Ext6.Select(selector1, _dummy, &e.C1),
+		}
 	}
 
 	// Torus compression absorbed:
@@ -329,7 +332,7 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 	}
 
 	res := pr.Ext12.One()
-	var prodLines [5]fields_bn254.E2
+	var prodLines [5]*fields_bn254.E2
 
 	var l1, l2 *lineEvaluation
 	Qacc := make([]*G2Affine, n)
@@ -358,8 +361,14 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 	// (assign line to res)
 	Qacc[0], l1 = pr.doubleStep(Qacc[0])
 	// line evaluation at P[0]
-	res.C1.B0 = *pr.MulByElement(&l1.R0, xNegOverY[0])
-	res.C1.B1 = *pr.MulByElement(&l1.R1, yInv[0])
+	res = &fields_bn254.E12{
+		C0: res.C0,
+		C1: fields_bn254.E6{
+			B0: *pr.MulByElement(&l1.R0, xNegOverY[0]),
+			B1: *pr.MulByElement(&l1.R1, yInv[0]),
+			B2: res.C1.B2,
+		},
+	}
 
 	if n >= 2 {
 		// k = 1, separately to avoid MulBy034 (res × ℓ)
@@ -367,16 +376,25 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 		Qacc[1], l1 = pr.doubleStep(Qacc[1])
 
 		// line evaluation at P[1]
-		l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY[1])
-		l1.R1 = *pr.MulByElement(&l1.R1, yInv[1])
+		l1 = &lineEvaluation{
+			R0: *pr.MulByElement(&l1.R0, xNegOverY[1]),
+			R1: *pr.MulByElement(&l1.R1, yInv[1]),
+		}
 
 		// ℓ × res
-		prodLines = *pr.Mul034By034(&l1.R0, &l1.R1, &res.C1.B0, &res.C1.B1)
-		res.C0.B0 = prodLines[0]
-		res.C0.B1 = prodLines[1]
-		res.C0.B2 = prodLines[2]
-		res.C1.B0 = prodLines[3]
-		res.C1.B1 = prodLines[4]
+		prodLines = pr.Mul034By034(&l1.R0, &l1.R1, &res.C1.B0, &res.C1.B1)
+		res = &fields_bn254.E12{
+			C0: fields_bn254.E6{
+				B0: *prodLines[0],
+				B1: *prodLines[1],
+				B2: *prodLines[2],
+			},
+			C1: fields_bn254.E6{
+				B0: *prodLines[3],
+				B1: *prodLines[4],
+				B2: res.C1.B2,
+			},
+		}
 	}
 
 	if n >= 3 {
@@ -385,11 +403,13 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 		Qacc[2], l1 = pr.doubleStep(Qacc[2])
 
 		// line evaluation at P[1]
-		l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY[2])
-		l1.R1 = *pr.MulByElement(&l1.R1, yInv[2])
+		l1 = &lineEvaluation{
+			R0: *pr.MulByElement(&l1.R0, xNegOverY[2]),
+			R1: *pr.MulByElement(&l1.R1, yInv[2]),
+		}
 
 		// ℓ × res
-		res = pr.Mul01234By034(&prodLines, &l1.R0, &l1.R1)
+		res = pr.Mul01234By034(prodLines, &l1.R0, &l1.R1)
 
 		// k >= 3
 		for k := 3; k < n; k++ {
@@ -397,8 +417,10 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 			Qacc[k], l1 = pr.doubleStep(Qacc[k])
 
 			// line evaluation at P[k]
-			l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY[k])
-			l1.R1 = *pr.MulByElement(&l1.R1, yInv[k])
+			l1 = &lineEvaluation{
+				R0: *pr.MulByElement(&l1.R0, xNegOverY[k]),
+				R1: *pr.MulByElement(&l1.R1, yInv[k]),
+			}
 
 			// ℓ × res
 			res = pr.MulBy034(res, &l1.R0, &l1.R1)
@@ -420,21 +442,25 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 		l2 = pr.lineCompute(Qacc[k], QNeg[k])
 
 		// line evaluation at P[k]
-		l2.R0 = *pr.MulByElement(&l2.R0, xNegOverY[k])
-		l2.R1 = *pr.MulByElement(&l2.R1, yInv[k])
+		l2 = &lineEvaluation{
+			R0: *pr.MulByElement(&l2.R0, xNegOverY[k]),
+			R1: *pr.MulByElement(&l2.R1, yInv[k]),
+		}
 
 		// Qacc[k] ← Qacc[k]+Q[k] and
 		// l1 the line ℓ passing Qacc[k] and Q[k]
 		Qacc[k], l1 = pr.addStep(Qacc[k], Q[k])
 
 		// line evaluation at P[k]
-		l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY[k])
-		l1.R1 = *pr.MulByElement(&l1.R1, yInv[k])
+		l1 = &lineEvaluation{
+			R0: *pr.MulByElement(&l1.R0, xNegOverY[k]),
+			R1: *pr.MulByElement(&l1.R1, yInv[k]),
+		}
 
 		// ℓ × ℓ
-		prodLines = *pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
+		prodLines = pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
 		// (ℓ × ℓ) × res
-		res = pr.MulBy01234(res, &prodLines)
+		res = pr.MulBy01234(res, prodLines)
 	}
 
 	l1s := make([]*lineEvaluation, n)
@@ -452,8 +478,10 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 				Qacc[k], l1s[k] = pr.doubleStep(Qacc[k])
 
 				// line evaluation at P[k]
-				l1s[k].R0 = *pr.MulByElement(&l1s[k].R0, xNegOverY[k])
-				l1s[k].R1 = *pr.MulByElement(&l1s[k].R1, yInv[k])
+				l1s[k] = &lineEvaluation{
+					R0: *pr.MulByElement(&l1s[k].R0, xNegOverY[k]),
+					R1: *pr.MulByElement(&l1s[k].R1, yInv[k]),
+				}
 
 			}
 
@@ -468,9 +496,9 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 			// mul lines 2-by-2
 			for k := 1; k < n; k += 2 {
 				// ℓ × ℓ
-				prodLines = *pr.Mul034By034(&l1s[k].R0, &l1s[k].R1, &l1s[k-1].R0, &l1s[k-1].R1)
+				prodLines = pr.Mul034By034(&l1s[k].R0, &l1s[k].R1, &l1s[k-1].R0, &l1s[k-1].R1)
 				// (ℓ × ℓ) × res
-				res = pr.MulBy01234(res, &prodLines)
+				res = pr.MulBy01234(res, prodLines)
 
 			}
 
@@ -482,17 +510,21 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 				Qacc[k], l1, l2 = pr.doubleAndAddStep(Qacc[k], Q[k])
 
 				// line evaluation at P[k]
-				l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY[k])
-				l1.R1 = *pr.MulByElement(&l1.R1, yInv[k])
+				l1 = &lineEvaluation{
+					R0: *pr.MulByElement(&l1.R0, xNegOverY[k]),
+					R1: *pr.MulByElement(&l1.R1, yInv[k]),
+				}
 
 				// line evaluation at P[k]
-				l2.R0 = *pr.MulByElement(&l2.R0, xNegOverY[k])
-				l2.R1 = *pr.MulByElement(&l2.R1, yInv[k])
+				l2 = &lineEvaluation{
+					R0: *pr.MulByElement(&l2.R0, xNegOverY[k]),
+					R1: *pr.MulByElement(&l2.R1, yInv[k]),
+				}
 
 				// ℓ × ℓ
-				prodLines = *pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
+				prodLines = pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
 				// (ℓ × ℓ) × res
-				res = pr.MulBy01234(res, &prodLines)
+				res = pr.MulBy01234(res, prodLines)
 
 			}
 
@@ -504,17 +536,21 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 				Qacc[k], l1, l2 = pr.doubleAndAddStep(Qacc[k], QNeg[k])
 
 				// line evaluation at P[k]
-				l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY[k])
-				l1.R1 = *pr.MulByElement(&l1.R1, yInv[k])
+				l1 = &lineEvaluation{
+					R0: *pr.MulByElement(&l1.R0, xNegOverY[k]),
+					R1: *pr.MulByElement(&l1.R1, yInv[k]),
+				}
 
 				// line evaluation at P[k]
-				l2.R0 = *pr.MulByElement(&l2.R0, xNegOverY[k])
-				l2.R1 = *pr.MulByElement(&l2.R1, yInv[k])
+				l2 = &lineEvaluation{
+					R0: *pr.MulByElement(&l2.R0, xNegOverY[k]),
+					R1: *pr.MulByElement(&l2.R1, yInv[k]),
+				}
 
 				// ℓ × ℓ
-				prodLines = *pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
+				prodLines = pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
 				// (ℓ × ℓ) × res
-				res = pr.MulBy01234(res, &prodLines)
+				res = pr.MulBy01234(res, prodLines)
 
 			}
 
@@ -527,34 +563,46 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 	Q1, Q2 := new(G2Affine), new(G2Affine)
 	for k := 0; k < n; k++ {
 		//Q1 = π(Q)
-		Q1.X = *pr.Ext2.Conjugate(&Q[k].X)
-		Q1.X = *pr.Ext2.MulByNonResidue1Power2(&Q1.X)
-		Q1.Y = *pr.Ext2.Conjugate(&Q[k].Y)
-		Q1.Y = *pr.Ext2.MulByNonResidue1Power3(&Q1.Y)
+		Q1X := pr.Ext2.Conjugate(&Q[k].X)
+		Q1X = pr.Ext2.MulByNonResidue1Power2(Q1X)
+		Q1Y := pr.Ext2.Conjugate(&Q[k].Y)
+		Q1Y = pr.Ext2.MulByNonResidue1Power3(Q1Y)
+		Q1 = &G2Affine{
+			X: *Q1X,
+			Y: *Q1Y,
+		}
 
 		// Q2 = -π²(Q)
-		Q2.X = *pr.Ext2.MulByNonResidue2Power2(&Q[k].X)
-		Q2.Y = *pr.Ext2.MulByNonResidue2Power3(&Q[k].Y)
-		Q2.Y = *pr.Ext2.Neg(&Q2.Y)
+
+		Q2Y := pr.Ext2.MulByNonResidue2Power3(&Q[k].Y)
+		Q2Y = pr.Ext2.Neg(Q2Y)
+		Q2 = &G2Affine{
+			X: *pr.Ext2.MulByNonResidue2Power2(&Q[k].X),
+			Y: *Q2Y,
+		}
 
 		// Qacc[k] ← Qacc[k]+π(Q) and
 		// l1 the line passing Qacc[k] and π(Q)
 		Qacc[k], l1 = pr.addStep(Qacc[k], Q1)
 
 		// line evaluation at P[k]
-		l1.R0 = *pr.Ext2.MulByElement(&l1.R0, xNegOverY[k])
-		l1.R1 = *pr.Ext2.MulByElement(&l1.R1, yInv[k])
+		l1 = &lineEvaluation{
+			R0: *pr.Ext2.MulByElement(&l1.R0, xNegOverY[k]),
+			R1: *pr.Ext2.MulByElement(&l1.R1, yInv[k]),
+		}
 
 		// l2 the line passing Qacc[k] and -π²(Q)
 		l2 = pr.lineCompute(Qacc[k], Q2)
 		// line evaluation at P[k]
-		l2.R0 = *pr.MulByElement(&l2.R0, xNegOverY[k])
-		l2.R1 = *pr.MulByElement(&l2.R1, yInv[k])
+		l2 = &lineEvaluation{
+			R0: *pr.MulByElement(&l2.R0, xNegOverY[k]),
+			R1: *pr.MulByElement(&l2.R1, yInv[k]),
+		}
 
 		// ℓ × ℓ
-		prodLines = *pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
+		prodLines = pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
 		// (ℓ × ℓ) × res
-		res = pr.MulBy01234(res, &prodLines)
+		res = pr.MulBy01234(res, prodLines)
 
 	}
 
@@ -752,14 +800,14 @@ func (pr Pairing) MillerLoopFixedQ(P *G1Affine) (*GTEl, error) {
 	res = pr.Square034(res)
 	// lines evaluations at P
 	// and ℓ × ℓ
-	prodLines := *pr.Mul034By034(
+	prodLines := pr.Mul034By034(
 		pr.MulByElement(&pr.lines[0][63], xOverY),
 		pr.MulByElement(&pr.lines[1][63], yInv),
 		pr.MulByElement(&pr.lines[2][63], xOverY),
 		pr.MulByElement(&pr.lines[3][63], yInv),
 	)
 	// (ℓ × ℓ) × res
-	res = pr.MulBy01234(res, &prodLines)
+	res = pr.MulBy01234(res, prodLines)
 
 	for i := 62; i >= 0; i-- {
 		res = pr.Square(res)
@@ -775,14 +823,14 @@ func (pr Pairing) MillerLoopFixedQ(P *G1Affine) (*GTEl, error) {
 		} else {
 			// lines evaluations at P
 			// and ℓ × ℓ
-			prodLines := *pr.Mul034By034(
+			prodLines := pr.Mul034By034(
 				pr.MulByElement(&pr.lines[0][i], xOverY),
 				pr.MulByElement(&pr.lines[1][i], yInv),
 				pr.MulByElement(&pr.lines[2][i], xOverY),
 				pr.MulByElement(&pr.lines[3][i], yInv),
 			)
 			// (ℓ × ℓ) × res
-			res = pr.MulBy01234(res, &prodLines)
+			res = pr.MulBy01234(res, prodLines)
 
 		}
 	}
@@ -790,14 +838,14 @@ func (pr Pairing) MillerLoopFixedQ(P *G1Affine) (*GTEl, error) {
 	// Compute  ℓ_{[6x₀+2]Q,π(Q)}(P) · ℓ_{[6x₀+2]Q+π(Q),-π²(Q)}(P)
 	// lines evaluations at P
 	// and ℓ × ℓ
-	prodLines = *pr.Mul034By034(
+	prodLines = pr.Mul034By034(
 		pr.MulByElement(&pr.lines[0][65], xOverY),
 		pr.MulByElement(&pr.lines[1][65], yInv),
 		pr.MulByElement(&pr.lines[0][66], xOverY),
 		pr.MulByElement(&pr.lines[1][66], yInv),
 	)
 	// (ℓ × ℓ) × res
-	res = pr.MulBy01234(res, &prodLines)
+	res = pr.MulBy01234(res, prodLines)
 
 	return res, nil
 }
@@ -807,7 +855,7 @@ func (pr Pairing) MillerLoopFixedQ(P *G1Affine) (*GTEl, error) {
 func (pr Pairing) DoubleMillerLoopFixedQ(P, T *G1Affine, Q *G2Affine) (*GTEl, error) {
 	res := pr.Ext12.One()
 
-	var prodLines [5]fields_bn254.E2
+	var prodLines [5]*fields_bn254.E2
 	var l1, l2 *lineEvaluation
 	var Qacc, QNeg *G2Affine
 	Qacc = Q
@@ -827,18 +875,20 @@ func (pr Pairing) DoubleMillerLoopFixedQ(P, T *G1Affine, Q *G2Affine) (*GTEl, er
 	Qacc, l1 = pr.doubleStep(Qacc)
 
 	// line evaluation at P
-	l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY)
-	l1.R1 = *pr.MulByElement(&l1.R1, yInv)
+	l1 = &lineEvaluation{
+		R0: *pr.MulByElement(&l1.R0, xNegOverY),
+		R1: *pr.MulByElement(&l1.R1, yInv),
+	}
 
 	// precomputed-ℓ × ℓ
-	prodLines = *pr.Mul034By034(
+	prodLines = pr.Mul034By034(
 		&l1.R0,
 		&l1.R1,
 		pr.MulByElement(&pr.lines[0][64], x2OverY2),
 		pr.MulByElement(&pr.lines[1][64], y2Inv),
 	)
 	// (precomputed-ℓ × ℓ) × res
-	res = pr.MulBy01234(res, &prodLines)
+	res = pr.MulBy01234(res, prodLines)
 
 	// i = 63, separately to avoid a doubleStep
 	// (at this point Qacc = 2Q, so 2Qacc-Q=3Q is equivalent to Qacc+Q=3Q
@@ -848,31 +898,35 @@ func (pr Pairing) DoubleMillerLoopFixedQ(P, T *G1Affine, Q *G2Affine) (*GTEl, er
 	l2 = pr.lineCompute(Qacc, QNeg)
 
 	// line evaluation at P
-	l2.R0 = *pr.MulByElement(&l2.R0, xNegOverY)
-	l2.R1 = *pr.MulByElement(&l2.R1, yInv)
+	l2 = &lineEvaluation{
+		R0: *pr.MulByElement(&l2.R0, xNegOverY),
+		R1: *pr.MulByElement(&l2.R1, yInv),
+	}
 
 	// Qacc ← Qacc+Q and
 	// l1 the line ℓ passing Qacc and Q
 	Qacc, l1 = pr.addStep(Qacc, Q)
 
 	// line evaluation at P
-	l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY)
-	l1.R1 = *pr.MulByElement(&l1.R1, yInv)
+	l1 = &lineEvaluation{
+		R0: *pr.MulByElement(&l1.R0, xNegOverY),
+		R1: *pr.MulByElement(&l1.R1, yInv),
+	}
 
 	// ℓ × ℓ
-	prodLines = *pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
+	prodLines = pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
 	// (ℓ × ℓ) × res
-	res = pr.MulBy01234(res, &prodLines)
+	res = pr.MulBy01234(res, prodLines)
 
 	// precomputed-ℓ × precomputed-ℓ
-	prodLines = *pr.Mul034By034(
+	prodLines = pr.Mul034By034(
 		pr.MulByElement(&pr.lines[0][63], x2OverY2),
 		pr.MulByElement(&pr.lines[1][63], y2Inv),
 		pr.MulByElement(&pr.lines[2][63], x2OverY2),
 		pr.MulByElement(&pr.lines[3][63], y2Inv),
 	)
 	// (precomputed-ℓ × precomputed-ℓ) × res
-	res = pr.MulBy01234(res, &prodLines)
+	res = pr.MulBy01234(res, prodLines)
 
 	// Compute ∏ᵢ { fᵢ_{6x₀+2,Q}(P) }
 	for i := 62; i >= 0; i-- {
@@ -887,29 +941,31 @@ func (pr Pairing) DoubleMillerLoopFixedQ(P, T *G1Affine, Q *G2Affine) (*GTEl, er
 			Qacc, l1 = pr.doubleStep(Qacc)
 
 			// line evaluation at P
-			l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY)
-			l1.R1 = *pr.MulByElement(&l1.R1, yInv)
+			l1 = &lineEvaluation{
+				R0: *pr.MulByElement(&l1.R0, xNegOverY),
+				R1: *pr.MulByElement(&l1.R1, yInv),
+			}
 
 			// precomputed-ℓ × ℓ
-			prodLines = *pr.Mul034By034(
+			prodLines = pr.Mul034By034(
 				&l1.R0,
 				&l1.R1,
 				pr.MulByElement(&pr.lines[0][i], x2OverY2),
 				pr.MulByElement(&pr.lines[1][i], y2Inv),
 			)
 			// (precomputed-ℓ × ℓ) × res
-			res = pr.MulBy01234(res, &prodLines)
+			res = pr.MulBy01234(res, prodLines)
 
 		case 1:
 			// precomputed-ℓ × precomputed-ℓ
-			prodLines = *pr.Mul034By034(
+			prodLines = pr.Mul034By034(
 				pr.MulByElement(&pr.lines[0][i], x2OverY2),
 				pr.MulByElement(&pr.lines[1][i], y2Inv),
 				pr.MulByElement(&pr.lines[2][i], x2OverY2),
 				pr.MulByElement(&pr.lines[3][i], y2Inv),
 			)
 			// (precomputed-ℓ × precomputed-ℓ) × res
-			res = pr.MulBy01234(res, &prodLines)
+			res = pr.MulBy01234(res, prodLines)
 
 			// Qacc ← 2Qacc+Q,
 			// l1 the line ℓ passing Qacc and Q
@@ -917,28 +973,32 @@ func (pr Pairing) DoubleMillerLoopFixedQ(P, T *G1Affine, Q *G2Affine) (*GTEl, er
 			Qacc, l1, l2 = pr.doubleAndAddStep(Qacc, Q)
 
 			// line evaluation at P
-			l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY)
-			l1.R1 = *pr.MulByElement(&l1.R1, yInv)
+			l1 = &lineEvaluation{
+				R0: *pr.MulByElement(&l1.R0, xNegOverY),
+				R1: *pr.MulByElement(&l1.R1, yInv),
+			}
 
 			// line evaluation at P
-			l2.R0 = *pr.MulByElement(&l2.R0, xNegOverY)
-			l2.R1 = *pr.MulByElement(&l2.R1, yInv)
+			l2 = &lineEvaluation{
+				R0: *pr.MulByElement(&l2.R0, xNegOverY),
+				R1: *pr.MulByElement(&l2.R1, yInv),
+			}
 
 			// ℓ × ℓ
-			prodLines = *pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
+			prodLines = pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
 			// (ℓ × ℓ) × res
-			res = pr.MulBy01234(res, &prodLines)
+			res = pr.MulBy01234(res, prodLines)
 
 		case -1:
 			// precomputed-ℓ × precomputed-ℓ
-			prodLines = *pr.Mul034By034(
+			prodLines = pr.Mul034By034(
 				pr.MulByElement(&pr.lines[0][i], x2OverY2),
 				pr.MulByElement(&pr.lines[1][i], y2Inv),
 				pr.MulByElement(&pr.lines[2][i], x2OverY2),
 				pr.MulByElement(&pr.lines[3][i], y2Inv),
 			)
 			// (precomputed-ℓ × precomputed-ℓ) × res
-			res = pr.MulBy01234(res, &prodLines)
+			res = pr.MulBy01234(res, prodLines)
 
 			// Qacc ← 2Qacc-Q,
 			// l1 the line ℓ passing Qacc and -Q
@@ -946,17 +1006,21 @@ func (pr Pairing) DoubleMillerLoopFixedQ(P, T *G1Affine, Q *G2Affine) (*GTEl, er
 			Qacc, l1, l2 = pr.doubleAndAddStep(Qacc, QNeg)
 
 			// line evaluation at P
-			l1.R0 = *pr.MulByElement(&l1.R0, xNegOverY)
-			l1.R1 = *pr.MulByElement(&l1.R1, yInv)
+			l1 = &lineEvaluation{
+				R0: *pr.MulByElement(&l1.R0, xNegOverY),
+				R1: *pr.MulByElement(&l1.R1, yInv),
+			}
 
 			// line evaluation at P
-			l2.R0 = *pr.MulByElement(&l2.R0, xNegOverY)
-			l2.R1 = *pr.MulByElement(&l2.R1, yInv)
+			l2 = &lineEvaluation{
+				R0: *pr.MulByElement(&l2.R0, xNegOverY),
+				R1: *pr.MulByElement(&l2.R1, yInv),
+			}
 
 			// ℓ × ℓ
-			prodLines = *pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
+			prodLines = pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
 			// (ℓ × ℓ) × res
-			res = pr.MulBy01234(res, &prodLines)
+			res = pr.MulBy01234(res, prodLines)
 
 		default:
 			return nil, errors.New("invalid loopCounter")
@@ -966,44 +1030,52 @@ func (pr Pairing) DoubleMillerLoopFixedQ(P, T *G1Affine, Q *G2Affine) (*GTEl, er
 	// Compute  ∏ᵢ { ℓᵢ_{[6x₀+2]Q,π(Q)}(P) · ℓᵢ_{[6x₀+2]Q+π(Q),-π²(Q)}(P) }
 	Q1, Q2 := new(G2Affine), new(G2Affine)
 	//Q1 = π(Q)
-	Q1.X = *pr.Ext2.Conjugate(&Q.X)
-	Q1.X = *pr.Ext2.MulByNonResidue1Power2(&Q1.X)
-	Q1.Y = *pr.Ext2.Conjugate(&Q.Y)
-	Q1.Y = *pr.Ext2.MulByNonResidue1Power3(&Q1.Y)
+	Q1X := pr.Ext2.Conjugate(&Q.X)
+	Q1Y := pr.Ext2.Conjugate(&Q.Y)
+	Q1 = &G2Affine{
+		X: *pr.Ext2.MulByNonResidue1Power2(Q1X),
+		Y: *pr.Ext2.MulByNonResidue1Power3(Q1Y),
+	}
 
 	// Q2 = -π²(Q)
-	Q2.X = *pr.Ext2.MulByNonResidue2Power2(&Q.X)
-	Q2.Y = *pr.Ext2.MulByNonResidue2Power3(&Q.Y)
-	Q2.Y = *pr.Ext2.Neg(&Q2.Y)
+	Q2Y := pr.Ext2.MulByNonResidue2Power3(&Q.Y)
+	Q2 = &G2Affine{
+		X: *pr.Ext2.MulByNonResidue2Power2(&Q.X),
+		Y: *pr.Ext2.Neg(Q2Y),
+	}
 
 	// Qacc ← Qacc+π(Q) and
 	// l1 the line passing Qacc and π(Q)
 	Qacc, l1 = pr.addStep(Qacc, Q1)
 
 	// line evaluation at P
-	l1.R0 = *pr.Ext2.MulByElement(&l1.R0, xNegOverY)
-	l1.R1 = *pr.Ext2.MulByElement(&l1.R1, yInv)
+	l1 = &lineEvaluation{
+		R0: *pr.Ext2.MulByElement(&l1.R0, xNegOverY),
+		R1: *pr.Ext2.MulByElement(&l1.R1, yInv),
+	}
 
 	// l2 the line passing Qacc and -π²(Q)
 	l2 = pr.lineCompute(Qacc, Q2)
 	// line evaluation at P
-	l2.R0 = *pr.MulByElement(&l2.R0, xNegOverY)
-	l2.R1 = *pr.MulByElement(&l2.R1, yInv)
+	l2 = &lineEvaluation{
+		R0: *pr.MulByElement(&l2.R0, xNegOverY),
+		R1: *pr.MulByElement(&l2.R1, yInv),
+	}
 
 	// ℓ × ℓ
-	prodLines = *pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
+	prodLines = pr.Mul034By034(&l1.R0, &l1.R1, &l2.R0, &l2.R1)
 	// (ℓ × ℓ) × res
-	res = pr.MulBy01234(res, &prodLines)
+	res = pr.MulBy01234(res, prodLines)
 
 	// precomputed-ℓ × precomputed-ℓ
-	prodLines = *pr.Mul034By034(
+	prodLines = pr.Mul034By034(
 		pr.MulByElement(&pr.lines[0][65], x2OverY2),
 		pr.MulByElement(&pr.lines[1][65], y2Inv),
 		pr.MulByElement(&pr.lines[0][66], x2OverY2),
 		pr.MulByElement(&pr.lines[1][66], y2Inv),
 	)
 	// (precomputed-ℓ × precomputed-ℓ) × res
-	res = pr.MulBy01234(res, &prodLines)
+	res = pr.MulBy01234(res, prodLines)
 
 	return res, nil
 }

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -560,7 +560,7 @@ func (pr Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 	}
 
 	// Compute  ∏ᵢ { ℓᵢ_{[6x₀+2]Q,π(Q)}(P) · ℓᵢ_{[6x₀+2]Q+π(Q),-π²(Q)}(P) }
-	Q1, Q2 := new(G2Affine), new(G2Affine)
+	var Q1, Q2 *G2Affine
 	for k := 0; k < n; k++ {
 		//Q1 = π(Q)
 		Q1X := pr.Ext2.Conjugate(&Q[k].X)
@@ -1028,7 +1028,7 @@ func (pr Pairing) DoubleMillerLoopFixedQ(P, T *G1Affine, Q *G2Affine) (*GTEl, er
 	}
 
 	// Compute  ∏ᵢ { ℓᵢ_{[6x₀+2]Q,π(Q)}(P) · ℓᵢ_{[6x₀+2]Q+π(Q),-π²(Q)}(P) }
-	Q1, Q2 := new(G2Affine), new(G2Affine)
+	var Q1, Q2 *G2Affine
 	//Q1 = π(Q)
 	Q1X := pr.Ext2.Conjugate(&Q.X)
 	Q1Y := pr.Ext2.Conjugate(&Q.Y)


### PR DESCRIPTION
# Description

With the upcoming pr #749 it is necessary that we do not change the limb values of `emulated.Element` values. Mostly the API is designed in a way that this doesn't happen (we pass in and out pointers and do not perform in-place modifications), but there are a few cases in nonnative algebra where the API is overridden. This is mostly due to that for structs containing nonnative elements we need to use the value instead of pointer to count the number of field elements to allocate and have initialized values.

For example, if we have definition like:
```go
type G1Affine struct {
    X, Y emulated.Element[emparams.BN254Fp]
}
```
and we compute
```go
var P G1Affine
P = curve.Add(c.G, c.Q)
P.X = *emulated.Add(&p.X, other)
```
then we modify the value `P.X`. Now, as the multiplication checks are deferred for amortizing some computations, we get a failed check.

This PR changes such occurrences, making #749 more streamlined. Similar changes are already incorporated in #846.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] Rebased #749 on top and all tests are working.

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

Not benchmarked, circuit stats are the same are the same.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

