### PR TITLE
feat: subgroup G1/G2 membership BW6-761 and BLS12-377

### DIFF
--- a/std/algebra/emulated/sw_bls12381/pairing.go
+++ b/std/algebra/emulated/sw_bls12381/pairing.go
@@ -268,7 +268,7 @@ func (pr Pairing) AssertIsOnTwist(Q *G2Affine) {
 	// Twist: Y² == X³ + aX + b, where a=0 and b=4(1+u)
 	// (X,Y) ∈ {Y² == X³ + aX + b} U (0,0)
 
-	// if Q=(0,0) we assign b=0 otherwise 3/(9+u), and continue
+	// if Q=(0,0) we assign b=0 otherwise 4(1+u), and continue
 	selector := pr.api.And(pr.Ext2.IsZero(&Q.P.X), pr.Ext2.IsZero(&Q.P.Y))
 	b := pr.Ext2.Select(selector, pr.Ext2.Zero(), pr.bTwist)
 

--- a/std/algebra/emulated/sw_bw6761/doc_test.go
+++ b/std/algebra/emulated/sw_bw6761/doc_test.go
@@ -23,6 +23,9 @@ func (c *PairCircuit) Define(api frontend.API) error {
 	if err != nil {
 		return fmt.Errorf("new pairing: %w", err)
 	}
+	// Check if the points are in the proper groups (up to the user choice)
+	pairing.AssertIsOnG1(&c.InG1)
+	pairing.AssertIsOnG2(&c.InG2)
 	// Pair method does not check that the points are in the proper groups.
 	// Compute the pairing
 	res, err := pairing.Pair([]*sw_bw6761.G1Affine{&c.InG1}, []*sw_bw6761.G2Affine{&c.InG2})

--- a/std/algebra/emulated/sw_bw6761/g1.go
+++ b/std/algebra/emulated/sw_bw6761/g1.go
@@ -1,8 +1,12 @@
 package sw_bw6761
 
 import (
+	"fmt"
+	"math/big"
+
 	bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761"
 	fr_bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761/fr"
+	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
 	"github.com/consensys/gnark/std/math/emulated"
 )
@@ -33,3 +37,183 @@ type ScalarField = emulated.BW6761Fr
 
 // BaseField is the [emulated.FieldParams] impelementation of the curve base field.
 type BaseField = emulated.BW6761Fp
+
+type G1 struct {
+	curveF *emulated.Field[BaseField]
+	w      *emulated.Element[BaseField]
+}
+
+func NewG1(api frontend.API) (*G1, error) {
+	ba, err := emulated.NewField[BaseField](api)
+	if err != nil {
+		return nil, fmt.Errorf("new base api: %w", err)
+	}
+	w := emulated.ValueOf[BaseField]("1968985824090209297278610739700577151397666382303825728450741611566800370218827257750865013421937292370006175842381275743914023380727582819905021229583192207421122272650305267822868639090213645505120388400344940985710520836292650")
+	return &G1{
+		curveF: ba,
+		w:      &w,
+	}, nil
+}
+
+func (g1 *G1) phi(q *G1Affine) *G1Affine {
+	x := g1.curveF.Mul(&q.X, g1.w)
+
+	return &G1Affine{
+		X: *x,
+		Y: q.Y,
+	}
+}
+
+func (g1 *G1) double(p *G1Affine) *G1Affine {
+	// compute λ = (3p.x²)/2*p.y
+	xx3a := g1.curveF.Mul(&p.X, &p.X)
+	xx3a = g1.curveF.MulConst(xx3a, big.NewInt(3))
+	y1 := g1.curveF.MulConst(&p.Y, big.NewInt(2))
+	λ := g1.curveF.Div(xx3a, y1)
+
+	// xr = λ²-2p.x
+	x1 := g1.curveF.MulConst(&p.X, big.NewInt(2))
+	λλ := g1.curveF.Mul(λ, λ)
+	xr := g1.curveF.Sub(λλ, x1)
+
+	// yr = λ(p-xr) - p.y
+	pxrx := g1.curveF.Sub(&p.X, xr)
+	λpxrx := g1.curveF.Mul(λ, pxrx)
+	yr := g1.curveF.Sub(λpxrx, &p.Y)
+
+	return &G1Affine{
+		X: *xr,
+		Y: *yr,
+	}
+}
+
+func (g1 *G1) doubleN(p *G1Affine, n int) *G1Affine {
+	pn := p
+	for s := 0; s < n; s++ {
+		pn = g1.double(pn)
+	}
+	return pn
+}
+
+func (g1 G1) add(p, q *G1Affine) *G1Affine {
+	// compute λ = (q.y-p.y)/(q.x-p.x)
+	qypy := g1.curveF.Sub(&q.Y, &p.Y)
+	qxpx := g1.curveF.Sub(&q.X, &p.X)
+	λ := g1.curveF.Div(qypy, qxpx)
+
+	// xr = λ²-p.x-q.x
+	λλ := g1.curveF.Mul(λ, λ)
+	qxpx = g1.curveF.Add(&p.X, &q.X)
+	xr := g1.curveF.Sub(λλ, qxpx)
+
+	// p.y = λ(p.x-r.x) - p.y
+	pxrx := g1.curveF.Sub(&p.X, xr)
+	λpxrx := g1.curveF.Mul(λ, pxrx)
+	yr := g1.curveF.Sub(λpxrx, &p.Y)
+
+	return &G1Affine{
+		X: *xr,
+		Y: *yr,
+	}
+}
+
+func (g1 G1) neg(p *G1Affine) *G1Affine {
+	xr := &p.X
+	yr := g1.curveF.Neg(&p.Y)
+	return &G1Affine{
+		X: *xr,
+		Y: *yr,
+	}
+}
+
+func (g1 G1) sub(p, q *G1Affine) *G1Affine {
+	qNeg := g1.neg(q)
+	return g1.add(p, qNeg)
+}
+
+func (g1 G1) doubleAndAdd(p, q *G1Affine) *G1Affine {
+
+	// compute λ1 = (q.y-p.y)/(q.x-p.x)
+	yqyp := g1.curveF.Sub(&q.Y, &p.Y)
+	xqxp := g1.curveF.Sub(&q.X, &p.X)
+	λ1 := g1.curveF.Div(yqyp, xqxp)
+
+	// compute x1 = λ1²-p.x-q.x
+	λ1λ1 := g1.curveF.Mul(λ1, λ1)
+	xqxp = g1.curveF.Add(&p.X, &q.X)
+	x2 := g1.curveF.Sub(λ1λ1, xqxp)
+
+	// ommit y1 computation
+	// compute λ1 = -λ1-1*p.y/(x1-p.x)
+	ypyp := g1.curveF.Add(&p.Y, &p.Y)
+	x2xp := g1.curveF.Sub(x2, &p.X)
+	λ2 := g1.curveF.Div(ypyp, x2xp)
+	λ2 = g1.curveF.Add(λ1, λ2)
+	λ2 = g1.curveF.Neg(λ2)
+
+	// compute x3 =λ2²-p.x-x3
+	λ2λ2 := g1.curveF.Mul(λ2, λ2)
+	x3 := g1.curveF.Sub(λ2λ2, &p.X)
+	x3 = g1.curveF.Sub(x3, x2)
+
+	// compute y3 = λ2*(p.x - x3)-p.y
+	y3 := g1.curveF.Sub(&p.X, x3)
+	y3 = g1.curveF.Mul(λ2, y3)
+	y3 = g1.curveF.Sub(y3, &p.Y)
+
+	return &G1Affine{
+		X: *x3,
+		Y: *y3,
+	}
+}
+
+func (g1 G1) triple(p *G1Affine) *G1Affine {
+
+	// compute λ = (3p.x²)/2*p.y
+	xx := g1.curveF.Mul(&p.X, &p.X)
+	xx = g1.curveF.MulConst(xx, big.NewInt(3))
+	y2 := g1.curveF.MulConst(&p.Y, big.NewInt(2))
+	λ1 := g1.curveF.Div(xx, y2)
+
+	// xr = λ²-2p.x
+	x2 := g1.curveF.MulConst(&p.X, big.NewInt(2))
+	λ1λ1 := g1.curveF.Mul(λ1, λ1)
+	x2 = g1.curveF.Sub(λ1λ1, x2)
+
+	// ommit y2 computation, and
+	// compute λ2 = 2p.y/(x2 − p.x) − λ1.
+	x1x2 := g1.curveF.Sub(&p.X, x2)
+	λ2 := g1.curveF.Div(y2, x1x2)
+	λ2 = g1.curveF.Sub(λ2, λ1)
+
+	// xr = λ²-p.x-x2
+	λ2λ2 := g1.curveF.Mul(λ2, λ2)
+	qxrx := g1.curveF.Add(x2, &p.X)
+	xr := g1.curveF.Sub(λ2λ2, qxrx)
+
+	// yr = λ(p.x-xr) - p.y
+	pxrx := g1.curveF.Sub(&p.X, xr)
+	λ2pxrx := g1.curveF.Mul(λ2, pxrx)
+	yr := g1.curveF.Sub(λ2pxrx, &p.Y)
+
+	return &G1Affine{
+		X: *xr,
+		Y: *yr,
+	}
+}
+
+func (g1 *G1) scalarMulBySeed(q *G1Affine) *G1Affine {
+	z := g1.triple(q)
+	z = g1.doubleAndAdd(z, q)
+	t0 := g1.double(z)
+	t0 = g1.double(t0)
+	z = g1.add(z, t0)
+	t1 := g1.triple(z)
+	t0 = g1.add(t0, t1)
+	t0 = g1.doubleN(t0, 9)
+	z = g1.doubleAndAdd(t0, z)
+	z = g1.doubleN(z, 45)
+	z = g1.doubleAndAdd(z, q)
+
+	return z
+}

--- a/std/algebra/emulated/sw_bw6761/g1.go
+++ b/std/algebra/emulated/sw_bw6761/g1.go
@@ -202,6 +202,7 @@ func (g1 G1) triple(p *G1Affine) *G1Affine {
 	}
 }
 
+// scalarMulBySeed computes the [x₀]q where x₀=9586122913090633729 is the seed of the curve.
 func (g1 *G1) scalarMulBySeed(q *G1Affine) *G1Affine {
 	z := g1.triple(q)
 	z = g1.doubleAndAdd(z, q)

--- a/std/algebra/emulated/sw_bw6761/g2.go
+++ b/std/algebra/emulated/sw_bw6761/g2.go
@@ -86,6 +86,7 @@ func (g2 *G2) phi(q *G2Affine) *G2Affine {
 	}
 }
 
+// scalarMulBySeed computes the [x₀]q where x₀=9586122913090633729 is the seed of the curve.
 func (g2 *G2) scalarMulBySeed(q *G2Affine) *G2Affine {
 	z := g2.triple(q)
 	z = g2.doubleAndAdd(z, q)

--- a/std/algebra/emulated/sw_bw6761/g2.go
+++ b/std/algebra/emulated/sw_bw6761/g2.go
@@ -1,7 +1,11 @@
 package sw_bw6761
 
 import (
+	"fmt"
+	"math/big"
+
 	bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761"
+	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
 	"github.com/consensys/gnark/std/math/emulated"
 )
@@ -52,4 +56,202 @@ func NewG2AffineFixedPlaceholder() G2Affine {
 	return G2Affine{
 		Lines: &lines,
 	}
+}
+
+type G2 struct {
+	curveF *emulated.Field[BaseField]
+	w      *emulated.Element[BaseField]
+}
+
+func NewG2(api frontend.API) (*G2, error) {
+	ba, err := emulated.NewField[BaseField](api)
+	if err != nil {
+		return nil, fmt.Errorf("new base api: %w", err)
+	}
+	w := emulated.ValueOf[BaseField]("4922464560225523242118178942575080391082002530232324381063048548642823052024664478336818169867474395270858391911405337707247735739826664939444490469542109391530482826728203582549674992333383150446779312029624171857054392282775648")
+	return &G2{
+		curveF: ba,
+		w:      &w,
+	}, nil
+}
+
+func (g2 *G2) phi(q *G2Affine) *G2Affine {
+	x := g2.curveF.Mul(&q.P.X, g2.w)
+
+	return &G2Affine{
+		P: g2AffP{
+			X: *x,
+			Y: q.P.Y,
+		},
+	}
+}
+
+func (g2 *G2) scalarMulBySeed(q *G2Affine) *G2Affine {
+	z := g2.triple(q)
+	z = g2.doubleAndAdd(z, q)
+	t0 := g2.double(z)
+	t0 = g2.double(t0)
+	z = g2.add(z, t0)
+	t1 := g2.triple(z)
+	t0 = g2.add(t0, t1)
+	t0 = g2.doubleN(t0, 9)
+	z = g2.doubleAndAdd(t0, z)
+	z = g2.doubleN(z, 45)
+	z = g2.doubleAndAdd(z, q)
+
+	return z
+}
+
+func (g2 G2) add(p, q *G2Affine) *G2Affine {
+	// compute λ = (q.y-p.y)/(q.x-p.x)
+	qypy := g2.curveF.Sub(&q.P.Y, &p.P.Y)
+	qxpx := g2.curveF.Sub(&q.P.X, &p.P.X)
+	λ := g2.curveF.Div(qypy, qxpx)
+
+	// xr = λ²-p.x-q.x
+	λλ := g2.curveF.Mul(λ, λ)
+	qxpx = g2.curveF.Add(&p.P.X, &q.P.X)
+	xr := g2.curveF.Sub(λλ, qxpx)
+
+	// p.y = λ(p.x-r.x) - p.y
+	pxrx := g2.curveF.Sub(&p.P.X, xr)
+	λpxrx := g2.curveF.Mul(λ, pxrx)
+	yr := g2.curveF.Sub(λpxrx, &p.P.Y)
+
+	return &G2Affine{
+		P: g2AffP{
+			X: *xr,
+			Y: *yr,
+		},
+	}
+}
+
+func (g2 G2) neg(p *G2Affine) *G2Affine {
+	xr := &p.P.X
+	yr := g2.curveF.Neg(&p.P.Y)
+	return &G2Affine{
+		P: g2AffP{
+			X: *xr,
+			Y: *yr,
+		},
+	}
+}
+
+func (g2 G2) sub(p, q *G2Affine) *G2Affine {
+	qNeg := g2.neg(q)
+	return g2.add(p, qNeg)
+}
+
+func (g2 *G2) double(p *G2Affine) *G2Affine {
+	// compute λ = (3p.x²)/2*p.y
+	xx3a := g2.curveF.Mul(&p.P.X, &p.P.X)
+	xx3a = g2.curveF.MulConst(xx3a, big.NewInt(3))
+	y2 := g2.curveF.MulConst(&p.P.Y, big.NewInt(2))
+	λ := g2.curveF.Div(xx3a, y2)
+
+	// xr = λ²-2p.x
+	x2 := g2.curveF.MulConst(&p.P.X, big.NewInt(2))
+	λλ := g2.curveF.Mul(λ, λ)
+	xr := g2.curveF.Sub(λλ, x2)
+
+	// yr = λ(p-xr) - p.y
+	pxrx := g2.curveF.Sub(&p.P.X, xr)
+	λpxrx := g2.curveF.Mul(λ, pxrx)
+	yr := g2.curveF.Sub(λpxrx, &p.P.Y)
+
+	return &G2Affine{
+		P: g2AffP{
+			X: *xr,
+			Y: *yr,
+		},
+	}
+}
+
+func (g2 *G2) doubleN(p *G2Affine, n int) *G2Affine {
+	pn := p
+	for s := 0; s < n; s++ {
+		pn = g2.double(pn)
+	}
+	return pn
+}
+
+func (g2 G2) doubleAndAdd(p, q *G2Affine) *G2Affine {
+
+	// compute λ1 = (q.y-p.y)/(q.x-p.x)
+	yqyp := g2.curveF.Sub(&q.P.Y, &p.P.Y)
+	xqxp := g2.curveF.Sub(&q.P.X, &p.P.X)
+	λ1 := g2.curveF.Div(yqyp, xqxp)
+
+	// compute x2 = λ1²-p.x-q.x
+	λ1λ1 := g2.curveF.Mul(λ1, λ1)
+	xqxp = g2.curveF.Add(&p.P.X, &q.P.X)
+	x2 := g2.curveF.Sub(λ1λ1, xqxp)
+
+	// ommit y2 computation
+	// compute λ2 = -λ1-2*p.y/(x2-p.x)
+	ypyp := g2.curveF.Add(&p.P.Y, &p.P.Y)
+	x2xp := g2.curveF.Sub(x2, &p.P.X)
+	λ2 := g2.curveF.Div(ypyp, x2xp)
+	λ2 = g2.curveF.Add(λ1, λ2)
+	λ2 = g2.curveF.Neg(λ2)
+
+	// compute x3 =λ2²-p.x-x3
+	λ2λ2 := g2.curveF.Mul(λ2, λ2)
+	x3 := g2.curveF.Sub(λ2λ2, &p.P.X)
+	x3 = g2.curveF.Sub(x3, x2)
+
+	// compute y3 = λ2*(p.x - x3)-p.y
+	y3 := g2.curveF.Sub(&p.P.X, x3)
+	y3 = g2.curveF.Mul(λ2, y3)
+	y3 = g2.curveF.Sub(y3, &p.P.Y)
+
+	return &G2Affine{
+		P: g2AffP{
+			X: *x3,
+			Y: *y3,
+		},
+	}
+}
+
+func (g2 G2) triple(p *G2Affine) *G2Affine {
+
+	// compute λ = (3p.x²)/2*p.y
+	xx := g2.curveF.Mul(&p.P.X, &p.P.X)
+	xx = g2.curveF.MulConst(xx, big.NewInt(3))
+	y2 := g2.curveF.MulConst(&p.P.Y, big.NewInt(2))
+	λ1 := g2.curveF.Div(xx, y2)
+
+	// xr = λ²-2p.x
+	x2 := g2.curveF.MulConst(&p.P.X, big.NewInt(2))
+	λ1λ1 := g2.curveF.Mul(λ1, λ1)
+	x2 = g2.curveF.Sub(λ1λ1, x2)
+
+	// ommit y2 computation, and
+	// compute λ2 = 2p.y/(x2 − p.x) − λ1.
+	x1x2 := g2.curveF.Sub(&p.P.X, x2)
+	λ2 := g2.curveF.Div(y2, x1x2)
+	λ2 = g2.curveF.Sub(λ2, λ1)
+
+	// xr = λ²-p.x-x2
+	λ2λ2 := g2.curveF.Mul(λ2, λ2)
+	qxrx := g2.curveF.Add(x2, &p.P.X)
+	xr := g2.curveF.Sub(λ2λ2, qxrx)
+
+	// yr = λ(p.x-xr) - p.y
+	pxrx := g2.curveF.Sub(&p.P.X, xr)
+	λ2pxrx := g2.curveF.Mul(λ2, pxrx)
+	yr := g2.curveF.Sub(λ2pxrx, &p.P.Y)
+
+	return &G2Affine{
+		P: g2AffP{
+			X: *xr,
+			Y: *yr,
+		},
+	}
+}
+
+// AssertIsEqual asserts that p and q are the same point.
+func (g2 *G2) AssertIsEqual(p, q *G2Affine) {
+	g2.curveF.AssertIsEqual(&p.P.X, &q.P.X)
+	g2.curveF.AssertIsEqual(&p.P.Y, &q.P.Y)
 }

--- a/std/algebra/emulated/sw_bw6761/pairing.go
+++ b/std/algebra/emulated/sw_bw6761/pairing.go
@@ -8,6 +8,7 @@ import (
 	bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/emulated/fields_bw6761"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
 	"github.com/consensys/gnark/std/math/emulated"
 )
 
@@ -15,6 +16,9 @@ type Pairing struct {
 	api frontend.API
 	*fields_bw6761.Ext6
 	curveF *emulated.Field[BaseField]
+	curve  *sw_emulated.Curve[BaseField, ScalarField]
+	g1     *G1
+	g2     *G2
 	g2gen  *G2Affine
 }
 
@@ -40,10 +44,25 @@ func NewPairing(api frontend.API) (*Pairing, error) {
 	if err != nil {
 		return nil, fmt.Errorf("new base api: %w", err)
 	}
+	curve, err := sw_emulated.New[BaseField, ScalarField](api, sw_emulated.GetBW6761Params())
+	if err != nil {
+		return nil, fmt.Errorf("new curve: %w", err)
+	}
+	g1, err := NewG1(api)
+	if err != nil {
+		return nil, fmt.Errorf("new G1 struct: %w", err)
+	}
+	g2, err := NewG2(api)
+	if err != nil {
+		return nil, fmt.Errorf("new G2 struct: %w", err)
+	}
 	return &Pairing{
 		api:    api,
 		Ext6:   fields_bw6761.NewExt6(api),
 		curveF: ba,
+		curve:  curve,
+		g1:     g1,
+		g2:     g2,
 	}, nil
 }
 
@@ -137,6 +156,66 @@ func (pr Pairing) PairingCheck(P []*G1Affine, Q []*G2Affine) error {
 
 func (pr Pairing) AssertIsEqual(x, y *GTEl) {
 	pr.Ext6.AssertIsEqual(x, y)
+}
+
+func (pr Pairing) AssertIsOnCurve(P *G1Affine) {
+	pr.curve.AssertIsOnCurve(P)
+}
+
+func (pr Pairing) AssertIsOnTwist(Q *G2Affine) {
+	// Twist: Y² == X³ + aX + b, where a=0 and b=4
+	// (X,Y) ∈ {Y² == X³ + aX + b} U (0,0)
+
+	// if Q=(0,0) we assign b=0 otherwise 4, and continue
+	selector := pr.api.And(pr.curveF.IsZero(&Q.P.X), pr.curveF.IsZero(&Q.P.Y))
+	bTwist := emulated.ValueOf[BaseField](4)
+	b := pr.curveF.Select(selector, pr.curveF.Zero(), &bTwist)
+
+	left := pr.curveF.Mul(&Q.P.Y, &Q.P.Y)
+	right := pr.curveF.Mul(&Q.P.X, &Q.P.X)
+	right = pr.curveF.Mul(right, &Q.P.X)
+	right = pr.curveF.Add(right, b)
+	pr.curveF.AssertIsEqual(left, right)
+}
+
+func (pr Pairing) AssertIsOnG1(P *G1Affine) {
+	// 1- Check P is on the curve
+	pr.AssertIsOnCurve(P)
+
+	// 2- Check P has the right subgroup order
+	// we check that [x₀+1]P == [-x₀³+x₀²-1]ϕ(P)
+	phiP := pr.g1.phi(P)
+	xPhiP := pr.g1.scalarMulBySeed(phiP)
+	x2PhiP := pr.g1.scalarMulBySeed(xPhiP)
+	x3PhiP := pr.g1.scalarMulBySeed(x2PhiP)
+
+	left := pr.g1.scalarMulBySeed(P)
+	left = pr.g1.add(left, P)
+	right := pr.g1.sub(x2PhiP, x3PhiP)
+	right = pr.g1.sub(right, phiP)
+
+	// [r]P == 0 <==> [x₀+1]P == [-x₀³+x₀²-1]ϕ(P)
+	pr.curve.AssertIsEqual(left, right)
+}
+
+func (pr Pairing) AssertIsOnG2(Q *G2Affine) {
+	// 1- Check Q is on the curve
+	pr.AssertIsOnTwist(Q)
+
+	// 2- Check Q has the right subgroup order
+	// we check that [x₀+1]Q == [-x₀³+x₀²-1]ϕ(Q)
+	phiQ := pr.g2.phi(Q)
+	xPhiQ := pr.g2.scalarMulBySeed(phiQ)
+	x2PhiQ := pr.g2.scalarMulBySeed(xPhiQ)
+	x3PhiQ := pr.g2.scalarMulBySeed(x2PhiQ)
+
+	left := pr.g2.scalarMulBySeed(Q)
+	left = pr.g2.add(left, Q)
+	right := pr.g2.sub(x2PhiQ, x3PhiQ)
+	right = pr.g2.sub(right, phiQ)
+
+	// [r]Q == 0 <==> [x₀+1]Q == [-x₀³+x₀²-1]ϕ(Q)
+	pr.g2.AssertIsEqual(left, right)
 }
 
 // seed x₀=9586122913090633729

--- a/std/algebra/emulated/sw_bw6761/pairing.go
+++ b/std/algebra/emulated/sw_bw6761/pairing.go
@@ -184,15 +184,14 @@ func (pr Pairing) AssertIsOnG1(P *G1Affine) {
 
 	// 2- Check P has the right subgroup order
 	// we check that [x₀+1]P == [-x₀³+x₀²-1]ϕ(P)
-	phiP := pr.g1.phi(P)
-	xPhiP := pr.g1.scalarMulBySeed(phiP)
-	x2PhiP := pr.g1.scalarMulBySeed(xPhiP)
-	x3PhiP := pr.g1.scalarMulBySeed(x2PhiP)
+	xP := pr.g1.scalarMulBySeed(P)
+	x2P := pr.g1.scalarMulBySeed(xP)
+	x3P := pr.g1.scalarMulBySeed(x2P)
 
-	left := pr.g1.scalarMulBySeed(P)
-	left = pr.g1.add(left, P)
-	right := pr.g1.sub(x2PhiP, x3PhiP)
-	right = pr.g1.sub(right, phiP)
+	left := pr.g1.add(xP, P)
+	right := pr.g1.sub(x2P, x3P)
+	right = pr.g1.sub(right, P)
+	right = pr.g1.phi(right)
 
 	// [r]P == 0 <==> [x₀+1]P == [-x₀³+x₀²-1]ϕ(P)
 	pr.curve.AssertIsEqual(left, right)
@@ -204,15 +203,14 @@ func (pr Pairing) AssertIsOnG2(Q *G2Affine) {
 
 	// 2- Check Q has the right subgroup order
 	// we check that [x₀+1]Q == [-x₀³+x₀²-1]ϕ(Q)
-	phiQ := pr.g2.phi(Q)
-	xPhiQ := pr.g2.scalarMulBySeed(phiQ)
-	x2PhiQ := pr.g2.scalarMulBySeed(xPhiQ)
-	x3PhiQ := pr.g2.scalarMulBySeed(x2PhiQ)
+	xQ := pr.g2.scalarMulBySeed(Q)
+	x2Q := pr.g2.scalarMulBySeed(xQ)
+	x3Q := pr.g2.scalarMulBySeed(x2Q)
 
-	left := pr.g2.scalarMulBySeed(Q)
-	left = pr.g2.add(left, Q)
-	right := pr.g2.sub(x2PhiQ, x3PhiQ)
-	right = pr.g2.sub(right, phiQ)
+	left := pr.g2.add(xQ, Q)
+	right := pr.g2.sub(x2Q, x3Q)
+	right = pr.g2.sub(right, Q)
+	right = pr.g2.phi(right)
 
 	// [r]Q == 0 <==> [x₀+1]Q == [-x₀³+x₀²-1]ϕ(Q)
 	pr.g2.AssertIsEqual(left, right)

--- a/std/algebra/emulated/sw_bw6761/pairing_test.go
+++ b/std/algebra/emulated/sw_bw6761/pairing_test.go
@@ -72,6 +72,8 @@ func (c *PairCircuit) Define(api frontend.API) error {
 	if err != nil {
 		return fmt.Errorf("new pairing: %w", err)
 	}
+	pairing.AssertIsOnG1(&c.InG1)
+	pairing.AssertIsOnG2(&c.InG2)
 	res, err := pairing.Pair([]*G1Affine{&c.InG1}, []*G2Affine{&c.InG2})
 	if err != nil {
 		return fmt.Errorf("pair: %w", err)
@@ -120,6 +122,8 @@ func (c *MultiPairCircuit) Define(api frontend.API) error {
 	if err != nil {
 		return fmt.Errorf("new pairing: %w", err)
 	}
+	pairing.AssertIsOnG1(&c.InG1)
+	pairing.AssertIsOnG2(&c.InG2)
 	P, Q := []*G1Affine{}, []*G2Affine{}
 	for i := 0; i < c.n; i++ {
 		P = append(P, &c.InG1)
@@ -191,6 +195,32 @@ func TestPairingCheckTestSolve(t *testing.T) {
 		In2G2: NewG2Affine(q2),
 	}
 	err := test.IsSolved(&PairingCheckCircuit{}, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}
+
+type GroupMembershipCircuit struct {
+	InG1 G1Affine
+	InG2 G2Affine
+}
+
+func (c *GroupMembershipCircuit) Define(api frontend.API) error {
+	pairing, err := NewPairing(api)
+	if err != nil {
+		return fmt.Errorf("new pairing: %w", err)
+	}
+	pairing.AssertIsOnG1(&c.InG1)
+	pairing.AssertIsOnG2(&c.InG2)
+	return nil
+}
+
+func TestGroupMembershipSolve(t *testing.T) {
+	assert := test.NewAssert(t)
+	p, q := randomG1G2Affines()
+	witness := GroupMembershipCircuit{
+		InG1: NewG1Affine(p),
+		InG2: NewG2Affine(q),
+	}
+	err := test.IsSolved(&GroupMembershipCircuit{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
 }
 

--- a/std/algebra/native/sw_bls12377/g1.go
+++ b/std/algebra/native/sw_bls12377/g1.go
@@ -147,6 +147,33 @@ func (p *G1Affine) Double(api frontend.API, p1 G1Affine) *G1Affine {
 	return p
 }
 
+func (P *G1Affine) doubleN(api frontend.API, Q *G1Affine, n int) *G1Affine {
+	pn := Q
+	for s := 0; s < n; s++ {
+		pn.Double(api, *pn)
+	}
+	return pn
+}
+
+func (P *G1Affine) scalarMulBySeed(api frontend.API, Q *G1Affine) *G1Affine {
+	var z, t0, t1 G1Affine
+	z.Double(api, *Q)
+	z.AddAssign(api, *Q)
+	z.DoubleAndAdd(api, &z, Q)
+	t0.Double(api, z)
+	t0.Double(api, t0)
+	z.AddAssign(api, t0)
+	t1.Double(api, z)
+	t1.AddAssign(api, z)
+	t0.AddAssign(api, t1)
+	t0.doubleN(api, &t0, 9)
+	z.DoubleAndAdd(api, &t0, &z)
+	z.doubleN(api, &z, 45)
+	P.DoubleAndAdd(api, &z, Q)
+
+	return P
+}
+
 // ScalarMul sets P = [s] Q and returns P.
 //
 // The method chooses an implementation based on scalar s. If it is constant,

--- a/std/algebra/native/sw_bls12377/g2.go
+++ b/std/algebra/native/sw_bls12377/g2.go
@@ -155,6 +155,33 @@ func (p *g2AffP) Double(api frontend.API, p1 g2AffP) *g2AffP {
 
 }
 
+func (P *g2AffP) doubleN(api frontend.API, Q *g2AffP, n int) *g2AffP {
+	pn := Q
+	for s := 0; s < n; s++ {
+		pn.Double(api, *pn)
+	}
+	return pn
+}
+
+func (P *g2AffP) scalarMulBySeed(api frontend.API, Q *g2AffP) *g2AffP {
+	var z, t0, t1 g2AffP
+	z.Double(api, *Q)
+	z.AddAssign(api, *Q)
+	z.DoubleAndAdd(api, &z, Q)
+	t0.Double(api, z)
+	t0.Double(api, t0)
+	z.AddAssign(api, t0)
+	t1.Double(api, z)
+	t1.AddAssign(api, z)
+	t0.AddAssign(api, t1)
+	t0.doubleN(api, &t0, 9)
+	z.DoubleAndAdd(api, &t0, &z)
+	z.doubleN(api, &z, 45)
+	P.DoubleAndAdd(api, &z, Q)
+
+	return P
+}
+
 // ScalarMul sets P = [s] Q and returns P.
 //
 // The method chooses an implementation based on scalar s. If it is constant,
@@ -521,6 +548,19 @@ func (P *g2AffP) ScalarMulBase(api frontend.API, s frontend.Variable) *g2AffP {
 
 	P.X = res.X
 	P.Y = res.Y
+
+	return P
+}
+
+func (P *g2AffP) psi(api frontend.API, q *g2AffP) *g2AffP {
+	var x, y fields_bls12377.E2
+	x.Conjugate(api, q.X)
+	x.MulByFp(api, x, "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410946")
+	y.Conjugate(api, q.Y)
+	y.MulByFp(api, y, "216465761340224619389371505802605247630151569547285782856803747159100223055385581585702401816380679166954762214499")
+
+	P.X = x
+	P.Y = y
 
 	return P
 }

--- a/std/algebra/native/sw_bls12377/pairing2.go
+++ b/std/algebra/native/sw_bls12377/pairing2.go
@@ -144,6 +144,21 @@ func (c *Curve) AssertIsOnTwist(p *G2Affine) {
 	left.AssertIsEqual(c.api, right)
 }
 
+func (c *Curve) AssertIsOnG2(P *G2Affine) {
+	// 1- Check P is on the curve
+	c.AssertIsOnTwist(P)
+
+	// 2- Check P has the right subgroup order
+	// [x₀]Q
+	var xP, psiP g2AffP
+	xP.scalarMulBySeed(c.api, &P.P)
+	// ψ(Q)
+	psiP.psi(c.api, &P.P)
+
+	// [r]Q == 0 <==>  ψ(Q) == [x₀]Q
+	xP.AssertIsEqual(c.api, psiP)
+}
+
 // Neg negates P and returns the result. Does not modify P.
 func (c *Curve) Neg(P *G1Affine) *G1Affine {
 	res := &G1Affine{

--- a/std/algebra/native/sw_bls12377/pairing2.go
+++ b/std/algebra/native/sw_bls12377/pairing2.go
@@ -111,9 +111,11 @@ func (c *Curve) AssertIsOnG1(P *G1Affine) {
 
 	// 2- Check P has the right subgroup order
 	// [x²]ϕ(P)
-	var phiP, _P G1Affine
-	cc := getInnerCurveConfig(c.api.Compiler().Field())
-	cc.phi1(c.api, &phiP, P)
+	phiP := G1Affine{
+		X: c.api.Mul(P.X, "80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945"),
+		Y: P.Y,
+	}
+	var _P G1Affine
 	_P.scalarMulBySeed(c.api, &phiP)
 	_P.scalarMulBySeed(c.api, &_P)
 	_P.Neg(c.api, _P)

--- a/std/algebra/native/sw_bls12377/pairing_test.go
+++ b/std/algebra/native/sw_bls12377/pairing_test.go
@@ -64,7 +64,12 @@ type pairingBLS377 struct {
 }
 
 func (circuit *pairingBLS377) Define(api frontend.API) error {
-
+	cr, err := NewCurve(api)
+	if err != nil {
+		return err
+	}
+	cr.AssertIsOnCurve(&circuit.P)
+	cr.AssertIsOnTwist(&circuit.Q)
 	pairingRes, _ := Pair(api, []G1Affine{circuit.P}, []G2Affine{circuit.Q})
 	pairingRes.AssertIsEqual(api, circuit.Res)
 

--- a/std/algebra/native/sw_bls12377/pairing_test.go
+++ b/std/algebra/native/sw_bls12377/pairing_test.go
@@ -218,6 +218,36 @@ func TestPairingCheckBLS377(t *testing.T) {
 
 }
 
+type groupMembership struct {
+	P G1Affine
+	Q G2Affine
+}
+
+func (circuit *groupMembership) Define(api frontend.API) error {
+	cr, err := NewCurve(api)
+	if err != nil {
+		return err
+	}
+	cr.AssertIsOnG1(&circuit.P)
+	cr.AssertIsOnG2(&circuit.Q)
+
+	return nil
+}
+
+func TestGroupMembership(t *testing.T) {
+
+	// pairing test data
+	P, Q, _, _ := pairingData()
+
+	// assign values to witness
+	witness := groupMembership{
+		P: NewG1Affine(P),
+		Q: NewG2Affine(Q),
+	}
+	assert := test.NewAssert(t)
+	assert.CheckCircuit(&groupMembership{}, test.WithValidAssignment(&witness), test.WithCurves(ecc.BW6_761))
+}
+
 // utils
 func pairingData() (P bls12377.G1Affine, Q bls12377.G2Affine, milRes, pairingRes bls12377.GT) {
 	_, _, P, Q = bls12377.Generators()

--- a/std/algebra/native/sw_bls12377/pairing_test.go
+++ b/std/algebra/native/sw_bls12377/pairing_test.go
@@ -69,7 +69,7 @@ func (circuit *pairingBLS377) Define(api frontend.API) error {
 		return err
 	}
 	cr.AssertIsOnG1(&circuit.P)
-	cr.AssertIsOnTwist(&circuit.Q)
+	cr.AssertIsOnG2(&circuit.Q)
 	pairingRes, _ := Pair(api, []G1Affine{circuit.P}, []G2Affine{circuit.Q})
 	pairingRes.AssertIsEqual(api, circuit.Res)
 

--- a/std/algebra/native/sw_bls12377/pairing_test.go
+++ b/std/algebra/native/sw_bls12377/pairing_test.go
@@ -68,7 +68,7 @@ func (circuit *pairingBLS377) Define(api frontend.API) error {
 	if err != nil {
 		return err
 	}
-	cr.AssertIsOnCurve(&circuit.P)
+	cr.AssertIsOnG1(&circuit.P)
 	cr.AssertIsOnTwist(&circuit.Q)
 	pairingRes, _ := Pair(api, []G1Affine{circuit.P}, []G2Affine{circuit.Q})
 	pairingRes.AssertIsEqual(api, circuit.Res)


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

This PR adds G1 and G2 subgroup memberships for BW6-761. It's up to the user to call these circuits for example before a pairing call.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

Added new tests for subgroup membership tests.

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

- For BLS12-377:

|                     | G1 curve membership | G2 curve membership | G1 subgroup membership | G2 subgroup membership |
| ----------- | ----------- | ----------- | -------------- | ------------- |
| SCS             | 11 | 32  | 971     |  2,267  |

So a total of 3,280 (without separate equality checks of each sub-circuit) if we want to test all membership for e.g. before a pairing circuit.

- For BW6-761:

|                     | G1 curve membership | G2 curve membership | G1 subgroup membership | G2 subgroup membership |
| ----------- | ----------- | ----------- | -------------- | ------------- |
| SCS             | 15,412 | 15,390  | 1,210,276     |  1,210,276  |

So a total of 2,189,173 (without separate equality checks of each sub-circuit) if we want to test all membership for e.g. before a pairing circuit.

**N.B.: note that for KZG verifier we (might) only need G1 membership as G2 points are fixed and corresponding lines pre-computed in the SRS.**

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

