### PR TITLE
fix: use subtraction with reduce in AssertIsEqual

### DIFF
--- a/std/math/emulated/field_assert.go
+++ b/std/math/emulated/field_assert.go
@@ -128,7 +128,7 @@ func (f *Field[T]) AssertIsEqual(a, b *Element[T]) {
 		return
 	}
 
-	diff := f.subNoReduce(b, a)
+	diff := f.Sub(b, a)
 
 	// we compute k such that diff / p == k
 	// so essentially, we say "I know an element k such that k*p == diff"

--- a/std/math/emulated/regression_test.go
+++ b/std/math/emulated/regression_test.go
@@ -94,3 +94,27 @@ func TestIssue867Division(t *testing.T) {
 	}
 	test.IsSolved(&testIssue867Circuit{A: ac, B: bc}, &testIssue867Circuit{A: a, B: b}, ecc.BLS12_381.ScalarField())
 }
+
+type testIssue1021Circuit struct {
+	A Element[BN254Fp]
+}
+
+func (c *testIssue1021Circuit) Define(api frontend.API) error {
+	f, err := NewField[BN254Fp](api)
+	if err != nil {
+		return err
+	}
+	b := f.NewElement(c.A)
+	p := f.Modulus()
+	for i := 0; i < 188; i++ {
+		b = f.Add(b, p)
+	}
+	f.AssertIsEqual(b, &c.A)
+	return nil
+}
+
+func TestIssue1021(t *testing.T) {
+	assert := test.NewAssert(t)
+	err := test.IsSolved(&testIssue1021Circuit{}, &testIssue1021Circuit{A: ValueOf[BN254Fp](10)}, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}


### PR DESCRIPTION
Thanks @hussein-aitlahcen for reporting and helping to debug. It was a difficult one 👍 

# Description

To show that two field elements are equal, we instead show that the difference of the field elements is a multiple of emulated modulus. However, for computing the difference we used non-reducing version of subtraction to avoid infinite cycles. With the new mulmod implementation the reducing versions do not call AssertIsEqual anymore so the infinite cycles are averted. Previously, for some edge cases the difference may overflow scalar field and solving may fail (see [here](https://github.com/Consensys/gnark/issues/1021#issuecomment-1916763099))

Fixes #1021 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Existing tests succeed.

- [x] Added TestIssue1021 for the minimal reproducible example.

# How has this been benchmarked?

Not benchmarked.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

