### PR TITLE
feat: add range check selector retrieval

### DIFF
--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -727,7 +727,11 @@ func (builder *builder) GetWireConstraints(wires []frontend.Variable, addMissing
 		}
 	}
 	if addMissing {
+		nbWitnessWires := builder.cs.GetNbPublicVariables() + builder.cs.GetNbSecretVariables()
 		for k := range lookup {
+			if k >= nbWitnessWires {
+				return nil, fmt.Errorf("addMissing is true, but wire %d is not a witness", k)
+			}
 			constraintIdx := builder.cs.AddSparseR1C(constraint.SparseR1C{
 				XA: uint32(k),
 				XC: uint32(k),


### PR DESCRIPTION
# Description

This PR adds an option to retrieve the IDs of the wire which were range checked through `frontend.Checker` interface.

cc @AlexandreBelling 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Tested in Wizard.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

