### PR TITLE
feat: groth16 solidity use calldatacopy for commitments

### DIFF
--- a/backend/groth16/bn254/solidity.go
+++ b/backend/groth16/bn254/solidity.go
@@ -545,10 +545,10 @@ contract Verifier {
             {{- $pcIndex := index $PublicAndCommitmentCommitted $i }}
             uint256[] memory publicAndCommitmentCommitted = new uint256[]({{(len $pcIndex)}});
             assembly ("memory-safe") {
-                let start := add(publicAndCommitmentCommitted, 0x20)
+                let publicAndCommitmentCommittedOffset := add(publicAndCommitmentCommitted, 0x20)
                 {{- range $j := intRange (len $pcIndex) }}
                 {{- $l := index $pcIndex $j }}
-                calldatacopy(add(start, {{mul $j 0x20}}), add(input, {{mul 0x20 (sub $l 1)}}), 0x20)
+                calldatacopy(add(publicAndCommitmentCommittedOffset, {{mul $j 0x20}}), add(input, {{mul 0x20 (sub $l 1)}}), 0x20)
                 {{- end }}
             }
 

--- a/backend/groth16/bn254/solidity.go
+++ b/backend/groth16/bn254/solidity.go
@@ -541,9 +541,11 @@ contract Verifier {
             }
             {{- end}}
             (uint256 Px, uint256 Py) = decompress_g1(compressedCommitmentPok);
+
+            uint256[] memory publicAndCommitmentCommitted;
             {{- range $i := intRange $numCommitments }}
             {{- $pcIndex := index $PublicAndCommitmentCommitted $i }}
-            uint256[] memory publicAndCommitmentCommitted = new uint256[]({{(len $pcIndex)}});
+            publicAndCommitmentCommitted = new uint256[]({{(len $pcIndex)}});
             assembly ("memory-safe") {
                 let publicAndCommitmentCommittedOffset := add(publicAndCommitmentCommitted, 0x20)
                 {{- range $j := intRange (len $pcIndex) }}
@@ -676,9 +678,10 @@ contract Verifier {
         {{- else }}
         // HashToField
         uint256[{{$numCommitments}}] memory publicCommitments;
+        uint256[] memory publicAndCommitmentCommitted;
         {{- range $i := intRange $numCommitments }}
         {{- $pcIndex := index $PublicAndCommitmentCommitted $i }}
-        uint256[] memory publicAndCommitmentCommitted = new uint256[]({{(len $pcIndex)}});
+        publicAndCommitmentCommitted = new uint256[]({{(len $pcIndex)}});
         assembly ("memory-safe") {
             let publicAndCommitmentCommittedOffset := add(publicAndCommitmentCommitted, 0x20)
             {{- range $j := intRange (len $pcIndex) }}

--- a/backend/groth16/bn254/solidity.go
+++ b/backend/groth16/bn254/solidity.go
@@ -545,6 +545,7 @@ contract Verifier {
             uint256[] memory publicAndCommitmentCommitted;
             {{- range $i := intRange $numCommitments }}
             {{- $pcIndex := index $PublicAndCommitmentCommitted $i }}
+            {{- if gt (len $pcIndex) 0 }}
             publicAndCommitmentCommitted = new uint256[]({{(len $pcIndex)}});
             assembly ("memory-safe") {
                 let publicAndCommitmentCommittedOffset := add(publicAndCommitmentCommitted, 0x20)
@@ -562,6 +563,7 @@ contract Verifier {
                 {{- end }}
                 calldatacopy(add(publicAndCommitmentCommittedOffset, {{mul $l 0x20}}), add(input, {{mul 0x20 (sub $segment_start 1)}}), {{mul 0x20 (sum 1 (sub $segment_end $segment_start))}})
             }
+            {{- end }}
 
             publicCommitments[{{$i}}] = uint256(
                 sha256(
@@ -690,6 +692,7 @@ contract Verifier {
         uint256[] memory publicAndCommitmentCommitted;
         {{- range $i := intRange $numCommitments }}
         {{- $pcIndex := index $PublicAndCommitmentCommitted $i }}
+        {{- if gt (len $pcIndex) 0 }}
         publicAndCommitmentCommitted = new uint256[]({{(len $pcIndex)}});
         assembly ("memory-safe") {
             let publicAndCommitmentCommittedOffset := add(publicAndCommitmentCommitted, 0x20)
@@ -707,6 +710,7 @@ contract Verifier {
             {{- end }}
             calldatacopy(add(publicAndCommitmentCommittedOffset, {{mul $l 0x20}}), add(input, {{mul 0x20 (sub $segment_start 1)}}), {{mul 0x20 (sum 1 (sub $segment_end $segment_start))}})
         }
+        {{- end }}
 
             publicCommitments[{{$i}}] = uint256(
                 sha256(

--- a/backend/groth16/bn254/solidity.go
+++ b/backend/groth16/bn254/solidity.go
@@ -548,10 +548,19 @@ contract Verifier {
             publicAndCommitmentCommitted = new uint256[]({{(len $pcIndex)}});
             assembly ("memory-safe") {
                 let publicAndCommitmentCommittedOffset := add(publicAndCommitmentCommitted, 0x20)
-                {{- range $j := intRange (len $pcIndex) }}
-                {{- $l := index $pcIndex $j }}
-                calldatacopy(add(publicAndCommitmentCommittedOffset, {{mul $j 0x20}}), add(input, {{mul 0x20 (sub $l 1)}}), 0x20)
+                {{- $segment_start := index $pcIndex 0 }}
+                {{- $segment_end := index $pcIndex 0 }}
+                {{- $l := 0 }}
+                {{- range $k := intRange (sub (len $pcIndex) 1) }}
+                    {{- $next := index $pcIndex (sum $k 1) }}
+                    {{- if ne $next (sum $segment_end 1) }}
+                calldatacopy(add(publicAndCommitmentCommittedOffset, {{mul $l 0x20}}), add(input, {{mul 0x20 (sub $segment_start 1)}}), {{mul 0x20 (sum 1 (sub $segment_end $segment_start))}})
+                        {{- $segment_start = $next }}
+                        {{- $l = (sum $k 1) }}
+                    {{- end }}
+                    {{- $segment_end = $next }}
                 {{- end }}
+                calldatacopy(add(publicAndCommitmentCommittedOffset, {{mul $l 0x20}}), add(input, {{mul 0x20 (sub $segment_start 1)}}), {{mul 0x20 (sum 1 (sub $segment_end $segment_start))}})
             }
 
             publicCommitments[{{$i}}] = uint256(
@@ -684,10 +693,19 @@ contract Verifier {
         publicAndCommitmentCommitted = new uint256[]({{(len $pcIndex)}});
         assembly ("memory-safe") {
             let publicAndCommitmentCommittedOffset := add(publicAndCommitmentCommitted, 0x20)
-            {{- range $j := intRange (len $pcIndex) }}
-            {{- $l := index $pcIndex $j }}
-            calldatacopy(add(publicAndCommitmentCommittedOffset, {{mul $j 0x20}}), add(input, {{mul 0x20 (sub $l 1)}}), 0x20)
+            {{- $segment_start := index $pcIndex 0 }}
+            {{- $segment_end := index $pcIndex 0 }}
+            {{- $l := 0 }}
+            {{- range $k := intRange (sub (len $pcIndex) 1) }}
+                {{- $next := index $pcIndex (sum $k 1) }}
+                {{- if ne $next (sum $segment_end 1) }}
+            calldatacopy(add(publicAndCommitmentCommittedOffset, {{mul $l 0x20}}), add(input, {{mul 0x20 (sub $segment_start 1)}}), {{mul 0x20 (sum 1 (sub $segment_end $segment_start))}})
+                    {{- $segment_start = $next }}
+                    {{- $l = (sum $k 1) }}
+                {{- end }}
+                {{- $segment_end = $next }}
             {{- end }}
+            calldatacopy(add(publicAndCommitmentCommittedOffset, {{mul $l 0x20}}), add(input, {{mul 0x20 (sub $segment_start 1)}}), {{mul 0x20 (sum 1 (sub $segment_end $segment_start))}})
         }
 
             publicCommitments[{{$i}}] = uint256(

--- a/std/math/polynomial/polynomial_test.go
+++ b/std/math/polynomial/polynomial_test.go
@@ -43,7 +43,7 @@ func testEvalPoly[FR emulated.FieldParams](t *testing.T, p []int64, at int64, ev
 		Evaluation: emulated.ValueOf[FR](evaluation),
 	}
 
-	assert.CheckCircuit(&evalPolyCircuit[FR]{P: make([]emulated.Element[FR], len(p))}, test.WithValidAssignment(&witness), test.NoSolidityChecks())
+	assert.CheckCircuit(&evalPolyCircuit[FR]{P: make([]emulated.Element[FR], len(p))}, test.WithValidAssignment(&witness))
 }
 
 func TestEvalPoly(t *testing.T) {
@@ -98,7 +98,7 @@ func testEvalMultiLin[FR emulated.FieldParams](t *testing.T) {
 		Evaluation: emulated.ValueOf[FR](17),
 	}
 
-	assert.CheckCircuit(&evalMultiLinCircuit[FR]{M: make([]emulated.Element[FR], 4), At: make([]emulated.Element[FR], 2)}, test.WithValidAssignment(&witness), test.NoSolidityChecks())
+	assert.CheckCircuit(&evalMultiLinCircuit[FR]{M: make([]emulated.Element[FR], 4), At: make([]emulated.Element[FR], 2)}, test.WithValidAssignment(&witness))
 }
 
 type evalEqCircuit[FR emulated.FieldParams] struct {
@@ -144,7 +144,7 @@ func testEvalEq[FR emulated.FieldParams](t *testing.T) {
 		Eq: emulated.ValueOf[FR](148665),
 	}
 
-	assert.CheckCircuit(&evalEqCircuit[FR]{X: make([]emulated.Element[FR], 4), Y: make([]emulated.Element[FR], 4)}, test.WithValidAssignment(&witness), test.NoSolidityChecks())
+	assert.CheckCircuit(&evalEqCircuit[FR]{X: make([]emulated.Element[FR], 4), Y: make([]emulated.Element[FR], 4)}, test.WithValidAssignment(&witness))
 }
 
 type interpolateLDECircuit[FR emulated.FieldParams] struct {
@@ -180,7 +180,7 @@ func testInterpolateLDE[FR emulated.FieldParams](t *testing.T, at int64, values 
 		Expected: emulated.ValueOf[FR](expected),
 	}
 
-	assert.CheckCircuit(&interpolateLDECircuit[FR]{Values: make([]emulated.Element[FR], len(values))}, test.WithValidAssignment(assignment), test.NoSolidityChecks())
+	assert.CheckCircuit(&interpolateLDECircuit[FR]{Values: make([]emulated.Element[FR], len(values))}, test.WithValidAssignment(assignment))
 }
 
 func TestInterpolateLDEOnRange(t *testing.T) {


### PR DESCRIPTION
# Description

Addresses some causes for `Stack too deep` or `memoryguard was present` compiler errors by using assembly to copy calldata to an array. Tracked as part of issue #1094 .
