### PR TITLE
Feat/plonk dummy setup

### DIFF
--- a/backend/plonk/bls12-377/setup.go
+++ b/backend/plonk/bls12-377/setup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/consensys/gnark/backend/plonk/internal"
 	"github.com/consensys/gnark/constraint"
 	cs "github.com/consensys/gnark/constraint/bls12-377"
+	"math/big"
 )
 
 // VerifyingKey stores the data needed to verify a proof:
@@ -106,8 +107,7 @@ type ProvingKey struct {
 	Domain [2]fft.Domain
 }
 
-// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
-func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+func setupCommon(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
 
 	var pk ProvingKey
 	var vk VerifyingKey
@@ -130,11 +130,6 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 		return nil, nil, errors.New("kzg srs is too small")
 	}
 	pk.Kzg.G1 = kzgSrs.Pk.G1[:int(vk.Size)+3]
-	var err error
-	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
-	if err != nil {
-		return nil, nil, err
-	}
 	vk.Kzg = kzgSrs.Vk
 
 	// step 2: ql, qr, qm, qo, qk, qcp in Lagrange Basis
@@ -149,15 +144,45 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	pk.trace.S2 = s[1]
 	pk.trace.S3 = s[2]
 
+	return &pk, &vk, nil
+}
+
+// Sets the toxic waste to a 4-th root of one
+func DummySetup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
+	pk.KzgLagrange.G1 = pk.Kzg.G1
+	if err = commitTraceDummySetup(&pk.trace, pk); err != nil {
+		return nil, nil, err
+	}
+
+	return pk, vk, nil
+}
+
+// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
+func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
 	// step 4: commit to s1, s2, s3, ql, qr, qm, qo, and (the incomplete version of) qk.
 	// All the above polynomials are expressed in canonical basis afterwards. This is why
 	// we save lqk before, because the prover needs to complete it in Lagrange form, and
 	// then express it on the Lagrange coset basis.
-	if err = commitTrace(&pk.trace, &pk); err != nil {
+	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
+	if err != nil {
+		return nil, nil, err
+	}
+	vk.Kzg = kzgSrs.Vk
+	if err = commitTrace(&pk.trace, pk); err != nil {
 		return nil, nil, err
 	}
 
-	return &pk, &vk, nil
+	return pk, vk, nil
 }
 
 // NbPublicWitness returns the expected public witness size (number of field elements)
@@ -222,6 +247,69 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		}
 		pt.Qcp[i] = iop.NewPolynomial(&qcp[i], lagReg)
 	}
+}
+
+// commitTrace commits to every polynomial in the trace, and put
+// the commitments int the verifying key.
+func commitTraceDummySetup(trace *Trace, pk *ProvingKey) error {
+
+	trace.Ql.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qr.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qm.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qo.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qk.ToCanonical(&pk.Domain[0]).ToRegular() // -> qk is not complete
+	trace.S1.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S2.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S3.ToCanonical(&pk.Domain[0]).ToRegular()
+
+	var err error
+	tau, err := fr.Generator(4)
+	if err != nil {
+		return err
+	}
+
+	var eval fr.Element
+	var bEval big.Int
+	pk.Vk.Qcp = make([]kzg.Digest, len(trace.Qcp))
+	for i := range trace.Qcp {
+		trace.Qcp[i].ToCanonical(&pk.Domain[0]).ToRegular()
+		eval = trace.Qcp[i].Evaluate(tau)
+		eval.BigInt(&bEval)
+		pk.Vk.Qcp[i].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+	}
+	eval = pk.trace.Ql.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Ql.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qr.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qr.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qm.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qm.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qo.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qo.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qk.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qk.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S1.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[0].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S2.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[1].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S3.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[2].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	return nil
 }
 
 // commitTrace commits to every polynomial in the trace, and put

--- a/backend/plonk/bls12-381/setup.go
+++ b/backend/plonk/bls12-381/setup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/consensys/gnark/backend/plonk/internal"
 	"github.com/consensys/gnark/constraint"
 	cs "github.com/consensys/gnark/constraint/bls12-381"
+	"math/big"
 )
 
 // VerifyingKey stores the data needed to verify a proof:
@@ -106,8 +107,7 @@ type ProvingKey struct {
 	Domain [2]fft.Domain
 }
 
-// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
-func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+func setupCommon(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
 
 	var pk ProvingKey
 	var vk VerifyingKey
@@ -130,11 +130,6 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 		return nil, nil, errors.New("kzg srs is too small")
 	}
 	pk.Kzg.G1 = kzgSrs.Pk.G1[:int(vk.Size)+3]
-	var err error
-	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
-	if err != nil {
-		return nil, nil, err
-	}
 	vk.Kzg = kzgSrs.Vk
 
 	// step 2: ql, qr, qm, qo, qk, qcp in Lagrange Basis
@@ -149,15 +144,45 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	pk.trace.S2 = s[1]
 	pk.trace.S3 = s[2]
 
+	return &pk, &vk, nil
+}
+
+// Sets the toxic waste to a 4-th root of one
+func DummySetup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
+	pk.KzgLagrange.G1 = pk.Kzg.G1
+	if err = commitTraceDummySetup(&pk.trace, pk); err != nil {
+		return nil, nil, err
+	}
+
+	return pk, vk, nil
+}
+
+// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
+func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
 	// step 4: commit to s1, s2, s3, ql, qr, qm, qo, and (the incomplete version of) qk.
 	// All the above polynomials are expressed in canonical basis afterwards. This is why
 	// we save lqk before, because the prover needs to complete it in Lagrange form, and
 	// then express it on the Lagrange coset basis.
-	if err = commitTrace(&pk.trace, &pk); err != nil {
+	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
+	if err != nil {
+		return nil, nil, err
+	}
+	vk.Kzg = kzgSrs.Vk
+	if err = commitTrace(&pk.trace, pk); err != nil {
 		return nil, nil, err
 	}
 
-	return &pk, &vk, nil
+	return pk, vk, nil
 }
 
 // NbPublicWitness returns the expected public witness size (number of field elements)
@@ -222,6 +247,69 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		}
 		pt.Qcp[i] = iop.NewPolynomial(&qcp[i], lagReg)
 	}
+}
+
+// commitTrace commits to every polynomial in the trace, and put
+// the commitments int the verifying key.
+func commitTraceDummySetup(trace *Trace, pk *ProvingKey) error {
+
+	trace.Ql.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qr.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qm.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qo.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qk.ToCanonical(&pk.Domain[0]).ToRegular() // -> qk is not complete
+	trace.S1.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S2.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S3.ToCanonical(&pk.Domain[0]).ToRegular()
+
+	var err error
+	tau, err := fr.Generator(4)
+	if err != nil {
+		return err
+	}
+
+	var eval fr.Element
+	var bEval big.Int
+	pk.Vk.Qcp = make([]kzg.Digest, len(trace.Qcp))
+	for i := range trace.Qcp {
+		trace.Qcp[i].ToCanonical(&pk.Domain[0]).ToRegular()
+		eval = trace.Qcp[i].Evaluate(tau)
+		eval.BigInt(&bEval)
+		pk.Vk.Qcp[i].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+	}
+	eval = pk.trace.Ql.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Ql.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qr.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qr.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qm.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qm.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qo.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qo.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qk.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qk.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S1.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[0].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S2.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[1].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S3.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[2].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	return nil
 }
 
 // commitTrace commits to every polynomial in the trace, and put

--- a/backend/plonk/bls24-315/setup.go
+++ b/backend/plonk/bls24-315/setup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/consensys/gnark/backend/plonk/internal"
 	"github.com/consensys/gnark/constraint"
 	cs "github.com/consensys/gnark/constraint/bls24-315"
+	"math/big"
 )
 
 // VerifyingKey stores the data needed to verify a proof:
@@ -106,8 +107,7 @@ type ProvingKey struct {
 	Domain [2]fft.Domain
 }
 
-// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
-func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+func setupCommon(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
 
 	var pk ProvingKey
 	var vk VerifyingKey
@@ -130,11 +130,6 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 		return nil, nil, errors.New("kzg srs is too small")
 	}
 	pk.Kzg.G1 = kzgSrs.Pk.G1[:int(vk.Size)+3]
-	var err error
-	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
-	if err != nil {
-		return nil, nil, err
-	}
 	vk.Kzg = kzgSrs.Vk
 
 	// step 2: ql, qr, qm, qo, qk, qcp in Lagrange Basis
@@ -149,15 +144,45 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	pk.trace.S2 = s[1]
 	pk.trace.S3 = s[2]
 
+	return &pk, &vk, nil
+}
+
+// Sets the toxic waste to a 4-th root of one
+func DummySetup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
+	pk.KzgLagrange.G1 = pk.Kzg.G1
+	if err = commitTraceDummySetup(&pk.trace, pk); err != nil {
+		return nil, nil, err
+	}
+
+	return pk, vk, nil
+}
+
+// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
+func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
 	// step 4: commit to s1, s2, s3, ql, qr, qm, qo, and (the incomplete version of) qk.
 	// All the above polynomials are expressed in canonical basis afterwards. This is why
 	// we save lqk before, because the prover needs to complete it in Lagrange form, and
 	// then express it on the Lagrange coset basis.
-	if err = commitTrace(&pk.trace, &pk); err != nil {
+	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
+	if err != nil {
+		return nil, nil, err
+	}
+	vk.Kzg = kzgSrs.Vk
+	if err = commitTrace(&pk.trace, pk); err != nil {
 		return nil, nil, err
 	}
 
-	return &pk, &vk, nil
+	return pk, vk, nil
 }
 
 // NbPublicWitness returns the expected public witness size (number of field elements)
@@ -222,6 +247,69 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		}
 		pt.Qcp[i] = iop.NewPolynomial(&qcp[i], lagReg)
 	}
+}
+
+// commitTrace commits to every polynomial in the trace, and put
+// the commitments int the verifying key.
+func commitTraceDummySetup(trace *Trace, pk *ProvingKey) error {
+
+	trace.Ql.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qr.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qm.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qo.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qk.ToCanonical(&pk.Domain[0]).ToRegular() // -> qk is not complete
+	trace.S1.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S2.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S3.ToCanonical(&pk.Domain[0]).ToRegular()
+
+	var err error
+	tau, err := fr.Generator(4)
+	if err != nil {
+		return err
+	}
+
+	var eval fr.Element
+	var bEval big.Int
+	pk.Vk.Qcp = make([]kzg.Digest, len(trace.Qcp))
+	for i := range trace.Qcp {
+		trace.Qcp[i].ToCanonical(&pk.Domain[0]).ToRegular()
+		eval = trace.Qcp[i].Evaluate(tau)
+		eval.BigInt(&bEval)
+		pk.Vk.Qcp[i].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+	}
+	eval = pk.trace.Ql.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Ql.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qr.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qr.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qm.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qm.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qo.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qo.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qk.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qk.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S1.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[0].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S2.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[1].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S3.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[2].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	return nil
 }
 
 // commitTrace commits to every polynomial in the trace, and put

--- a/backend/plonk/bls24-317/setup.go
+++ b/backend/plonk/bls24-317/setup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/consensys/gnark/backend/plonk/internal"
 	"github.com/consensys/gnark/constraint"
 	cs "github.com/consensys/gnark/constraint/bls24-317"
+	"math/big"
 )
 
 // VerifyingKey stores the data needed to verify a proof:
@@ -106,8 +107,7 @@ type ProvingKey struct {
 	Domain [2]fft.Domain
 }
 
-// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
-func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+func setupCommon(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
 
 	var pk ProvingKey
 	var vk VerifyingKey
@@ -130,11 +130,6 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 		return nil, nil, errors.New("kzg srs is too small")
 	}
 	pk.Kzg.G1 = kzgSrs.Pk.G1[:int(vk.Size)+3]
-	var err error
-	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
-	if err != nil {
-		return nil, nil, err
-	}
 	vk.Kzg = kzgSrs.Vk
 
 	// step 2: ql, qr, qm, qo, qk, qcp in Lagrange Basis
@@ -149,15 +144,45 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	pk.trace.S2 = s[1]
 	pk.trace.S3 = s[2]
 
+	return &pk, &vk, nil
+}
+
+// Sets the toxic waste to a 4-th root of one
+func DummySetup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
+	pk.KzgLagrange.G1 = pk.Kzg.G1
+	if err = commitTraceDummySetup(&pk.trace, pk); err != nil {
+		return nil, nil, err
+	}
+
+	return pk, vk, nil
+}
+
+// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
+func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
 	// step 4: commit to s1, s2, s3, ql, qr, qm, qo, and (the incomplete version of) qk.
 	// All the above polynomials are expressed in canonical basis afterwards. This is why
 	// we save lqk before, because the prover needs to complete it in Lagrange form, and
 	// then express it on the Lagrange coset basis.
-	if err = commitTrace(&pk.trace, &pk); err != nil {
+	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
+	if err != nil {
+		return nil, nil, err
+	}
+	vk.Kzg = kzgSrs.Vk
+	if err = commitTrace(&pk.trace, pk); err != nil {
 		return nil, nil, err
 	}
 
-	return &pk, &vk, nil
+	return pk, vk, nil
 }
 
 // NbPublicWitness returns the expected public witness size (number of field elements)
@@ -222,6 +247,69 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		}
 		pt.Qcp[i] = iop.NewPolynomial(&qcp[i], lagReg)
 	}
+}
+
+// commitTrace commits to every polynomial in the trace, and put
+// the commitments int the verifying key.
+func commitTraceDummySetup(trace *Trace, pk *ProvingKey) error {
+
+	trace.Ql.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qr.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qm.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qo.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qk.ToCanonical(&pk.Domain[0]).ToRegular() // -> qk is not complete
+	trace.S1.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S2.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S3.ToCanonical(&pk.Domain[0]).ToRegular()
+
+	var err error
+	tau, err := fr.Generator(4)
+	if err != nil {
+		return err
+	}
+
+	var eval fr.Element
+	var bEval big.Int
+	pk.Vk.Qcp = make([]kzg.Digest, len(trace.Qcp))
+	for i := range trace.Qcp {
+		trace.Qcp[i].ToCanonical(&pk.Domain[0]).ToRegular()
+		eval = trace.Qcp[i].Evaluate(tau)
+		eval.BigInt(&bEval)
+		pk.Vk.Qcp[i].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+	}
+	eval = pk.trace.Ql.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Ql.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qr.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qr.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qm.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qm.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qo.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qo.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qk.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qk.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S1.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[0].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S2.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[1].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S3.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[2].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	return nil
 }
 
 // commitTrace commits to every polynomial in the trace, and put

--- a/backend/plonk/bn254/setup.go
+++ b/backend/plonk/bn254/setup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/consensys/gnark/backend/plonk/internal"
 	"github.com/consensys/gnark/constraint"
 	cs "github.com/consensys/gnark/constraint/bn254"
+	"math/big"
 )
 
 // VerifyingKey stores the data needed to verify a proof:
@@ -106,8 +107,7 @@ type ProvingKey struct {
 	Domain [2]fft.Domain
 }
 
-// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
-func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+func setupCommon(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
 
 	var pk ProvingKey
 	var vk VerifyingKey
@@ -130,11 +130,6 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 		return nil, nil, errors.New("kzg srs is too small")
 	}
 	pk.Kzg.G1 = kzgSrs.Pk.G1[:int(vk.Size)+3]
-	var err error
-	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
-	if err != nil {
-		return nil, nil, err
-	}
 	vk.Kzg = kzgSrs.Vk
 
 	// step 2: ql, qr, qm, qo, qk, qcp in Lagrange Basis
@@ -149,15 +144,45 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	pk.trace.S2 = s[1]
 	pk.trace.S3 = s[2]
 
+	return &pk, &vk, nil
+}
+
+// Sets the toxic waste to a 4-th root of one
+func DummySetup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
+	pk.KzgLagrange.G1 = pk.Kzg.G1
+	if err = commitTraceDummySetup(&pk.trace, pk); err != nil {
+		return nil, nil, err
+	}
+
+	return pk, vk, nil
+}
+
+// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
+func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
 	// step 4: commit to s1, s2, s3, ql, qr, qm, qo, and (the incomplete version of) qk.
 	// All the above polynomials are expressed in canonical basis afterwards. This is why
 	// we save lqk before, because the prover needs to complete it in Lagrange form, and
 	// then express it on the Lagrange coset basis.
-	if err = commitTrace(&pk.trace, &pk); err != nil {
+	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
+	if err != nil {
+		return nil, nil, err
+	}
+	vk.Kzg = kzgSrs.Vk
+	if err = commitTrace(&pk.trace, pk); err != nil {
 		return nil, nil, err
 	}
 
-	return &pk, &vk, nil
+	return pk, vk, nil
 }
 
 // NbPublicWitness returns the expected public witness size (number of field elements)
@@ -222,6 +247,69 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		}
 		pt.Qcp[i] = iop.NewPolynomial(&qcp[i], lagReg)
 	}
+}
+
+// commitTrace commits to every polynomial in the trace, and put
+// the commitments int the verifying key.
+func commitTraceDummySetup(trace *Trace, pk *ProvingKey) error {
+
+	trace.Ql.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qr.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qm.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qo.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qk.ToCanonical(&pk.Domain[0]).ToRegular() // -> qk is not complete
+	trace.S1.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S2.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S3.ToCanonical(&pk.Domain[0]).ToRegular()
+
+	var err error
+	tau, err := fr.Generator(4)
+	if err != nil {
+		return err
+	}
+
+	var eval fr.Element
+	var bEval big.Int
+	pk.Vk.Qcp = make([]kzg.Digest, len(trace.Qcp))
+	for i := range trace.Qcp {
+		trace.Qcp[i].ToCanonical(&pk.Domain[0]).ToRegular()
+		eval = trace.Qcp[i].Evaluate(tau)
+		eval.BigInt(&bEval)
+		pk.Vk.Qcp[i].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+	}
+	eval = pk.trace.Ql.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Ql.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qr.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qr.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qm.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qm.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qo.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qo.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qk.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qk.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S1.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[0].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S2.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[1].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S3.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[2].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	return nil
 }
 
 // commitTrace commits to every polynomial in the trace, and put

--- a/backend/plonk/bw6-633/setup.go
+++ b/backend/plonk/bw6-633/setup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/consensys/gnark/backend/plonk/internal"
 	"github.com/consensys/gnark/constraint"
 	cs "github.com/consensys/gnark/constraint/bw6-633"
+	"math/big"
 )
 
 // VerifyingKey stores the data needed to verify a proof:
@@ -106,8 +107,7 @@ type ProvingKey struct {
 	Domain [2]fft.Domain
 }
 
-// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
-func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+func setupCommon(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
 
 	var pk ProvingKey
 	var vk VerifyingKey
@@ -130,11 +130,6 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 		return nil, nil, errors.New("kzg srs is too small")
 	}
 	pk.Kzg.G1 = kzgSrs.Pk.G1[:int(vk.Size)+3]
-	var err error
-	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
-	if err != nil {
-		return nil, nil, err
-	}
 	vk.Kzg = kzgSrs.Vk
 
 	// step 2: ql, qr, qm, qo, qk, qcp in Lagrange Basis
@@ -149,15 +144,45 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	pk.trace.S2 = s[1]
 	pk.trace.S3 = s[2]
 
+	return &pk, &vk, nil
+}
+
+// Sets the toxic waste to a 4-th root of one
+func DummySetup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
+	pk.KzgLagrange.G1 = pk.Kzg.G1
+	if err = commitTraceDummySetup(&pk.trace, pk); err != nil {
+		return nil, nil, err
+	}
+
+	return pk, vk, nil
+}
+
+// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
+func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
 	// step 4: commit to s1, s2, s3, ql, qr, qm, qo, and (the incomplete version of) qk.
 	// All the above polynomials are expressed in canonical basis afterwards. This is why
 	// we save lqk before, because the prover needs to complete it in Lagrange form, and
 	// then express it on the Lagrange coset basis.
-	if err = commitTrace(&pk.trace, &pk); err != nil {
+	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
+	if err != nil {
+		return nil, nil, err
+	}
+	vk.Kzg = kzgSrs.Vk
+	if err = commitTrace(&pk.trace, pk); err != nil {
 		return nil, nil, err
 	}
 
-	return &pk, &vk, nil
+	return pk, vk, nil
 }
 
 // NbPublicWitness returns the expected public witness size (number of field elements)
@@ -222,6 +247,69 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		}
 		pt.Qcp[i] = iop.NewPolynomial(&qcp[i], lagReg)
 	}
+}
+
+// commitTrace commits to every polynomial in the trace, and put
+// the commitments int the verifying key.
+func commitTraceDummySetup(trace *Trace, pk *ProvingKey) error {
+
+	trace.Ql.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qr.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qm.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qo.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qk.ToCanonical(&pk.Domain[0]).ToRegular() // -> qk is not complete
+	trace.S1.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S2.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S3.ToCanonical(&pk.Domain[0]).ToRegular()
+
+	var err error
+	tau, err := fr.Generator(4)
+	if err != nil {
+		return err
+	}
+
+	var eval fr.Element
+	var bEval big.Int
+	pk.Vk.Qcp = make([]kzg.Digest, len(trace.Qcp))
+	for i := range trace.Qcp {
+		trace.Qcp[i].ToCanonical(&pk.Domain[0]).ToRegular()
+		eval = trace.Qcp[i].Evaluate(tau)
+		eval.BigInt(&bEval)
+		pk.Vk.Qcp[i].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+	}
+	eval = pk.trace.Ql.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Ql.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qr.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qr.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qm.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qm.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qo.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qo.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qk.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qk.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S1.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[0].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S2.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[1].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S3.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[2].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	return nil
 }
 
 // commitTrace commits to every polynomial in the trace, and put

--- a/backend/plonk/plonk.go
+++ b/backend/plonk/plonk.go
@@ -119,6 +119,31 @@ func Setup(ccs constraint.ConstraintSystem, kzgSrs kzg.SRS) (ProvingKey, Verifyi
 
 }
 
+// Setup prepares the public data associated to a circuit + public inputs.
+// The SRS is
+func DummySetup(ccs constraint.ConstraintSystem, kzgSrs kzg.SRS) (ProvingKey, VerifyingKey, error) {
+
+	switch tccs := ccs.(type) {
+	case *cs_bn254.SparseR1CS:
+		return plonk_bn254.DummySetup(tccs, *kzgSrs.(*kzg_bn254.SRS))
+	case *cs_bls12381.SparseR1CS:
+		return plonk_bls12381.DummySetup(tccs, *kzgSrs.(*kzg_bls12381.SRS))
+	case *cs_bls12377.SparseR1CS:
+		return plonk_bls12377.DummySetup(tccs, *kzgSrs.(*kzg_bls12377.SRS))
+	case *cs_bw6761.SparseR1CS:
+		return plonk_bw6761.DummySetup(tccs, *kzgSrs.(*kzg_bw6761.SRS))
+	case *cs_bls24317.SparseR1CS:
+		return plonk_bls24317.DummySetup(tccs, *kzgSrs.(*kzg_bls24317.SRS))
+	case *cs_bls24315.SparseR1CS:
+		return plonk_bls24315.DummySetup(tccs, *kzgSrs.(*kzg_bls24315.SRS))
+	case *cs_bw6633.SparseR1CS:
+		return plonk_bw6633.DummySetup(tccs, *kzgSrs.(*kzg_bw6633.SRS))
+	default:
+		panic("unrecognized SparseR1CS curve type")
+	}
+
+}
+
 // Prove generates PLONK proof from a circuit, associated preprocessed public data, and the witness
 // if the force flag is set:
 //

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.8.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/bavard v0.1.13
-	github.com/consensys/gnark-crypto v0.12.2-0.20231012161402-206544105834
+	github.com/consensys/gnark-crypto v0.12.2-0.20231013081401-76478b0c722b
 	github.com/fxamacker/cbor/v2 v2.5.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/consensys/gnark-crypto v0.12.2-0.20231011163455-248eba3f4df7 h1:WY7/e
 github.com/consensys/gnark-crypto v0.12.2-0.20231011163455-248eba3f4df7/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
 github.com/consensys/gnark-crypto v0.12.2-0.20231012161402-206544105834 h1:o+Q1/PSZfNkoUAl/Gf5N/u+H6LkOzR3gF0mS8nRSWYM=
 github.com/consensys/gnark-crypto v0.12.2-0.20231012161402-206544105834/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
+github.com/consensys/gnark-crypto v0.12.2-0.20231013081401-76478b0c722b h1:cdwSQo/czoaRqSq6U2TkKxBv2MOHUCUq/MIWYQYnWpY=
+github.com/consensys/gnark-crypto v0.12.2-0.20231013081401-76478b0c722b/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.setup.go.tmpl
@@ -5,10 +5,11 @@ import (
 	{{- template "import_fft" . }}
 	{{- template "import_backend_cs" . }}
 	"fmt"
+	"math/big"
 	"github.com/consensys/gnark-crypto/ecc/{{toLower .Curve}}/fr/iop"
 	"github.com/consensys/gnark-crypto/ecc"
-	"github.com/consensys/gnark/backend/plonk/internal"
 	"github.com/consensys/gnark/constraint"
+	"github.com/consensys/gnark/backend/plonk/internal"
 )
 
 // VerifyingKey stores the data needed to verify a proof:
@@ -88,8 +89,7 @@ type ProvingKey struct {
 	Domain [2]fft.Domain
 }
 
-// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
-func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+func setupCommon(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
 
 	var pk ProvingKey
 	var vk VerifyingKey
@@ -108,15 +108,10 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	vk.SizeInv.SetUint64(vk.Size).Inverse(&vk.SizeInv)
 	vk.Generator.Set(&pk.Domain[0].Generator)
 	vk.NbPublicVariables = uint64(len(spr.Public))
-	if len(kzgSrs.Pk.G1) < int(vk.Size) +3 { // + 3 for the kzg.Open of blinded poly
+	if len(kzgSrs.Pk.G1) < int(vk.Size)+3 { // + 3 for the kzg.Open of blinded poly
 		return nil, nil, errors.New("kzg srs is too small")
 	}
 	pk.Kzg.G1 = kzgSrs.Pk.G1[:int(vk.Size)+3]
-	var err error
-	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
-	if err != nil {
-		return nil, nil, err
-	}
 	vk.Kzg = kzgSrs.Vk
 
 	// step 2: ql, qr, qm, qo, qk, qcp in Lagrange Basis
@@ -131,15 +126,45 @@ func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, erro
 	pk.trace.S2 = s[1]
 	pk.trace.S3 = s[2]
 
+	return &pk, &vk, nil
+}
+
+// Sets the toxic waste to a 4-th root of one
+func DummySetup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
+	pk.KzgLagrange.G1 = pk.Kzg.G1
+	if err = commitTraceDummySetup(&pk.trace, pk); err != nil {
+		return nil, nil, err
+	}
+
+	return pk, vk, nil
+}
+
+// TODO modify the signature to receive the SRS in Lagrange form (optional argument ?)
+func Setup(spr *cs.SparseR1CS, kzgSrs kzg.SRS) (*ProvingKey, *VerifyingKey, error) {
+
+	pk, vk, err := setupCommon(spr, kzgSrs)
+	if err != nil {
+		return pk, vk, err
+	}
 	// step 4: commit to s1, s2, s3, ql, qr, qm, qo, and (the incomplete version of) qk.
 	// All the above polynomials are expressed in canonical basis afterwards. This is why
 	// we save lqk before, because the prover needs to complete it in Lagrange form, and
 	// then express it on the Lagrange coset basis.
-	if err = commitTrace(&pk.trace, &pk); err != nil {
+	pk.KzgLagrange.G1, err = kzg.ToLagrangeG1(kzgSrs.Pk.G1[:int(vk.Size)])
+	if err != nil {
+		return nil, nil, err
+	}
+	vk.Kzg = kzgSrs.Vk
+	if err = commitTrace(&pk.trace, pk); err != nil {
 		return nil, nil, err
 	}
 
-	return &pk, &vk, nil
+	return pk, vk, nil
 }
 
 // NbPublicWitness returns the expected public witness size (number of field elements)
@@ -204,6 +229,69 @@ func BuildTrace(spr *cs.SparseR1CS, pt *Trace) {
 		}
 		pt.Qcp[i] = iop.NewPolynomial(&qcp[i], lagReg)
 	}
+}
+
+// commitTrace commits to every polynomial in the trace, and put
+// the commitments int the verifying key.
+func commitTraceDummySetup(trace *Trace, pk *ProvingKey) error {
+
+	trace.Ql.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qr.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qm.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qo.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.Qk.ToCanonical(&pk.Domain[0]).ToRegular() // -> qk is not complete
+	trace.S1.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S2.ToCanonical(&pk.Domain[0]).ToRegular()
+	trace.S3.ToCanonical(&pk.Domain[0]).ToRegular()
+
+	var err error
+	tau, err := fr.Generator(4)
+	if err != nil {
+		return err
+	}
+
+	var eval fr.Element
+	var bEval big.Int
+	pk.Vk.Qcp = make([]kzg.Digest, len(trace.Qcp))
+	for i := range trace.Qcp {
+		trace.Qcp[i].ToCanonical(&pk.Domain[0]).ToRegular()
+		eval = trace.Qcp[i].Evaluate(tau)
+		eval.BigInt(&bEval)
+		pk.Vk.Qcp[i].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+	}
+	eval = pk.trace.Ql.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Ql.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qr.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qr.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qm.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qm.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qo.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qo.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.Qk.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.Qk.ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S1.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[0].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S2.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[1].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	eval = pk.trace.S3.Evaluate(tau)
+	eval.BigInt(&bEval)
+	pk.Vk.S[2].ScalarMultiplication(&pk.Kzg.G1[0], &bEval)
+
+	return nil
 }
 
 // commitTrace commits to every polynomial in the trace, and put

--- a/test/kzg_srs.go
+++ b/test/kzg_srs.go
@@ -57,14 +57,14 @@ func NewKZGSRS(ccs constraint.ConstraintSystem) (kzg.SRS, error) {
 	return newKZGSRS(utils.FieldToCurve(ccs.Field()), kzgSize, alpha)
 }
 
-// NewDummyKZGSRS generates an SRS with τ = 1 for fast generation
+// NewDummyKZGSRS generates an SRS with τ = -1 for fast generation
 //
 // /!\ method to call for benchmarking only
 func NewDummyKZGSRS(ccs constraint.ConstraintSystem) (kzg.SRS, error) {
 
 	kzgSize := getSizeSRS(ccs)
 
-	return newKZGSRS(utils.FieldToCurve(ccs.Field()), kzgSize, big.NewInt(1))
+	return newKZGSRS(utils.FieldToCurve(ccs.Field()), kzgSize, big.NewInt(-1))
 }
 
 func getSizeSRS(ccs constraint.ConstraintSystem) uint64 {


### PR DESCRIPTION
# Description

Addition of `NewDummyKZGSRS` method to generate quickly a valid KZG SRS.

Fixes #856 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been benchmarked?

Only the commitments and the SRS are dummy here, the polynomials are the same as with the real setup to not tamper the benchmarks (for instance if some polynomials are sparse)

Dummy setup:
```
goos: darwin
goarch: amd64
pkg: github.com/consensys/gnark/backend/plonk
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkSetup/dummy_setup/bn254-12   	              19	  57782215 ns/op
BenchmarkSetup/dummy_setup/bls12_377-12         	      18	  58763740 ns/op
BenchmarkSetup/dummy_setup/bls12_381-12         	      20	  56002303 ns/op
BenchmarkSetup/dummy_setup/bw6_761-12           	      12	 101444790 ns/op
BenchmarkSetup/dummy_setup/bls24_315-12               19	  57350197 ns/op
BenchmarkSetup/dummy_setup/bw6_633-12                 14	  77773802 ns/op
BenchmarkSetup/dummy_setup/bls24_317-12         	      20	  56390946 ns/op
```

Real Setup
```
goos: darwin
goarch: amd64
pkg: github.com/consensys/gnark/backend/plonk
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkSetup/real_setup/bn254-12              	       1	6282835391 ns/op
BenchmarkSetup/real_setup/bls12_377-12          	       1	10051589093 ns/op
BenchmarkSetup/real_setup/bls12_381-12          	       1	11786147568 ns/op
BenchmarkSetup/real_setup/bw6_761-12            	       1	66445937941 ns/op
BenchmarkSetup/real_setup/bls24_315-12          	       1	9584633145 ns/op
BenchmarkSetup/real_setup/bw6_633-12            	       1	38487090447 ns/op
BenchmarkSetup/real_setup/bls24_317-12          	       1	8255227405 ns/op

```

The prover is balanced between the dummy setup and the real setup, slight slower with the dummy setup (?)

Dummy setup
```
goos: darwin
goarch: amd64
pkg: github.com/consensys/gnark/backend/plonk
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkProver/dummy_setup/bn254-12   	                       2	 792198837 ns/op
BenchmarkProver/dummy_setup/bls12_377-12         	       1	1041769904 ns/op
BenchmarkProver/dummy_setup/bls12_381-12         	       1	1090507916 ns/op
BenchmarkProver/dummy_setup/bw6_761-12           	       1	5334756209 ns/op
BenchmarkProver/dummy_setup/bls24_315-12         	       1	1044636604 ns/op
BenchmarkProver/dummy_setup/bw6_633-12           	       1	3066959819 ns/op
BenchmarkProver/dummy_setup/bls24_317-12         	       2	 963285206 ns/op
```

Real setup
```
goos: darwin
goarch: amd64
pkg: github.com/consensys/gnark/backend/plonk
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkProver/real_setup/bn254-12              	       2	 915068212 ns/op
BenchmarkProver/real_setup/bls12_377-12          	       1	1262755442 ns/op
BenchmarkProver/real_setup/bls12_381-12          	       1	1283596118 ns/op
BenchmarkProver/real_setup/bw6_761-12            	       1	7280592635 ns/op
BenchmarkProver/real_setup/bls24_315-12          	       1	1317290421 ns/op
BenchmarkProver/real_setup/bw6_633-12            	       1	4274448361 ns/op
BenchmarkProver/real_setup/bls24_317-12          	       1	1305268749 ns/op

```
