### PR TITLE
perf(ecdsa): use GLV in JointScalarMulBase

### DIFF
--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -854,7 +854,7 @@ func (c *Curve[B, S]) ScalarMulBase(s *emulated.Element[S], opts ...algopts.Alge
 // This saves the Select logic related to (0,0) and the use of AddUnified to
 // handle the 0-scalar edge case.
 func (c *Curve[B, S]) JointScalarMulBase(p *AffinePoint[B], s2, s1 *emulated.Element[S]) *AffinePoint[B] {
-	return c.jointScalarMul(p, c.Generator(), s1, s2)
+	return c.jointScalarMul(c.Generator(), p, s1, s2)
 }
 
 // MultiScalarMul computes the multi scalar multiplication of the points P and

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -854,67 +854,7 @@ func (c *Curve[B, S]) ScalarMulBase(s *emulated.Element[S], opts ...algopts.Alge
 // This saves the Select logic related to (0,0) and the use of AddUnified to
 // handle the 0-scalar edge case.
 func (c *Curve[B, S]) JointScalarMulBase(p *AffinePoint[B], s2, s1 *emulated.Element[S]) *AffinePoint[B] {
-	g := c.Generator()
-	gm := c.GeneratorMultiples()
-
-	var st S
-	s1r := c.scalarApi.Reduce(s1)
-	s1Bits := c.scalarApi.ToBits(s1r)
-	s2r := c.scalarApi.Reduce(s2)
-	s2Bits := c.scalarApi.ToBits(s2r)
-	n := st.Modulus().BitLen()
-
-	// fixed-base
-	// i = 1, 2
-	// gm[0] = 3g, gm[1] = 5g, gm[2] = 7g
-	res1 := c.Lookup2(s1Bits[1], s1Bits[2], g, &gm[0], &gm[1], &gm[2])
-	// var-base
-	// i = 1
-	Rb := c.triple(p)
-	R0 := c.Select(s2Bits[1], Rb, p)
-	R1 := c.Select(s2Bits[1], p, Rb)
-	// i = 2
-	Rb = c.doubleAndAddSelect(s2Bits[2], R0, R1)
-	R0 = c.Select(s2Bits[2], Rb, R0)
-	R1 = c.Select(s2Bits[2], R1, Rb)
-
-	for i := 3; i <= n-3; i++ {
-		// fixed-base
-		// gm[i] = [2^i]g
-		tmp1 := c.add(res1, &gm[i])
-		res1 = c.Select(s1Bits[i], tmp1, res1)
-		// var-base
-		Rb = c.doubleAndAddSelect(s2Bits[i], R0, R1)
-		R0 = c.Select(s2Bits[i], Rb, R0)
-		R1 = c.Select(s2Bits[i], R1, Rb)
-
-	}
-
-	// i = n-2
-	// fixed-base
-	tmp1 := c.add(res1, &gm[n-2])
-	res1 = c.Select(s1Bits[n-2], tmp1, res1)
-	// var-base
-	Rb = c.doubleAndAddSelect(s2Bits[n-2], R0, R1)
-	R0 = c.Select(s2Bits[n-2], Rb, R0)
-	R1 = c.Select(s2Bits[n-2], R1, Rb)
-
-	// i = n-1
-	// fixed-base
-	tmp1 = c.add(res1, &gm[n-1])
-	res1 = c.Select(s1Bits[n-1], tmp1, res1)
-	// var-base
-	Rb = c.doubleAndAddSelect(s2Bits[n-1], R0, R1)
-	R0 = c.Select(s2Bits[n-1], Rb, R0)
-
-	// i = 0
-	// fixed-base
-	tmp1 = c.add(res1, c.Neg(g))
-	res1 = c.Select(s1Bits[0], res1, tmp1)
-	// var-base
-	R0 = c.Select(s2Bits[0], R0, c.add(R0, c.Neg(p)))
-
-	return c.add(res1, R0)
+	return c.jointScalarMul(p, c.Generator(), s1, s2)
 }
 
 // MultiScalarMul computes the multi scalar multiplication of the points P and


### PR DESCRIPTION
# Description

A tiny PR to use GLV in JointScalarMulBase (needed for ECDSA verifier and ECRECOVER precompile). This takes down the ECRECOVER precompile SCS count from **1.2M** to **688k**.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

Tests in `std/signature/ecdsa` and `std/evmprecompiles` pass. 

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

For ECDSA-Secp256k1 in a B254 SNARK:

- SCS:

|                            | Old                           | New                        |
| --------------- | ------------------- | ------------------ |
| ECDSA verifier  |        1,204,561          |         682,603         |
| ECRECOVER     |        1,210,308          |         688,362         |

- R1CS:

|                            | Old                           | New                        |
| --------------- | ------------------- | ------------------ |
| ECDSA verifier  |      310,721               |         174,047          |
| ECRECOVER     |      313,570               |         176,884         |

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

