### PR TITLE
feat: add MulNoReduce and Sum methods in field emulation

### DIFF
--- a/std/math/emulated/element_test.go
+++ b/std/math/emulated/element_test.go
@@ -3,6 +3,7 @@ package emulated
 import (
 	"crypto/rand"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"testing"
@@ -968,5 +969,49 @@ func testSqrt[T FieldParams](t *testing.T) {
 			}
 		}
 		assert.ProverSucceeded(&SqrtCircuit[T]{}, &SqrtCircuit[T]{X: ValueOf[T](X), Expected: ValueOf[T](exp)}, test.WithCurves(testCurve), test.NoSerializationChecks(), test.WithBackends(backend.GROTH16, backend.PLONK))
+	}, testName[T]())
+}
+
+type MulNoReduceCircuit[T FieldParams] struct {
+	A, B, C          Element[T]
+	expectedOverflow uint
+	expectedNbLimbs  int
+}
+
+func (c *MulNoReduceCircuit[T]) Define(api frontend.API) error {
+	f, err := NewField[T](api)
+	if err != nil {
+		return err
+	}
+	res := f.MulNoReduce(&c.A, &c.B)
+	f.AssertIsEqual(res, &c.C)
+	if res.overflow != c.expectedOverflow {
+		return fmt.Errorf("unexpected overflow: got %d, expected %d", res.overflow, c.expectedOverflow)
+	}
+	if len(res.Limbs) != c.expectedNbLimbs {
+		return fmt.Errorf("unexpected number of limbs: got %d, expected %d", len(res.Limbs), c.expectedNbLimbs)
+	}
+	return nil
+}
+
+func TestMulNoReduce(t *testing.T) {
+	testMulNoReduce[Goldilocks](t)
+	testMulNoReduce[Secp256k1Fp](t)
+	testMulNoReduce[BN254Fp](t)
+}
+
+func testMulNoReduce[T FieldParams](t *testing.T) {
+	var fp T
+	assert := test.NewAssert(t)
+	assert.Run(func(assert *test.Assert) {
+		A, _ := rand.Int(rand.Reader, fp.Modulus())
+		B, _ := rand.Int(rand.Reader, fp.Modulus())
+		C := new(big.Int).Mul(A, B)
+		C.Mod(C, fp.Modulus())
+		expectedLimbs := 2*fp.NbLimbs() - 1
+		expectedOverFlow := math.Ceil(math.Log2(float64(expectedLimbs+1))) + float64(fp.BitsPerLimb())
+		circuit := &MulNoReduceCircuit[T]{expectedOverflow: uint(expectedOverFlow), expectedNbLimbs: int(expectedLimbs)}
+		assignment := &MulNoReduceCircuit[T]{A: ValueOf[T](A), B: ValueOf[T](B), C: ValueOf[T](C)}
+		assert.CheckCircuit(circuit, test.WithValidAssignment(assignment))
 	}, testName[T]())
 }

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -444,6 +444,9 @@ func (f *Field[T]) mulPreCond(a, b *Element[T]) (nextOverflow uint, err error) {
 	return
 }
 
+// MulNoReduce computes a*b and returns the result without reducing it modulo
+// the field order. The number of limbs of the returned element depends on the
+// number of limbs of the inputs.
 func (f *Field[T]) MulNoReduce(a, b *Element[T]) *Element[T] {
 	return f.reduceAndOp(f.mulNoReduce, f.mulPreCond, a, b)
 }

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -443,3 +443,20 @@ func (f *Field[T]) mulPreCond(a, b *Element[T]) (nextOverflow uint, err error) {
 	}
 	return
 }
+
+func (f *Field[T]) MulNoReduce(a, b *Element[T]) *Element[T] {
+	return f.reduceAndOp(f.mulNoReduce, f.mulPreCond, a, b)
+}
+
+func (f *Field[T]) mulNoReduce(a, b *Element[T], nextoverflow uint) *Element[T] {
+	resLimbs := make([]frontend.Variable, nbMultiplicationResLimbs(len(a.Limbs), len(b.Limbs)))
+	for i := range resLimbs {
+		resLimbs[i] = 0
+	}
+	for i := range a.Limbs {
+		for j := range b.Limbs {
+			resLimbs[i+j] = f.api.MulAcc(resLimbs[i+j], a.Limbs[i], b.Limbs[j])
+		}
+	}
+	return f.newInternalElement(resLimbs, nextoverflow)
+}

--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -3,6 +3,7 @@ package emulated
 import (
 	"errors"
 	"fmt"
+	"math/bits"
 
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/selector"
@@ -130,6 +131,34 @@ func (f *Field[T]) add(a, b *Element[T], nextOverflow uint) *Element[T] {
 		}
 	}
 	return f.newInternalElement(limbs, nextOverflow)
+}
+
+func (f *Field[T]) AddMany(inputs ...*Element[T]) *Element[T] {
+	if len(inputs) == 0 {
+		return f.Zero()
+	}
+	overflow := uint(0)
+	nbLimbs := 0
+	for i := range inputs {
+		f.enforceWidthConditional(inputs[i])
+		if inputs[i].overflow > overflow {
+			overflow = inputs[i].overflow
+		}
+		if len(inputs[i].Limbs) > nbLimbs {
+			nbLimbs = len(inputs[i].Limbs)
+		}
+	}
+	addOverflow := bits.Len(uint(len(inputs)))
+	limbs := make([]frontend.Variable, nbLimbs)
+	for i := range limbs {
+		limbs[i] = 0
+	}
+	for i := range inputs {
+		for j := range inputs[i].Limbs {
+			limbs[j] = f.api.Add(limbs[j], inputs[i].Limbs[j])
+		}
+	}
+	return f.newInternalElement(limbs, overflow+uint(addOverflow))
 }
 
 // Reduce reduces a modulo the field order and returns it.

--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -137,6 +137,9 @@ func (f *Field[T]) Sum(inputs ...*Element[T]) *Element[T] {
 	if len(inputs) == 0 {
 		return f.Zero()
 	}
+	if len(inputs) == 1 {
+		return inputs[0]
+	}
 	overflow := uint(0)
 	nbLimbs := 0
 	for i := range inputs {

--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -133,7 +133,7 @@ func (f *Field[T]) add(a, b *Element[T], nextOverflow uint) *Element[T] {
 	return f.newInternalElement(limbs, nextOverflow)
 }
 
-func (f *Field[T]) AddMany(inputs ...*Element[T]) *Element[T] {
+func (f *Field[T]) Sum(inputs ...*Element[T]) *Element[T] {
 	if len(inputs) == 0 {
 		return f.Zero()
 	}


### PR DESCRIPTION
# Description

Non-reducing multiplication can be useful in contexts where we craft the non-native operations in a order where we know that we're going to use addition chains after. Doing this allows us to call the modular reduction later, saving constraints due to not having to reduce twice (before and after addition chains). For example, the approach can be used for computing inner products, where we first compute `a_i * b_i`, then compute `c = \sum_i a_i * b_i` and finally only reduce `c` once.

Depends on #1064 being merged.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestMulNoReduce

# How has this been benchmarked?

New methods, no impact on existing performance.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

