### PR TITLE
feat: cache lookup blueprint entries in solving phase

### DIFF
--- a/constraint/bls12-377/system.go
+++ b/constraint/bls12-377/system.go
@@ -74,6 +74,13 @@ func (cs *system) Solve(witness witness.Witness, opts ...csolver.Option) (any, e
 		return nil, err
 	}
 
+	// reset the stateful blueprints
+	for i := range cs.Blueprints {
+		if b, ok := cs.Blueprints[i].(constraint.BlueprintStateful); ok {
+			b.Reset()
+		}
+	}
+
 	// defer log printing once all solver.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solver.printLogs(cs.Logs)

--- a/constraint/bls12-381/system.go
+++ b/constraint/bls12-381/system.go
@@ -74,6 +74,13 @@ func (cs *system) Solve(witness witness.Witness, opts ...csolver.Option) (any, e
 		return nil, err
 	}
 
+	// reset the stateful blueprints
+	for i := range cs.Blueprints {
+		if b, ok := cs.Blueprints[i].(constraint.BlueprintStateful); ok {
+			b.Reset()
+		}
+	}
+
 	// defer log printing once all solver.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solver.printLogs(cs.Logs)

--- a/constraint/bls24-315/system.go
+++ b/constraint/bls24-315/system.go
@@ -74,6 +74,13 @@ func (cs *system) Solve(witness witness.Witness, opts ...csolver.Option) (any, e
 		return nil, err
 	}
 
+	// reset the stateful blueprints
+	for i := range cs.Blueprints {
+		if b, ok := cs.Blueprints[i].(constraint.BlueprintStateful); ok {
+			b.Reset()
+		}
+	}
+
 	// defer log printing once all solver.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solver.printLogs(cs.Logs)

--- a/constraint/bls24-317/system.go
+++ b/constraint/bls24-317/system.go
@@ -74,6 +74,13 @@ func (cs *system) Solve(witness witness.Witness, opts ...csolver.Option) (any, e
 		return nil, err
 	}
 
+	// reset the stateful blueprints
+	for i := range cs.Blueprints {
+		if b, ok := cs.Blueprints[i].(constraint.BlueprintStateful); ok {
+			b.Reset()
+		}
+	}
+
 	// defer log printing once all solver.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solver.printLogs(cs.Logs)

--- a/constraint/blueprint.go
+++ b/constraint/blueprint.go
@@ -67,6 +67,14 @@ type BlueprintHint interface {
 	DecompressHint(h *HintMapping, instruction Instruction)
 }
 
+// BlueprintStateful indicates that the blueprint can be reset to its initial state.
+type BlueprintStateful interface {
+	BlueprintSolvable
+
+	// Reset is called by the solver between invocation of Solve.
+	Reset()
+}
+
 // Compressible represent an object that knows how to encode itself as a []uint32.
 type Compressible interface {
 	// Compress interprets the objects as a LinearExpression and encodes it as a []uint32.

--- a/constraint/blueprint_logderivlookup.go
+++ b/constraint/blueprint_logderivlookup.go
@@ -2,6 +2,7 @@ package constraint
 
 import (
 	"fmt"
+	"sync"
 )
 
 // TODO @gbotrel this shouldn't be there, but we need to figure out a clean way to serialize
@@ -16,28 +17,41 @@ type BlueprintLookupHint struct {
 	maxLevel         Level
 	maxLevelPosition int
 	maxLevelOffset   int
+
+	// cache the resolved entries by the solver
+	cachedEntries []Element
+	cachedOffset  int
+	lock          sync.Mutex
 }
 
-// ensures BlueprintLookupHint implements the BlueprintSolvable interface
-var _ BlueprintSolvable = (*BlueprintLookupHint)(nil)
+// ensures BlueprintLookupHint implements the BlueprintStateful interface
+var _ BlueprintStateful = (*BlueprintLookupHint)(nil)
 
 func (b *BlueprintLookupHint) Solve(s Solver, inst Instruction) error {
 	nbEntries := int(inst.Calldata[1])
-	entries := make([]Element, nbEntries)
 
-	// read the static entries from the blueprint
-	// TODO @gbotrel cache that.
-	offset, delta := 0, 0
-	for i := 0; i < nbEntries; i++ {
-		entries[i], delta = s.Read(b.EntriesCalldata[offset:])
-		offset += delta
+	// check if we already cached the entries
+	b.lock.Lock()
+	if len(b.cachedEntries) < nbEntries {
+		// we need to cache more entries
+		offset, delta := b.cachedOffset, 0
+		for i := len(b.cachedEntries); i < nbEntries; i++ {
+			b.cachedEntries = append(b.cachedEntries, Element{})
+			b.cachedEntries[i], delta = s.Read(b.EntriesCalldata[offset:])
+			offset += delta
+		}
+		b.cachedOffset = offset
 	}
+	b.lock.Unlock()
+
+	// we only append to the entries and never resize the slice; so we can access these indices safely
+	entries := b.cachedEntries[:nbEntries]
 
 	nbInputs := int(inst.Calldata[2])
 
 	// read the inputs from the instruction
 	inputs := make([]Element, nbInputs)
-	offset = 3
+	offset, delta := 3, 0
 	for i := 0; i < nbInputs; i++ {
 		inputs[i], delta = s.Read(inst.Calldata[offset:])
 		offset += delta
@@ -55,6 +69,21 @@ func (b *BlueprintLookupHint) Solve(s Solver, inst Instruction) error {
 		s.SetValue(uint32(i+int(inst.WireOffset)), entries[idx])
 	}
 	return nil
+}
+
+func (b *BlueprintLookupHint) Reset() {
+	// first we need to compute the capacity; that is 1 element per linear expression in the entries.
+	// this must be accurate since solver is multi threaded and we don't want to resize the slice
+	// while the solver is running.
+	capacity := 0
+	for i := 0; i < len(b.EntriesCalldata); i++ {
+		n := int(b.EntriesCalldata[i]) // length of the linear expression
+		capacity++
+		i += 2 * n // skip the linear expression
+	}
+
+	b.cachedEntries = make([]Element, 0, capacity)
+	b.cachedOffset = 0
 }
 
 func (b *BlueprintLookupHint) CalldataSize() int {

--- a/constraint/bn254/system.go
+++ b/constraint/bn254/system.go
@@ -74,6 +74,13 @@ func (cs *system) Solve(witness witness.Witness, opts ...csolver.Option) (any, e
 		return nil, err
 	}
 
+	// reset the stateful blueprints
+	for i := range cs.Blueprints {
+		if b, ok := cs.Blueprints[i].(constraint.BlueprintStateful); ok {
+			b.Reset()
+		}
+	}
+
 	// defer log printing once all solver.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solver.printLogs(cs.Logs)

--- a/constraint/bw6-633/system.go
+++ b/constraint/bw6-633/system.go
@@ -74,6 +74,13 @@ func (cs *system) Solve(witness witness.Witness, opts ...csolver.Option) (any, e
 		return nil, err
 	}
 
+	// reset the stateful blueprints
+	for i := range cs.Blueprints {
+		if b, ok := cs.Blueprints[i].(constraint.BlueprintStateful); ok {
+			b.Reset()
+		}
+	}
+
 	// defer log printing once all solver.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solver.printLogs(cs.Logs)

--- a/constraint/bw6-761/system.go
+++ b/constraint/bw6-761/system.go
@@ -74,6 +74,13 @@ func (cs *system) Solve(witness witness.Witness, opts ...csolver.Option) (any, e
 		return nil, err
 	}
 
+	// reset the stateful blueprints
+	for i := range cs.Blueprints {
+		if b, ok := cs.Blueprints[i].(constraint.BlueprintStateful); ok {
+			b.Reset()
+		}
+	}
+
 	// defer log printing once all solver.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solver.printLogs(cs.Logs)

--- a/constraint/tinyfield/system.go
+++ b/constraint/tinyfield/system.go
@@ -74,6 +74,13 @@ func (cs *system) Solve(witness witness.Witness, opts ...csolver.Option) (any, e
 		return nil, err
 	}
 
+	// reset the stateful blueprints
+	for i := range cs.Blueprints {
+		if b, ok := cs.Blueprints[i].(constraint.BlueprintStateful); ok {
+			b.Reset()
+		}
+	}
+
 	// defer log printing once all solver.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solver.printLogs(cs.Logs)

--- a/internal/generator/backend/template/representations/system.go.tmpl
+++ b/internal/generator/backend/template/representations/system.go.tmpl
@@ -59,6 +59,13 @@ func (cs *system) Solve(witness witness.Witness, opts ...csolver.Option) (any, e
 		return nil, err
 	}
 
+	// reset the stateful blueprints
+	for i := range cs.Blueprints {
+		if b, ok := cs.Blueprints[i].(constraint.BlueprintStateful); ok {
+			b.Reset()
+		}
+	}
+
 	// defer log printing once all solver.values are computed
 	// (or sooner, if a constraint is not satisfied)
 	defer solver.printLogs(cs.Logs)

--- a/test/engine.go
+++ b/test/engine.go
@@ -128,6 +128,14 @@ func IsSolved(circuit, witness frontend.Circuit, field *big.Int, opts ...TestEng
 	log := logger.Logger()
 	log.Debug().Msg("running circuit in test engine")
 	cptAdd, cptMul, cptSub, cptToBinary, cptFromBinary, cptAssertIsEqual = 0, 0, 0, 0, 0, 0
+
+	// first we reset the stateful blueprints
+	for i := range e.blueprints {
+		if b, ok := e.blueprints[i].(constraint.BlueprintStateful); ok {
+			b.Reset()
+		}
+	}
+
 	if err = c.Define(e); err != nil {
 		return fmt.Errorf("define: %w", err)
 	}


### PR DESCRIPTION
See https://github.com/Consensys/gnark/issues/898 . 

Adds `blueprint.Reset()` and `BlueprintLookup` now maintains a cache of resolved entries during solving time. 