### PR TITLE
feat: use n-bit mux for switching PLONK verification keys

### DIFF
--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -453,6 +453,19 @@ func (c *Curve[B, S]) Lookup2(b0, b1 frontend.Variable, i0, i1, i2, i3 *AffinePo
 	}
 }
 
+func (c *Curve[B, S]) Mux(sel frontend.Variable, inputs ...*AffinePoint[B]) *AffinePoint[B] {
+	xs := make([]*emulated.Element[B], len(inputs))
+	ys := make([]*emulated.Element[B], len(inputs))
+	for i := range inputs {
+		xs[i] = &inputs[i].X
+		ys[i] = &inputs[i].Y
+	}
+	return &AffinePoint[B]{
+		X: *c.baseApi.Mux(sel, xs...),
+		Y: *c.baseApi.Mux(sel, ys...),
+	}
+}
+
 // ScalarMul computes s * p and returns it. It doesn't modify p nor s.
 // This function doesn't check that the p is on the curve. See AssertIsOnCurve.
 //

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -453,6 +453,9 @@ func (c *Curve[B, S]) Lookup2(b0, b1 frontend.Variable, i0, i1, i2, i3 *AffinePo
 	}
 }
 
+// Mux performs a lookup from the inputs and returns inputs[sel]. It is most
+// efficient for power of two lengths of the inputs, but works for any number of
+// inputs.
 func (c *Curve[B, S]) Mux(sel frontend.Variable, inputs ...*AffinePoint[B]) *AffinePoint[B] {
 	xs := make([]*emulated.Element[B], len(inputs))
 	ys := make([]*emulated.Element[B], len(inputs))

--- a/std/algebra/interfaces.go
+++ b/std/algebra/interfaces.go
@@ -71,6 +71,9 @@ type Curve[FR emulated.FieldParams, G1El G1ElementT] interface {
 	//   - p4 if b0=1 and b1=1.
 	Lookup2(b1 frontend.Variable, b2 frontend.Variable, p1 *G1El, p2 *G1El, p3 *G1El, p4 *G1El) *G1El
 
+	// Mux performs a lookup from the inputs and returns inputs[sel]. It is most
+	// efficient for power of two lengths of the inputs, but works for any
+	// number of inputs.
 	Mux(sel frontend.Variable, inputs ...*G1El) *G1El
 }
 

--- a/std/algebra/interfaces.go
+++ b/std/algebra/interfaces.go
@@ -70,6 +70,8 @@ type Curve[FR emulated.FieldParams, G1El G1ElementT] interface {
 	//   - p3 if b0=0 and b1=1,
 	//   - p4 if b0=1 and b1=1.
 	Lookup2(b1 frontend.Variable, b2 frontend.Variable, p1 *G1El, p2 *G1El, p3 *G1El, p4 *G1El) *G1El
+
+	Mux(sel frontend.Variable, inputs ...*G1El) *G1El
 }
 
 // Pairing allows to compute the bi-linear pairing of G1 and G2 elements.

--- a/std/algebra/native/sw_bls12377/pairing2.go
+++ b/std/algebra/native/sw_bls12377/pairing2.go
@@ -214,6 +214,9 @@ func (c *Curve) Lookup2(b1, b2 frontend.Variable, p1, p2, p3, p4 *G1Affine) *G1A
 	}
 }
 
+// Mux performs a lookup from the inputs and returns inputs[sel]. It is most
+// efficient for power of two lengths of the inputs, but works for any number of
+// inputs.
 func (c *Curve) Mux(sel frontend.Variable, inputs ...*G1Affine) *G1Affine {
 	xs := make([]frontend.Variable, len(inputs))
 	ys := make([]frontend.Variable, len(inputs))

--- a/std/algebra/native/sw_bls12377/pairing2.go
+++ b/std/algebra/native/sw_bls12377/pairing2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/consensys/gnark/std/math/bits"
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/std/math/emulated/emparams"
+	"github.com/consensys/gnark/std/selector"
 )
 
 // Curve allows G1 operations in BLS12-377.
@@ -210,6 +211,19 @@ func (c *Curve) Lookup2(b1, b2 frontend.Variable, p1, p2, p3, p4 *G1Affine) *G1A
 	return &G1Affine{
 		X: c.api.Lookup2(b1, b2, p1.X, p2.X, p3.X, p4.X),
 		Y: c.api.Lookup2(b1, b2, p1.Y, p2.Y, p3.Y, p4.Y),
+	}
+}
+
+func (c *Curve) Mux(sel frontend.Variable, inputs ...*G1Affine) *G1Affine {
+	xs := make([]frontend.Variable, len(inputs))
+	ys := make([]frontend.Variable, len(inputs))
+	for i := range inputs {
+		xs[i] = inputs[i].X
+		ys[i] = inputs[i].Y
+	}
+	return &G1Affine{
+		X: selector.Mux(c.api, sel, xs...),
+		Y: selector.Mux(c.api, sel, ys...),
 	}
 }
 

--- a/std/algebra/native/sw_bls12377/pairing2_test.go
+++ b/std/algebra/native/sw_bls12377/pairing2_test.go
@@ -1,0 +1,55 @@
+package sw_bls12377
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
+	fr_bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+)
+
+type MuxCircuitTest struct {
+	Selector frontend.Variable
+	Inputs   [8]G1Affine
+	Expected G1Affine
+}
+
+func (c *MuxCircuitTest) Define(api frontend.API) error {
+	cr, err := NewCurve(api)
+	if err != nil {
+		return err
+	}
+	els := make([]*G1Affine, len(c.Inputs))
+	for i := range c.Inputs {
+		els[i] = &c.Inputs[i]
+	}
+	res := cr.Mux(c.Selector, els...)
+	cr.AssertIsEqual(res, &c.Expected)
+	return nil
+}
+
+func TestMux(t *testing.T) {
+	assert := test.NewAssert(t)
+	circuit := MuxCircuitTest{}
+	r := make([]fr_bls12377.Element, len(circuit.Inputs))
+	for i := range r {
+		r[i].SetRandom()
+	}
+	selector, _ := rand.Int(rand.Reader, big.NewInt(int64(len(r))))
+	expectedR := r[selector.Int64()]
+	expected := new(bls12377.G1Affine).ScalarMultiplicationBase(expectedR.BigInt(new(big.Int)))
+	witness := MuxCircuitTest{
+		Selector: selector,
+		Expected: NewG1Affine(*expected),
+	}
+	for i := range r {
+		eli := new(bls12377.G1Affine).ScalarMultiplicationBase(r[i].BigInt(new(big.Int)))
+		witness.Inputs[i] = NewG1Affine(*eli)
+	}
+	err := test.IsSolved(&circuit, &witness, ecc.BW6_761.ScalarField())
+	assert.NoError(err)
+}

--- a/std/algebra/native/sw_bls24315/pairing2.go
+++ b/std/algebra/native/sw_bls24315/pairing2.go
@@ -214,6 +214,9 @@ func (c *Curve) Lookup2(b1, b2 frontend.Variable, p1, p2, p3, p4 *G1Affine) *G1A
 	}
 }
 
+// Mux performs a lookup from the inputs and returns inputs[sel]. It is most
+// efficient for power of two lengths of the inputs, but works for any number of
+// inputs.
 func (c *Curve) Mux(sel frontend.Variable, inputs ...*G1Affine) *G1Affine {
 	xs := make([]frontend.Variable, len(inputs))
 	ys := make([]frontend.Variable, len(inputs))

--- a/std/algebra/native/sw_bls24315/pairing2.go
+++ b/std/algebra/native/sw_bls24315/pairing2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/consensys/gnark/std/math/bits"
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/std/math/emulated/emparams"
+	"github.com/consensys/gnark/std/selector"
 )
 
 // Curve allows G1 operations in BLS24-315.
@@ -210,6 +211,19 @@ func (c *Curve) Lookup2(b1, b2 frontend.Variable, p1, p2, p3, p4 *G1Affine) *G1A
 	return &G1Affine{
 		X: c.api.Lookup2(b1, b2, p1.X, p2.X, p3.X, p4.X),
 		Y: c.api.Lookup2(b1, b2, p1.Y, p2.Y, p3.Y, p4.Y),
+	}
+}
+
+func (c *Curve) Mux(sel frontend.Variable, inputs ...*G1Affine) *G1Affine {
+	xs := make([]frontend.Variable, len(inputs))
+	ys := make([]frontend.Variable, len(inputs))
+	for i := range inputs {
+		xs[i] = inputs[i].X
+		ys[i] = inputs[i].Y
+	}
+	return &G1Affine{
+		X: selector.Mux(c.api, sel, xs...),
+		Y: selector.Mux(c.api, sel, ys...),
 	}
 }
 

--- a/std/algebra/native/sw_bls24315/pairing2_test.go
+++ b/std/algebra/native/sw_bls24315/pairing2_test.go
@@ -1,0 +1,55 @@
+package sw_bls24315
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315"
+	fr_bls24315 "github.com/consensys/gnark-crypto/ecc/bls24-315/fr"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+)
+
+type MuxCircuitTest struct {
+	Selector frontend.Variable
+	Inputs   [8]G1Affine
+	Expected G1Affine
+}
+
+func (c *MuxCircuitTest) Define(api frontend.API) error {
+	cr, err := NewCurve(api)
+	if err != nil {
+		return err
+	}
+	els := make([]*G1Affine, len(c.Inputs))
+	for i := range c.Inputs {
+		els[i] = &c.Inputs[i]
+	}
+	res := cr.Mux(c.Selector, els...)
+	cr.AssertIsEqual(res, &c.Expected)
+	return nil
+}
+
+func TestMux(t *testing.T) {
+	assert := test.NewAssert(t)
+	circuit := MuxCircuitTest{}
+	r := make([]fr_bls24315.Element, len(circuit.Inputs))
+	for i := range r {
+		r[i].SetRandom()
+	}
+	selector, _ := rand.Int(rand.Reader, big.NewInt(int64(len(r))))
+	expectedR := r[selector.Int64()]
+	expected := new(bls24315.G1Affine).ScalarMultiplicationBase(expectedR.BigInt(new(big.Int)))
+	witness := MuxCircuitTest{
+		Selector: selector,
+		Expected: NewG1Affine(*expected),
+	}
+	for i := range r {
+		eli := new(bls24315.G1Affine).ScalarMultiplicationBase(r[i].BigInt(new(big.Int)))
+		witness.Inputs[i] = NewG1Affine(*eli)
+	}
+	err := test.IsSolved(&circuit, &witness, ecc.BW6_761.ScalarField())
+	assert.NoError(err)
+}

--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -267,6 +267,11 @@ func (f *Field[T]) Lookup2(b0, b1 frontend.Variable, a, b, c, d *Element[T]) *El
 	return e
 }
 
+// Mux selects element inputs[sel] and returns it. The number of the limbs and
+// overflow in the result is the maximum of the inputs'. If the inputs are very
+// unbalanced, then reduce the inputs before calling the method. It is most
+// efficient for power of two lengths of the inputs, but works for any
+// number of inputs.
 func (f *Field[T]) Mux(sel frontend.Variable, inputs ...*Element[T]) *Element[T] {
 	if len(inputs) == 0 {
 		return nil

--- a/std/recursion/plonk/verifier.go
+++ b/std/recursion/plonk/verifier.go
@@ -1241,6 +1241,9 @@ func (v *Verifier[FR, G1El, G2El, GtEl]) SwitchVerificationKey(bvk BaseVerifying
 			return ret, fmt.Errorf("inconsistent circuit verification key")
 		}
 	}
+	// initialize the destination with correctly allocating space for the
+	// commitment selectors and commitment indices. Then in the muxing method
+	// can already assume that all inputs and outputs match in size.
 	cvk := CircuitVerifyingKey[FR, G1El]{
 		Qcp:                         make([]kzg.Commitment[G1El], nbCmts),
 		CommitmentConstraintIndexes: make([]frontend.Variable, nbCmts),
@@ -1253,54 +1256,122 @@ func (v *Verifier[FR, G1El, G2El, GtEl]) SwitchVerificationKey(bvk BaseVerifying
 }
 
 func (v *Verifier[FR, G1El, G2El, GtEl]) muxCircuitVerifyingKey(idx frontend.Variable, cvks []CircuitVerifyingKey[FR, G1El], ret *CircuitVerifyingKey[FR, G1El]) {
+	// this method switches between the fields of the circuit verifying key. The
+	// circuit verifying key is the structure:
+	//
+	//    type CircuitVerifyingKey[FR emulated.FieldParams, G1El algebra.G1ElementT] struct {
+	//       Size      frontend.Variable
+	//       SizeInv   emulated.Element[FR]
+	//       Generator emulated.Element[FR]
+	//       S [3]kzg.Commitment[G1El]
+	//       Ql, Qr, Qm, Qo, Qk kzg.Commitment[G1El]
+	//       Qcp []kzg.Commitment[G1El]
+	//       CommitmentConstraintIndexes []frontend.Variable
+	//    }
+	//
+	// We already have the methods for muxing native elements, non-native
+	// elements and G1 points, but cannot directly call them as the variables we
+	// want to select between are fields in CircuitVerifying struct. So we first
+	// have to map from the strct fields to slices which can be passed to
+	// corresponding mux methods.
+	//
+	// Now - there is some repetition, we cannot collect the elements from the
+	// structures directly, but have to use reflection to obtain the pointer to
+	// the field.
+	//
+	// Finally - in non-native field implementation we only width constrain the
+	// limbs first time the witness element is used. This means that instead of
+	// passing values we have to pass the exact pointers of the fields so that
+	// we wouldn't width constraint more than have to.
+
+	// initialize the values we use to gather information about the field types.
+	//   * circuit verification key (we will iterate over fields of this)
 	var cvkT CircuitVerifyingKey[FR, G1El]
+	//   * emulated element (generator, size inverse)
 	var scalarT emulated.Element[FR]
+	//   * KZG commitment (selector polys)
 	var kzgT kzg.Commitment[G1El]
+	//   * array of 3 KZG commitment separately to avoid implementing recursive methods.
 	var ST [3]kzg.Commitment[G1El]
+	//   * slice of KZG commitment separately to avoid implementing recursive methods.
 	var QcpT []kzg.Commitment[G1El]
+	//   * commitment indices in the circuit. Used to compute the commitment.
 	var CommitmentIndexT []frontend.Variable
-	retV := reflect.ValueOf(ret).Elem()
+	//   * we have omitted Size, but it is not well checkable before we have it
+	//   initialized. But there may be separate cases when Size is a constant,
+	//   so we instead handle it in the default clause.
+
+	// initializing all reflect.Type for type switching below.
 	cvkv := reflect.TypeOf(cvkT)
 	scalarv := reflect.TypeOf(scalarT)
 	kzgv := reflect.TypeOf(kzgT)
 	STv := reflect.TypeOf(ST)
 	Qcpv := reflect.TypeOf(QcpT)
 	civ := reflect.TypeOf(CommitmentIndexT)
+
+	// additionally, we already initialize reflect.Value of the destination
+	// where we are going to store all the mux results. Similarly have to use
+	// reflection to be able to write to arbitrary field.
+	//
+	// NB! we received pointer to allow modifying inline as the slices are
+	// already initialized to correct sizes.
+	retV := reflect.ValueOf(ret).Elem()
+
+	// we iterate over all fields of the CircuitVerifyingKey and decide which mux to use.
 	for i := 0; i < cvkv.NumField(); i++ {
 		field := cvkv.Field(i)
 		switch field.Type {
 		case scalarv:
+			// it is non-native element. Pass the field id to the specialized map+mux method.
 			sRet := v.muxScalar(i, idx, cvks)
+			// retrieve the pointer of the destination field where we're going
+			// to write the mux result.
 			retFieldS, ok := retV.Field(i).Addr().Interface().(*emulated.Element[FR])
 			if !ok {
 				panic("can not cast to element")
 			}
+			// finally, overwrite the empty field in the destination circuit verification key.
 			*retFieldS = sRet
 		case kzgv:
+			// it is KZG commitment. Pass the field id to the specialized
+			// map+mux method. Indicate with -1 that the field value is
+			// commitment directly (not in a slice).
 			kzgRet := v.muxKzg(i, -1, idx, cvks)
+			// retrieve the pointer of the destination field where we're going
+			// to write the mux result.
 			retFieldKzg, ok := retV.Field(i).FieldByName("G1El").Addr().Interface().(*G1El)
 			if !ok {
 				panic("can not cast point")
 			}
+			// finally, overwrite the empty field in the destination circuit verification key.
 			*retFieldKzg = *kzgRet
 		case STv, Qcpv:
+			// special case of the previous where we have the commitments in a
+			// slice or array. We also pass the index of commitment so the
+			// specialized map+mux can locate correctly.
 			nbElem := retV.Field(i).Len()
 			for j := 0; j < nbElem; j++ {
 				kzgRet := v.muxKzg(i, j, idx, cvks)
+				// retrieve the pointer of the destination field where we're going
+				// to write the mux result.
 				retFieldKzg, ok := retV.Field(i).Index(j).FieldByName("G1El").Addr().Interface().(*G1El)
 				if !ok {
 					panic("can not cast point")
 				}
+				// finally, overwrite the empty field in the destination circuit verification key.
 				*retFieldKzg = *kzgRet
 			}
 		case civ:
 			nbElem := retV.Field(i).Len()
 			for j := 0; j < nbElem; j++ {
 				vRet := v.muxVariable(i, j, idx, cvks)
+				// retrieve the pointer of the destination field where we're going
+				// to write the mux result.
 				retFieldVar, ok := retV.Field(i).Index(j).Addr().Interface().(*frontend.Variable)
 				if !ok {
 					panic("can not cast to variable")
 				}
+				// finally, overwrite the empty field in the destination circuit verification key.
 				*retFieldVar = vRet
 			}
 		default:
@@ -1318,25 +1389,34 @@ func (v *Verifier[FR, G1El, G2El, GtEl]) muxCircuitVerifyingKey(idx frontend.Var
 }
 
 func (v *Verifier[FR, G1El, G2El, GtEl]) muxScalar(fieldIdx int, idx frontend.Variable, cvks []CircuitVerifyingKey[FR, G1El]) emulated.Element[FR] {
+	// collect the non-native elements from the CircuitVerificationKey indexed by field index.
 	els := make([]*emulated.Element[FR], len(cvks))
 	for i := range cvks {
+		// we work with pointer here to have addressable fields.
 		vv := reflect.ValueOf(&cvks[i]).Elem()
+		// there is only one more trick here -- we need to directly work on
+		// pointers for the automatic limb constrainment to work. So call Addr().
 		s, ok := vv.Field(fieldIdx).Addr().Interface().(*emulated.Element[FR])
 		if !ok {
 			panic("can not cast to scalar")
 		}
 		els[i] = s
 	}
+	// now it is easy to mux 👍
 	el := v.scalarApi.Mux(idx, els...)
 	return *el
 }
 
 func (v *Verifier[FR, G1El, G2El, GtEl]) muxKzg(fieldIdx int, sliceIdx int, idx frontend.Variable, cvks []CircuitVerifyingKey[FR, G1El]) *G1El {
+	// collects the G1 elements from the CircuitVerificationKey indexed by field index
 	els := make([]*G1El, len(cvks))
 	for i := range cvks {
 		var cmt *G1El
 		var ok bool
 		vv := reflect.ValueOf(&cvks[i]).Elem()
+		// there are two cases - for S and Qcp the KZG commitments are inside
+		// array and var-length array. We handle both direct and enumeratable
+		// case.
 		if sliceIdx < 0 {
 			cmt, ok = vv.Field(fieldIdx).FieldByName("G1El").Addr().Interface().(*G1El)
 		} else {
@@ -1347,15 +1427,18 @@ func (v *Verifier[FR, G1El, G2El, GtEl]) muxKzg(fieldIdx int, sliceIdx int, idx 
 		}
 		els[i] = cmt
 	}
+	// now it is easy to mux 👍
 	el := v.curve.Mux(idx, els...)
 	return el
 }
 
 func (v *Verifier[FR, G1El, G2El, GtEl]) muxVariable(fieldIdx int, sliceIdx int, idx frontend.Variable, cvks []CircuitVerifyingKey[FR, G1El]) frontend.Variable {
+	// collects the native elements for muxing.
 	vals := make([]frontend.Variable, len(cvks))
 	for i := range cvks {
 		var variable frontend.Variable
 		vv := reflect.ValueOf(cvks[i])
+		// here we can work with values as we do not do any more magic.
 		if sliceIdx < 0 {
 			variable = vv.Field(fieldIdx).Interface()
 		} else {
@@ -1363,6 +1446,7 @@ func (v *Verifier[FR, G1El, G2El, GtEl]) muxVariable(fieldIdx int, sliceIdx int,
 		}
 		vals[i] = variable
 	}
+	// mux
 	val := selector.Mux(v.api, idx, vals...)
 	return val
 }

--- a/std/recursion/plonk/verifier_test.go
+++ b/std/recursion/plonk/verifier_test.go
@@ -430,7 +430,7 @@ func (c *AggregagationCircuit[FR, G1El, G2El, GtEl]) Define(api frontend.API) er
 func TestBLS12InBW6Multi(t *testing.T) {
 	innerField := ecc.BLS12_377.ScalarField()
 	outerField := ecc.BW6_761.ScalarField()
-	nbCircuits := 4
+	nbCircuits := 5
 	nbProofs := 5
 	assert := test.NewAssert(t)
 	ccss, vks, pks := getParametricSetups(assert, innerField, nbCircuits)


### PR DESCRIPTION
# Description

This PR changes the mux from `Lookup2` to `selector.Mux` which allows arbitrary switching. The change is backwards compatible (previously we threw an error if had more than 4 keys).

Fixes #966 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestMux for non-native elements
- [x] TestMux for G1 elements (native and 2-chains)
- [x] Implemented PLONK aggregate verification with 5 keys instead of four.

# How has this been benchmarked?

PLONK recursion over 10 proofs increase from 313833 to 314402.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

