### PR TITLE
Fix std/recursion/plonk native and emulated examples

### DIFF
--- a/std/recursion/plonk/native_doc_test.go
+++ b/std/recursion/plonk/native_doc_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/consensys/gnark/test/unsafekzg"
 )
 
-// Example of verifying recursively BLS12-371 PLONK proof in BW6-761 PLONK circuit using field emulation
+// Example of verifying recursively BLS12-377 PLONK proof in BW6-761 PLONK circuit using field emulation
 func Example_native() {
 	// compute the proof which we want to verify recursively
-	innerCcs, innerVK, innerWitness, innerProof := computeInnerProof(ecc.BW6_761.ScalarField(), ecc.BN254.ScalarField())
+	innerCcs, innerVK, innerWitness, innerProof := computeInnerProof(
+		ecc.BLS12_377.ScalarField(), ecc.BW6_761.ScalarField(),
+	)
 
 	// initialize the witness elements
 	circuitVk, err := plonk.ValueOfVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine](innerVK)
@@ -39,7 +41,7 @@ func Example_native() {
 		Proof:        circuitProof,
 	}
 	// compile the outer circuit
-	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, outerCircuit)
+	ccs, err := frontend.Compile(ecc.BW6_761.ScalarField(), scs.NewBuilder, outerCircuit)
 	if err != nil {
 		panic("compile failed: " + err.Error())
 	}
@@ -57,7 +59,7 @@ func Example_native() {
 	}
 
 	// create prover witness from the assignment
-	secretWitness, err := frontend.NewWitness(outerAssignment, ecc.BN254.ScalarField())
+	secretWitness, err := frontend.NewWitness(outerAssignment, ecc.BW6_761.ScalarField())
 	if err != nil {
 		panic("secret witness failed: " + err.Error())
 	}
@@ -74,7 +76,7 @@ func Example_native() {
 		panic("proving failed: " + err.Error())
 	}
 
-	// verify the Groth16 proof
+	// verify the PLONK proof
 	err = native_plonk.Verify(outerProof, vk, publicWitness)
 	if err != nil {
 		panic("circuit verification failed: " + err.Error())

--- a/std/recursion/plonk/native_doc_test.go
+++ b/std/recursion/plonk/native_doc_test.go
@@ -45,7 +45,7 @@ func Example_native() {
 	}
 
 	// NB! UNSAFE! Use MPC.
-	srs, srsLagrange, err := unsafekzg.NewSRS(innerCcs)
+	srs, srsLagrange, err := unsafekzg.NewSRS(ccs)
 	if err != nil {
 		panic(err)
 	}

--- a/std/recursion/plonk/nonnative_doc_test.go
+++ b/std/recursion/plonk/nonnative_doc_test.go
@@ -131,7 +131,7 @@ func Example_emulated() {
 	}
 
 	// NB! UNSAFE! Use MPC.
-	srs, srsLagrange, err := unsafekzg.NewSRS(innerCcs)
+	srs, srsLagrange, err := unsafekzg.NewSRS(ccs)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Description

While studying in-circuit verification with PLONK, I found the existing examples to be of great help. During my research, I discovered some flaws in them and decided to correct these issues for others who might evaluate the same feature in the future.

~Fixes # (issue)~ Currently, there is no dedicated ticket reporting this problem. This PR is primarily a convenience change that does not alter the actual library code. Therefore, I did not think it was necessary to open a ticket. However, please let me know if doing so is required; I would be happy to create one and update this paragraph accordingly.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

These examples are not actual Golang tests, but converting them for such use is straightforward. What I did was simply rename `func Example_emulated()` to `func Example_emulated(t *testing.T)` (and did the same for the other example). This change is sufficient to transform them into Golang-style test cases and run them accordingly.

One could also create a separate project and copy the code, which is a reasonable first step for anyone developing their own program with in-circuit PLONK verification.

# How has this been benchmarked?

Since this is just an example, I did not perform any benchmarking.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

No, but this does not seem relevant since the examples serve, to some extent, as tests themselves.

- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

No, but since I'm modifying only examples, this does not seem to be relevant.