### PR TITLE
Clarifying Documentation Through Corrections in Code Comments

### DIFF
--- a/constraint/r1cs.go
+++ b/constraint/r1cs.go
@@ -135,7 +135,7 @@ func (it *R1CIterator) Next() *R1C {
 // 	if cptHints != 0 {
 // 		// TODO @gbotrel @ivokub investigate --> emulated hints seems to go in this path a lot.
 // 		sbb.WriteString(strconv.Itoa(cptHints))
-// 		sbb.WriteString(" unconstrained hints; i.e. wire created through NewHint() but doesn't not appear in the constraint system")
+// 		sbb.WriteString(" unconstrained hints; i.e. wire created through NewHint() but does not appear in the constraint system")
 // 		sbb.WriteByte('\n')
 // 		log := logger.Logger()
 // 		log.Warn().Err(errors.New(sbb.String())).Send()

--- a/constraint/system.go
+++ b/constraint/system.go
@@ -71,7 +71,7 @@ type ConstraintSystem interface {
 	// debug information only once.
 	AttachDebugInfo(debugInfo DebugInfo, constraintID []int)
 
-	// CheckUnconstrainedWires returns and error if the constraint system has wires that are not uniquely constrained.
+	// CheckUnconstrainedWires returns an error if the constraint system has wires that are not uniquely constrained.
 	// This is experimental.
 	CheckUnconstrainedWires() error
 

--- a/frontend/api.go
+++ b/frontend/api.go
@@ -106,7 +106,7 @@ type API interface {
 	//  * -1 if i1<i2.
 	//
 	// If the absolute difference between the variables i1 and i2 is known, then
-	// it is more efficient to use the bounded methdods in package
+	// it is more efficient to use the bounded methods in package
 	// [github.com/consensys/gnark/std/math/bits].
 	Cmp(i1, i2 Variable) Variable
 
@@ -127,7 +127,7 @@ type API interface {
 	// AssertIsLessOrEqual fails if v > bound.
 	//
 	// If the absolute difference between the variables b and bound is known, then
-	// it is more efficient to use the bounded methdods in package
+	// it is more efficient to use the bounded methods in package
 	// [github.com/consensys/gnark/std/math/bits].
 	AssertIsLessOrEqual(v Variable, bound Variable)
 

--- a/frontend/compile.go
+++ b/frontend/compile.go
@@ -78,7 +78,7 @@ func parseCircuit(builder Builder, circuit Circuit) (err error) {
 	log := logger.Logger()
 	log.Info().Int("nbSecret", s.Secret).Int("nbPublic", s.Public).Msg("parsed circuit inputs")
 
-	// leaf handlers are called when encoutering leafs in the circuit data struct
+	// leaf handlers are called when encountering leafs in the circuit data struct
 	// leafs are Constraints that need to be initialized in the context of compiling a circuit
 	variableAdder := func(targetVisibility schema.Visibility) func(f schema.LeafInfo, tInput reflect.Value) error {
 		return func(f schema.LeafInfo, tInput reflect.Value) error {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,4 +1,4 @@
-// Package logger provides a configurable logger accross gnark components
+// Package logger provides a configurable logger across gnark components
 //
 // The root logger defined by default uses github.com/rs/zerolog with a console writer
 package logger
@@ -29,7 +29,7 @@ func SetOutput(w io.Writer) {
 	logger = logger.Output(w)
 }
 
-// Set allow a gnark user to overhide the global logger
+// Set allow a gnark user to override the global logger
 func Set(l zerolog.Logger) {
 	logger = l
 }

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -26,7 +26,7 @@ var (
 // Profile represents an active constraint system profiling session.
 type Profile struct {
 	// defaults to ./gnark.pprof
-	// if blank, profiile is not written to disk
+	// if blank, profile is not written to disk
 	filePath string
 
 	// actual pprof profile struct

--- a/profile/profile_worker.go
+++ b/profile/profile_worker.go
@@ -11,7 +11,7 @@ import (
 )
 
 // since we are assuming usage of this package from a single go routine, this channel only has
-// one "producer", and one "consumer". it's purpose is to guarantee the order of execution of
+// one "producer", and one "consumer". its purpose is to guarantee the order of execution of
 // adding / removing a profiling session and sampling events, while enabling the caller
 // (frontend.Compile) to sample the events asynchronously.
 var chCommands = make(chan command, 100)

--- a/std/commitments/kzg/verifier.go
+++ b/std/commitments/kzg/verifier.go
@@ -486,7 +486,7 @@ func (v *Verifier[FR, G1El, G2El, GTEl]) BatchVerifySinglePoint(digests []Commit
 func (v *Verifier[FR, G1El, G2El, GTEl]) BatchVerifyMultiPoints(digests []Commitment[G1El], proofs []OpeningProof[FR, G1El], points []emulated.Element[FR], vk VerifyingKey[G1El, G2El]) error {
 	var fr FR
 
-	// check consistency nb proogs vs nb digests
+	// check consistency nb proofs vs nb digests
 	if len(digests) != len(proofs) {
 		return fmt.Errorf("number of commitments doesn't match number of proofs")
 	}

--- a/std/internal/logderivarg/logderivarg.go
+++ b/std/internal/logderivarg/logderivarg.go
@@ -6,7 +6,7 @@
 //
 //	∏_{f∈F} (x-f)^count(f, S) == ∏_{s∈S} x-s,
 //
-// where function `count` counts the number of occurences of f in S. The problem
+// where function `count` counts the number of occurrences of f in S. The problem
 // with this approach is the high cost for exponentiating the left-hand side of
 // the equation. However, in [Haböck22] it was shown that when avoiding the
 // poles, we can perform the same check for the log-derivative variant of the


### PR DESCRIPTION
I've made a few small fixes in the code. These changes will make things clearer and more professional. 
Here's what I've done:

1. *Commit 1510c482d0ce*: Fixed a spelling mistake - 'occurences' to 'occurrences'.
2. *Commit 2dd657516f54*: Changed 'proogs' to 'proofs'.
3. *Commit 646707201085*: Corrected 'it's purpose' to 'its purpose'.
4. *Commit 62ee7f025791*: Fixed 'profiile' to 'profile'.
5. *Commit 66596e916d37*: Updated 'encoutering' to 'encountering'.
6. *Commit 8ce301eb5184*: Changed 'overhide' to 'override' and 'accross' to 'across'.
7. *Commit 7aa874fbb270*: Tweaked an error message to make it clearer.
8. *Commit b1076889bde8*: Fixed a confusing part where 'doesn't not' should be 'does not'.
9. *Commit 62d1f4c48d94*: Corrected 'methdods' to 'methods'.

The fix in commit b1076889bde8 is important because it was misleading before with the double negative "doesn't not", please check that the correct way is "does not".
