### PR TITLE
fix: use G1 generator from SRS

### DIFF
--- a/std/commitments/kzg/verifier.go
+++ b/std/commitments/kzg/verifier.go
@@ -545,7 +545,7 @@ func (v *Verifier[FR, G1El, G2El, GTEl]) FoldProofsMultiPoint(digests []Commitme
 	}
 
 	// compute commitment to folded Eval  [∑ᵢλᵢfᵢ(aᵢ)]G₁
-	foldedEvalsCommit := v.curve.ScalarMulBase(foldedEvals)
+	foldedEvalsCommit := v.curve.ScalarMul(&vk.G1, foldedEvals)
 
 	// compute foldedDigests = ∑ᵢλᵢ[fᵢ(α)]G₁ - [∑ᵢλᵢfᵢ(aᵢ)]G₁
 	tmp := v.curve.Neg(foldedEvalsCommit)


### PR DESCRIPTION
# Description

In #949 we optimized in KZG folding to use curve basepoint to evaluate foldedEval, but KZG SRS G1 generator may be different. This PR reverts the change.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Tests work downstream in Linea prover.

# How has this been benchmarked?


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

