### PR TITLE
perf/fix: assume variable as zero constant when subtracting from itself

### DIFF
--- a/frontend/cs/r1cs/api_assertions.go
+++ b/frontend/cs/r1cs/api_assertions.go
@@ -28,6 +28,15 @@ import (
 
 // AssertIsEqual adds an assertion in the constraint builder (i1 == i2)
 func (builder *builder) AssertIsEqual(i1, i2 frontend.Variable) {
+	c1, i1Constant := builder.constantValue(i1)
+	c2, i2Constant := builder.constantValue(i2)
+
+	if i1Constant && i2Constant {
+		if c1 != c2 {
+			panic("non-equal constant values")
+		}
+		return
+	}
 	// encoded 1 * i1 == i2
 	r := builder.getLinearExpression(builder.toVariable(i1))
 	o := builder.getLinearExpression(builder.toVariable(i2))

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -308,6 +308,9 @@ func (builder *builder) constantValue(v frontend.Variable) (constraint.Element, 
 			// and are always reduced to one element. may not always be true?
 			return constraint.Element{}, false
 		}
+		if _v[0].Coeff.IsZero() {
+			return constraint.Element{}, true
+		}
 		if !(_v[0].WireID() == 0) { // public ONE WIRE
 			return constraint.Element{}, false
 		}

--- a/frontend/cs/r1cs/r1cs_test.go
+++ b/frontend/cs/r1cs/r1cs_test.go
@@ -167,7 +167,7 @@ type subSameNoConstraintCircuit struct {
 
 func (c *subSameNoConstraintCircuit) Define(api frontend.API) error {
 	r := api.Sub(c.A, c.A)
-	api.AssertIsEqual(r, 1)
+	api.AssertIsEqual(r, 0)
 	return nil
 }
 

--- a/frontend/cs/r1cs/r1cs_test.go
+++ b/frontend/cs/r1cs/r1cs_test.go
@@ -160,3 +160,23 @@ func TestPreCompileHook(t *testing.T) {
 		t.Error("callback not called")
 	}
 }
+
+type subSameNoConstraintCircuit struct {
+	A frontend.Variable
+}
+
+func (c *subSameNoConstraintCircuit) Define(api frontend.API) error {
+	r := api.Sub(c.A, c.A)
+	api.AssertIsEqual(r, 1)
+	return nil
+}
+
+func TestSubSameNoConstraint(t *testing.T) {
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), NewBuilder, &subSameNoConstraintCircuit{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ccs.GetNbConstraints() != 0 {
+		t.Fatal("expected 0 constraints")
+	}
+}

--- a/frontend/cs/scs/api_test.go
+++ b/frontend/cs/scs/api_test.go
@@ -238,3 +238,22 @@ func TestMulAccFastTrack(t *testing.T) {
 	assert.NoError(err)
 	_ = solution
 }
+
+type subSameNoConstraintCircuit struct {
+	A frontend.Variable
+}
+
+func (c *subSameNoConstraintCircuit) Define(api frontend.API) error {
+	r := api.Sub(c.A, c.A)
+	api.AssertIsEqual(r, 0)
+	return nil
+}
+
+func TestSubSameNoConstraint(t *testing.T) {
+	assert := test.NewAssert(t)
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &subSameNoConstraintCircuit{})
+	assert.NoError(err)
+	if ccs.GetNbConstraints() != 0 {
+		t.Fatal("expected 0 constraints")
+	}
+}

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -312,7 +312,10 @@ func (builder *builder) ConstantValue(v frontend.Variable) (*big.Int, bool) {
 }
 
 func (builder *builder) constantValue(v frontend.Variable) (constraint.Element, bool) {
-	if _, ok := v.(expr.Term); ok {
+	if vv, ok := v.(expr.Term); ok {
+		if vv.Coeff.IsZero() {
+			return constraint.Element{}, true
+		}
 		return constraint.Element{}, false
 	}
 	return builder.cs.FromInterface(v), true


### PR DESCRIPTION
# Description

The issue has been reported by @wuestholz. When we perform `x = api.Sub(A, A)`, then we do not take the fast path that `x` is a constant zero neither for scs or r1cs builder.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestSubSameNoConstraint for scs
- [x] TestSubSameNoConstraint for r1cs

# How has this been benchmarked?

Not benchmarked

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

