### PR TITLE
feat: add hint calling with either native inputs or outputs

### DIFF
--- a/std/math/emulated/field_hint.go
+++ b/std/math/emulated/field_hint.go
@@ -189,6 +189,18 @@ func (f *Field[T]) NewHintWithNativeOutput(hf solver.Hint, nbOutputs int, inputs
 // non-native elements. There is [UnwrapHintWithNativeInput] function which
 // performs corresponding recomposition of limbs into integer values (and vice
 // verse for output).
+//
+// This method is an alternation of [NewHint] method, which allows to pass
+// native inputs to the hint function and returns nonnative outputs. This is
+// useful when the inputs do not necessarily have to be emulated elements (e.g.
+// indices) and allows to work between different fields.
+//
+// The hint function for this method is defined as:
+//
+//	func HintFn(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int) error {
+//	    return emulated.UnwrapHintWithNativeInput(nativeInputs, nativeOutputs, func(emulatedMod *big.Int, inputs, outputs []*big.Int) error {
+//	        // in the function we have access to both native and nonantive modulus
+//	    })}
 func (f *Field[T]) NewHintWithNativeInput(hf solver.Hint, nbOutputs int, inputs ...frontend.Variable) ([]*Element[T], error) {
 	nativeInputs := f.wrapHintNatives(inputs...)
 	nbNativeOutputs := int(f.fParams.NbLimbs()) * nbOutputs

--- a/std/math/emulated/field_hint.go
+++ b/std/math/emulated/field_hint.go
@@ -158,13 +158,21 @@ func (f *Field[T]) NewHint(hf solver.Hint, nbOutputs int, inputs ...*Element[T])
 // NewHintWithNativeOutput allows to call the emulation hint function hf on
 // nonnative inputs, expecting nbOutputs results. This function splits
 // internally the emulated element into limbs and passes these to the hint
-// function. There is [UnwrapHint] function which performs corresponding
-// recomposition of limbs into integer values (and vice verse for output).
+// function. There is [UnwrapHintWithNativeOutput] function which performs
+// corresponding recomposition of limbs into integer values (and vice verse for
+// output).
 //
 // This method is an alternation of [NewHint] method, which allows to pass
 // nonnative inputs to the hint function and returns native outputs. This is
 // useful when the outputs do not necessarily have to be emulated elements (e.g.
 // bits) as it skips enforcing range checks on the outputs.
+//
+// The hint function for this method is defined as:
+//
+//	func HintFn(nativeMod *big.Int, inputs, outputs []*big.Int) error {
+//	    return emulated.UnwrapHintWithNativeOutput(inputs, outputs, func(emulatedMod *big.Int, inputs, outputs []*big.Int) error {
+//	        // in the function we have access to both native and nonantive modulus
+//	    })}
 func (f *Field[T]) NewHintWithNativeOutput(hf solver.Hint, nbOutputs int, inputs ...*Element[T]) ([]frontend.Variable, error) {
 	nativeInputs := f.wrapHint(inputs...)
 	nbNativeOutputs := nbOutputs

--- a/std/math/emulated/field_test.go
+++ b/std/math/emulated/field_test.go
@@ -1,8 +1,10 @@
 package emulated
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark/frontend"
@@ -130,4 +132,178 @@ func TestSubConstantCircuit(t *testing.T) {
 
 	_, err = frontend.Compile(testCurve.ScalarField(), r1cs.NewBuilder, &circuit, frontend.IgnoreUnconstrainedInputs())
 	assert.NoError(err)
+}
+
+func nnaHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int) error {
+	return UnwrapHint(nativeInputs, nativeOutputs, func(mod *big.Int, inputs, outputs []*big.Int) error {
+		nominator := inputs[0]
+		denominator := inputs[1]
+		res := new(big.Int).ModInverse(denominator, mod)
+		if res == nil {
+			return fmt.Errorf("no modular inverse")
+		}
+		res.Mul(res, nominator)
+		res.Mod(res, mod)
+		outputs[0].Set(res)
+		return nil
+	})
+}
+
+type hintCircuit[T FieldParams] struct {
+	Nominator   Element[T]
+	Denominator Element[T]
+	Expected    Element[T]
+}
+
+func (c *hintCircuit[T]) Define(api frontend.API) error {
+	field, err := NewField[T](api)
+	if err != nil {
+		return err
+	}
+	res, err := field.NewHint(nnaHint, 1, &c.Nominator, &c.Denominator)
+	if err != nil {
+		return err
+	}
+	field.AssertIsEqual(res[0], &c.Expected)
+	return nil
+}
+
+func testHint[T FieldParams](t *testing.T) {
+	var fr T
+	assert := test.NewAssert(t)
+	a, _ := rand.Int(rand.Reader, fr.Modulus())
+	b, _ := rand.Int(rand.Reader, fr.Modulus())
+	c := new(big.Int).ModInverse(b, fr.Modulus())
+	c.Mul(c, a)
+	c.Mod(c, fr.Modulus())
+
+	circuit := hintCircuit[T]{}
+	witness := hintCircuit[T]{
+		Nominator:   ValueOf[T](a),
+		Denominator: ValueOf[T](b),
+		Expected:    ValueOf[T](c),
+	}
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness))
+}
+
+func TestHint(t *testing.T) {
+	testHint[Goldilocks](t)
+	testHint[Secp256k1Fp](t)
+	testHint[BN254Fp](t)
+}
+
+func nativeInputHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int) error {
+	return UnwrapHintWithNativeInput(nativeInputs, nativeOutputs, func(nonnativeMod *big.Int, inputs, outputs []*big.Int) error {
+		nominator := inputs[0]
+		denominator := inputs[1]
+		res := new(big.Int).ModInverse(denominator, nonnativeMod)
+		if res == nil {
+			return fmt.Errorf("no modular inverse")
+		}
+		res.Mul(res, nominator)
+		res.Mod(res, nonnativeMod)
+		outputs[0].Set(res)
+		return nil
+	})
+}
+
+type hintNativeInputCircuit[T FieldParams] struct {
+	Nominator   frontend.Variable
+	Denominator frontend.Variable
+	Expected    Element[T]
+}
+
+func (c *hintNativeInputCircuit[T]) Define(api frontend.API) error {
+	field, err := NewField[T](api)
+	if err != nil {
+		return err
+	}
+	res, err := field.NewHintWithNativeInput(nativeInputHint, 1, c.Nominator, c.Denominator)
+	if err != nil {
+		return err
+	}
+	field.AssertIsEqual(res[0], &c.Expected)
+	return nil
+}
+
+func testHintNativeInput[T FieldParams](t *testing.T) {
+	var fr T
+	assert := test.NewAssert(t)
+	a, _ := rand.Int(rand.Reader, testCurve.ScalarField())
+	b, _ := rand.Int(rand.Reader, testCurve.ScalarField())
+	c := new(big.Int).ModInverse(b, fr.Modulus())
+	c.Mul(c, a)
+	c.Mod(c, fr.Modulus())
+
+	circuit := hintNativeInputCircuit[T]{}
+	witness := hintNativeInputCircuit[T]{
+		Nominator:   a,
+		Denominator: b,
+		Expected:    ValueOf[T](c),
+	}
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(testCurve))
+}
+
+func TestHintNativeInput(t *testing.T) {
+	testHintNativeInput[Goldilocks](t)
+	testHintNativeInput[Secp256k1Fp](t)
+	testHintNativeInput[BN254Fp](t)
+}
+
+func nativeOutputHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int) error {
+	return UnwrapHintWithNativeOutput(nativeInputs, nativeOutputs, func(nonnativeMod *big.Int, inputs, outputs []*big.Int) error {
+		nominator := inputs[0]
+		denominator := inputs[1]
+		res := new(big.Int).ModInverse(denominator, nativeMod)
+		if res == nil {
+			return fmt.Errorf("no modular inverse")
+		}
+		res.Mul(res, nominator)
+		res.Mod(res, nativeMod)
+		outputs[0].Set(res)
+		return nil
+	})
+}
+
+type hintNativeOutputCircuit[T FieldParams] struct {
+	Nominator   Element[T]
+	Denominator Element[T]
+	Expected    frontend.Variable
+}
+
+func (c *hintNativeOutputCircuit[T]) Define(api frontend.API) error {
+	field, err := NewField[T](api)
+	if err != nil {
+		return err
+	}
+	res, err := field.NewHintWithNativeOutput(nativeOutputHint, 1, &c.Nominator, &c.Denominator)
+	if err != nil {
+		return err
+	}
+	api.AssertIsEqual(res[0], c.Expected)
+	return nil
+}
+
+func testHintNativeOutput[T FieldParams](t *testing.T) {
+	var fr T
+	assert := test.NewAssert(t)
+	a, _ := rand.Int(rand.Reader, fr.Modulus())
+	b, _ := rand.Int(rand.Reader, fr.Modulus())
+	c := new(big.Int).ModInverse(b, testCurve.ScalarField())
+	c.Mul(c, a)
+	c.Mod(c, testCurve.ScalarField())
+
+	circuit := hintNativeOutputCircuit[T]{}
+	witness := hintNativeOutputCircuit[T]{
+		Nominator:   ValueOf[T](a),
+		Denominator: ValueOf[T](b),
+		Expected:    c,
+	}
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(testCurve))
+}
+
+func TestHintNativeOutput(t *testing.T) {
+	testHintNativeOutput[Goldilocks](t)
+	testHintNativeOutput[Secp256k1Fp](t)
+	testHintNativeOutput[BN254Fp](t)
 }


### PR DESCRIPTION
# Description

Related to #1061.

This PR adds an optional methods for calling hints with native inputs or outputs. For example, in #1061 we use it to return the sign bits for the non-native inputs. By being more precise with the native inputs and outputs, we can save constraints due not having to range check the created elements.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestHintNativeInput
- [x] TestHint
- [x] TestHintNativeOutput

# How has this been benchmarked?

Not benchmarked. 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

