### PR TITLE
feat: SHA2 partial precompile

### DIFF
--- a/std/evmprecompiles/02-sha256.go
+++ b/std/evmprecompiles/02-sha256.go
@@ -2,7 +2,6 @@ package evmprecompiles
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/math/uints"
@@ -71,19 +70,4 @@ func SHA256Permute(api frontend.API, prevDigest [16]frontend.Variable, block [32
 	for i := range computedDigest {
 		uapi.AssertEq(computedDigest[i], expectedDigestU32[i])
 	}
-}
-
-func uint16ToUint8(mod *big.Int, inputs []*big.Int, outputs []*big.Int) error {
-	if len(outputs) != 2*len(inputs) {
-		return fmt.Errorf("invalid number of outputs")
-	}
-	mask := big.NewInt(0xff)
-	for i, v := range inputs {
-		if v.BitLen() > 16 {
-			return fmt.Errorf("input %d is too large", i)
-		}
-		outputs[2*i].And(v, mask)
-		outputs[2*i+1].Rsh(v, 8)
-	}
-	return nil
 }

--- a/std/evmprecompiles/02-sha256.go
+++ b/std/evmprecompiles/02-sha256.go
@@ -1,3 +1,89 @@
 package evmprecompiles
 
-// will implement later
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/uints"
+	"github.com/consensys/gnark/std/permutation/sha2"
+)
+
+// SHA256Permute implements the SHA256 permutation function as used inside the
+// [SHA256] precompile call.
+//
+// The input prevDigest is the previous digest, blocks is the block of data to
+// be hashed and expectedDigest is the expected digest. This function computes
+// the new digest by hashing the previous digest and the block of data, and then
+// asserts that the computed digest is equal to the expected digest.
+//
+// We assume the inputs prevDigest, block and expectedDigest are arrays of
+// 16-bit integers. We also assume that the caller has already range checked the
+// values to be in range.
+//
+// [SHA256]: https://ethereum.github.io/execution-specs/src/ethereum/paris/vm/precompiled_contracts/sha256.py.html
+func SHA256Permute(api frontend.API, prevDigest [16]frontend.Variable, block [32]frontend.Variable, expectedDigest [16]frontend.Variable) {
+	uapi, err := uints.New[uints.U32](api)
+	if err != nil {
+		panic(fmt.Sprintf("new uapi: %v", err))
+	}
+	// map inputs to supported by gnark
+	var prevDigestU32 [8]uints.U32
+	var blockU32 [16]uints.U32
+	var expectedDigestU32 [8]uints.U32
+	toComposeInput := append(prevDigest[:], block[:]...)
+	toComposeInput = append(toComposeInput, expectedDigest[:]...)
+	byteSplit, err := api.Compiler().NewHint(uint16ToUint8, 128, toComposeInput...)
+	if err != nil {
+		panic(fmt.Sprintf("convert u16 to u8: %v", err))
+	}
+	for i := 0; i < len(byteSplit)/2; i++ {
+		recomposed := api.Add(api.Mul(byteSplit[i*2+1], 1<<8), byteSplit[i*2])
+		api.AssertIsEqual(recomposed, toComposeInput[i])
+	}
+	for i := range prevDigestU32 {
+		prevDigestU32[i] = uapi.PackLSB(
+			uapi.ByteValueOf(byteSplit[i*4+0]),
+			uapi.ByteValueOf(byteSplit[i*4+1]),
+			uapi.ByteValueOf(byteSplit[i*4+2]),
+			uapi.ByteValueOf(byteSplit[i*4+3]),
+		)
+	}
+	for i := range blockU32 {
+		blockU32[i] = uapi.PackMSB(
+			uapi.ByteValueOf(byteSplit[32+i*4+0]),
+			uapi.ByteValueOf(byteSplit[32+i*4+1]),
+			uapi.ByteValueOf(byteSplit[32+i*4+2]),
+			uapi.ByteValueOf(byteSplit[32+i*4+3]),
+		)
+	}
+	for i := range expectedDigestU32 {
+		expectedDigestU32[i] = uapi.PackLSB(
+			uapi.ByteValueOf(byteSplit[96+i*4+0]),
+			uapi.ByteValueOf(byteSplit[96+i*4+1]),
+			uapi.ByteValueOf(byteSplit[96+i*4+2]),
+			uapi.ByteValueOf(byteSplit[96+i*4+3]),
+		)
+	}
+	// compute in-circuit new digest from prevDigest and block
+	computedDigest := sha2.PermuteU32(uapi, prevDigestU32, blockU32)
+	// assert that in-circuit computed digest == expectedDigest
+	for i := range computedDigest {
+		uapi.AssertEq(computedDigest[i], expectedDigestU32[i])
+	}
+}
+
+func uint16ToUint8(mod *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	if len(outputs) != 2*len(inputs) {
+		return fmt.Errorf("invalid number of outputs")
+	}
+	mask := big.NewInt(0xff)
+	for i, v := range inputs {
+		if v.BitLen() > 16 {
+			return fmt.Errorf("input %d is too large", i)
+		}
+		outputs[2*i].And(v, mask)
+		outputs[2*i+1].Rsh(v, 8)
+	}
+	return nil
+}

--- a/std/evmprecompiles/02-sha256_test.go
+++ b/std/evmprecompiles/02-sha256_test.go
@@ -1,0 +1,53 @@
+package evmprecompiles
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+)
+
+type sha256PermuteCircuit struct {
+	PrevDigest     [16]frontend.Variable
+	Block          [32]frontend.Variable
+	ExpectedDigest [16]frontend.Variable
+}
+
+func (c *sha256PermuteCircuit) Define(api frontend.API) error {
+	SHA256Permute(api, c.PrevDigest, c.Block, c.ExpectedDigest)
+	return nil
+}
+
+var fixedIV [16]uint16 = [16]uint16{
+	0x0001, 0x0010, 0x0100, 0x1000, 0x0008, 0x0080, 0x0800, 0x8000,
+	0x000f, 0x00f0, 0x0f00, 0xf000, 0x0001, 0x0001, 0x0001, 0x0001,
+}
+
+var fixedBlock [32]uint16 = [32]uint16{
+	0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008,
+	0x0009, 0x000a, 0x000b, 0x000c, 0x000d, 0x000e, 0x000f, 0x0010,
+	0x0011, 0x0012, 0x0013, 0x0014, 0x0015, 0x0016, 0x0017, 0x0018,
+	0x0019, 0x001a, 0x001b, 0x001c, 0x001d, 0x001e, 0x001f, 0x0020,
+}
+
+var expectedDigest [16]uint16 = [16]uint16{
+	0xd2d6, 0xeaf0, 0xa1c5, 0xc819, 0xac97, 0x25fe, 0x6c74, 0x4cf0,
+	0x7f2f, 0xa2ba, 0x82ec, 0xea3b, 0x46aa, 0x6ef0, 0x236a, 0x8f63,
+}
+
+func TestSha256Permute(t *testing.T) {
+	assert := test.NewAssert(t)
+	witness := sha256PermuteCircuit{}
+	for i := range witness.PrevDigest {
+		witness.PrevDigest[i] = fixedIV[i]
+	}
+	for i := range witness.Block {
+		witness.Block[i] = fixedBlock[i]
+	}
+	for i := range witness.ExpectedDigest {
+		witness.ExpectedDigest[i] = expectedDigest[i]
+	}
+	err := test.IsSolved(&sha256PermuteCircuit{}, &witness, ecc.BLS12_377.ScalarField())
+	assert.NoError(err)
+}

--- a/std/evmprecompiles/doc.go
+++ b/std/evmprecompiles/doc.go
@@ -4,7 +4,7 @@
 // easier integration. The main functionality is implemented elsewhere. This
 // package right now implements:
 //  1. ECRECOVER ✅ -- function [ECRecover]
-//  2. SHA256 ❌ -- in progress
+//  2. SHA256 ✅ -- function [SHA256Permute]
 //  3. RIPEMD160 ❌ -- postponed
 //  4. ID ❌ -- trivial to implement without function
 //  5. EXPMOD ✅ -- function [Expmod]

--- a/std/permutation/sha2/sha2block.go
+++ b/std/permutation/sha2/sha2block.go
@@ -16,10 +16,18 @@ var _K = uints.NewU32Array([]uint32{
 })
 
 func Permute(uapi *uints.BinaryField[uints.U32], currentHash [8]uints.U32, p [64]uints.U8) (newHash [8]uints.U32) {
+	var pu32 [16]uints.U32
+	for i := range pu32 {
+		pu32[i] = uapi.PackMSB(p[4*i], p[4*i+1], p[4*i+2], p[4*i+3])
+	}
+	return PermuteU32(uapi, currentHash, pu32)
+}
+
+func PermuteU32(uapi *uints.BinaryField[uints.U32], currentHash [8]uints.U32, p [16]uints.U32) (newHash [8]uints.U32) {
 	var w [64]uints.U32
 
 	for i := 0; i < 16; i++ {
-		w[i] = uapi.PackMSB(p[4*i], p[4*i+1], p[4*i+2], p[4*i+3])
+		w[i] = p[i]
 	}
 
 	for i := 16; i < 64; i++ {


### PR DESCRIPTION
# Description

This PR adds dedicated precompile circuit for SHA256 permutation on 16-bit limbs (as provided by zkEVM). Keeping in draft until final interface is determined.

Related #466 and #576 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestSHA256Permutation for fixed inputs

# How has this been benchmarked?



# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

