### PR TITLE
fix: scs add/mul when recorded constraint is 0

### DIFF
--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -138,6 +138,14 @@ func (builder *builder) Mul(i1, i2 frontend.Variable, in ...frontend.Variable) f
 	if len(vars) == 0 {
 		return builder.cs.ToBigInt(k)
 	}
+	if k.IsZero() {
+		return 0
+	}
+	for i := range vars {
+		if vars[i].Coeff.IsZero() {
+			return 0
+		}
+	}
 	l := builder.mulConstant(vars[0], k)
 
 	return builder.splitProd(l, vars[1:])

--- a/frontend/cs/scs/api_test.go
+++ b/frontend/cs/scs/api_test.go
@@ -186,6 +186,33 @@ func TestExistDiv02(t *testing.T) {
 	assert.NoError(err)
 }
 
+type TestZeroMulNoConstraintCircuit struct {
+	A, B frontend.Variable
+}
+
+func (c *TestZeroMulNoConstraintCircuit) Define(api frontend.API) error {
+	// case 1
+	t1 := api.Mul(0, c.A)
+	t2 := api.Mul(t1, c.B)
+
+	t3 := api.Sub(c.A, c.A)
+	t4 := api.Mul(3, t3)
+
+	// test solver
+	api.AssertIsEqual(t2, 0)
+	api.AssertIsEqual(t4, 0)
+	return nil
+}
+
+func TestZeroMulNoConstraint(t *testing.T) {
+	assert := test.NewAssert(t)
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &TestZeroMulNoConstraintCircuit{})
+	assert.NoError(err)
+	if ccs.GetNbConstraints() != 0 {
+		t.Fatal("expected 0 constraints")
+	}
+}
+
 type mulAccFastTrackCircuit struct {
 	A, B frontend.Variable
 	Res  frontend.Variable

--- a/frontend/cs/scs/api_test.go
+++ b/frontend/cs/scs/api_test.go
@@ -147,9 +147,43 @@ func TestExistDiv0(t *testing.T) {
 		Res7: 0, Res8: 55,
 	}, ecc.BN254.ScalarField())
 	assert.NoError(err)
-	solution, err := ccs.Solve(w)
+	_, err = ccs.Solve(w)
 	assert.NoError(err)
-	_ = solution
+}
+
+type IssueDiv0Circuit2 struct {
+	A1, B1 frontend.Variable
+
+	Res1, Res2 frontend.Variable
+}
+
+func (c *IssueDiv0Circuit2) Define(api frontend.API) error {
+	// case 1
+	b1 := api.Mul(0, c.A1)
+	b2 := api.Mul(4, c.B1)
+	t1 := api.Mul(b1, b2)
+
+	b3 := api.Mul(2, c.A1)
+	b4 := api.Mul(5, c.B1)
+	t2 := api.Mul(b3, b4)
+
+	// test solver
+	api.AssertIsEqual(t1, c.Res1)
+	api.AssertIsEqual(t2, c.Res2)
+	return nil
+}
+
+func TestExistDiv02(t *testing.T) {
+	assert := test.NewAssert(t)
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &IssueDiv0Circuit2{})
+	assert.NoError(err)
+	w, err := frontend.NewWitness(&IssueDiv0Circuit2{
+		A1: 11, B1: 21,
+		Res1: 0, Res2: 2310,
+	}, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	_, err = ccs.Solve(w)
+	assert.NoError(err)
 }
 
 type mulAccFastTrackCircuit struct {

--- a/frontend/cs/scs/api_test.go
+++ b/frontend/cs/scs/api_test.go
@@ -135,9 +135,6 @@ func (c *IssueDiv0Circuit) Define(api frontend.API) error {
 func TestExistDiv0(t *testing.T) {
 	assert := test.NewAssert(t)
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &IssueDiv0Circuit{})
-	if err != nil {
-		t.Fatal(err)
-	}
 	assert.NoError(err)
 	w, err := frontend.NewWitness(&IssueDiv0Circuit{
 		A1: 11, B1: 21,

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -518,7 +518,7 @@ func (builder *builder) addConstraintExist(a, b expr.Term, k constraint.Element)
 			q4 := qR
 			q3 = builder.cs.Mul(q3, q2)
 			q1 = builder.cs.Mul(q1, q4)
-			if q1 == q3 && !q2.IsZero() {
+			if q1 == q3 {
 				// no need to introduce a new constraint;
 				// compute n, the coefficient for the output wire
 				q2, ok = builder.cs.Inverse(q2)
@@ -583,14 +583,14 @@ func (builder *builder) mulConstraintExist(a, b expr.Term) (expr.Term, bool) {
 		// recompute the qM coeff and check that it matches;
 		qM := builder.cs.Mul(a.Coeff, b.Coeff)
 		tm := builder.cs.MakeTerm(qM, 0)
-		N := builder.cs.GetCoefficient(int(c.QM))
-		if int(c.QM) != tm.CoeffID() && !N.IsZero() {
+		if int(c.QM) != tm.CoeffID() {
 			// so we wanted to compute
 			// N * xC == qM*xA*xB
 			// but found a constraint
 			// xC == qM'*xA*xB
 			// the coefficient for our resulting wire is different;
 			// N = qM / qM'
+			N := builder.cs.GetCoefficient(int(c.QM))
 			N, ok := builder.cs.Inverse(N)
 			if !ok {
 				panic("div by 0") // sanity check.

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -518,7 +518,7 @@ func (builder *builder) addConstraintExist(a, b expr.Term, k constraint.Element)
 			q4 := qR
 			q3 = builder.cs.Mul(q3, q2)
 			q1 = builder.cs.Mul(q1, q4)
-			if q1 == q3 {
+			if q1 == q3 && !q2.IsZero() {
 				// no need to introduce a new constraint;
 				// compute n, the coefficient for the output wire
 				q2, ok = builder.cs.Inverse(q2)
@@ -583,14 +583,14 @@ func (builder *builder) mulConstraintExist(a, b expr.Term) (expr.Term, bool) {
 		// recompute the qM coeff and check that it matches;
 		qM := builder.cs.Mul(a.Coeff, b.Coeff)
 		tm := builder.cs.MakeTerm(qM, 0)
-		if int(c.QM) != tm.CoeffID() {
+		N := builder.cs.GetCoefficient(int(c.QM))
+		if int(c.QM) != tm.CoeffID() && !N.IsZero() {
 			// so we wanted to compute
 			// N * xC == qM*xA*xB
 			// but found a constraint
 			// xC == qM'*xA*xB
 			// the coefficient for our resulting wire is different;
 			// N = qM / qM'
-			N := builder.cs.GetCoefficient(int(c.QM))
 			N, ok := builder.cs.Inverse(N)
 			if !ok {
 				panic("div by 0") // sanity check.


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

In `addConstraintExist` and `mulConstraintExist` we re-use cached constraints to avoid introducing new ones and compute a division for the output wire. But when some of the coefficients are 0 we panic because of a `div by 0`. This PR avoids this by checking if the coefficient is 0. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

The test `TestVarScalarMulG2EdgeCases` in https://github.com/Consensys/gnark/blob/7cc8816179d5a257c770da506cbb8789b19be20b/std/algebra/native/sw_bls12377/g2_test.go#L288 fails for PLONK without this PR.

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

N/A

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

