### PR TITLE
feat: add secp256k1 curve default initializer

### DIFF
--- a/std/algebra/defaults.go
+++ b/std/algebra/defaults.go
@@ -51,6 +51,12 @@ func GetCurve[FR emulated.FieldParams, G1El G1ElementT](api frontend.API) (Curve
 			return ret, fmt.Errorf("new curve: %w", err)
 		}
 		*s = c
+	case *Curve[emparams.Secp256k1Fr, sw_emulated.AffinePoint[emparams.Secp256k1Fp]]:
+		c, err := sw_emulated.New[emparams.Secp256k1Fp, emparams.Secp256k1Fr](api, sw_emulated.GetSecp256k1Params())
+		if err != nil {
+			return ret, fmt.Errorf("new curve: %w", err)
+		}
+		*s = c
 	default:
 		return ret, fmt.Errorf("unknown type parametrisation")
 	}

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -7,6 +7,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/algopts"
 	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/std/math/emulated/emparams"
 	"golang.org/x/exp/slices"
 )
 
@@ -127,6 +128,11 @@ func (c *Curve[B, S]) MarshalG1(p AffinePoint[B]) []frontend.Variable {
 	res := make([]frontend.Variable, 2*nbBits)
 	copy(res, bx)
 	copy(res[len(bx):], by)
+	switch any(fp).(type) {
+	case emparams.Secp256k1Fp:
+		// in gnark-crypto we do not store the infinity bit for secp256k1 points
+		return res
+	}
 	xZ := c.baseApi.IsZero(x)
 	yZ := c.baseApi.IsZero(y)
 	isZero := c.api.Mul(xZ, yZ)


### PR DESCRIPTION
# Description

Adds secp256k1 for the `std/algebra` package method `GetCurve` based on base and scalar field. It is not pairing friendly curve, so haven't implemented the corresponding method for `GetPairing`.

This helper is useful for curve agnostic curve operation implementations.

Additionally, as the secp256k1 curve in gnark-crypto currently is handwritten instead of code-generated and we do not marshal infinity points separately, then added a fast path for point marshalling which corresponds to gnark-crypto. The issue being that we do not have space for the infinity bits as the scalar field is 256 bits.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Only helper methods.

# How has this been benchmarked?

Not benchmarked

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

