### PR TITLE
Fix `sw_emulated` test

### DIFF
--- a/std/algebra/emulated/sw_emulated/doc_test.go
+++ b/std/algebra/emulated/sw_emulated/doc_test.go
@@ -18,7 +18,7 @@ type ExampleCurveCircuit[Base, Scalar emulated.FieldParams] struct {
 }
 
 func (c *ExampleCurveCircuit[B, S]) Define(api frontend.API) error {
-	curve, err := sw_emulated.New[B, S](api, sw_emulated.GetCurveParams[emulated.BN254Fp]())
+	curve, err := sw_emulated.New[B, S](api, sw_emulated.GetCurveParams[emulated.Secp256k1Fp]())
 	if err != nil {
 		panic("initalize new curve")
 	}
@@ -42,8 +42,8 @@ func ExampleCurve() {
 	circuit := ExampleCurveCircuit[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{}
 	witness := ExampleCurveCircuit[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
 		Res: sw_emulated.AffinePoint[emulated.Secp256k1Fp]{
-			X: emulated.ValueOf[emulated.Secp256k1Fp](g.X),
-			Y: emulated.ValueOf[emulated.Secp256k1Fp](g.Y),
+			X: emulated.ValueOf[emulated.Secp256k1Fp](Q.X),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](Q.Y),
 		},
 	}
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
@@ -82,4 +82,11 @@ func ExampleCurve() {
 	} else {
 		fmt.Println("verify")
 	}
+	// Output:
+	// result ([5101572491822586484 7988715582840633164 10154617462969804093 9788323565107423858], [12871521579461060004 12592355681102286208 17300415163085174132 96321138099943804])compiled
+	// setup done
+	// secret witness
+	// public witness
+	// proof
+	// verify
 }


### PR DESCRIPTION
# Description

The `doc_test.go` in `sw_emulated` was not passing. Fixed the curve being used in the circuit, the witness points (use the computed `Q` instead of the base point) and added expected outputs.

Fixes #888

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] `go fmt`
- [x] `go vet` 
- [x] `go test doc_test.go` 

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

N/A

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

