### PR TITLE
fix: use platform independent method for counting new multiplication overflow from result limb count

### DIFF
--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -3,8 +3,8 @@ package emulated
 import (
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
+	"math/bits"
 
 	"github.com/consensys/gnark/frontend"
 )
@@ -199,7 +199,11 @@ func (f *Field[T]) MulConst(a *Element[T], c *big.Int) *Element[T] {
 func (f *Field[T]) mulPreCond(a, b *Element[T]) (nextOverflow uint, err error) {
 	reduceRight := a.overflow < b.overflow
 	nbResLimbs := nbMultiplicationResLimbs(len(a.Limbs), len(b.Limbs))
-	nextOverflow = f.fParams.BitsPerLimb() + uint(math.Log2(float64(2*nbResLimbs-1))) + 1 + a.overflow + b.overflow
+	nbLimbsOverflow := uint(1)
+	if nbResLimbs > 0 {
+		nbLimbsOverflow = uint(bits.Len(uint(2*nbResLimbs - 1)))
+	}
+	nextOverflow = f.fParams.BitsPerLimb() + nbLimbsOverflow + a.overflow + b.overflow
 	if nextOverflow > f.maxOverflow() {
 		err = overflowError{op: "mul", nextOverflow: nextOverflow, maxOverflow: f.maxOverflow(), reduceRight: reduceRight}
 	}

--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -15,7 +15,7 @@ func (f *Field[T]) Div(a, b *Element[T]) *Element[T] {
 }
 
 func (f *Field[T]) divPreCond(a, b *Element[T]) (nextOverflow uint, err error) {
-	mulOf, err := f.mulPreCond(&Element[T]{overflow: 0}, b)
+	mulOf, err := f.mulPreCond(&Element[T]{Limbs: make([]frontend.Variable, f.fParams.NbLimbs()), overflow: 0}, b)
 	if err != nil {
 		return mulOf, err
 	}
@@ -45,7 +45,7 @@ func (f *Field[T]) Inverse(a *Element[T]) *Element[T] {
 }
 
 func (f *Field[T]) inversePreCond(a, _ *Element[T]) (nextOverflow uint, err error) {
-	mulOf, err := f.mulPreCond(a, &Element[T]{overflow: 0}) // order is important, we want that reduce left side
+	mulOf, err := f.mulPreCond(a, &Element[T]{Limbs: make([]frontend.Variable, f.fParams.NbLimbs()), overflow: 0}) // order is important, we want that reduce left side
 	if err != nil {
 		return mulOf, err
 	}

--- a/std/math/emulated/hints.go
+++ b/std/math/emulated/hints.go
@@ -43,7 +43,11 @@ func (f *Field[T]) computeMultiplicationHint(leftLimbs, rightLimbs []frontend.Va
 // nbMultiplicationResLimbs returns the number of limbs which fit the
 // multiplication result.
 func nbMultiplicationResLimbs(lenLeft, lenRight int) int {
-	return lenLeft + lenRight - 1
+	res := lenLeft + lenRight - 1
+	if res < 0 {
+		res = 0
+	}
+	return res
 }
 
 // MultiplicationHint unpacks the factors and parameters from inputs, computes


### PR DESCRIPTION
# Description

When we count the new overflow for the multiplication result in field emulation, then part of the computation depends on the number of limbs of the multiplication result. Previously, we used `uint(math.Log2(float64(2*nbResLimbs-1)))+1`, but this lead to inconsistent results when `nbResLimbs` was 0. In that case we take log2 of a negative value which is `NaN`. However, on ARM `uint(NaN) = 0` but on x86 `uint(NaN) = math.Max`.

We now use `bits.Len` which is correct for all platforms and avoids doing cast to floating point values.

Additionally, added a check that in case we compute number of limbs for two inputs both having zero inputs. Reviewing code-base, this edge case does not happen, but adding as a protective measure.

This bug appeared when we compoute inverse and division overflows. There, we reused multiplication precondition for computing overflow, but had omitted the number of limbs for the result from the hint. This PR also fixes these calls.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Test suite.

# How has this been benchmarked?

Not benchmarked.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
