### PR TITLE
Perf: variant of the Karabina cyclotomic squaring

### DIFF
--- a/std/algebra/emulated/fields_bw6761/e6.go
+++ b/std/algebra/emulated/fields_bw6761/e6.go
@@ -105,10 +105,103 @@ func (e Ext6) Square(x *E6) *E6 {
 	}
 }
 
-// Karabina's compressed cyclotomic square
+// Karabina's compressed cyclotomic square SQR12345
+// https://eprint.iacr.org/2010/542.pdf
+// Sec. 5.6 with minor modifications to fit our tower
+func (e Ext6) CyclotomicSquareKarabina12345(x *E6) *E6 {
+	x = e.Reduce(x)
+
+	// h4 = -g4 + 3((g3+g5)(g1+c*g2)-g1g5-c*g3g2)
+	g1g5 := e.fp.Mul(&x.B0.A1, &x.B1.A2)
+	g3g2 := e.fp.Mul(&x.B1.A0, &x.B0.A2)
+	h4 := mulFpByNonResidue(e.fp, &x.B0.A2)
+	h4 = e.fp.Add(h4, &x.B0.A1)
+	t := e.fp.Add(&x.B1.A0, &x.B1.A2)
+	h4 = e.fp.Mul(h4, t)
+	h4 = e.fp.Sub(h4, g1g5)
+	t = mulFpByNonResidue(e.fp, g3g2)
+	h4 = e.fp.Sub(h4, t)
+	h4 = e.fp.MulConst(h4, big.NewInt(3))
+	h4 = e.fp.Sub(h4, &x.B1.A1)
+
+	// h3 = 2(g3+3c*g1g5)
+	h3 := mulFpByNonResidue(e.fp, g1g5)
+	h3 = e.fp.MulConst(h3, big.NewInt(3))
+	h3 = e.fp.Add(h3, &x.B1.A0)
+	h3 = e.fp.MulConst(h3, big.NewInt(2))
+
+	// h2 = 3((g1+g5)(g1+c*g5)-c*g1g5-g1g5)-2g2
+	t = mulFpByNonResidue(e.fp, &x.B1.A2)
+	t = e.fp.Add(t, &x.B0.A1)
+	h2 := e.fp.Add(&x.B1.A2, &x.B0.A1)
+	h2 = e.fp.Mul(h2, t)
+	h2 = e.fp.Sub(h2, g1g5)
+	t = mulFpByNonResidue(e.fp, g1g5)
+	h2 = e.fp.Sub(h2, t)
+	h2 = e.fp.MulConst(h2, big.NewInt(3))
+	t = e.fp.MulConst(&x.B0.A2, big.NewInt(2))
+	h2 = e.fp.Sub(h2, t)
+
+	// h1 = 3((g3+g2)(g3+c*g2)-c*g3g2-g3g2)-2g1
+	t = mulFpByNonResidue(e.fp, &x.B0.A2)
+	t = e.fp.Add(t, &x.B1.A0)
+	h1 := e.fp.Add(&x.B0.A2, &x.B1.A0)
+	h1 = e.fp.Mul(h1, t)
+	h1 = e.fp.Sub(h1, g3g2)
+	t = mulFpByNonResidue(e.fp, g3g2)
+	h1 = e.fp.Sub(h1, t)
+	h1 = e.fp.MulConst(h1, big.NewInt(3))
+	t = e.fp.MulConst(&x.B0.A1, big.NewInt(2))
+	h1 = e.fp.Sub(h1, t)
+
+	// h5 = 2(g5+3g3g2)
+	h5 := e.fp.MulConst(g3g2, big.NewInt(3))
+	h5 = e.fp.Add(h5, &x.B1.A2)
+	h5 = e.fp.MulConst(h5, big.NewInt(2))
+
+	return &E6{
+		B0: E3{
+			A0: x.B0.A0,
+			A1: *h1,
+			A2: *h2,
+		},
+		B1: E3{
+			A0: *h3,
+			A1: *h4,
+			A2: *h5,
+		},
+	}
+}
+
+// DecompressKarabina12345 decompresses Karabina's cyclotomic square result SQR12345
+func (e Ext6) DecompressKarabina12345(x *E6) *E6 {
+	x = e.Reduce(x)
+
+	// h0 = (2g4^2 + g3g5 - 3g2g1)*c + 1
+	t0 := e.fp.Mul(&x.B0.A1, &x.B0.A2)
+	t0 = e.fp.MulConst(t0, big.NewInt(3))
+	t1 := e.fp.Mul(&x.B1.A0, &x.B1.A2)
+	h0 := e.fp.Mul(&x.B1.A1, &x.B1.A1)
+	h0 = e.fp.MulConst(h0, big.NewInt(2))
+	h0 = e.fp.Add(h0, t1)
+	h0 = e.fp.Sub(h0, t0)
+	h0 = mulFpByNonResidue(e.fp, h0)
+	h0 = e.fp.Add(h0, e.fp.One())
+
+	return &E6{
+		B0: E3{
+			A0: *h0,
+			A1: x.B0.A1,
+			A2: x.B0.A2,
+		},
+		B1: x.B1,
+	}
+}
+
+// Karabina's compressed cyclotomic square SQR2345
 // https://eprint.iacr.org/2010/542.pdf
 // Th. 3.2 with minor modifications to fit our tower
-func (e Ext6) CyclotomicSquareCompressed(x *E6) *E6 {
+func (e Ext6) CyclotomicSquareKarabina2345(x *E6) *E6 {
 	x = e.Reduce(x)
 	z := e.Copy(x)
 
@@ -183,7 +276,7 @@ func (e Ext6) CyclotomicSquareCompressed(x *E6) *E6 {
 	return z
 }
 
-// DecompressKarabina Karabina's cyclotomic square result
+// DecompressKarabina2345 decompresses Karabina's cyclotomic square result SQR2345
 // if g3 != 0
 //
 //	g4 = (E * g5^2 + 3 * g1^2 - 2 * g2)/4g3
@@ -194,7 +287,7 @@ func (e Ext6) CyclotomicSquareCompressed(x *E6) *E6 {
 //
 // if g3=g2=0 then g4=g5=g1=0 and g0=1 (x=1)
 // Theorem 3.1 is well-defined for all x in Gϕₙ\{1}
-func (e Ext6) DecompressKarabina(x *E6) *E6 {
+func (e Ext6) DecompressKarabina2345(x *E6) *E6 {
 
 	x = e.Reduce(x)
 
@@ -246,7 +339,7 @@ func (e Ext6) DecompressKarabina(x *E6) *E6 {
 	t[2] = e.fp.Sub(t[2], t[1])
 	// t1 = g3 * g5 (g3 can be 0)
 	t[1] = e.fp.Mul(&x.B1.A0, &x.B1.A2)
-	// c₀ = E * (2 * g4² + g3 * g5 - 3 * g2 * g1) + 1
+	// g0 = E * (2 * g4² + g3 * g5 - 3 * g2 * g1) + 1
 	t[2] = e.fp.Add(t[2], t[1])
 
 	z.B0.A0 = *mulFpByNonResidue(e.fp, t[2])

--- a/std/algebra/emulated/fields_bw6761/e6_pairing.go
+++ b/std/algebra/emulated/fields_bw6761/e6_pairing.go
@@ -6,9 +6,16 @@ import (
 	"github.com/consensys/gnark/std/math/emulated"
 )
 
-func (e Ext6) nSquareCompressed(z *E6, n int) *E6 {
+func (e Ext6) nSquareKarabina2345(z *E6, n int) *E6 {
 	for i := 0; i < n; i++ {
-		z = e.CyclotomicSquareCompressed(z)
+		z = e.CyclotomicSquareKarabina2345(z)
+	}
+	return z
+}
+
+func (e Ext6) nSquareKarabina12345(z *E6, n int) *E6 {
+	for i := 0; i < n; i++ {
+		z = e.CyclotomicSquareKarabina12345(z)
 	}
 	return z
 }
@@ -18,20 +25,20 @@ func (e Ext6) nSquareCompressed(z *E6, n int) *E6 {
 func (e Ext6) ExpX0Minus1(z *E6) *E6 {
 	z = e.Reduce(z)
 	result := e.Copy(z)
-	result = e.nSquareCompressed(result, 5)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina12345(result, 5)
+	result = e.DecompressKarabina12345(result)
 	result = e.Mul(result, z)
 	z33 := e.Copy(result)
-	result = e.nSquareCompressed(result, 7)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina12345(result, 7)
+	result = e.DecompressKarabina12345(result)
 	result = e.Mul(result, z33)
-	result = e.nSquareCompressed(result, 4)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina12345(result, 4)
+	result = e.DecompressKarabina12345(result)
 	result = e.Mul(result, z)
 	result = e.CyclotomicSquare(result)
 	result = e.Mul(result, z)
-	result = e.nSquareCompressed(result, 46)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina2345(result, 46)
+	result = e.DecompressKarabina2345(result)
 
 	return result
 }
@@ -41,29 +48,29 @@ func (e Ext6) ExpX0Minus1(z *E6) *E6 {
 func (e Ext6) ExpX0Minus1Square(z *E6) *E6 {
 	z = e.Reduce(z)
 	result := e.Copy(z)
-	result = e.nSquareCompressed(result, 3)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina12345(result, 3)
+	result = e.DecompressKarabina12345(result)
 	t0 := e.CyclotomicSquare(result)
 	t2 := e.Mul(z, t0)
 	result = e.Mul(result, t2)
 	t0 = e.Mul(z, result)
 	t1 := e.CyclotomicSquare(t0)
 	t1 = e.Mul(t2, t1)
-	t3 := e.nSquareCompressed(t1, 7)
-	t3 = e.DecompressKarabina(t3)
+	t3 := e.nSquareKarabina12345(t1, 7)
+	t3 = e.DecompressKarabina12345(t3)
 	t2 = e.Mul(t2, t3)
-	t2 = e.nSquareCompressed(t2, 11)
-	t2 = e.DecompressKarabina(t2)
+	t2 = e.nSquareKarabina12345(t2, 11)
+	t2 = e.DecompressKarabina12345(t2)
 	t1 = e.Mul(t1, t2)
 	t0 = e.Mul(t0, t1)
-	t0 = e.nSquareCompressed(t0, 7)
-	t0 = e.DecompressKarabina(t0)
+	t0 = e.nSquareKarabina12345(t0, 7)
+	t0 = e.DecompressKarabina12345(t0)
 	result = e.Mul(result, t0)
-	result = e.nSquareCompressed(result, 3)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina12345(result, 3)
+	result = e.DecompressKarabina12345(result)
 	result = e.Mul(z, result)
-	result = e.nSquareCompressed(result, 92)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina2345(result, 92)
+	result = e.DecompressKarabina2345(result)
 
 	return result
 
@@ -75,20 +82,20 @@ func (e Ext6) ExpX0Plus1(z *E6) *E6 {
 	z = e.Reduce(z)
 	result := e.Copy(z)
 	t := e.CyclotomicSquare(result)
-	result = e.nSquareCompressed(t, 4)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina12345(t, 4)
+	result = e.DecompressKarabina12345(result)
 	result = e.Mul(result, z)
 	z33 := e.Copy(result)
-	result = e.nSquareCompressed(result, 7)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina12345(result, 7)
+	result = e.DecompressKarabina12345(result)
 	result = e.Mul(result, z33)
-	result = e.nSquareCompressed(result, 4)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina12345(result, 4)
+	result = e.DecompressKarabina12345(result)
 	result = e.Mul(result, z)
 	result = e.CyclotomicSquare(result)
 	result = e.Mul(result, z)
-	result = e.nSquareCompressed(result, 46)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina2345(result, 46)
+	result = e.DecompressKarabina2345(result)
 	result = e.Mul(result, t)
 
 	return result
@@ -104,14 +111,14 @@ func (e Ext6) ExptMinus1Div3(z *E6) *E6 {
 	result = e.Mul(result, z)
 	result = e.CyclotomicSquare(result)
 	result = e.Mul(result, z)
-	t0 := e.nSquareCompressed(result, 7)
-	t0 = e.DecompressKarabina(t0)
+	t0 := e.nSquareKarabina12345(result, 7)
+	t0 = e.DecompressKarabina2345(t0)
 	result = e.Mul(result, t0)
-	result = e.nSquareCompressed(result, 5)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina12345(result, 5)
+	result = e.DecompressKarabina12345(result)
 	result = e.Mul(result, z)
-	result = e.nSquareCompressed(result, 46)
-	result = e.DecompressKarabina(result)
+	result = e.nSquareKarabina2345(result, 46)
+	result = e.DecompressKarabina2345(result)
 
 	return result
 }
@@ -138,8 +145,8 @@ func (e Ext6) ExpC2(z *E6) *E6 {
 	z = e.Reduce(z)
 	result := e.CyclotomicSquare(z)
 	result = e.Mul(result, z)
-	t0 := e.nSquareCompressed(result, 4)
-	t0 = e.DecompressKarabina(t0)
+	t0 := e.nSquareKarabina12345(result, 4)
+	t0 = e.DecompressKarabina12345(t0)
 	result = e.Mul(result, t0)
 	result = e.CyclotomicSquare(result)
 	result = e.Mul(result, z)

--- a/std/algebra/emulated/fields_bw6761/e6_test.go
+++ b/std/algebra/emulated/fields_bw6761/e6_test.go
@@ -245,18 +245,18 @@ func TestConjugateFp6(t *testing.T) {
 	assert.NoError(err)
 }
 
-type e6CyclotomicSquareCompressed struct {
+type e6CyclotomicSquareKarabina2345 struct {
 	A, B E6
 }
 
-func (circuit *e6CyclotomicSquareCompressed) Define(api frontend.API) error {
+func (circuit *e6CyclotomicSquareKarabina2345) Define(api frontend.API) error {
 	e := NewExt6(api)
-	expected := e.CyclotomicSquareCompressed(&circuit.A)
+	expected := e.CyclotomicSquareKarabina2345(&circuit.A)
 	e.AssertIsEqual(expected, &circuit.B)
 	return nil
 }
 
-func TestCyclotomicSquareCompressedFp6(t *testing.T) {
+func TestCyclotomicSquareKarabina2345Fp6(t *testing.T) {
 	assert := test.NewAssert(t)
 	// witness values
 	var a, b bw6761.E6
@@ -264,27 +264,27 @@ func TestCyclotomicSquareCompressedFp6(t *testing.T) {
 	b.Set(&a)
 	b.CyclotomicSquareCompressed(&a)
 
-	witness := e6CyclotomicSquareCompressed{
+	witness := e6CyclotomicSquareKarabina2345{
 		A: FromE6(&a),
 		B: FromE6(&b),
 	}
 
-	err := test.IsSolved(&e6CyclotomicSquareCompressed{}, &witness, ecc.BN254.ScalarField())
+	err := test.IsSolved(&e6CyclotomicSquareKarabina2345{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
 }
 
-type e6DecompressKarabina struct {
+type e6DecompressKarabina2345 struct {
 	A, B E6
 }
 
-func (circuit *e6DecompressKarabina) Define(api frontend.API) error {
+func (circuit *e6DecompressKarabina2345) Define(api frontend.API) error {
 	e := NewExt6(api)
-	expected := e.DecompressKarabina(&circuit.A)
+	expected := e.DecompressKarabina2345(&circuit.A)
 	e.AssertIsEqual(expected, &circuit.B)
 	return nil
 }
 
-func TestDecompressKarabinaFp6(t *testing.T) {
+func TestDecompressKarabina2345Fp6(t *testing.T) {
 	assert := test.NewAssert(t)
 	// witness values
 	var a, b bw6761.E6
@@ -292,12 +292,12 @@ func TestDecompressKarabinaFp6(t *testing.T) {
 	b.Set(&a)
 	a.DecompressKarabina(&a)
 
-	witness := e6DecompressKarabina{
+	witness := e6DecompressKarabina2345{
 		A: FromE6(&b),
 		B: FromE6(&a),
 	}
 
-	err := test.IsSolved(&e6DecompressKarabina{}, &witness, ecc.BN254.ScalarField())
+	err := test.IsSolved(&e6DecompressKarabina2345{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
 }
 

--- a/std/algebra/native/fields_bls12377/e12_pairing.go
+++ b/std/algebra/native/fields_bls12377/e12_pairing.go
@@ -2,6 +2,20 @@ package fields_bls12377
 
 import "github.com/consensys/gnark/frontend"
 
+// nSquareKarabina2345 repeated compressed cyclotmic square
+func (e *E12) nSquareKarabina2345(api frontend.API, n int) {
+	for i := 0; i < n; i++ {
+		e.CyclotomicSquareKarabina2345(api, *e)
+	}
+}
+
+// nSquareKarabina12345 repeated compressed cyclotmic square
+func (e *E12) nSquareKarabina12345(api frontend.API, n int) {
+	for i := 0; i < n; i++ {
+		e.CyclotomicSquareKarabina12345(api, *e)
+	}
+}
+
 // Square034 squares a sparse element in Fp12
 func (e *E12) Square034(api frontend.API, x E12) *E12 {
 	var c0, c2, c3 E6
@@ -116,20 +130,20 @@ func (e *E12) Expt(api frontend.API, e1 E12, exponent uint64) *E12 {
 
 	res := e1
 
-	res.nSquareCompressed(api, 5)
-	res.Decompress(api, res)
+	res.nSquareKarabina2345(api, 5)
+	res.DecompressKarabina2345(api, res)
 	res.Mul(api, res, e1)
 	x33 := res
-	res.nSquareCompressed(api, 7)
-	res.Decompress(api, res)
+	res.nSquareKarabina2345(api, 7)
+	res.DecompressKarabina2345(api, res)
 	res.Mul(api, res, x33)
-	res.nSquareCompressed(api, 4)
-	res.Decompress(api, res)
+	res.nSquareKarabina2345(api, 4)
+	res.DecompressKarabina2345(api, res)
 	res.Mul(api, res, e1)
 	res.CyclotomicSquare(api, res)
 	res.Mul(api, res, e1)
-	res.nSquareCompressed(api, 46)
-	res.Decompress(api, res)
+	res.nSquareKarabina2345(api, 46)
+	res.DecompressKarabina2345(api, res)
 	res.Mul(api, res, e1)
 
 	*e = res

--- a/std/algebra/native/fields_bls12377/e12_test.go
+++ b/std/algebra/native/fields_bls12377/e12_test.go
@@ -198,25 +198,25 @@ func TestFp12CyclotomicSquare(t *testing.T) {
 
 }
 
-type fp12CycloSquareCompressed struct {
+type fp12CycloSquareKarabina2345 struct {
 	A E12
 	B E12 `gnark:",public"`
 }
 
-func (circuit *fp12CycloSquareCompressed) Define(api frontend.API) error {
+func (circuit *fp12CycloSquareKarabina2345) Define(api frontend.API) error {
 
 	var u, v E12
 	u.Square(api, circuit.A)
-	v.CyclotomicSquareCompressed(api, circuit.A)
-	v.Decompress(api, v)
+	v.CyclotomicSquareKarabina2345(api, circuit.A)
+	v.DecompressKarabina2345(api, v)
 	u.AssertIsEqual(api, v)
 	u.AssertIsEqual(api, circuit.B)
 	return nil
 }
 
-func TestFp12CyclotomicSquareCompressed(t *testing.T) {
+func TestFp12CyclotomicSquareKarabina2345(t *testing.T) {
 
-	var circuit, witness fp12CycloSquareCompressed
+	var circuit, witness fp12CycloSquareKarabina2345
 
 	// witness values
 	var a, b bls12377.E12

--- a/std/algebra/native/fields_bls24315/e24.go
+++ b/std/algebra/native/fields_bls24315/e24.go
@@ -185,7 +185,7 @@ func (e *E24) Square(api frontend.API, x E24) *E24 {
 
 // Karabina's compressed cyclotomic square
 // https://eprint.iacr.org/2010/542.pdf
-func (e *E24) CyclotomicSquareCompressed(api frontend.API, x E24) *E24 {
+func (e *E24) CyclotomicSquareKarabina2345(api frontend.API, x E24) *E24 {
 	var t [7]E4
 
 	// t0 = g1²
@@ -257,8 +257,8 @@ func (e *E24) CyclotomicSquareCompressed(api frontend.API, x E24) *E24 {
 	return e
 }
 
-// Decompress Karabina's cyclotomic square result
-func (e *E24) Decompress(api frontend.API, x E24) *E24 {
+// DecompressKarabina2345 Karabina's cyclotomic square result
+func (e *E24) DecompressKarabina2345(api frontend.API, x E24) *E24 {
 
 	var t [3]E4
 	var _t [2]E4
@@ -549,10 +549,10 @@ func (e *E24) DivUnchecked(api frontend.API, e1, e2 E24) *E24 {
 	return e
 }
 
-// nSquareCompressed repeated compressed cyclotmic square
-func (e *E24) nSquareCompressed(api frontend.API, n int) {
+// nSquareKarabina2345 repeated compressed cyclotmic square
+func (e *E24) nSquareKarabina2345(api frontend.API, n int) {
 	for i := 0; i < n; i++ {
-		e.CyclotomicSquareCompressed(api, *e)
+		e.CyclotomicSquareKarabina2345(api, *e)
 	}
 }
 

--- a/std/algebra/native/fields_bls24315/e24_pairing.go
+++ b/std/algebra/native/fields_bls24315/e24_pairing.go
@@ -78,13 +78,13 @@ func (e *E24) Expt(api frontend.API, x E24, exponent uint64) *E24 {
 
 	res.nSquare(api, 2)
 	res.Mul(api, res, xInv)
-	res.nSquareCompressed(api, 8)
-	res.Decompress(api, res)
+	res.nSquareKarabina2345(api, 8)
+	res.DecompressKarabina2345(api, res)
 	res.Mul(api, res, xInv)
 	res.nSquare(api, 2)
 	res.Mul(api, res, x)
-	res.nSquareCompressed(api, 20)
-	res.Decompress(api, res)
+	res.nSquareKarabina2345(api, 20)
+	res.DecompressKarabina2345(api, res)
 	res.Mul(api, res, xInv)
 	res.Conjugate(api, res)
 

--- a/std/algebra/native/fields_bls24315/e24_test.go
+++ b/std/algebra/native/fields_bls24315/e24_test.go
@@ -194,25 +194,25 @@ func TestFp24CyclotomicSquare(t *testing.T) {
 
 }
 
-type fp24CycloSquareCompressed struct {
+type fp24CycloSquareKarabina2345 struct {
 	A E24
 	B E24 `gnark:",public"`
 }
 
-func (circuit *fp24CycloSquareCompressed) Define(api frontend.API) error {
+func (circuit *fp24CycloSquareKarabina2345) Define(api frontend.API) error {
 
 	var u, v E24
 	u.Square(api, circuit.A)
-	v.CyclotomicSquareCompressed(api, circuit.A)
-	v.Decompress(api, v)
+	v.CyclotomicSquareKarabina2345(api, circuit.A)
+	v.DecompressKarabina2345(api, v)
 	u.AssertIsEqual(api, v)
 	u.AssertIsEqual(api, circuit.B)
 	return nil
 }
 
-func TestFp24CyclotomicSquareCompressed(t *testing.T) {
+func TestFp24CyclotomicSquareKarabina2345(t *testing.T) {
 
-	var circuit, witness fp24CycloSquareCompressed
+	var circuit, witness fp24CycloSquareKarabina2345
 
 	// witness values
 	var a, b bls24315.E24
@@ -225,7 +225,7 @@ func TestFp24CyclotomicSquareCompressed(t *testing.T) {
 	tmp.Mul(&tmp, &a)
 	a.FrobeniusQuad(&tmp).Mul(&a, &tmp)
 
-	b.CyclotomicSquare(&a)
+	b.CyclotomicSquareCompressed(&a)
 	b.DecompressKarabina(&b)
 	witness.A.Assign(&a)
 	witness.B.Assign(&b)


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Currently we implement Theorem 3.2 from https://eprint.iacr.org/2010/542.pdf whenever we have 3 repeated squaring or more in the final exponentiation. It is the fastest variant of cyclotomic squaring but in-circuit the selector logic to handle branching cases when denominators are zero makes it not always the best in some cases. This PR compares different variants in Sec. 5 and proposes a tradeoff:
- For the native case, when repeated squaring size is:
    - 1 or 2 --> we choose Granger-Scott
    - 3 --> we choose Karabina SQR12345 (*implemented in this PR*)
    - 4 or more --> we choose Karabina SQR2345 (*implemented previously*)
So nothing changes concretely for BLS12-377 since we do not encouter the case of size 3.

- For emulated case, it difficult to theoretically set a threshold due to emulated arithmetic but empirically for BW6-761:
    - for sizes 1 and 2 --> we use Granger-Scott
    - for sizes 3, 4, 5, 7 and 11 --> we use Karabina SQR12345 (*implemented in this PR*)
    - for size 46 and 92 --> we use Karabina SQR2345 (*implemented previously*)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

`TestExptFp6` and `TestFinalExponentiationTestSolve` are used here to test the new Karabina variants. Otherwise we need to implement the go version of these in gnark-crypto.

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

For BW6-761, this saves 290826 SCS in the Final exp.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

