### PR TITLE
fix: emulated hint tests

### DIFF
--- a/std/math/emulated/field_test.go
+++ b/std/math/emulated/field_test.go
@@ -282,6 +282,7 @@ func (c *hintNativeOutputCircuit[T]) Define(api frontend.API) error {
 		return err
 	}
 	api.AssertIsEqual(res[0], c.Expected)
+	api.AssertIsDifferent(c.Expected, 0)
 	return nil
 }
 

--- a/std/math/emulated/field_test.go
+++ b/std/math/emulated/field_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/test"
@@ -183,7 +184,7 @@ func testHint[T FieldParams](t *testing.T) {
 		Denominator: ValueOf[T](b),
 		Expected:    ValueOf[T](c),
 	}
-	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness))
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithSolverOpts(solver.WithHints(nnaHint)))
 }
 
 func TestHint(t *testing.T) {
@@ -241,7 +242,7 @@ func testHintNativeInput[T FieldParams](t *testing.T) {
 		Denominator: b,
 		Expected:    ValueOf[T](c),
 	}
-	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(testCurve))
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(testCurve), test.WithSolverOpts(solver.WithHints(nativeInputHint)))
 }
 
 func TestHintNativeInput(t *testing.T) {
@@ -299,7 +300,7 @@ func testHintNativeOutput[T FieldParams](t *testing.T) {
 		Denominator: ValueOf[T](b),
 		Expected:    c,
 	}
-	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(testCurve))
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(testCurve), test.WithSolverOpts(solver.WithHints(nativeOutputHint)))
 }
 
 func TestHintNativeOutput(t *testing.T) {


### PR DESCRIPTION
# Description

Fixes tests not appearing in PR CI. Include hints in solver and add a dummy constraint to have larger than of size 1.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- Tests succeeding now.



# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

