### PR TITLE
perf: mark the result of `builder.IsZero` as boolean to save constraints when used in future

### DIFF
--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -565,6 +565,8 @@ func (builder *builder) IsZero(i1 frontend.Variable) frontend.Variable {
 
 	builder.cs.AttachDebugInfo(debug, []int{c1, c2})
 
+	builder.MarkBoolean(m)
+
 	return m
 }
 

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -515,6 +515,8 @@ func (builder *builder) IsZero(i1 frontend.Variable) frontend.Variable {
 		qM: a.Coeff,
 	})
 
+	builder.MarkBoolean(m)
+
 	return m
 }
 


### PR DESCRIPTION
# Description

Hi there, thanks for your amazing work!

In the current implementation of gnark, `builder.Select` introduces a constraint to enforce that the condition is boolean. However, when the condition is from the result of `builder.IsZero`, this constraint is unnecessary, as `builder.IsZero` always returns a value `m` that is guaranteed to be either 0 or 1.

This PR marks `m` in `builder.IsZero` as boolean, so that we can save 1 constraint when using the result in subsequent operations like `Select`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A)
- [ ] I have made corresponding changes to the documentation (N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A)
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (N/A)

