### PR TITLE
fix: Decompressor to return -1 when output doesn't fit

### DIFF
--- a/std/compress/lzss/snark.go
+++ b/std/compress/lzss/snark.go
@@ -15,7 +15,7 @@ import (
 // it is on the caller to ensure that the dictionary is correct; in particular it must consist of bytes. Decompress does not check this.
 // it is recommended to pack the dictionary using compress.Pack and take a MiMC checksum of it.
 // d will consist of bytes
-// It returns the length of d as a frontend.Variable
+// It returns the length of d as a frontend.Variable; if the decompressed stream doesn't fit in d, dLength will be "-1"
 func Decompress(api frontend.API, c []frontend.Variable, cLength frontend.Variable, d, dict []frontend.Variable, level lzss.Level) (dLength frontend.Variable, err error) {
 
 	// size-related "constants"
@@ -62,7 +62,7 @@ func Decompress(api frontend.API, c []frontend.Variable, cLength frontend.Variab
 	copyLen := frontend.Variable(0) // remaining length of the current copy
 	copyLen01 := frontend.Variable(1)
 	eof := frontend.Variable(0)
-	dLength = 0
+	dLength = -1
 
 	for outI := range d {
 
@@ -114,7 +114,7 @@ func Decompress(api frontend.API, c []frontend.Variable, cLength frontend.Variab
 
 		eofNow := rangeChecker.IsLessThan(byteNbWords, api.Sub(cLength, inI)) // less than a byte left; meaning we are at the end of the input
 
-		dLength = api.Add(dLength, api.Mul(api.Sub(eofNow, eof), outI+1)) // if eof, don't advance dLength
+		dLength = api.Add(dLength, api.Mul(api.Sub(eofNow, eof), outI+2)) // if eof, don't advance dLength
 		eof = eofNow
 
 	}

--- a/std/compress/lzss/snark.go
+++ b/std/compress/lzss/snark.go
@@ -62,7 +62,7 @@ func Decompress(api frontend.API, c []frontend.Variable, cLength frontend.Variab
 	copyLen := frontend.Variable(0) // remaining length of the current copy
 	copyLen01 := frontend.Variable(1)
 	eof := frontend.Variable(0)
-	dLength = -1
+	dLength = -1 // if the following loop ends before hitting eof, we will get the "error" value -1 for dLength
 
 	for outI := range d {
 
@@ -114,7 +114,9 @@ func Decompress(api frontend.API, c []frontend.Variable, cLength frontend.Variab
 
 		eofNow := rangeChecker.IsLessThan(byteNbWords, api.Sub(cLength, inI)) // less than a byte left; meaning we are at the end of the input
 
-		dLength = api.Add(dLength, api.Mul(api.Sub(eofNow, eof), outI+2)) // if eof, don't advance dLength
+		// if eof, don't advance dLength
+		// if eof was JUST hit, dLength += outI + 2; so dLength = -1 + outI + 2 = outI + 1 which is the current output length
+		dLength = api.Add(dLength, api.Mul(api.Sub(eofNow, eof), outI+2))
 		eof = eofNow
 
 	}

--- a/std/compress/lzss/snark_test.go
+++ b/std/compress/lzss/snark_test.go
@@ -107,6 +107,7 @@ func TestOutBufTooShort(t *testing.T) {
 	const truncationAmount = 3
 	d := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	compressor, err := lzss.NewCompressor(nil, lzss.BestCompression)
+	require.NoError(t, err)
 	c, err := compressor.Compress(d)
 	require.NoError(t, err)
 


### PR DESCRIPTION
# Description

Currently, when the output buffer `d` is not long enough to contain the decompressed stream, `Decompress` returns `dLength = 0` which is seen as a valid output. This PR changes that to -1 which in any cryptographic prime-order field is so large it cannot be confused with a valid output length.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

[`TestOutBufTooShort`](https://github.com/Consensys/gnark/blob/fix/compressor/truncated-input/std/compress/lzss/snark_test.go#L106)

# How has this been benchmarked?

No benchmark. Performance impact expected to be negligible.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

