### PR TITLE
feat: different PLONK circuit verification

### DIFF
--- a/std/recursion/plonk/doc.go
+++ b/std/recursion/plonk/doc.go
@@ -1,2 +1,5 @@
 // Package plonk implements in-circuit PLONK verifier.
+//
+// NB! The circuit allows verifying proofs of PLONK circuits of size up to 2**30
+// constraints.
 package plonk

--- a/std/recursion/plonk/verifier_test.go
+++ b/std/recursion/plonk/verifier_test.go
@@ -358,7 +358,7 @@ func getParametricSetups(assert *test.Assert, field *big.Int, nbParams int) ([]c
 	vks := make([]native_plonk.VerifyingKey, nbParams)
 	pks := make([]native_plonk.ProvingKey, nbParams)
 	for i := range ccss {
-		ccss[i], err = frontend.Compile(field, scs.NewBuilder, &InnerCircuitParametric{parameter: i + 64})
+		ccss[i], err = frontend.Compile(field, scs.NewBuilder, &InnerCircuitParametric{parameter: 8 << i})
 		assert.NoError(err)
 	}
 
@@ -387,7 +387,7 @@ func getRandomParametricProof(assert *test.Assert, field, outer *big.Int, ccss [
 	x, err := rand.Int(rand.Reader, field)
 	assert.NoError(err)
 	y := new(big.Int).Set(x)
-	for i := 0; i < idx+64; i++ {
+	for i := 0; i < (8 << idx); i++ {
 		y.Mul(y, y)
 		y.Mod(y, field)
 	}

--- a/std/recursion/plonk/verifier_test.go
+++ b/std/recursion/plonk/verifier_test.go
@@ -410,7 +410,7 @@ func getRandomParametricProof(assert *test.Assert, field, outer *big.Int, ccss [
 
 type AggregagationCircuit[FR emulated.FieldParams, G1El algebra.G1ElementT, G2El algebra.G2ElementT, GtEl algebra.GtElementT] struct {
 	BaseKey     BaseVerifyingKey[FR, G1El, G2El] `gnark:"-"`
-	CircuitKeys []CircuitVerifyingKey[G1El]
+	CircuitKeys []CircuitVerifyingKey[FR, G1El]
 	Selectors   []frontend.Variable
 	Proofs      []Proof[FR, G1El, G2El]
 	Witnesses   []Witness[FR] `gnark:",public"`
@@ -443,9 +443,9 @@ func TestBLS12InBW6Multi(t *testing.T) {
 
 	circuitBvk, err := ValueOfBaseVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine](vks[0])
 	assert.NoError(err)
-	circuitVks := make([]CircuitVerifyingKey[sw_bls12377.G1Affine], nbCircuits)
+	circuitVks := make([]CircuitVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine], nbCircuits)
 	for i := range circuitVks {
-		circuitVks[i], err = ValueOfCircuitVerifyingKey[sw_bls12377.G1Affine](vks[i])
+		circuitVks[i], err = ValueOfCircuitVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine](vks[i])
 		assert.NoError(err)
 	}
 	circuitSelector := make([]frontend.Variable, nbProofs)
@@ -464,13 +464,13 @@ func TestBLS12InBW6Multi(t *testing.T) {
 	}
 	aggCircuit := &AggregagationCircuit[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine, sw_bls12377.GT]{
 		BaseKey:     circuitBvk,
-		CircuitKeys: make([]CircuitVerifyingKey[sw_bls12377.G1Affine], nbCircuits),
+		CircuitKeys: make([]CircuitVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine], nbCircuits),
 		Selectors:   make([]frontend.Variable, nbProofs),
 		Proofs:      make([]Proof[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine], nbProofs),
 		Witnesses:   make([]Witness[sw_bls12377.ScalarField], nbProofs),
 	}
 	for i := 0; i < nbCircuits; i++ {
-		aggCircuit.CircuitKeys[i] = PlaceholderCircuitVerifyingKey[sw_bls12377.G1Affine](ccss[i])
+		aggCircuit.CircuitKeys[i] = PlaceholderCircuitVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine](ccss[i])
 	}
 	for i := 0; i < nbProofs; i++ {
 		aggCircuit.Proofs[i] = PlaceholderProof[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine](ccss[0])
@@ -488,7 +488,7 @@ func TestBLS12InBW6Multi(t *testing.T) {
 
 type AggregagationCircuitWithHash[FR emulated.FieldParams, G1El algebra.G1ElementT, G2El algebra.G2ElementT, GtEl algebra.GtElementT] struct {
 	BaseKey     BaseVerifyingKey[FR, G1El, G2El] `gnark:"-"`
-	CircuitKeys []CircuitVerifyingKey[G1El]
+	CircuitKeys []CircuitVerifyingKey[FR, G1El]
 	Selectors   []frontend.Variable
 	Proofs      []Proof[FR, G1El, G2El]
 	Witnesses   []Witness[FR]
@@ -548,9 +548,9 @@ func TestBLS12InBW6MultiHashed(t *testing.T) {
 
 	circuitBvk, err := ValueOfBaseVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine](vks[0])
 	assert.NoError(err)
-	circuitVks := make([]CircuitVerifyingKey[sw_bls12377.G1Affine], nbCircuits)
+	circuitVks := make([]CircuitVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine], nbCircuits)
 	for i := range circuitVks {
-		circuitVks[i], err = ValueOfCircuitVerifyingKey[sw_bls12377.G1Affine](vks[i])
+		circuitVks[i], err = ValueOfCircuitVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine](vks[i])
 		assert.NoError(err)
 	}
 	circuitSelector := make([]frontend.Variable, nbProofs)
@@ -589,13 +589,13 @@ func TestBLS12InBW6MultiHashed(t *testing.T) {
 
 	aggCircuit := &AggregagationCircuitWithHash[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine, sw_bls12377.GT]{
 		BaseKey:     circuitBvk,
-		CircuitKeys: make([]CircuitVerifyingKey[sw_bls12377.G1Affine], nbCircuits),
+		CircuitKeys: make([]CircuitVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine], nbCircuits),
 		Selectors:   make([]frontend.Variable, nbProofs),
 		Proofs:      make([]Proof[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine], nbProofs),
 		Witnesses:   make([]Witness[sw_bls12377.ScalarField], nbProofs),
 	}
 	for i := 0; i < nbCircuits; i++ {
-		aggCircuit.CircuitKeys[i] = PlaceholderCircuitVerifyingKey[sw_bls12377.G1Affine](ccss[i])
+		aggCircuit.CircuitKeys[i] = PlaceholderCircuitVerifyingKey[sw_bls12377.ScalarField, sw_bls12377.G1Affine](ccss[i])
 	}
 	for i := 0; i < nbProofs; i++ {
 		aggCircuit.Proofs[i] = PlaceholderProof[sw_bls12377.ScalarField, sw_bls12377.G1Affine, sw_bls12377.G2Affine](ccss[0])


### PR DESCRIPTION
# Description

Currently we didn't switch on the circuit size and generator when doing multi-proof verification. This PR includes these parts in PLONK verification key in circuit specific VK. Additionally, had to change the exponentiation by the circuit size to use variable instead of a constant.

Related #966 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

All current tests work. 

# How has this been benchmarked?

Previously verifying over 10 proofs cost was 291527, now 313833, so approx 7% increase. BUT, for the example circuits the circuits we were aggregating were small and we did fixed exponetiation, so only essentially a few non-native muls. Now we do variable exponentiation for 30-bit exponents. But circuits in practice are actually closer to 30 bits (25-26 bits imo), so the difference shouldn't be that significant.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

