### PR TITLE
feat: add option for enforcing number of goroutines for the solver

### DIFF
--- a/constraint/bls12-377/solver.go
+++ b/constraint/bls12-377/solver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rs/zerolog"
 	"math"
 	"math/big"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,7 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger zerolog.Logger
+	logger    zerolog.Logger
+	nbThreads int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,6 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
+		nbThreads:       opt.NbThreads,
 		q:               cs.Field(),
 	}
 
@@ -429,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
+	chTasks := make(chan []int, solver.nbThreads)
+	chError := make(chan error, solver.nbThreads)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := 0; i < solver.nbThreads; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -465,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 {
+		if maxCPU <= 1.0 || solver.nbThreads == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -477,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := runtime.NumCPU()
+		nbTasks := solver.nbThreads
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bls12-377/solver.go
+++ b/constraint/bls12-377/solver.go
@@ -47,8 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger    zerolog.Logger
-	nbThreads int
+	logger  zerolog.Logger
+	nbTasks int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,7 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
-		nbThreads:       opt.NbThreads,
+		nbTasks:         opt.NbTasks,
 		q:               cs.Field(),
 	}
 
@@ -430,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, solver.nbThreads)
-	chError := make(chan error, solver.nbThreads)
+	chTasks := make(chan []int, solver.nbTasks)
+	chError := make(chan error, solver.nbTasks)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < solver.nbThreads; i++ {
+	for i := 0; i < solver.nbTasks; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -466,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 || solver.nbThreads == 1 {
+		if maxCPU <= 1.0 || solver.nbTasks == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -478,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := solver.nbThreads
+		nbTasks := solver.nbTasks
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bls12-381/solver.go
+++ b/constraint/bls12-381/solver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rs/zerolog"
 	"math"
 	"math/big"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,7 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger zerolog.Logger
+	logger    zerolog.Logger
+	nbThreads int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,6 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
+		nbThreads:       opt.NbThreads,
 		q:               cs.Field(),
 	}
 
@@ -429,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
+	chTasks := make(chan []int, solver.nbThreads)
+	chError := make(chan error, solver.nbThreads)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := 0; i < solver.nbThreads; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -465,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 {
+		if maxCPU <= 1.0 || solver.nbThreads == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -477,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := runtime.NumCPU()
+		nbTasks := solver.nbThreads
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bls12-381/solver.go
+++ b/constraint/bls12-381/solver.go
@@ -47,8 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger    zerolog.Logger
-	nbThreads int
+	logger  zerolog.Logger
+	nbTasks int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,7 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
-		nbThreads:       opt.NbThreads,
+		nbTasks:         opt.NbTasks,
 		q:               cs.Field(),
 	}
 
@@ -430,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, solver.nbThreads)
-	chError := make(chan error, solver.nbThreads)
+	chTasks := make(chan []int, solver.nbTasks)
+	chError := make(chan error, solver.nbTasks)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < solver.nbThreads; i++ {
+	for i := 0; i < solver.nbTasks; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -466,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 || solver.nbThreads == 1 {
+		if maxCPU <= 1.0 || solver.nbTasks == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -478,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := solver.nbThreads
+		nbTasks := solver.nbTasks
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bls24-315/solver.go
+++ b/constraint/bls24-315/solver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rs/zerolog"
 	"math"
 	"math/big"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,7 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger zerolog.Logger
+	logger    zerolog.Logger
+	nbThreads int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,6 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
+		nbThreads:       opt.NbThreads,
 		q:               cs.Field(),
 	}
 
@@ -429,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
+	chTasks := make(chan []int, solver.nbThreads)
+	chError := make(chan error, solver.nbThreads)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := 0; i < solver.nbThreads; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -465,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 {
+		if maxCPU <= 1.0 || solver.nbThreads == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -477,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := runtime.NumCPU()
+		nbTasks := solver.nbThreads
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bls24-315/solver.go
+++ b/constraint/bls24-315/solver.go
@@ -47,8 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger    zerolog.Logger
-	nbThreads int
+	logger  zerolog.Logger
+	nbTasks int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,7 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
-		nbThreads:       opt.NbThreads,
+		nbTasks:         opt.NbTasks,
 		q:               cs.Field(),
 	}
 
@@ -430,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, solver.nbThreads)
-	chError := make(chan error, solver.nbThreads)
+	chTasks := make(chan []int, solver.nbTasks)
+	chError := make(chan error, solver.nbTasks)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < solver.nbThreads; i++ {
+	for i := 0; i < solver.nbTasks; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -466,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 || solver.nbThreads == 1 {
+		if maxCPU <= 1.0 || solver.nbTasks == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -478,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := solver.nbThreads
+		nbTasks := solver.nbTasks
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bls24-317/solver.go
+++ b/constraint/bls24-317/solver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rs/zerolog"
 	"math"
 	"math/big"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,7 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger zerolog.Logger
+	logger    zerolog.Logger
+	nbThreads int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,6 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
+		nbThreads:       opt.NbThreads,
 		q:               cs.Field(),
 	}
 
@@ -429,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
+	chTasks := make(chan []int, solver.nbThreads)
+	chError := make(chan error, solver.nbThreads)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := 0; i < solver.nbThreads; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -465,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 {
+		if maxCPU <= 1.0 || solver.nbThreads == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -477,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := runtime.NumCPU()
+		nbTasks := solver.nbThreads
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bls24-317/solver.go
+++ b/constraint/bls24-317/solver.go
@@ -47,8 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger    zerolog.Logger
-	nbThreads int
+	logger  zerolog.Logger
+	nbTasks int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,7 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
-		nbThreads:       opt.NbThreads,
+		nbTasks:         opt.NbTasks,
 		q:               cs.Field(),
 	}
 
@@ -430,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, solver.nbThreads)
-	chError := make(chan error, solver.nbThreads)
+	chTasks := make(chan []int, solver.nbTasks)
+	chError := make(chan error, solver.nbTasks)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < solver.nbThreads; i++ {
+	for i := 0; i < solver.nbTasks; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -466,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 || solver.nbThreads == 1 {
+		if maxCPU <= 1.0 || solver.nbTasks == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -478,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := solver.nbThreads
+		nbTasks := solver.nbTasks
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bn254/solver.go
+++ b/constraint/bn254/solver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rs/zerolog"
 	"math"
 	"math/big"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,7 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger zerolog.Logger
+	logger    zerolog.Logger
+	nbThreads int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,6 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
+		nbThreads:       opt.NbThreads,
 		q:               cs.Field(),
 	}
 
@@ -429,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
+	chTasks := make(chan []int, solver.nbThreads)
+	chError := make(chan error, solver.nbThreads)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := 0; i < solver.nbThreads; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -465,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 {
+		if maxCPU <= 1.0 || solver.nbThreads == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -477,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := runtime.NumCPU()
+		nbTasks := solver.nbThreads
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bn254/solver.go
+++ b/constraint/bn254/solver.go
@@ -47,8 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger    zerolog.Logger
-	nbThreads int
+	logger  zerolog.Logger
+	nbTasks int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,7 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
-		nbThreads:       opt.NbThreads,
+		nbTasks:         opt.NbTasks,
 		q:               cs.Field(),
 	}
 
@@ -430,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, solver.nbThreads)
-	chError := make(chan error, solver.nbThreads)
+	chTasks := make(chan []int, solver.nbTasks)
+	chError := make(chan error, solver.nbTasks)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < solver.nbThreads; i++ {
+	for i := 0; i < solver.nbTasks; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -466,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 || solver.nbThreads == 1 {
+		if maxCPU <= 1.0 || solver.nbTasks == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -478,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := solver.nbThreads
+		nbTasks := solver.nbTasks
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bw6-633/solver.go
+++ b/constraint/bw6-633/solver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rs/zerolog"
 	"math"
 	"math/big"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,7 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger zerolog.Logger
+	logger    zerolog.Logger
+	nbThreads int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,6 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
+		nbThreads:       opt.NbThreads,
 		q:               cs.Field(),
 	}
 
@@ -429,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
+	chTasks := make(chan []int, solver.nbThreads)
+	chError := make(chan error, solver.nbThreads)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := 0; i < solver.nbThreads; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -465,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 {
+		if maxCPU <= 1.0 || solver.nbThreads == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -477,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := runtime.NumCPU()
+		nbTasks := solver.nbThreads
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bw6-633/solver.go
+++ b/constraint/bw6-633/solver.go
@@ -47,8 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger    zerolog.Logger
-	nbThreads int
+	logger  zerolog.Logger
+	nbTasks int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,7 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
-		nbThreads:       opt.NbThreads,
+		nbTasks:         opt.NbTasks,
 		q:               cs.Field(),
 	}
 
@@ -430,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, solver.nbThreads)
-	chError := make(chan error, solver.nbThreads)
+	chTasks := make(chan []int, solver.nbTasks)
+	chError := make(chan error, solver.nbTasks)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < solver.nbThreads; i++ {
+	for i := 0; i < solver.nbTasks; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -466,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 || solver.nbThreads == 1 {
+		if maxCPU <= 1.0 || solver.nbTasks == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -478,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := solver.nbThreads
+		nbTasks := solver.nbTasks
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bw6-761/solver.go
+++ b/constraint/bw6-761/solver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rs/zerolog"
 	"math"
 	"math/big"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,7 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger zerolog.Logger
+	logger    zerolog.Logger
+	nbThreads int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,6 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
+		nbThreads:       opt.NbThreads,
 		q:               cs.Field(),
 	}
 
@@ -429,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
+	chTasks := make(chan []int, solver.nbThreads)
+	chError := make(chan error, solver.nbThreads)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := 0; i < solver.nbThreads; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -465,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 {
+		if maxCPU <= 1.0 || solver.nbThreads == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -477,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := runtime.NumCPU()
+		nbTasks := solver.nbThreads
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/bw6-761/solver.go
+++ b/constraint/bw6-761/solver.go
@@ -47,8 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger    zerolog.Logger
-	nbThreads int
+	logger  zerolog.Logger
+	nbTasks int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,7 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
-		nbThreads:       opt.NbThreads,
+		nbTasks:         opt.NbTasks,
 		q:               cs.Field(),
 	}
 
@@ -430,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, solver.nbThreads)
-	chError := make(chan error, solver.nbThreads)
+	chTasks := make(chan []int, solver.nbTasks)
+	chError := make(chan error, solver.nbTasks)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < solver.nbThreads; i++ {
+	for i := 0; i < solver.nbTasks; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -466,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 || solver.nbThreads == 1 {
+		if maxCPU <= 1.0 || solver.nbTasks == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -478,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := solver.nbThreads
+		nbTasks := solver.nbTasks
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/solver/options.go
+++ b/constraint/solver/options.go
@@ -17,7 +17,7 @@ type Option func(*Config) error
 type Config struct {
 	HintFunctions map[HintID]Hint // defaults to all built-in hint functions
 	Logger        zerolog.Logger  // defaults to gnark.Logger
-	NbThreads     int             // defaults to runtime.NumCPU()
+	NbTasks       int             // defaults to runtime.NumCPU()
 }
 
 // WithHints is a solver option that specifies additional hint functions to be used
@@ -57,19 +57,19 @@ func WithLogger(l zerolog.Logger) Option {
 	}
 }
 
-// WithNbThreads sets the number of gorutines to use for the solver. If not set,
-// then the number of goroutines is set to runtime.NumCPU().
+// WithNbTasks sets the number of parallel workers to use for the solver. If not
+// set, then the number of workers is set to runtime.NumCPU().
 //
 // The option may be useful for debugging the solver behaviour and restricting
 // the CPU usage. Note that this is not hard limit - in case the solver calls a
 // hint function which may create more goroutines, the number of goroutines may
 // exceed the limit.
-func WithNbThreads(nbThreads int) Option {
+func WithNbTasks(nbTasks int) Option {
 	return func(opt *Config) error {
-		if nbThreads <= 0 {
-			return fmt.Errorf("invalid number of threads: %d", nbThreads)
+		if nbTasks <= 0 {
+			return fmt.Errorf("invalid number of threads: %d", nbTasks)
 		}
-		opt.NbThreads = nbThreads
+		opt.NbTasks = nbTasks
 		return nil
 	}
 }
@@ -79,7 +79,7 @@ func NewConfig(opts ...Option) (Config, error) {
 	log := logger.Logger()
 	opt := Config{Logger: log}
 	opt.HintFunctions = cloneHintRegistry()
-	opt.NbThreads = runtime.NumCPU()
+	opt.NbTasks = runtime.NumCPU()
 	for _, option := range opts {
 		if err := option(&opt); err != nil {
 			return Config{}, err

--- a/constraint/solver/options.go
+++ b/constraint/solver/options.go
@@ -1,6 +1,9 @@
 package solver
 
 import (
+	"fmt"
+	"runtime"
+
 	"github.com/consensys/gnark/logger"
 	"github.com/rs/zerolog"
 )
@@ -14,6 +17,7 @@ type Option func(*Config) error
 type Config struct {
 	HintFunctions map[HintID]Hint // defaults to all built-in hint functions
 	Logger        zerolog.Logger  // defaults to gnark.Logger
+	NbThreads     int             // defaults to runtime.NumCPU()
 }
 
 // WithHints is a solver option that specifies additional hint functions to be used
@@ -53,11 +57,29 @@ func WithLogger(l zerolog.Logger) Option {
 	}
 }
 
+// WithNbThreads sets the number of gorutines to use for the solver. If not set,
+// then the number of goroutines is set to runtime.NumCPU().
+//
+// The option may be useful for debugging the solver behaviour and restricting
+// the CPU usage. Note that this is not hard limit - in case the solver calls a
+// hint function which may create more goroutines, the number of goroutines may
+// exceed the limit.
+func WithNbThreads(nbThreads int) Option {
+	return func(opt *Config) error {
+		if nbThreads <= 0 {
+			return fmt.Errorf("invalid number of threads: %d", nbThreads)
+		}
+		opt.NbThreads = nbThreads
+		return nil
+	}
+}
+
 // NewConfig returns a default SolverConfig with given prover options opts applied.
 func NewConfig(opts ...Option) (Config, error) {
 	log := logger.Logger()
 	opt := Config{Logger: log}
 	opt.HintFunctions = cloneHintRegistry()
+	opt.NbThreads = runtime.NumCPU()
 	for _, option := range opts {
 		if err := option(&opt); err != nil {
 			return Config{}, err

--- a/constraint/solver/options.go
+++ b/constraint/solver/options.go
@@ -69,6 +69,11 @@ func WithNbTasks(nbTasks int) Option {
 		if nbTasks <= 0 {
 			return fmt.Errorf("invalid number of threads: %d", nbTasks)
 		}
+		if nbTasks > 512 {
+			// limit the number of tasks to 512. This is to avoid possible
+			// saturation of the runtime scheduler.
+			nbTasks = 512
+		}
 		opt.NbTasks = nbTasks
 		return nil
 	}

--- a/constraint/tinyfield/solver.go
+++ b/constraint/tinyfield/solver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rs/zerolog"
 	"math"
 	"math/big"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,7 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger zerolog.Logger
+	logger    zerolog.Logger
+	nbThreads int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,6 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
+		nbThreads:       opt.NbThreads,
 		q:               cs.Field(),
 	}
 
@@ -429,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
+	chTasks := make(chan []int, solver.nbThreads)
+	chError := make(chan error, solver.nbThreads)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := 0; i < solver.nbThreads; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -465,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 {
+		if maxCPU <= 1.0 || solver.nbThreads == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -477,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := runtime.NumCPU()
+		nbTasks := solver.nbThreads
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/constraint/tinyfield/solver.go
+++ b/constraint/tinyfield/solver.go
@@ -47,8 +47,8 @@ type solver struct {
 	mHintsFunctions map[csolver.HintID]csolver.Hint
 
 	// used to out api.Println
-	logger    zerolog.Logger
-	nbThreads int
+	logger  zerolog.Logger
+	nbTasks int
 
 	a, b, c fr.Vector // R1CS solver will compute the a,b,c matrices
 
@@ -96,7 +96,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 		solved:          make([]bool, nbWires),
 		mHintsFunctions: hintFunctions,
 		logger:          opt.Logger,
-		nbThreads:       opt.NbThreads,
+		nbTasks:         opt.NbTasks,
 		q:               cs.Field(),
 	}
 
@@ -430,13 +430,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup
-	chTasks := make(chan []int, solver.nbThreads)
-	chError := make(chan error, solver.nbThreads)
+	chTasks := make(chan []int, solver.nbTasks)
+	chError := make(chan error, solver.nbTasks)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < solver.nbThreads; i++ {
+	for i := 0; i < solver.nbTasks; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -466,7 +466,7 @@ func (solver *solver) run() error {
 		// max CPU to use
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 || solver.nbThreads == 1 {
+		if maxCPU <= 1.0 || solver.nbTasks == 1 {
 			// we do it sequentially
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -478,7 +478,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower.
-		nbTasks := solver.nbThreads
+		nbTasks := solver.nbTasks
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/internal/generator/backend/template/representations/solver.go.tmpl
+++ b/internal/generator/backend/template/representations/solver.go.tmpl
@@ -5,7 +5,6 @@ import (
 	"sync/atomic"
 	"strings"
 	"strconv"
-	"runtime"
 	"sync"
 	"math"
     "github.com/consensys/gnark/constraint"
@@ -30,6 +29,7 @@ type solver struct {
 
 	// used to out api.Println
 	logger        zerolog.Logger
+	nbThreads     int
 
 	a,b,c fr.Vector // R1CS solver will compute the a,b,c matrices 
 
@@ -77,6 +77,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 			solved: make([]bool, nbWires),
 			mHintsFunctions: hintFunctions,
 			logger: opt.Logger,
+			nbThreads: opt.NbThreads,
 			q: cs.Field(),
 	}
 
@@ -424,13 +425,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup 
-	chTasks := make(chan []int, runtime.NumCPU())
-	chError := make(chan error, runtime.NumCPU())
+	chTasks := make(chan []int, solver.nbThreads)
+	chError := make(chan error, solver.nbThreads)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := 0; i < solver.nbThreads; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -460,7 +461,7 @@ func (solver *solver) run() error {
 		// max CPU to use 
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 {
+		if maxCPU <= 1.0 || solver.nbThreads == 1 {
 			// we do it sequentially 
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -472,7 +473,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower. 
-		nbTasks :=  runtime.NumCPU()
+		nbTasks := solver.nbThreads
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/internal/generator/backend/template/representations/solver.go.tmpl
+++ b/internal/generator/backend/template/representations/solver.go.tmpl
@@ -29,7 +29,7 @@ type solver struct {
 
 	// used to out api.Println
 	logger        zerolog.Logger
-	nbThreads     int
+	nbTasks       int
 
 	a,b,c fr.Vector // R1CS solver will compute the a,b,c matrices 
 
@@ -77,7 +77,7 @@ func newSolver(cs *system, witness fr.Vector, opts ...csolver.Option) (*solver, 
 			solved: make([]bool, nbWires),
 			mHintsFunctions: hintFunctions,
 			logger: opt.Logger,
-			nbThreads: opt.NbThreads,
+			nbTasks: opt.NbTasks,
 			q: cs.Field(),
 	}
 
@@ -425,13 +425,13 @@ func (solver *solver) run() error {
 	// then we check that the constraint is valid
 	// if a[i] * b[i] != c[i]; it means the constraint is not satisfied
 	var wg sync.WaitGroup 
-	chTasks := make(chan []int, solver.nbThreads)
-	chError := make(chan error, solver.nbThreads)
+	chTasks := make(chan []int, solver.nbTasks)
+	chError := make(chan error, solver.nbTasks)
 
 	// start a worker pool
 	// each worker wait on chTasks
 	// a task is a slice of constraint indexes to be solved
-	for i := 0; i < solver.nbThreads; i++ {
+	for i := 0; i < solver.nbTasks; i++ {
 		go func() {
 			var scratch scratch
 			for t := range chTasks {
@@ -461,7 +461,7 @@ func (solver *solver) run() error {
 		// max CPU to use 
 		maxCPU := float64(len(level)) / minWorkPerCPU
 
-		if maxCPU <= 1.0 || solver.nbThreads == 1 {
+		if maxCPU <= 1.0 || solver.nbTasks == 1 {
 			// we do it sequentially 
 			for _, i := range level {
 				if err := solver.processInstruction(solver.Instructions[i], &scratch); err != nil {
@@ -473,7 +473,7 @@ func (solver *solver) run() error {
 
 		// number of tasks for this level is set to number of CPU
 		// but if we don't have enough work for all our CPU, it can be lower. 
-		nbTasks := solver.nbThreads
+		nbTasks := solver.nbTasks
 		maxTasks := int(math.Ceil(maxCPU))
 		if nbTasks > maxTasks {
 			nbTasks = maxTasks

--- a/internal/regression_tests/issue1048/issue1048_test.go
+++ b/internal/regression_tests/issue1048/issue1048_test.go
@@ -1,0 +1,100 @@
+package issue1048
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/test"
+)
+
+var (
+	h1Unlocker chan struct{}
+	h2Unlocker chan struct{}
+)
+
+func HintControllable1(mod *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	for range h1Unlocker {
+	}
+	// add some sleep to this test to ensure that if there is parallelism, this
+	// hint returns second.
+	time.Sleep(100 * time.Millisecond)
+	return fmt.Errorf("hint controllable 1")
+}
+
+func HintControllable2(mod *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	for range h2Unlocker {
+	}
+	return fmt.Errorf("hint controllable 2")
+}
+
+type Circuit struct {
+	A frontend.Variable
+}
+
+func (c *Circuit) Define(api frontend.API) error {
+	_, err := api.Compiler().NewHint(HintControllable1, 1, c.A)
+	if err != nil {
+		return err
+	}
+	// the solver groups currently instructions into group of 50. So there needs to be at least 50 instructions.
+	for i := 0; i < 50; i++ {
+		api.AssertIsEqual(c.A, c.A)
+	}
+	_, err = api.Compiler().NewHint(HintControllable2, 1, c.A)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TestTwoTasksOrder tests that when we run multiple tasks, then indeed they are
+// run in parallel. And if there is one task, then it indeed is one task (with
+// high probability).
+func TestTwoTasksOrder(t *testing.T) {
+	assert := test.NewAssert(t)
+
+	var circuit Circuit
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
+	assert.NoError(err)
+	assignment := Circuit{A: 10}
+	wit, err := frontend.NewWitness(&assignment, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	// case where second hint returns first
+	h1Unlocker = make(chan struct{})
+	h2Unlocker = make(chan struct{})
+	go func() {
+		h2Unlocker <- struct{}{}
+		close(h2Unlocker)
+		// let some time pass to ensure HintControllable2 returns first
+		time.Sleep(100 * time.Millisecond)
+		h1Unlocker <- struct{}{}
+		close(h1Unlocker)
+	}()
+	_, err = ccs.Solve(wit, solver.WithNbTasks(2), solver.WithHints(HintControllable1, HintControllable2))
+	assert.Equal(err.Error(), "hint controllable 2")
+
+	// case where first hint returns first
+	h1Unlocker = make(chan struct{})
+	h2Unlocker = make(chan struct{})
+	go func() {
+		h1Unlocker <- struct{}{}
+		close(h1Unlocker)
+		// let some time pass to ensure HintControllable1 returns first
+		time.Sleep(100 * time.Millisecond)
+		h2Unlocker <- struct{}{}
+		close(h2Unlocker)
+	}()
+	_, err = ccs.Solve(wit, solver.WithNbTasks(2), solver.WithHints(HintControllable1, HintControllable2))
+	assert.Equal(err.Error(), "hint controllable 1")
+
+	// with one task, the first hint always returns first. If not we get a deadlock (not tested here)
+	_, err = ccs.Solve(wit, solver.WithNbTasks(1), solver.WithHints(HintControllable1, HintControllable2))
+	assert.Equal(err.Error(), "hint controllable 1")
+}

--- a/internal/regression_tests/issue1048/issue1048_test.go
+++ b/internal/regression_tests/issue1048/issue1048_test.go
@@ -19,11 +19,11 @@ var (
 )
 
 func HintControllable1(mod *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	time.Sleep(100 * time.Millisecond)
 	for range h1Unlocker {
 	}
 	// add some sleep to this test to ensure that if there is parallelism, this
 	// hint returns second.
-	time.Sleep(100 * time.Millisecond)
 	return fmt.Errorf("hint controllable 1")
 }
 


### PR DESCRIPTION
# Description

This PR allows restricting the number of threads in solver. This is mainly useful for debugging the solver as the solving order is deterministic.

Fixes #1048 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?


# How has this been benchmarked?



# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

