### PR TITLE
feat: Fiat-Shamir transcript using a short hash

### DIFF
--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -116,6 +116,9 @@ func (c *Curve[B, S]) MarshalG1(p AffinePoint[B]) []frontend.Variable {
 	res := make([]frontend.Variable, 2*nbBits)
 	copy(res, bx)
 	copy(res[len(bx):], by)
+	xZ := c.baseApi.IsZero(x)
+	yZ := c.baseApi.IsZero(y)
+	res[1] = c.api.Mul(xZ, yZ)
 	return res
 }
 

--- a/std/algebra/native/sw_bls12377/g1_test.go
+++ b/std/algebra/native/sw_bls12377/g1_test.go
@@ -83,23 +83,33 @@ func (c *MarshalG1Test) Define(api frontend.API) error {
 func TestMarshalG1(t *testing.T) {
 	assert := test.NewAssert(t)
 
-	// sample a random point
-	var r fr.Element
-	r.SetRandom()
-	var br big.Int
-	r.BigInt(&br)
-	_, _, g, _ := bls12377.Generators()
-	g.ScalarMultiplication(&g, &br)
-	gBytes := g.Marshal()
-	var witness MarshalG1Test
-	witness.P.Assign(&g)
-	for i := 0; i < 96; i++ {
-		for j := 0; j < 8; j++ {
-			witness.R[i*8+j] = (gBytes[i] >> (7 - j)) & 1
+	testfn := func(r fr.Element) {
+		var br big.Int
+		r.BigInt(&br)
+		_, _, g, _ := bls12377.Generators()
+		g.ScalarMultiplication(&g, &br)
+		gBytes := g.Marshal()
+		var witness MarshalG1Test
+		witness.P.Assign(&g)
+		for i := 0; i < 96; i++ {
+			for j := 0; j < 8; j++ {
+				witness.R[i*8+j] = (gBytes[i] >> (7 - j)) & 1
+			}
 		}
+		var circuit MarshalG1Test
+		assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(ecc.BW6_761))
 	}
-	var circuit MarshalG1Test
-	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(ecc.BW6_761))
+	assert.Run(func(assert *test.Assert) {
+		// sample a random point
+		var r fr.Element
+		r.SetRandom()
+		testfn(r)
+	})
+	assert.Run(func(assert *test.Assert) {
+		var r fr.Element
+		r.SetZero()
+		testfn(r)
+	})
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/std/algebra/native/sw_bls12377/pairing2.go
+++ b/std/algebra/native/sw_bls12377/pairing2.go
@@ -46,6 +46,9 @@ func (c *Curve) MarshalG1(P G1Affine) []frontend.Variable {
 		res[i] = x[nbBits-1-i]
 		res[i+nbBits] = y[nbBits-1-i]
 	}
+	xZ := c.api.IsZero(P.X)
+	yZ := c.api.IsZero(P.Y)
+	res[1] = c.api.Mul(xZ, yZ)
 	return res
 }
 

--- a/std/algebra/native/sw_bls24315/pairing2.go
+++ b/std/algebra/native/sw_bls24315/pairing2.go
@@ -46,6 +46,9 @@ func (c *Curve) MarshalG1(P G1Affine) []frontend.Variable {
 		res[i] = x[nbBits-1-i]
 		res[i+nbBits] = y[nbBits-1-i]
 	}
+	xZ := c.api.IsZero(P.X)
+	yZ := c.api.IsZero(P.Y)
+	res[1] = c.api.Mul(xZ, yZ)
 	return res
 }
 

--- a/std/commitments/fri/fri.go
+++ b/std/commitments/fri/fri.go
@@ -98,7 +98,7 @@ func (s RadixTwoFri) verifyProofOfProximitySingleRound(api frontend.API, salt fr
 		xis[i] = paddNaming(fmt.Sprintf("x%d", i), frSize)
 	}
 	xis[s.nbSteps] = paddNaming("s0", frSize)
-	fs := fiatshamir.NewTranscript(api, s.h, xis...)
+	fs := fiatshamir.NewTranscript(api, s.h, xis)
 	xi := make([]frontend.Variable, s.nbSteps)
 
 	// the salt is binded to the first challenge, to ensure the challenges

--- a/std/commitments/fri/fri.go
+++ b/std/commitments/fri/fri.go
@@ -98,7 +98,7 @@ func (s RadixTwoFri) verifyProofOfProximitySingleRound(api frontend.API, salt fr
 		xis[i] = paddNaming(fmt.Sprintf("x%d", i), frSize)
 	}
 	xis[s.nbSteps] = paddNaming("s0", frSize)
-	fs := fiatshamir.NewTranscript(api, s.h, xis)
+	fs := fiatshamir.NewTranscript(api, s.h, xis, fiatshamir.WithDomainSeparation())
 	xi := make([]frontend.Variable, s.nbSteps)
 
 	// the salt is binded to the first challenge, to ensure the challenges

--- a/std/fiat-shamir/transcript.go
+++ b/std/fiat-shamir/transcript.go
@@ -53,7 +53,7 @@ type challenge struct {
 // NewTranscript returns a new transcript.
 // h is the hash function that is used to compute the challenges.
 // challenges are the name of the challenges. The order is important.
-func NewTranscript(api frontend.API, h hash.FieldHasher, challengesID ...string) Transcript {
+func NewTranscript(api frontend.API, h hash.FieldHasher, challengesID []string) *Transcript {
 	n := len(challengesID)
 	t := Transcript{
 		challenges: make(map[string]challenge, n),
@@ -65,7 +65,7 @@ func NewTranscript(api frontend.API, h hash.FieldHasher, challengesID ...string)
 		t.challenges[challengesID[i]] = challenge{position: i}
 	}
 
-	return t
+	return &t
 }
 
 // Bind binds the challenge to value. A challenge can be binded to an

--- a/std/fiat-shamir/transcript.go
+++ b/std/fiat-shamir/transcript.go
@@ -101,8 +101,8 @@ func (t *Transcript) Bind(challengeID string, values []frontend.Variable) error 
 
 // ComputeChallenge computes the challenge corresponding to the given name.
 // The resulting variable is:
-// * H(name ∥ previous_challenge ∥ binded_values...) if the challenge is not the first one
-// * H(name ∥ binded_values... ) if it's is the first challenge
+//   - H(name ∥ previous_challenge ∥ binded_values...) if the challenge is not the first one
+//   - H(name ∥ binded_values... ) if it's is the first challenge
 func (t *Transcript) ComputeChallenge(challengeID string) (frontend.Variable, error) {
 	var err error
 	challenge, ok := t.challenges[challengeID]

--- a/std/fiat-shamir/transcript_test.go
+++ b/std/fiat-shamir/transcript_test.go
@@ -45,7 +45,7 @@ func (circuit *FiatShamirCircuit) Define(api frontend.API) error {
 	}
 
 	// New transcript with 3 challenges to be derived
-	tsSnark := NewTranscript(api, &hSnark, "alpha", "beta", "gamma")
+	tsSnark := NewTranscript(api, &hSnark, []string{"alpha", "beta", "gamma"})
 
 	// Bind challenges
 	if err := tsSnark.Bind("alpha", circuit.Bindings[0][:]); err != nil {

--- a/std/fiat-shamir/transcript_test.go
+++ b/std/fiat-shamir/transcript_test.go
@@ -46,7 +46,7 @@ func (circuit *FiatShamirCircuit) Define(api frontend.API) error {
 	}
 
 	// New transcript with 3 challenges to be derived
-	tsSnark := NewTranscript(api, &hSnark, []string{"alpha", "beta", "gamma"})
+	tsSnark := NewTranscript(api, &hSnark, []string{"alpha", "beta", "gamma"}, WithDomainSeparation())
 
 	// Bind challenges
 	if err := tsSnark.Bind("alpha", circuit.Bindings[0][:]); err != nil {

--- a/std/fiat-shamir/transcript_test.go
+++ b/std/fiat-shamir/transcript_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fiatshamir
 
 import (
+	"crypto/rand"
 	"math/big"
 	"testing"
 
@@ -83,6 +84,7 @@ func (circuit *FiatShamirCircuit) Define(api frontend.API) error {
 }
 
 func TestFiatShamir(t *testing.T) {
+	var err error
 	assert := test.NewAssert(t)
 
 	testData := map[ecc.ID]hash.Hash{
@@ -101,10 +103,11 @@ func TestFiatShamir(t *testing.T) {
 		// instantiate the hash and the transcript in plain go
 		ts := fiatshamir.NewTranscript(h.New(), "alpha", "beta", "gamma")
 
-		var bindings [3][4]big.Int
+		var bindings [3][4]*big.Int
 		for i := 0; i < 3; i++ {
 			for j := 0; j < 4; j++ {
-				bindings[i][j].SetUint64(uint64(i * j))
+				bindings[i][j], err = rand.Int(rand.Reader, curveID.ScalarField())
+				assert.NoError(err)
 			}
 		}
 		frSize := utils.ByteLen(curveID.ScalarField())

--- a/std/gkr/gkr.go
+++ b/std/gkr/gkr.go
@@ -2,11 +2,12 @@ package gkr
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/consensys/gnark/frontend"
 	fiatshamir "github.com/consensys/gnark/std/fiat-shamir"
 	"github.com/consensys/gnark/std/polynomial"
 	"github.com/consensys/gnark/std/sumcheck"
-	"strconv"
 )
 
 // @tabaie TODO: Contains many things copy-pasted from gnark-crypto. Generify somehow?
@@ -198,9 +199,7 @@ func setup(api frontend.API, c Circuit, assignment WireAssignment, transcriptSet
 
 	if transcriptSettings.Transcript == nil {
 		challengeNames := ChallengeNames(o.sorted, o.nbVars, transcriptSettings.Prefix)
-		transcript := fiatshamir.NewTranscript(
-			api, transcriptSettings.Hash, challengeNames...)
-		o.transcript = &transcript
+		o.transcript = fiatshamir.NewTranscript(api, transcriptSettings.Hash, challengeNames)
 		if err = o.transcript.Bind(challengeNames[0], transcriptSettings.BaseChallenges); err != nil {
 			return o, err
 		}

--- a/std/recursion/wrapped_hash_test.go
+++ b/std/recursion/wrapped_hash_test.go
@@ -13,9 +13,12 @@ import (
 	fr_bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	fr_bn254 "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761"
+	cryptofs "github.com/consensys/gnark-crypto/fiat-shamir"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_bw6761"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls12377"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls24315"
 	"github.com/consensys/gnark/std/recursion"
@@ -256,4 +259,114 @@ func TestHashMarshalScalar(t *testing.T) {
 		}
 		assert.CheckCircuit(circuit, test.WithCurves(ecc.BW6_633), test.WithValidAssignment(assignment), test.NoFuzzing(), test.NoSerializationChecks(), test.NoSolidityChecks())
 	})
+}
+
+type transcriptCircuit[S algebra.ScalarT, G1El algebra.G1ElementT] struct {
+	Challenges [3]string
+	Points     [3][3]G1El
+	Expected   [3]frontend.Variable
+
+	target *big.Int
+}
+
+func (c *transcriptCircuit[S, G1El]) Define(api frontend.API) error {
+	fs, err := recursion.NewTranscript(api, c.target, c.Challenges[:])
+	if err != nil {
+		return fmt.Errorf("new transcript: %w", err)
+	}
+	curve, err := algebra.GetCurve[S, G1El](api)
+	if err != nil {
+		return fmt.Errorf("get curve: %w", err)
+	}
+	for i := range c.Points {
+		for j := range c.Points[i] {
+			if err := fs.Bind(c.Challenges[i], curve.MarshalG1(c.Points[i][j])); err != nil {
+				return fmt.Errorf("bind[%d][%d] %w", i, j, err)
+			}
+		}
+	}
+	for i := range c.Expected {
+		res, err := fs.ComputeChallenge(c.Challenges[i])
+		if err != nil {
+			return fmt.Errorf("compute challenge %d: %w", i, err)
+		}
+		api.AssertIsEqual(res, c.Expected[i])
+	}
+	return nil
+}
+
+func TestTranscriptMarsha(t *testing.T) {
+	assert := test.NewAssert(t)
+	assert.Run(func(assert *test.Assert) {
+		h, err := recursion.NewShort(ecc.BW6_761.ScalarField(), ecc.BLS12_377.ScalarField())
+		assert.NoError(err)
+		challenges := [3]string{"alfa", "beta", "gamma"}
+		fs := cryptofs.NewTranscript(h, challenges[:]...)
+		var points [3][3]sw_bls12377.G1Affine
+		for i := range points {
+			for j := range points[i] {
+				var p bls12377.G1Affine
+				r, err := rand.Int(rand.Reader, ecc.BLS12_377.ScalarField())
+				assert.NoError(err)
+				p.ScalarMultiplicationBase(r)
+				points[i][j] = sw_bls12377.NewG1Affine(p)
+				if err := fs.Bind(challenges[i], p.Marshal()); err != nil {
+					t.Fatal("bind", err)
+				}
+			}
+		}
+		var expected [3]frontend.Variable
+		for i := range expected {
+			res, err := fs.ComputeChallenge(challenges[i])
+			assert.NoError(err)
+			expected[i] = res
+		}
+		circuit := &transcriptCircuit[sw_bls12377.Scalar, sw_bls12377.G1Affine]{
+			Challenges: challenges,
+			target:     ecc.BLS12_377.ScalarField(),
+		}
+		assignment := &transcriptCircuit[sw_bls12377.Scalar, sw_bls12377.G1Affine]{
+			Challenges: challenges,
+			Points:     points,
+			Expected:   expected,
+			target:     ecc.BLS12_377.ScalarField(),
+		}
+		assert.CheckCircuit(circuit, test.WithValidAssignment(assignment), test.WithCurves(ecc.BW6_761), test.NoFuzzing(), test.NoSerializationChecks())
+	}, "bw6_761")
+	assert.Run(func(assert *test.Assert) {
+		h, err := recursion.NewShort(ecc.BN254.ScalarField(), ecc.BW6_761.ScalarField())
+		assert.NoError(err)
+		challenges := [3]string{"alfa", "beta", "gamma"}
+		fs := cryptofs.NewTranscript(h, challenges[:]...)
+		var points [3][3]sw_bw6761.G1Affine
+		for i := range points {
+			for j := range points[i] {
+				var p bw6761.G1Affine
+				r, err := rand.Int(rand.Reader, ecc.BW6_761.ScalarField())
+				assert.NoError(err)
+				p.ScalarMultiplicationBase(r)
+				points[i][j] = sw_bw6761.NewG1Affine(p)
+				if err := fs.Bind(challenges[i], p.Marshal()); err != nil {
+					t.Fatal("bind", err)
+				}
+			}
+		}
+		var expected [3]frontend.Variable
+		for i := range expected {
+			res, err := fs.ComputeChallenge(challenges[i])
+			assert.NoError(err)
+			expected[i] = res
+		}
+		circuit := &transcriptCircuit[sw_bw6761.Scalar, sw_bw6761.G1Affine]{
+			Challenges: challenges,
+			target:     ecc.BW6_761.ScalarField(),
+		}
+		assignment := &transcriptCircuit[sw_bw6761.Scalar, sw_bw6761.G1Affine]{
+			Challenges: challenges,
+			Points:     points,
+			Expected:   expected,
+			target:     ecc.BW6_761.ScalarField(),
+		}
+		assert.CheckCircuit(circuit, test.WithValidAssignment(assignment), test.WithCurves(ecc.BN254), test.NoFuzzing(), test.NoSerializationChecks())
+	}, "bn254")
 }

--- a/std/sumcheck/sumcheck.go
+++ b/std/sumcheck/sumcheck.go
@@ -2,10 +2,11 @@ package sumcheck
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/consensys/gnark/frontend"
 	fiatshamir "github.com/consensys/gnark/std/fiat-shamir"
 	"github.com/consensys/gnark/std/polynomial"
-	"strconv"
 )
 
 // LazyClaims is the Claims data structure on the verifier side. It is "lazy" in that it has to compute fewer things.
@@ -37,8 +38,7 @@ func setupTranscript(api frontend.API, claimsNum int, varsNum int, settings *fia
 		challengeNames[i+numChallenges-varsNum] = prefix + strconv.Itoa(i)
 	}
 	if settings.Transcript == nil {
-		transcript := fiatshamir.NewTranscript(api, settings.Hash, challengeNames...)
-		settings.Transcript = &transcript
+		settings.Transcript = fiatshamir.NewTranscript(api, settings.Hash, challengeNames)
 	}
 
 	return challengeNames, settings.Transcript.Bind(challengeNames[0], settings.BaseChallenges)

--- a/std/sumcheck/sumcheck.go
+++ b/std/sumcheck/sumcheck.go
@@ -38,7 +38,7 @@ func setupTranscript(api frontend.API, claimsNum int, varsNum int, settings *fia
 		challengeNames[i+numChallenges-varsNum] = prefix + strconv.Itoa(i)
 	}
 	if settings.Transcript == nil {
-		settings.Transcript = fiatshamir.NewTranscript(api, settings.Hash, challengeNames)
+		settings.Transcript = fiatshamir.NewTranscript(api, settings.Hash, challengeNames, fiatshamir.WithDomainSeparation())
 	}
 
 	return challengeNames, settings.Transcript.Bind(challengeNames[0], settings.BaseChallenges)


### PR DESCRIPTION
# Description

Implement gnark-crypto compatible Fiat-Shamir transcript using a short MiMC hash for proof recursion.

All tests seem to be working, but I'm not sure about the option `WithDomainSeparation`. I think it is too agressive on gnark-crypto side to enforce domain separation with the `string:` string when hasher has `WriteString` method. I would make it optional as in gnark. Imo right now the behaviour is not documented and quite difficult to debug.

Related #847 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?

- [x] Transcript test with 2-chains
- [x] Transcript test with field emulation

# How has this been benchmarked?

Not benchmarked

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

