### PR TITLE
chore: cleanup documentation examples

### DIFF
--- a/std/algebra/emulated/sw_bls12381/doc_test.go
+++ b/std/algebra/emulated/sw_bls12381/doc_test.go
@@ -53,38 +53,26 @@ func ExamplePairing() {
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	secretWitness, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness")
 	}
 	publicWitness, err := secretWitness.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness")
 	}
 	proof, err := groth16.Prove(ccs, pk, secretWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proof")
 	}
 	err = groth16.Verify(proof, vk, publicWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verify")
 	}
 }
 

--- a/std/algebra/emulated/sw_bn254/doc_test.go
+++ b/std/algebra/emulated/sw_bn254/doc_test.go
@@ -53,38 +53,26 @@ func ExamplePairing() {
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	secretWitness, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness")
 	}
 	publicWitness, err := secretWitness.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness")
 	}
 	proof, err := groth16.Prove(ccs, pk, secretWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proof")
 	}
 	err = groth16.Verify(proof, vk, publicWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verify")
 	}
 }
 

--- a/std/algebra/emulated/sw_bw6761/doc_test.go
+++ b/std/algebra/emulated/sw_bw6761/doc_test.go
@@ -51,38 +51,26 @@ func ExamplePairing() {
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	secretWitness, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness")
 	}
 	publicWitness, err := secretWitness.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness")
 	}
 	proof, err := groth16.Prove(ccs, pk, secretWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proof")
 	}
 	err = groth16.Verify(proof, vk, publicWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verify")
 	}
 }
 

--- a/std/commitments/kzg/native_doc_test.go
+++ b/std/commitments/kzg/native_doc_test.go
@@ -2,7 +2,6 @@ package kzg_test
 
 import (
 	"crypto/rand"
-	"fmt"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	fr_bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
@@ -126,6 +125,4 @@ func Example_native() {
 	if err != nil {
 		panic("circuit verification failed: " + err.Error())
 	}
-	fmt.Println("done")
-	// Output: done
 }

--- a/std/commitments/kzg/nonnative_doc_test.go
+++ b/std/commitments/kzg/nonnative_doc_test.go
@@ -148,6 +148,4 @@ func Example_emulated() {
 	if err != nil {
 		panic("circuit verification failed: " + err.Error())
 	}
-	fmt.Println("done")
-	// Output: done
 }

--- a/std/lookup/logderivlookup/doc_test.go
+++ b/std/lookup/logderivlookup/doc_test.go
@@ -47,44 +47,27 @@ func Example() {
 	ccs, err := frontend.Compile(field, r1cs.NewBuilder, &LookupCircuit{})
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	secretWitness, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness")
 	}
 	publicWitness, err := secretWitness.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness")
 	}
 	proof, err := groth16.Prove(ccs, pk, secretWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proof")
 	}
 	err = groth16.Verify(proof, vk, publicWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verify")
 	}
-	// Output:
-	// compiled
-	// setup done
-	// secret witness
-	// public witness
-	// proof
-	// verify
+	fmt.Println("done")
+	// Output: done
 }

--- a/std/math/cmp/doc_isless_test.go
+++ b/std/math/cmp/doc_isless_test.go
@@ -2,12 +2,13 @@ package cmp_test
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/std/math/cmp"
-	"math/big"
 )
 
 // sortCheckerCircuit is a circuit that uses BoundedComparator.IsLess method to
@@ -42,43 +43,27 @@ func ExampleBoundedComparator_IsLess() {
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	secretWitness, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness")
 	}
 	publicWitness, err := secretWitness.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness")
 	}
 	proof, err := groth16.Prove(ccs, pk, secretWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proof")
 	}
 	err = groth16.Verify(proof, vk, publicWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verify")
 	}
-	// Output: compiled
-	// setup done
-	// secret witness
-	// public witness
-	// proof
-	// verify
+	fmt.Println("done")
+	// Output: done
 }

--- a/std/math/emulated/doc_example_field_test.go
+++ b/std/math/emulated/doc_example_field_test.go
@@ -41,43 +41,27 @@ func ExampleField() {
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	witnessData, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness parsed")
 	}
 	publicWitnessData, err := witnessData.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness parsed")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	proof, err := groth16.Prove(ccs, pk, witnessData, backend.WithSolverOptions(solver.WithHints(emulated.GetHints()...)))
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proved")
 	}
 	err = groth16.Verify(proof, vk, publicWitnessData)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verified")
 	}
-	// Output: compiled
-	// secret witness parsed
-	// public witness parsed
-	// setup done
-	// proved
-	// verified
+	fmt.Println("done")
+	// Output: done
 }

--- a/std/math/emulated/field_hint_test.go
+++ b/std/math/emulated/field_hint_test.go
@@ -74,43 +74,27 @@ func ExampleField_NewHint() {
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	witnessData, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness parsed")
 	}
 	publicWitnessData, err := witnessData.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness parsed")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	proof, err := groth16.Prove(ccs, pk, witnessData, backend.WithSolverOptions(solver.WithHints(HintExample)))
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proved")
 	}
 	err = groth16.Verify(proof, vk, publicWitnessData)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verified")
 	}
-	// Output: compiled
-	// secret witness parsed
-	// public witness parsed
-	// setup done
-	// proved
-	// verified
+	fmt.Println("done")
+	// Output: done
 }

--- a/std/multicommit/doc_test.go
+++ b/std/multicommit/doc_test.go
@@ -61,44 +61,27 @@ func ExampleWithCommitment() {
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	secretWitness, err := frontend.NewWitness(&assignment, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness")
 	}
 	publicWitness, err := secretWitness.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness")
 	}
 	proof, err := groth16.Prove(ccs, pk, secretWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proof")
 	}
 	err = groth16.Verify(proof, vk, publicWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verify")
 	}
-	// Output:
-	// compiled
-	// setup done
-	// secret witness
-	// public witness
-	// proof
-	// verify
+	fmt.Println("done")
+	// Output: done
 }

--- a/std/recursion/groth16/native_doc_test.go
+++ b/std/recursion/groth16/native_doc_test.go
@@ -1,8 +1,6 @@
 package groth16_test
 
 import (
-	"fmt"
-
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/frontend"
@@ -84,6 +82,4 @@ func Example_native() {
 	if err != nil {
 		panic("circuit verification failed: " + err.Error())
 	}
-	fmt.Println("done")
-	// Output: done
 }

--- a/std/recursion/groth16/nonnative_doc_test.go
+++ b/std/recursion/groth16/nonnative_doc_test.go
@@ -163,6 +163,4 @@ func Example_emulated() {
 	if err != nil {
 		panic("circuit verification failed: " + err.Error())
 	}
-	fmt.Println("done")
-	// Output: done
 }

--- a/std/selector/doc_map_test.go
+++ b/std/selector/doc_map_test.go
@@ -37,43 +37,27 @@ func ExampleMap() {
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	secretWitness, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness")
 	}
 	publicWitness, err := secretWitness.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness")
 	}
 	proof, err := groth16.Prove(ccs, pk, secretWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proof")
 	}
 	err = groth16.Verify(proof, vk, publicWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verify")
 	}
-	// Output: compiled
-	// setup done
-	// secret witness
-	// public witness
-	// proof
-	// verify
+	fmt.Println("done")
+	// Output: done
 }

--- a/std/selector/doc_mux_test.go
+++ b/std/selector/doc_mux_test.go
@@ -35,43 +35,27 @@ func ExampleMux() {
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	secretWitness, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness")
 	}
 	publicWitness, err := secretWitness.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness")
 	}
 	proof, err := groth16.Prove(ccs, pk, secretWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proof")
 	}
 	err = groth16.Verify(proof, vk, publicWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verify")
 	}
-	// Output: compiled
-	// setup done
-	// secret witness
-	// public witness
-	// proof
-	// verify
+	fmt.Println("done")
+	// Output: done
 }

--- a/std/selector/doc_partition_test.go
+++ b/std/selector/doc_partition_test.go
@@ -1,12 +1,11 @@
 package selector_test
 
-import "github.com/consensys/gnark/frontend"
-
 import (
 	"fmt"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
+	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/std/selector"
 )
@@ -38,43 +37,27 @@ func ExamplePartition() {
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("compiled")
 	}
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("setup done")
 	}
 	secretWitness, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("secret witness")
 	}
 	publicWitness, err := secretWitness.Public()
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("public witness")
 	}
 	proof, err := groth16.Prove(ccs, pk, secretWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("proof")
 	}
 	err = groth16.Verify(proof, vk, publicWitness)
 	if err != nil {
 		panic(err)
-	} else {
-		fmt.Println("verify")
 	}
-	// Output: compiled
-	// setup done
-	// secret witness
-	// public witness
-	// proof
-	// verify
+	fmt.Println("done")
+	// Output: done
 }


### PR DESCRIPTION
# Description

Cleaned up the examples in the documentation. Removed print lines to make the examples more succinct and removed "Output" comments from slow examples to speed up testing.

## Type of change

- [x] Refactoring

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

