### PR TITLE
fix(emulated/pairing): reduce G2 point before computeLines

### DIFF
--- a/std/algebra/emulated/fields_bls12381/e2.go
+++ b/std/algebra/emulated/fields_bls12381/e2.go
@@ -76,6 +76,13 @@ func (e Ext2) MulByConstElement(x *E2, y *big.Int) *E2 {
 	}
 }
 
+func (e Ext2) Reduce(x *E2) *E2 {
+	var z E2
+	z.A0 = *e.fp.Reduce(&x.A0)
+	z.A1 = *e.fp.Reduce(&x.A1)
+	return &z
+}
+
 func (e Ext2) Conjugate(x *E2) *E2 {
 	z0 := x.A0
 	z1 := e.fp.Neg(&x.A1)

--- a/std/algebra/emulated/fields_bn254/e2.go
+++ b/std/algebra/emulated/fields_bn254/e2.go
@@ -77,6 +77,13 @@ func (e Ext2) MulByConstElement(x *E2, y *big.Int) *E2 {
 	}
 }
 
+func (e Ext2) Reduce(x *E2) *E2 {
+	var z E2
+	z.A0 = *e.fp.Reduce(&x.A0)
+	z.A1 = *e.fp.Reduce(&x.A1)
+	return &z
+}
+
 func (e Ext2) Conjugate(x *E2) *E2 {
 	z0 := x.A0
 	z1 := e.fp.Neg(&x.A1)

--- a/std/algebra/emulated/sw_bls12381/precomputations.go
+++ b/std/algebra/emulated/sw_bls12381/precomputations.go
@@ -30,7 +30,11 @@ func precomputeLines(Q bls12381.G2Affine) lineEvaluations {
 }
 
 func (p *Pairing) computeLines(Q *g2AffP) lineEvaluations {
-
+	// manually reduce Q before computing lines
+	Q = &g2AffP{
+		X: *p.Ext2.Reduce(&Q.X),
+		Y: *p.Ext2.Reduce(&Q.Y),
+	}
 	var cLines lineEvaluations
 	Qacc := Q
 	n := len(loopCounter)

--- a/std/algebra/emulated/sw_bn254/precomputations.go
+++ b/std/algebra/emulated/sw_bn254/precomputations.go
@@ -30,7 +30,11 @@ func precomputeLines(Q bn254.G2Affine) lineEvaluations {
 }
 
 func (p *Pairing) computeLines(Q *g2AffP) lineEvaluations {
-
+	// manually reduce Q before computing lines
+	Q = &g2AffP{
+		X: *p.Ext2.Reduce(&Q.X),
+		Y: *p.Ext2.Reduce(&Q.Y),
+	}
 	var cLines lineEvaluations
 	Qacc := Q
 	QNeg := &g2AffP{

--- a/std/algebra/emulated/sw_bw6761/precomputations.go
+++ b/std/algebra/emulated/sw_bw6761/precomputations.go
@@ -30,6 +30,11 @@ func precomputeLines(Q bw6761.G2Affine) lineEvaluations {
 }
 
 func (p *Pairing) computeLines(Q *g2AffP) lineEvaluations {
+	// manually reduce Q before computing lines
+	Q = &g2AffP{
+		X: *p.curveF.Reduce(&Q.X),
+		Y: *p.curveF.Reduce(&Q.Y),
+	}
 	var cLines lineEvaluations
 	imQ := &g2AffP{
 		X: *p.curveF.Mul(&Q.X, &thirdRootOne),


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Fixes #1021 

Quick hack for the emulated pairing until we find a proper fix for the field emulation edge case https://github.com/Consensys/gnark/issues/1021#issuecomment-1916763099.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

Same tests.

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

No

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

