### PR TITLE
test: refactor and avoid concurrent call to register

### DIFF
--- a/test/assert_checkcircuit.go
+++ b/test/assert_checkcircuit.go
@@ -78,6 +78,9 @@ func (assert *Assert) CheckCircuit(circuit frontend.Circuit, opts ...TestingOpti
 					// 2- if we are not running the full prover;
 					// we need to run the solver on the constraint system only
 					if !opt.checkProver {
+						if opt.skipTestEngine {
+							return
+						}
 						for _, w := range invalidWitnesses {
 							w := w
 							assert.Run(func(assert *Assert) {


### PR DESCRIPTION
# Description

* Make `std/gkr` use `assert.CheckCircuit`
* When `NoTestEngine` is set, skip `ccs.Solve` checks in `test` package.