### PR TITLE
Fix: edge cases in the Karabina cyclotomic square decompression

### DIFF
--- a/std/algebra/emulated/fields_bw6761/e3.go
+++ b/std/algebra/emulated/fields_bw6761/e3.go
@@ -399,3 +399,10 @@ func FromE3(a *bw6761.E3) E3 {
 		A2: emulated.ValueOf[emulated.BW6761Fp](a.A2),
 	}
 }
+
+func (e Ext3) Select(selector frontend.Variable, z1, z0 *E3) *E3 {
+	a0 := e.fp.Select(selector, &z1.A0, &z0.A0)
+	a1 := e.fp.Select(selector, &z1.A1, &z0.A1)
+	a2 := e.fp.Select(selector, &z1.A2, &z0.A2)
+	return &E3{A0: *a0, A1: *a1, A2: *a2}
+}

--- a/std/algebra/emulated/fields_bw6761/e6.go
+++ b/std/algebra/emulated/fields_bw6761/e6.go
@@ -199,7 +199,7 @@ func (e Ext6) DecompressKarabina(x *E6) *E6 {
 	var z E6
 
 	var t [3]*baseEl
-	var _t [3]*baseEl
+	var _t [2]*baseEl
 	one := e.fp.One()
 
 	// if g3 == 0
@@ -230,7 +230,7 @@ func (e Ext6) DecompressKarabina(x *E6) *E6 {
 	t[0] = e.fp.Select(selector1, _t[0], t[0])
 	t[1] = e.fp.Select(selector1, _t[1], t[1])
 	// g4 = dummy value, continue
-	t[1] = e.fp.Select(selector2, e.fp.One(), t[1])
+	t[1] = e.fp.Select(selector2, one, t[1])
 
 	z.B1.A1 = *e.fp.Div(t[0], t[1])
 

--- a/std/algebra/emulated/sw_bw6761/pairing_test.go
+++ b/std/algebra/emulated/sw_bw6761/pairing_test.go
@@ -142,7 +142,6 @@ func TestMultiPairTestSolve(t *testing.T) {
 	}
 }
 
-/*
 type PairingCheckCircuit struct {
 	In1G1 G1Affine
 	In2G1 G1Affine
@@ -177,7 +176,6 @@ func TestPairingCheckTestSolve(t *testing.T) {
 	err := test.IsSolved(&PairingCheckCircuit{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
 }
-*/
 
 // bench
 func BenchmarkPairing(b *testing.B) {

--- a/std/algebra/native/fields_bls12377/e12.go
+++ b/std/algebra/native/fields_bls12377/e12.go
@@ -263,28 +263,44 @@ func (e *E12) CyclotomicSquareCompressed(api frontend.API, x E12) *E12 {
 // Decompress Karabina's cyclotomic square result
 func (e *E12) Decompress(api frontend.API, x E12) *E12 {
 
-	// TODO: hadle the g3==0 case with MUX
-
 	var t [3]E2
+	var _t [2]E2
 	var one E2
 	one.SetOne()
 
-	// t0 = g1²
+	// if g3 == 0
+	// t0 = 2 * g1 * g5
+	// t1 = g2
+	selector1 := x.C1.B0.IsZero(api)
+	_t[0].Square(api, x.C0.B1)
+	_t[0].Double(api, _t[0])
+	_t[1] = x.C0.B2
+
+	// if g2 == g3 == 0
+	selector2 := _t[1].IsZero(api)
+
+	// if g3 != 0
+	// t0 = E * g5^2 + 3 * g1^2 - 2 * g2
+	// t1 = 4 * g3
 	t[0].Square(api, x.C0.B1)
-	// t1 = 3 * g1² - 2 * g2
 	t[1].Sub(api, t[0], x.C0.B2).
 		Double(api, t[1]).
 		Add(api, t[1], t[0])
-	// t0 = E * g5² + t1
 	t[2].Square(api, x.C1.B2)
 	t[0].MulByNonResidue(api, t[2]).
 		Add(api, t[0], t[1])
-	// t1 = 4 * g3
 	t[1].Double(api, x.C1.B0).
 		Double(api, t[1])
-	// z4 = g4 / t1
+
+	// g4 = (E * g5^2 + 3 * g1^2 - 2 * g2)/4g3 or (2 * g1 * g5)/g2
+	t[0].Select(api, selector1, _t[0], t[0])
+	t[1].Select(api, selector1, _t[1], t[1])
+	// g4 = dummy value, continue
+	t[1].Select(api, selector2, one, t[1])
+
 	e.C1.B1.DivUnchecked(api, t[0], t[1])
 
+	// Rest of the computation for all cases
 	// t1 = g2 * g1
 	t[1].Mul(api, x.C0.B2, x.C0.B1)
 	// t2 = 2 * g4² - 3 * g2 * g1
@@ -303,6 +319,8 @@ func (e *E12) Decompress(api frontend.API, x E12) *E12 {
 	e.C0.B2 = x.C0.B2
 	e.C1.B0 = x.C1.B0
 	e.C1.B2 = x.C1.B2
+
+	e.Select(api, api.And(selector1, selector2), *e.SetOne(), *e)
 
 	return e
 }

--- a/std/algebra/native/fields_bls12377/e2.go
+++ b/std/algebra/native/fields_bls12377/e2.go
@@ -45,6 +45,11 @@ func (e *E2) SetOne() *E2 {
 	return e
 }
 
+// IsZero returns 1 if the element is equal to 0 and 0 otherwise
+func (e *E2) IsZero(api frontend.API) frontend.Variable {
+	return api.And(api.IsZero(e.A0), api.IsZero(e.A1))
+}
+
 func (e *E2) assign(e1 []frontend.Variable) {
 	e.A0 = e1[0]
 	e.A1 = e1[1]

--- a/std/algebra/native/sw_bls12377/pairing.go
+++ b/std/algebra/native/sw_bls12377/pairing.go
@@ -273,6 +273,22 @@ func Pair(api frontend.API, P []G1Affine, Q []G2Affine) (GT, error) {
 	return FinalExponentiation(api, f), nil
 }
 
+// PairingCheck calculates the reduced pairing for a set of points and asserts if the result is One
+// ∏ᵢ e(Pᵢ, Qᵢ) =? 1
+//
+// This function doesn't check that the inputs are in the correct subgroups. See AssertIsOnG1 and AssertIsOnG2.
+func PairingCheck(api frontend.API, P []G1Affine, Q []G2Affine) error {
+	f, err := Pair(api, P, Q)
+	if err != nil {
+		return err
+	}
+	var one GT
+	one.SetOne()
+	f.AssertIsEqual(api, one)
+
+	return nil
+}
+
 // doubleAndAddStep doubles p1 and adds p2 to the result in affine coordinates, and evaluates the line in Miller loop
 // https://eprint.iacr.org/2022/1162 (Section 6.1)
 func doubleAndAddStep(api frontend.API, p1, p2 *G2Affine) (G2Affine, lineEvaluation, lineEvaluation) {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Fixes #858 

TODO: 
- [x] Emulated BW6-671
- [x] Native BLS12-377
- [ ] Native BLS24-315

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

The multi-pairing computation `e(P,Q)*e(-P,Q)` returns 1. In this case the `g3 == g2 == 0` edge case is triggered. The function `PairingCheck()` and corresponding test were added to emulated bw6-761 and 2-chains.

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

WIP

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

