### PR TITLE
feat: test engine is a range checker

### DIFF
--- a/test/engine.go
+++ b/test/engine.go
@@ -781,3 +781,40 @@ func (e *engine) MustBeLessOrEqCst(aBits []frontend.Variable, bound *big.Int, aF
 		panic(fmt.Sprintf("%d > %d", v, bound))
 	}
 }
+
+// Check asserts that the value given by v is less than 2^bits.
+func (e *engine) Check(v frontend.Variable, bits int) {
+
+	var i big.Int
+
+	switch vv := v.(type) {
+	case *big.Int:
+		i.Set(vv)
+	case int:
+		i.SetInt64(int64(vv))
+	case int8:
+		i.SetInt64(int64(vv))
+	case int16:
+		i.SetInt64(int64(vv))
+	case int32:
+		i.SetInt64(int64(vv))
+	case int64:
+		i.SetInt64(vv)
+	case uint8:
+		i.SetUint64(uint64(vv))
+	case uint16:
+		i.SetUint64(uint64(vv))
+	case uint32:
+		i.SetUint64(uint64(vv))
+	case uint64:
+		i.SetUint64(vv)
+	default:
+		panic(fmt.Errorf("unsupported type %T", vv))
+	}
+
+	i.Mod(&i, e.modulus())
+
+	if i.BitLen() > bits {
+		panic(fmt.Sprintf("%s > 2^%d", i.Text(10), bits))
+	}
+}

--- a/test/engine_test.go
+++ b/test/engine_test.go
@@ -125,6 +125,15 @@ type rangeCheckTestCircuit struct {
 }
 
 func (c *rangeCheckTestCircuit) Define(api frontend.API) error {
-	rangecheck.New(api).Check(c.X, c.bits)
+	r := rangecheck.New(api)
+
+	r.Check(c.X, c.bits)
+
+	// 0 ≤ X ≤ 2ᵇⁱᵗˢ - 1 ⇔ - 2ᵇⁱᵗˢ + 1 ≤ -X ≤ 0 ⇔ 0 ≤ (2ᵇⁱᵗˢ - 1) - X ≤ 2ᵇⁱᵗˢ - 1
+	// i.e. X is in range iff (2ᵇⁱᵗˢ - 1) - X is
+	bound := big.NewInt(1)
+	bound.Lsh(bound, uint(c.bits)).Sub(bound, big.NewInt(1))
+	r.Check(api.Sub(bound, c.X), c.bits)
+
 	return nil
 }


### PR DESCRIPTION
This PR fits the test engine to the `frontend.Rangechecker` interface, with the effect that now its range assertions are checked during the `Define` method, giving a clearer error in case of failure as compared with a failed deferred call.

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Previous rangecheck tests pass. A [new test](https://github.com/Consensys/gnark/blob/feat/engine-rangechecker/test/engine_test.go#L109) has also been added but I am not sure if it's necessary.

# How has this been benchmarked?

No benchmarking.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

