### PR TITLE
fix: non-native arithmetic with variable modulus various fixes

### DIFF
--- a/std/math/emulated/composition.go
+++ b/std/math/emulated/composition.go
@@ -67,7 +67,9 @@ func decompose(input *big.Int, nbBits uint, res []*big.Int) error {
 // then no such underflow happens and s = a-b (mod p) as the padding is multiple
 // of p.
 func subPadding(modulus *big.Int, bitsPerLimbs uint, overflow uint, nbLimbs uint) []*big.Int {
-
+	if modulus.Cmp(big.NewInt(0)) == 0 {
+		panic("modulus is zero")
+	}
 	// first, we build a number nLimbs, such that nLimbs > b;
 	// here b is defined by its bounds, that is b is an element with nbLimbs of (bitsPerLimbs+overflow)
 	// so a number nLimbs > b, is simply taking the next power of 2 over this bound .


### PR DESCRIPTION
# Description

This PR collects various fixes to non-native arithmetic with variable modulus:
- in case the provided variable modulus in non-native arithmetic is zero, then return more descriptive panic trace


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# How has this been tested?


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

