### PR TITLE
perf: non-native multilinear polynomial evaluation

### DIFF
--- a/std/math/polynomial/polynomial.go
+++ b/std/math/polynomial/polynomial.go
@@ -156,6 +156,9 @@ func (p *Polynomial[FR]) EvalMultilinearMany(at []*emulated.Element[FR], M ...Mu
 }
 
 func (p *Polynomial[FR]) partialMultilinearEval(at []*emulated.Element[FR]) []*emulated.Element[FR] {
+	if len(at) == 0 {
+		return []*emulated.Element[FR]{p.f.One()}
+	}
 	res := []*emulated.Element[FR]{p.f.Sub(p.f.One(), at[len(at)-1]), at[len(at)-1]}
 	at = at[:len(at)-1]
 	for len(at) > 0 {

--- a/std/math/polynomial/polynomial.go
+++ b/std/math/polynomial/polynomial.go
@@ -3,6 +3,7 @@ package polynomial
 import (
 	"fmt"
 	"math/big"
+	"math/bits"
 
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/math/emulated"
@@ -102,45 +103,85 @@ func (p *Polynomial[FR]) EvalUnivariate(P Univariate[FR], at *emulated.Element[F
 
 // EvalMultilinear evaluates multilinear polynomial at variable values at. It
 // returns the evaluation. The method does not mutate the inputs.
-func (p *Polynomial[FR]) EvalMultilinear(M Multilinear[FR], at []*emulated.Element[FR]) (*emulated.Element[FR], error) {
-	var s *emulated.Element[FR]
-	scaleCorrectionFactor := p.f.One()
-	for len(M) > 1 {
-		if len(M) >= minFoldScaledLogSize {
-			M, s = p.foldScaled(M, at[0])
-			scaleCorrectionFactor = p.f.Mul(scaleCorrectionFactor, s)
-		} else {
-			M = p.fold(M, at[0])
-		}
-		at = at[1:]
+func (p *Polynomial[FR]) EvalMultilinear(at []*emulated.Element[FR], M Multilinear[FR]) (*emulated.Element[FR], error) {
+	ret, err := p.EvalMultilinearMany(at, M)
+	if err != nil {
+		return nil, err
 	}
-	if len(at) != 0 {
+	return ret[0], nil
+}
+
+// EvalMultilinearMany evaluates multilinear polynomials at variable values at. It
+// returns the evaluations. The method does not mutate the inputs.
+//
+// The method allows to share computations of computing the coefficients of the
+// multilinear polynomials at the given evaluation points.
+func (p *Polynomial[FR]) EvalMultilinearMany(at []*emulated.Element[FR], M ...Multilinear[FR]) ([]*emulated.Element[FR], error) {
+	lenM := len(M[0])
+	for i := range M {
+		if len(M[i]) != lenM {
+			return nil, fmt.Errorf("incompatible multilinear polynomial sizes")
+		}
+	}
+	mlelems := make([][]*emulated.Element[FR], len(M))
+	for i := range M {
+		mlelems[i] = FromSlice(M[i])
+	}
+	if bits.OnesCount(uint(lenM)) != 1 {
+		return nil, fmt.Errorf("multilinear polynomial length must be a power of 2")
+	}
+	nbExpvars := bits.Len(uint(lenM)) - 1
+	if len(at) != nbExpvars {
 		return nil, fmt.Errorf("incompatible evaluation vector size")
 	}
-	return p.f.Mul(&M[0], scaleCorrectionFactor), nil
+	split1 := nbExpvars / 2
+	nbSplit1Elems := 1 << split1
+	split2 := nbExpvars - split1
+	nbSplit2Elems := 1 << split2
+	partialMLEval1 := p.partialMultilinearEval(at[:split1])
+	partialMLEval2 := p.partialMultilinearEval(at[split1:])
+	sums := make([]*emulated.Element[FR], len(M))
+	for k := range mlelems {
+		partialSums := make([]*emulated.Element[FR], nbSplit2Elems)
+		for i := range partialSums {
+			b := make([]*emulated.Element[FR], nbSplit1Elems)
+			for j := range b {
+				b[j] = mlelems[k][i+j*nbSplit2Elems]
+			}
+			partialSums[i] = p.innerProduct(b, partialMLEval1)
+		}
+		sums[k] = p.innerProduct(partialSums, partialMLEval2)
+	}
+	return sums, nil
 }
 
-func (p *Polynomial[FR]) fold(M Multilinear[FR], at *emulated.Element[FR]) Multilinear[FR] {
-	mid := len(M) / 2
-	R := make([]emulated.Element[FR], mid)
-	for j := range R {
-		diff := p.f.Sub(&M[mid+j], &M[j])
-		diffAt := p.f.Mul(diff, at)
-		R[j] = *p.f.Add(&M[j], diffAt)
+func (p *Polynomial[FR]) partialMultilinearEval(at []*emulated.Element[FR]) []*emulated.Element[FR] {
+	res := []*emulated.Element[FR]{p.f.Sub(p.f.One(), at[len(at)-1]), at[len(at)-1]}
+	at = at[:len(at)-1]
+	for len(at) > 0 {
+		newRes := make([]*emulated.Element[FR], len(res)*2)
+		x := at[len(at)-1]
+		for j := range res {
+			resX := p.f.Mul(res[j], x)
+			newRes[j] = p.f.Sub(res[j], resX)
+			newRes[j+len(res)] = resX
+		}
+		res = newRes
+		at = at[:len(at)-1]
 	}
-	return R
+	return res
 }
 
-func (p *Polynomial[FR]) foldScaled(M Multilinear[FR], at *emulated.Element[FR]) (Multilinear[FR], *emulated.Element[FR]) {
-	denom := p.f.Sub(p.f.One(), at)
-	coeff := p.f.Div(at, denom)
-	mid := len(M) / 2
-	R := make([]emulated.Element[FR], mid)
-	for j := range R {
-		tmp := p.f.Mul(&M[mid+j], coeff)
-		R[j] = *p.f.Add(&M[j], tmp)
+func (p *Polynomial[FR]) innerProduct(a, b []*emulated.Element[FR]) *emulated.Element[FR] {
+	if len(a) != len(b) {
+		panic(fmt.Sprintf("incompatible sizes: %d and %d", len(a), len(b)))
 	}
-	return R, denom
+	muls := make([]*emulated.Element[FR], len(a))
+	for i := range a {
+		muls[i] = p.f.MulNoReduce(a[i], b[i])
+	}
+	res := p.f.Sum(muls...)
+	return res
 }
 
 func (p *Polynomial[FR]) computeDeltaAtNaive(at *emulated.Element[FR], vLen int) []*emulated.Element[FR] {

--- a/std/math/polynomial/polynomial_oldeval_test.go
+++ b/std/math/polynomial/polynomial_oldeval_test.go
@@ -1,0 +1,50 @@
+package polynomial
+
+import (
+	"fmt"
+
+	"github.com/consensys/gnark/std/math/emulated"
+)
+
+// evalMultilinearOld evaluates a multilinear polynomial at a given point.
+// This is the old version of the function, which is kept for comparison purposes.
+func (p *Polynomial[FR]) evalMultilinearOld(M Multilinear[FR], at []*emulated.Element[FR]) (*emulated.Element[FR], error) {
+	var s *emulated.Element[FR]
+	scaleCorrectionFactor := p.f.One()
+	for len(M) > 1 {
+		if len(M) >= minFoldScaledLogSize {
+			M, s = p.foldScaled(M, at[0])
+			scaleCorrectionFactor = p.f.Mul(scaleCorrectionFactor, s)
+		} else {
+			M = p.fold(M, at[0])
+		}
+		at = at[1:]
+	}
+	if len(at) != 0 {
+		return nil, fmt.Errorf("incompatible evaluation vector size")
+	}
+	return p.f.Mul(&M[0], scaleCorrectionFactor), nil
+}
+
+func (p *Polynomial[FR]) fold(M Multilinear[FR], at *emulated.Element[FR]) Multilinear[FR] {
+	mid := len(M) / 2
+	R := make([]emulated.Element[FR], mid)
+	for j := range R {
+		diff := p.f.Sub(&M[mid+j], &M[j])
+		diffAt := p.f.Mul(diff, at)
+		R[j] = *p.f.Add(&M[j], diffAt)
+	}
+	return R
+}
+
+func (p *Polynomial[FR]) foldScaled(M Multilinear[FR], at *emulated.Element[FR]) (Multilinear[FR], *emulated.Element[FR]) {
+	denom := p.f.Sub(p.f.One(), at)
+	coeff := p.f.Div(at, denom)
+	mid := len(M) / 2
+	R := make([]emulated.Element[FR], mid)
+	for j := range R {
+		tmp := p.f.Mul(&M[mid+j], coeff)
+		R[j] = *p.f.Add(&M[j], tmp)
+	}
+	return R, denom
+}

--- a/std/math/polynomial/polynomial_test.go
+++ b/std/math/polynomial/polynomial_test.go
@@ -62,7 +62,7 @@ func (c *evalMultiLinCircuit[FR]) Define(api frontend.API) error {
 	}
 	// M := polynomial.FromSlice(c.M)
 	X := FromSlice(c.At)
-	res, err := p.EvalMultilinear(c.M, X)
+	res, err := p.EvalMultilinear(X, c.M)
 	if err != nil {
 		return err
 	}
@@ -201,4 +201,114 @@ func TestInterpolateQuadraticExtension(t *testing.T) {
 	// The polynomial is 1 + 2X + 3X²
 	testInterpolateLDE[emparams.BN254Fr](t, 3, []int64{1, 6, 17}, 34)
 	testInterpolateLDE[emparams.BN254Fr](t, -1, []int64{1, 6, 17}, 2)
+}
+
+type TestPartialMultilinearEvalCircuit[FR emulated.FieldParams] struct {
+	At []emulated.Element[FR] `gnark:",public"`
+}
+
+func (c *TestPartialMultilinearEvalCircuit[FR]) Define(api frontend.API) error {
+	p, err := New[FR](api)
+	if err != nil {
+		return err
+	}
+	f, err := emulated.NewField[FR](api)
+	if err != nil {
+		return err
+	}
+	At := FromSlice(c.At)
+	coefs := p.partialMultilinearEval(At)
+	res := f.Zero()
+	for i := range coefs {
+		res = f.Add(res, coefs[i])
+	}
+	ones := make([]emulated.Element[FR], 1<<len(c.At))
+	for i := range ones {
+		ones[i] = emulated.ValueOf[FR](1)
+	}
+	evaled, err := p.EvalMultilinear(At, ones)
+	if err != nil {
+		return err
+	}
+	f.AssertIsEqual(res, evaled)
+	return nil
+}
+
+func TestPartialMultilinearEval(t *testing.T) {
+	testPartialMultilinearEval[emparams.BN254Fr](t, []int64{2, 3, 4, 5})
+}
+
+func testPartialMultilinearEval[FR emulated.FieldParams](t *testing.T, at []int64) {
+	assert := test.NewAssert(t)
+	atAssignment := make([]emulated.Element[FR], len(at))
+	for i := range at {
+		atAssignment[i] = emulated.ValueOf[FR](at[i])
+	}
+	assignment := &TestPartialMultilinearEvalCircuit[FR]{
+		At: atAssignment,
+	}
+	assert.CheckCircuit(&TestPartialMultilinearEvalCircuit[FR]{At: make([]emulated.Element[FR], len(atAssignment))}, test.WithValidAssignment(assignment))
+}
+
+type TestEvalMultilinear2Circuit[FR emulated.FieldParams] struct {
+	M  []Multilinear[FR]      `gnark:",public"`
+	At []emulated.Element[FR] `gnark:",secret"`
+}
+
+func (c *TestEvalMultilinear2Circuit[FR]) Define(api frontend.API) error {
+	f, err := emulated.NewField[FR](api)
+	if err != nil {
+		return err
+	}
+	p, err := New[FR](api)
+	if err != nil {
+		return err
+	}
+	X := FromSlice(c.At)
+	res2, err := p.EvalMultilinearMany(X, c.M...)
+	if err != nil {
+		return err
+	}
+	for i := range c.M {
+		res, err := p.evalMultilinearOld(c.M[i], X)
+		if err != nil {
+			return err
+		}
+		f.AssertIsEqual(res2[i], res)
+	}
+	return nil
+}
+
+func TestEvalMultiLin2(t *testing.T) {
+	testEvalMultiLin2[emparams.BN254Fr](t)
+}
+
+func testEvalMultiLin2[FR emulated.FieldParams](t *testing.T) {
+	assert := test.NewAssert(t)
+	nbML := 4
+	nbVar := 3
+	nbVals := 1 << nbVar
+
+	M := make([]Multilinear[FR], nbML)
+	for i := range M {
+		M[i] = make([]emulated.Element[FR], nbVals)
+		for j := range M[i] {
+			M[i][j] = emulated.ValueOf[FR](1 + nbML*i + j)
+		}
+	}
+	X := make([]emulated.Element[FR], 3)
+	for i := range X {
+		X[i] = emulated.ValueOf[FR](5 + i)
+	}
+
+	// M = 2 X₀ + X₁ + 1
+	witness := TestEvalMultilinear2Circuit[FR]{
+		M:  M,
+		At: X,
+	}
+	circuit := &TestEvalMultilinear2Circuit[FR]{M: make([]Multilinear[FR], nbML), At: make([]emulated.Element[FR], nbVar)}
+	for i := range circuit.M {
+		circuit.M[i] = make([]emulated.Element[FR], nbVals)
+	}
+	assert.CheckCircuit(circuit, test.WithValidAssignment(&witness))
 }

--- a/std/math/polynomial/polynomial_test.go
+++ b/std/math/polynomial/polynomial_test.go
@@ -1,4 +1,4 @@
-package polynomial_test
+package polynomial
 
 import (
 	"testing"
@@ -6,7 +6,6 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/std/math/emulated/emparams"
-	"github.com/consensys/gnark/std/math/polynomial"
 	"github.com/consensys/gnark/test"
 )
 
@@ -17,7 +16,7 @@ type evalPolyCircuit[FR emulated.FieldParams] struct {
 }
 
 func (c *evalPolyCircuit[FR]) Define(api frontend.API) error {
-	p, err := polynomial.New[FR](api)
+	p, err := New[FR](api)
 	if err != nil {
 		return err
 	}
@@ -57,12 +56,12 @@ type evalMultiLinCircuit[FR emulated.FieldParams] struct {
 }
 
 func (c *evalMultiLinCircuit[FR]) Define(api frontend.API) error {
-	p, err := polynomial.New[FR](api)
+	p, err := New[FR](api)
 	if err != nil {
 		return err
 	}
 	// M := polynomial.FromSlice(c.M)
-	X := polynomial.FromSlice(c.At)
+	X := FromSlice(c.At)
 	res, err := p.EvalMultilinear(c.M, X)
 	if err != nil {
 		return err
@@ -108,12 +107,12 @@ type evalEqCircuit[FR emulated.FieldParams] struct {
 }
 
 func (c *evalEqCircuit[FR]) Define(api frontend.API) error {
-	p, err := polynomial.New[FR](api)
+	p, err := New[FR](api)
 	if err != nil {
 		return err
 	}
-	X := polynomial.FromSlice(c.X)
-	Y := polynomial.FromSlice(c.Y)
+	X := FromSlice(c.X)
+	Y := FromSlice(c.Y)
 	evaluation := p.EvalEqual(X, Y)
 	f, err := emulated.NewField[FR](api)
 	if err != nil {
@@ -154,11 +153,11 @@ type interpolateLDECircuit[FR emulated.FieldParams] struct {
 }
 
 func (c *interpolateLDECircuit[FR]) Define(api frontend.API) error {
-	p, err := polynomial.New[FR](api)
+	p, err := New[FR](api)
 	if err != nil {
 		return err
 	}
-	vals := polynomial.FromSlice(c.Values)
+	vals := FromSlice(c.Values)
 	res := p.InterpolateLDE(&c.At, vals)
 	f, err := emulated.NewField[FR](api)
 	if err != nil {

--- a/std/recursion/sumcheck/claimable_gate.go
+++ b/std/recursion/sumcheck/claimable_gate.go
@@ -139,12 +139,9 @@ func (g *gateClaim[FR]) AssertEvaluation(r []*emulated.Element[FR], combinationC
 	// For that, we first have to map the random challenges to a random input to
 	// the gate. As the inputs mapping is given by multilinear extension, then
 	// this means evaluating the MLE at the random point.
-	inputEvals := make([]*emulated.Element[FR], len(g.inputPreprocessors))
-	for i := range inputEvals {
-		inputEvals[i], err = g.p.EvalMultilinear(g.inputPreprocessors[i], r)
-		if err != nil {
-			return fmt.Errorf("eval multilin: %w", err)
-		}
+	inputEvals, err := g.p.EvalMultilinearMany(r, g.inputPreprocessors...)
+	if err != nil {
+		return fmt.Errorf("eval multilin: %w", err)
 	}
 	// now, we can evaluate the gate at the random input.
 	gateEval := g.gate.Evaluate(g.engine, inputEvals...)

--- a/std/recursion/sumcheck/claimable_multilinear.go
+++ b/std/recursion/sumcheck/claimable_multilinear.go
@@ -53,7 +53,7 @@ func (fn *multilinearClaim[FR]) Degree(i int) int {
 }
 
 func (fn *multilinearClaim[FR]) AssertEvaluation(r []*emulated.Element[FR], combinationCoeff *emulated.Element[FR], expectedValue *emulated.Element[FR], proof EvaluationProof) error {
-	val, err := fn.p.EvalMultilinear(fn.ml, r)
+	val, err := fn.p.EvalMultilinear(r, fn.ml)
 	if err != nil {
 		return fmt.Errorf("eval: %w", err)
 	}


### PR DESCRIPTION
# Description

This PR optimizes evaluation of multilinear polynomials.

Previously, we folded the multilinear polynomial one variable at a time, but this is sub-optimal approach when using non-native arithmetic as we have to perform many modular multiplications.

Now, instead, we split the variables `x1, ..., xn` into two similar size partitions `x1, .., x_{n/2}` and `x_{n/2+1}, ..., xn`. We then compute recursively all possible combinations `prod({x1, (1-x1)}, ..., {x_{n/2}, 1-x_{n/2}})` and `prod({x_{n/2+1}, (1-x_{n/2+1})}, ..., {x_n, 1-x_n})` first and then compute the corresponding evaluated coefficients `(1-x1)*...*(1-xn) f0` ... `x1*...*xn f_{2^n}` one by one with the combinations using non-reducing multiplication and addition chains.

With doing the addition chains and non-reducing multiplications, we can save significantly on modular reductions. Additionally, we can reuse the computations when we're computing several ML evaluations which is useful later for the sumcheck verifier.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestEvalMultiLin2 -- checks consistency with the previous implementation (which is kept for testing purposes)
- [x] TestPartialMultilinearEval

# How has this been benchmarked?

Ran the tests from the local scalar multiplication with sumcheck -- for MLE of size 2^17 the reduction is from 33039039 constraints to 4502862 constraints.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

