### PR TITLE
feat: emulated mimc (WIP)

### DIFF
--- a/examples/rollup/circuit_test.go
+++ b/examples/rollup/circuit_test.go
@@ -97,10 +97,10 @@ func (t *circuitInclusionProof) Define(api frontend.API) error {
 		return err
 	}
 
-	t.MerkleProofReceiverBefore[0].VerifyProof(api, &hashFunc, t.LeafReceiver[0])
-	t.MerkleProofReceiverAfter[0].VerifyProof(api, &hashFunc, t.LeafReceiver[0])
-	t.MerkleProofSenderBefore[0].VerifyProof(api, &hashFunc, t.LeafSender[0])
-	t.MerkleProofSenderAfter[0].VerifyProof(api, &hashFunc, t.LeafSender[0])
+	t.MerkleProofReceiverBefore[0].VerifyProof(api, hashFunc, t.LeafReceiver[0])
+	t.MerkleProofReceiverAfter[0].VerifyProof(api, hashFunc, t.LeafReceiver[0])
+	t.MerkleProofSenderBefore[0].VerifyProof(api, hashFunc, t.LeafSender[0])
+	t.MerkleProofSenderAfter[0].VerifyProof(api, hashFunc, t.LeafSender[0])
 
 	return nil
 }

--- a/std/hash/hash.go
+++ b/std/hash/hash.go
@@ -19,6 +19,7 @@ package hash
 
 import (
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/std/math/uints"
 )
 
@@ -60,6 +61,20 @@ type BinaryHasher interface {
 // the length of the input is the total number of bytes written.
 type BinaryFixedLengthHasher interface {
 	BinaryHasher
+
 	// FixedLengthSum returns digest of the first length bytes.
 	FixedLengthSum(length frontend.Variable) []uints.U8
+}
+
+// FieldHasherNonNative is generic definition of the [FieldHasher] interface
+// which allows working on a non-native field.
+type FieldHasherNonNative[T emulated.FieldParams] interface {
+	// Sum computes the hash of the internal state of the hash function.
+	Sum() emulated.Element[T]
+
+	// Write populate the internal state of the hash function with data. The inputs are native field elements.
+	Write(data ...emulated.Element[T])
+
+	// Reset empty the internal state and put the intermediate state to zero.
+	Reset()
 }

--- a/std/hash/mimc/mimc.go
+++ b/std/hash/mimc/mimc.go
@@ -36,12 +36,13 @@ type MiMC struct {
 }
 
 // NewMiMC returns a MiMC instance, than can be used in a gnark circuit
-func NewMiMC(api frontend.API) (MiMC, error) {
+func NewMiMC(api frontend.API) (*MiMC, error) {
 	// TODO @gbotrel use field
 	if constructor, ok := newMimc[utils.FieldToCurve(api.Compiler().Field())]; ok {
-		return constructor(api), nil
+		constructed := constructor(api)
+		return &constructed, nil
 	}
-	return MiMC{}, errors.New("unknown curve id")
+	return &MiMC{}, errors.New("unknown curve id")
 }
 
 // Write adds more data to the running hash.

--- a/std/signature/eddsa/eddsa_test.go
+++ b/std/signature/eddsa/eddsa_test.go
@@ -52,7 +52,7 @@ func (circuit *eddsaCircuit) Define(api frontend.API) error {
 	}
 
 	// verify the signature in the cs
-	return Verify(curve, circuit.Signature, circuit.Message, circuit.PublicKey, &mimc)
+	return Verify(curve, circuit.Signature, circuit.Message, circuit.PublicKey, mimc)
 }
 
 func TestEddsa(t *testing.T) {


### PR DESCRIPTION
Work in progress WIP for emulated MiMC. Do not merge!

Open issues right now:
* [ ] we get an import cycle because we use mimc in for logderivargument and multicommit. Both in both cases we do not need to use MiMC specifically. There, we can also do the squaring instead of using MiMC. Actually this is already implemented in the mulmod PR. After we have merged that we can change mimc.NewMiMC to return hash.FieldHasher instead. Then it is clearer what the function is about. Most importantly, then we can also implement `hash.FieldHasherGeneric[t emulated.FieldParam]` as an interface.
* [ ] implement emulated mimc
* [ ] implement Fiat-Shamir using `hash.FieldHasherGeneric`

cc @ThomasPiellard 

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Fixes #848 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [ ] Test A
- [ ] Test B

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

