### PR TITLE
fix IsZero bug in std/math/emulated/field_assert.go

### DIFF
--- a/std/math/emulated/field_assert.go
+++ b/std/math/emulated/field_assert.go
@@ -198,7 +198,7 @@ func (f *Field[T]) IsZero(a *Element[T]) frontend.Variable {
 	f.AssertIsInRange(ca)
 	res := f.api.IsZero(ca.Limbs[0])
 	for i := 1; i < len(ca.Limbs); i++ {
-		f.api.Mul(res, f.api.IsZero(ca.Limbs[i]))
+		res = f.api.Mul(res, f.api.IsZero(ca.Limbs[i]))
 	}
 	return res
 }

--- a/std/math/emulated/field_assert_test.go
+++ b/std/math/emulated/field_assert_test.go
@@ -1,0 +1,54 @@
+package emulated
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+	"testing"
+)
+
+type ZeroCircuit[T FieldParams] struct {
+	Var    Element[T]
+	IsZero frontend.Variable `gnark:",public"`
+}
+
+func (c *ZeroCircuit[T]) Define(api frontend.API) error {
+	f, err := NewField[T](api)
+	if err != nil {
+		return err
+	}
+	res := f.IsZero(&c.Var)
+	f.api.AssertIsEqual(res, c.IsZero)
+	return nil
+}
+
+func TestZeroCircuit(t *testing.T) {
+	assert := test.NewAssert(t)
+	type T = BLS12381Fp
+	var circuit, witness ZeroCircuit[T]
+	{
+		//Non-zero
+		el := Element[T]{
+			Limbs:    []frontend.Variable{0, 1, 0, 1, 0, 1},
+			overflow: 0,
+			internal: true,
+		}
+		witness.Var = el
+		witness.IsZero = 0
+
+		err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())
+		assert.NoError(err)
+	}
+	{
+		//Zero
+		el := Element[T]{
+			Limbs:    []frontend.Variable{0, 0, 0, 0, 0, 0},
+			overflow: 0,
+			internal: true,
+		}
+		witness.Var = el
+		witness.IsZero = 1
+
+		err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())
+		assert.NoError(err)
+	}
+}


### PR DESCRIPTION
# Description
Fix the IsZero() bug in std/math/emulated/field_assert.go

Fixes # (issue)
https://github.com/Consensys/gnark/issues/980

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?
zero and Non-zero tests have been implemented in field_assert_test.go


# How has this been benchmarked?
No benchmark has been done

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

