### PR TITLE
fix: assign baseChallenge correctly while verifying gkr solution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.5.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b
+	github.com/icza/bitio v1.1.0
 	github.com/ingonyama-zk/iciclegnark v0.1.0
 	github.com/leanovate/gopter v0.2.9
 	github.com/rs/zerolog v1.30.0
@@ -22,7 +23,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/icza/bitio v1.1.0 // indirect
 	github.com/ingonyama-zk/icicle v0.0.0-20230928131117-97f0079e5c71 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
-github.com/consensys/compress v0.2.0 h1:aBg3YJe8ZFUxm/RF+ppx/URFsZq3aJ6o8isLDQysYDA=
-github.com/consensys/compress v0.2.0/go.mod h1:Ne8+cGKjqgjF1dlHapZx38pHzWpaBYhsKxQa+JPl0zM=
 github.com/consensys/compress v0.2.1-0.20240103160955-e4fcce3dc96a h1:0Y7y1JXtP8O/nL7LHpBt62pGZ87so63uWrYqUoq920s=
 github.com/consensys/compress v0.2.1-0.20240103160955-e4fcce3dc96a/go.mod h1:Ne8+cGKjqgjF1dlHapZx38pHzWpaBYhsKxQa+JPl0zM=
 github.com/consensys/gnark-crypto v0.12.2-0.20231221171913-5d5eded6bb15 h1:mcxhrDtXKIepsKXofxSuXRst+41yzAcoNWKIotsjMTQ=

--- a/std/gkr/gkr.go
+++ b/std/gkr/gkr.go
@@ -338,10 +338,11 @@ func Verify(api frontend.API, c Circuit, assignment WireAssignment, proof Proof,
 			}
 		} else if err = sumcheck.Verify(
 			api, claim, proof[i], fiatshamir.WithTranscript(o.transcript, wirePrefix+strconv.Itoa(i)+".", baseChallenge...),
-		); err != nil {
+		); err == nil {
+			baseChallenge = finalEvalProof
+		} else {
 			return err
 		}
-		baseChallenge = finalEvalProof
 		claims.deleteClaim(wire)
 	}
 	return nil


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Fixes failed assertion while verifying GKR solution(`(gkr.Solution).Verify` function) with other than non-constant hash functions (like mimc or poseidon). Inspired by https://github.com/Consensys/gnark-crypto/blob/master/ecc/bn254/fr/gkr/gkr.go#L688

I added new test case `TestMiMCFullDepthNoDepSolveWithMiMCHash`, which fails without this change with following error:
```
Error:      	Received unexpected error:
        	            	constraint #37111 is not satisfied: [assertIsEqual] 10420734889032269308690831442195287995987323506521353207282897974178519295845 == 19485199868485599785212267512534296132678646505698908814492864400056160446973
        	            	r1cs.(*builder).AssertIsEqual
        	            		/Users/ahmety/gnark/frontend/cs/r1cs/api_assertions.go:38
        	            	gkr.(*eqTimesGateEvalSumcheckLazyClaims).VerifyFinalEval
        	            		/Users/ahmety/gnark/std/gkr/gkr.go:110
        	            	sumcheck.Verify
        	            		/Users/ahmety/gnark/std/sumcheck/sumcheck.go:104
        	            	gkr.Verify
        	            		/Users/ahmety/gnark/std/gkr/gkr.go:339
        	            	gkr.Solution.Verify
        	            		/Users/ahmety/gnark/std/gkr/compile.go:197
        	            	gkr.(*mimcNoDepCircuit).Define
        	            		/Users/ahmety/gnark/std/gkr/api_test.go:596

        	Test:       	TestMiMCFullDepthNoDepSolveWithMiMCHash
```


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

Any GKR solution verification with non-constant hash function is failing at same step(`VerifyFinalEval`). `TestMiMCFullDepthNoDepSolveWithMiMCHash` added to reproduce the error

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

Not benchmarked

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

