### PR TITLE
fix: remove shorthash override for same field

### DIFF
--- a/std/recursion/plonk/verifier_test.go
+++ b/std/recursion/plonk/verifier_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/consensys/gnark/frontend/cs/scs"
 	"github.com/consensys/gnark/std/algebra"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bls12381"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_bn254"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_bw6761"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls12377"
 	"github.com/consensys/gnark/std/math/emulated"
@@ -292,6 +293,32 @@ func TestBLS12381InBN254Commit(t *testing.T) {
 		VerifyingKey: circuitVk,
 	}
 	outerAssignment := &OuterCircuit[sw_bls12381.ScalarField, sw_bls12381.G1Affine, sw_bls12381.G2Affine, sw_bls12381.GTEl]{
+		InnerWitness: circuitWitness,
+		Proof:        circuitProof,
+	}
+	err = test.IsSolved(outerCircuit, outerAssignment, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}
+
+func TestBN254InBN254Commit(t *testing.T) {
+
+	assert := test.NewAssert(t)
+	innerCcs, innerVK, innerWitness, innerProof := getInnerCommit(assert, ecc.BN254.ScalarField(), ecc.BN254.ScalarField())
+
+	// outer proof
+	circuitVk, err := ValueOfVerifyingKey[sw_bn254.ScalarField, sw_bn254.G1Affine, sw_bn254.G2Affine](innerVK)
+	assert.NoError(err)
+	circuitWitness, err := ValueOfWitness[sw_bn254.ScalarField](innerWitness)
+	assert.NoError(err)
+	circuitProof, err := ValueOfProof[sw_bn254.ScalarField, sw_bn254.G1Affine, sw_bn254.G2Affine](innerProof)
+	assert.NoError(err)
+
+	outerCircuit := &OuterCircuit[sw_bn254.ScalarField, sw_bn254.G1Affine, sw_bn254.G2Affine, sw_bn254.GTEl]{
+		InnerWitness: PlaceholderWitness[sw_bn254.ScalarField](innerCcs),
+		Proof:        PlaceholderProof[sw_bn254.ScalarField, sw_bn254.G1Affine, sw_bn254.G2Affine](innerCcs),
+		VerifyingKey: circuitVk,
+	}
+	outerAssignment := &OuterCircuit[sw_bn254.ScalarField, sw_bn254.G1Affine, sw_bn254.G2Affine, sw_bn254.GTEl]{
 		InnerWitness: circuitWitness,
 		Proof:        circuitProof,
 	}

--- a/std/recursion/wrapped_hash.go
+++ b/std/recursion/wrapped_hash.go
@@ -65,9 +65,6 @@ func NewShort(current, target *big.Int) (hash.Hash, error) {
 		return nil, fmt.Errorf("no default mimc for scalar field: %s", current.String())
 	}
 	hh := h.New()
-	if target.Cmp(current) == 0 {
-		return hh, nil
-	}
 	nbBits := target.BitLen()
 	if nbBits > current.BitLen() {
 		nbBits = current.BitLen()
@@ -164,9 +161,6 @@ func NewHash(api frontend.API, target *big.Int, bitmode bool) (stdhash.FieldHash
 	h, err := mimc.NewMiMC(api)
 	if err != nil {
 		return nil, fmt.Errorf("get mimc: %w", err)
-	}
-	if api.Compiler().Field().Cmp(target) == 0 {
-		return &h, nil
 	}
 	nbBits := target.BitLen()
 	if nbBits > api.Compiler().FieldBitLen() {


### PR DESCRIPTION
Reported by @readygo67 in #1000.

# Description

For proof recursion, we are using "short-hash". When computing Fiat-Shamir challenges in-circuit then instead of emulating the whole MiMC hash in non-native, we instead use the native hash of the circuit and map the values to the target field. For this mapping, we have to perform binary decomposition of the inputs and outputs to ensure that the constructed elements fit into the field.

We had a premature optimization for the case where the target field and native field are the same, then we omitted the binary decomposition by using native hash instead. However, this doesn't work well with the rest of the stack (Fiat-Shamir transcript object and recursion implementations), as we do not exclude bits what the rest of the stack assumes are removed.

It would be difficult to retrofit as would require handling edge-cases in point marshalling, Fiat-Shamir and recursion gadgets, so it is better to remove the optimization in whole. This PR does exactly this.

Fixes #1000.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] Test BN254-in-BN254 PLONK verification

# How has this been benchmarked?

Not benchmarked

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

