### PR TITLE
perf,feat: groth16.ProvingKey implements BinaryDumper using gnark-crypto unsafe

### DIFF
--- a/backend/groth16/bls12-377/marshal.go
+++ b/backend/groth16/bls12-377/marshal.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-377"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/pedersen"
+	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
 	"io"
 )
@@ -371,4 +372,166 @@ func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) 
 	}
 
 	return n + dec.BytesRead(), nil
+}
+
+// WriteDump behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+// Output is compatible with ReadDump, with the caveat that, not only the points are not checked for
+// correctness, but the raw bytes are platform dependent (endianness, etc.)
+func (pk *ProvingKey) WriteDump(w io.Writer) error {
+	// it behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+
+	// start by writing an unsafe marker to fail early.
+	if err := unsafe.WriteMarker(w); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.WriteTo(w); err != nil {
+		return err
+	}
+
+	enc := curve.NewEncoder(w, curve.RawEncoding())
+	nbWires := uint64(len(pk.InfinityA))
+
+	toEncode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// pk.G1.A,
+		// pk.G1.B,
+		// pk.G1.Z,
+		// pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// pk.G2.B,
+		nbWires,
+		pk.NbInfinityA,
+		pk.NbInfinityB,
+		pk.InfinityA,
+		pk.InfinityB,
+		uint32(len(pk.CommitmentKeys)),
+	}
+
+	for _, v := range toEncode {
+		if err := enc.Encode(v); err != nil {
+			return err
+		}
+	}
+
+	// dump slices of points
+	if err := unsafe.WriteSlice(w, pk.G1.A); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.B); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.Z); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.K); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G2.B); err != nil {
+		return err
+	}
+
+	for i := range pk.CommitmentKeys {
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].Basis); err != nil {
+			return err
+		}
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].BasisExpSigma); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ReadDump reads a ProvingKey from a dump written by WriteDump.
+// This is platform dependent and very unsafe (no checks, no endianness translation, etc.)
+func (pk *ProvingKey) ReadDump(r io.Reader) error {
+	// read the marker to fail early in case of malformed input
+	if err := unsafe.ReadMarker(r); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.ReadFrom(r); err != nil {
+		return err
+	}
+
+	dec := curve.NewDecoder(r, curve.NoSubgroupChecks())
+
+	var nbWires uint64
+	var nbCommitments uint32
+
+	toDecode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// &pk.G1.A,
+		// &pk.G1.B,
+		// &pk.G1.Z,
+		// &pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// &pk.G2.B,
+		&nbWires,
+		&pk.NbInfinityA,
+		&pk.NbInfinityB,
+	}
+
+	for _, v := range toDecode {
+		if err := dec.Decode(v); err != nil {
+			return err
+		}
+	}
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+
+	if err := dec.Decode(&pk.InfinityA); err != nil {
+		return err
+	}
+	if err := dec.Decode(&pk.InfinityB); err != nil {
+		return err
+	}
+	if err := dec.Decode(&nbCommitments); err != nil {
+		return err
+	}
+
+	// read slices of points
+	var err error
+	pk.G1.A, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.B, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.Z, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.K, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G2.B, _, err = unsafe.ReadSlice[[]curve.G2Affine](r)
+	if err != nil {
+		return err
+	}
+
+	pk.CommitmentKeys = make([]pedersen.ProvingKey, nbCommitments)
+	for i := range pk.CommitmentKeys {
+		pk.CommitmentKeys[i].Basis, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+		pk.CommitmentKeys[i].BasisExpSigma, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
 }

--- a/backend/groth16/bls12-377/marshal_test.go
+++ b/backend/groth16/bls12-377/marshal_test.go
@@ -187,9 +187,16 @@ func TestProvingKeySerialization(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) })
-			return err == nil
+			if err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
 
+			if err := io.DumpRoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
+			return true
 		},
 		GenG1(),
 		GenG2(),

--- a/backend/groth16/bls12-381/marshal.go
+++ b/backend/groth16/bls12-381/marshal.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls12-381"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/pedersen"
+	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
 	"io"
 )
@@ -371,4 +372,166 @@ func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) 
 	}
 
 	return n + dec.BytesRead(), nil
+}
+
+// WriteDump behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+// Output is compatible with ReadDump, with the caveat that, not only the points are not checked for
+// correctness, but the raw bytes are platform dependent (endianness, etc.)
+func (pk *ProvingKey) WriteDump(w io.Writer) error {
+	// it behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+
+	// start by writing an unsafe marker to fail early.
+	if err := unsafe.WriteMarker(w); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.WriteTo(w); err != nil {
+		return err
+	}
+
+	enc := curve.NewEncoder(w, curve.RawEncoding())
+	nbWires := uint64(len(pk.InfinityA))
+
+	toEncode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// pk.G1.A,
+		// pk.G1.B,
+		// pk.G1.Z,
+		// pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// pk.G2.B,
+		nbWires,
+		pk.NbInfinityA,
+		pk.NbInfinityB,
+		pk.InfinityA,
+		pk.InfinityB,
+		uint32(len(pk.CommitmentKeys)),
+	}
+
+	for _, v := range toEncode {
+		if err := enc.Encode(v); err != nil {
+			return err
+		}
+	}
+
+	// dump slices of points
+	if err := unsafe.WriteSlice(w, pk.G1.A); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.B); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.Z); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.K); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G2.B); err != nil {
+		return err
+	}
+
+	for i := range pk.CommitmentKeys {
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].Basis); err != nil {
+			return err
+		}
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].BasisExpSigma); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ReadDump reads a ProvingKey from a dump written by WriteDump.
+// This is platform dependent and very unsafe (no checks, no endianness translation, etc.)
+func (pk *ProvingKey) ReadDump(r io.Reader) error {
+	// read the marker to fail early in case of malformed input
+	if err := unsafe.ReadMarker(r); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.ReadFrom(r); err != nil {
+		return err
+	}
+
+	dec := curve.NewDecoder(r, curve.NoSubgroupChecks())
+
+	var nbWires uint64
+	var nbCommitments uint32
+
+	toDecode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// &pk.G1.A,
+		// &pk.G1.B,
+		// &pk.G1.Z,
+		// &pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// &pk.G2.B,
+		&nbWires,
+		&pk.NbInfinityA,
+		&pk.NbInfinityB,
+	}
+
+	for _, v := range toDecode {
+		if err := dec.Decode(v); err != nil {
+			return err
+		}
+	}
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+
+	if err := dec.Decode(&pk.InfinityA); err != nil {
+		return err
+	}
+	if err := dec.Decode(&pk.InfinityB); err != nil {
+		return err
+	}
+	if err := dec.Decode(&nbCommitments); err != nil {
+		return err
+	}
+
+	// read slices of points
+	var err error
+	pk.G1.A, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.B, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.Z, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.K, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G2.B, _, err = unsafe.ReadSlice[[]curve.G2Affine](r)
+	if err != nil {
+		return err
+	}
+
+	pk.CommitmentKeys = make([]pedersen.ProvingKey, nbCommitments)
+	for i := range pk.CommitmentKeys {
+		pk.CommitmentKeys[i].Basis, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+		pk.CommitmentKeys[i].BasisExpSigma, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
 }

--- a/backend/groth16/bls12-381/marshal_test.go
+++ b/backend/groth16/bls12-381/marshal_test.go
@@ -187,9 +187,16 @@ func TestProvingKeySerialization(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) })
-			return err == nil
+			if err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
 
+			if err := io.DumpRoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
+			return true
 		},
 		GenG1(),
 		GenG2(),

--- a/backend/groth16/bls24-315/marshal.go
+++ b/backend/groth16/bls24-315/marshal.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-315"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/pedersen"
+	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
 	"io"
 )
@@ -371,4 +372,166 @@ func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) 
 	}
 
 	return n + dec.BytesRead(), nil
+}
+
+// WriteDump behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+// Output is compatible with ReadDump, with the caveat that, not only the points are not checked for
+// correctness, but the raw bytes are platform dependent (endianness, etc.)
+func (pk *ProvingKey) WriteDump(w io.Writer) error {
+	// it behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+
+	// start by writing an unsafe marker to fail early.
+	if err := unsafe.WriteMarker(w); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.WriteTo(w); err != nil {
+		return err
+	}
+
+	enc := curve.NewEncoder(w, curve.RawEncoding())
+	nbWires := uint64(len(pk.InfinityA))
+
+	toEncode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// pk.G1.A,
+		// pk.G1.B,
+		// pk.G1.Z,
+		// pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// pk.G2.B,
+		nbWires,
+		pk.NbInfinityA,
+		pk.NbInfinityB,
+		pk.InfinityA,
+		pk.InfinityB,
+		uint32(len(pk.CommitmentKeys)),
+	}
+
+	for _, v := range toEncode {
+		if err := enc.Encode(v); err != nil {
+			return err
+		}
+	}
+
+	// dump slices of points
+	if err := unsafe.WriteSlice(w, pk.G1.A); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.B); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.Z); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.K); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G2.B); err != nil {
+		return err
+	}
+
+	for i := range pk.CommitmentKeys {
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].Basis); err != nil {
+			return err
+		}
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].BasisExpSigma); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ReadDump reads a ProvingKey from a dump written by WriteDump.
+// This is platform dependent and very unsafe (no checks, no endianness translation, etc.)
+func (pk *ProvingKey) ReadDump(r io.Reader) error {
+	// read the marker to fail early in case of malformed input
+	if err := unsafe.ReadMarker(r); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.ReadFrom(r); err != nil {
+		return err
+	}
+
+	dec := curve.NewDecoder(r, curve.NoSubgroupChecks())
+
+	var nbWires uint64
+	var nbCommitments uint32
+
+	toDecode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// &pk.G1.A,
+		// &pk.G1.B,
+		// &pk.G1.Z,
+		// &pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// &pk.G2.B,
+		&nbWires,
+		&pk.NbInfinityA,
+		&pk.NbInfinityB,
+	}
+
+	for _, v := range toDecode {
+		if err := dec.Decode(v); err != nil {
+			return err
+		}
+	}
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+
+	if err := dec.Decode(&pk.InfinityA); err != nil {
+		return err
+	}
+	if err := dec.Decode(&pk.InfinityB); err != nil {
+		return err
+	}
+	if err := dec.Decode(&nbCommitments); err != nil {
+		return err
+	}
+
+	// read slices of points
+	var err error
+	pk.G1.A, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.B, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.Z, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.K, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G2.B, _, err = unsafe.ReadSlice[[]curve.G2Affine](r)
+	if err != nil {
+		return err
+	}
+
+	pk.CommitmentKeys = make([]pedersen.ProvingKey, nbCommitments)
+	for i := range pk.CommitmentKeys {
+		pk.CommitmentKeys[i].Basis, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+		pk.CommitmentKeys[i].BasisExpSigma, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
 }

--- a/backend/groth16/bls24-315/marshal_test.go
+++ b/backend/groth16/bls24-315/marshal_test.go
@@ -187,9 +187,16 @@ func TestProvingKeySerialization(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) })
-			return err == nil
+			if err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
 
+			if err := io.DumpRoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
+			return true
 		},
 		GenG1(),
 		GenG2(),

--- a/backend/groth16/bls24-317/marshal.go
+++ b/backend/groth16/bls24-317/marshal.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bls24-317"
 
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/pedersen"
+	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
 	"io"
 )
@@ -371,4 +372,166 @@ func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) 
 	}
 
 	return n + dec.BytesRead(), nil
+}
+
+// WriteDump behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+// Output is compatible with ReadDump, with the caveat that, not only the points are not checked for
+// correctness, but the raw bytes are platform dependent (endianness, etc.)
+func (pk *ProvingKey) WriteDump(w io.Writer) error {
+	// it behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+
+	// start by writing an unsafe marker to fail early.
+	if err := unsafe.WriteMarker(w); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.WriteTo(w); err != nil {
+		return err
+	}
+
+	enc := curve.NewEncoder(w, curve.RawEncoding())
+	nbWires := uint64(len(pk.InfinityA))
+
+	toEncode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// pk.G1.A,
+		// pk.G1.B,
+		// pk.G1.Z,
+		// pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// pk.G2.B,
+		nbWires,
+		pk.NbInfinityA,
+		pk.NbInfinityB,
+		pk.InfinityA,
+		pk.InfinityB,
+		uint32(len(pk.CommitmentKeys)),
+	}
+
+	for _, v := range toEncode {
+		if err := enc.Encode(v); err != nil {
+			return err
+		}
+	}
+
+	// dump slices of points
+	if err := unsafe.WriteSlice(w, pk.G1.A); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.B); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.Z); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.K); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G2.B); err != nil {
+		return err
+	}
+
+	for i := range pk.CommitmentKeys {
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].Basis); err != nil {
+			return err
+		}
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].BasisExpSigma); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ReadDump reads a ProvingKey from a dump written by WriteDump.
+// This is platform dependent and very unsafe (no checks, no endianness translation, etc.)
+func (pk *ProvingKey) ReadDump(r io.Reader) error {
+	// read the marker to fail early in case of malformed input
+	if err := unsafe.ReadMarker(r); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.ReadFrom(r); err != nil {
+		return err
+	}
+
+	dec := curve.NewDecoder(r, curve.NoSubgroupChecks())
+
+	var nbWires uint64
+	var nbCommitments uint32
+
+	toDecode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// &pk.G1.A,
+		// &pk.G1.B,
+		// &pk.G1.Z,
+		// &pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// &pk.G2.B,
+		&nbWires,
+		&pk.NbInfinityA,
+		&pk.NbInfinityB,
+	}
+
+	for _, v := range toDecode {
+		if err := dec.Decode(v); err != nil {
+			return err
+		}
+	}
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+
+	if err := dec.Decode(&pk.InfinityA); err != nil {
+		return err
+	}
+	if err := dec.Decode(&pk.InfinityB); err != nil {
+		return err
+	}
+	if err := dec.Decode(&nbCommitments); err != nil {
+		return err
+	}
+
+	// read slices of points
+	var err error
+	pk.G1.A, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.B, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.Z, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.K, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G2.B, _, err = unsafe.ReadSlice[[]curve.G2Affine](r)
+	if err != nil {
+		return err
+	}
+
+	pk.CommitmentKeys = make([]pedersen.ProvingKey, nbCommitments)
+	for i := range pk.CommitmentKeys {
+		pk.CommitmentKeys[i].Basis, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+		pk.CommitmentKeys[i].BasisExpSigma, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
 }

--- a/backend/groth16/bls24-317/marshal_test.go
+++ b/backend/groth16/bls24-317/marshal_test.go
@@ -187,9 +187,16 @@ func TestProvingKeySerialization(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) })
-			return err == nil
+			if err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
 
+			if err := io.DumpRoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
+			return true
 		},
 		GenG1(),
 		GenG2(),

--- a/backend/groth16/bn254/marshal.go
+++ b/backend/groth16/bn254/marshal.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/pedersen"
+	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
 	"io"
 )
@@ -371,4 +372,166 @@ func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) 
 	}
 
 	return n + dec.BytesRead(), nil
+}
+
+// WriteDump behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+// Output is compatible with ReadDump, with the caveat that, not only the points are not checked for
+// correctness, but the raw bytes are platform dependent (endianness, etc.)
+func (pk *ProvingKey) WriteDump(w io.Writer) error {
+	// it behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+
+	// start by writing an unsafe marker to fail early.
+	if err := unsafe.WriteMarker(w); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.WriteTo(w); err != nil {
+		return err
+	}
+
+	enc := curve.NewEncoder(w, curve.RawEncoding())
+	nbWires := uint64(len(pk.InfinityA))
+
+	toEncode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// pk.G1.A,
+		// pk.G1.B,
+		// pk.G1.Z,
+		// pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// pk.G2.B,
+		nbWires,
+		pk.NbInfinityA,
+		pk.NbInfinityB,
+		pk.InfinityA,
+		pk.InfinityB,
+		uint32(len(pk.CommitmentKeys)),
+	}
+
+	for _, v := range toEncode {
+		if err := enc.Encode(v); err != nil {
+			return err
+		}
+	}
+
+	// dump slices of points
+	if err := unsafe.WriteSlice(w, pk.G1.A); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.B); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.Z); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.K); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G2.B); err != nil {
+		return err
+	}
+
+	for i := range pk.CommitmentKeys {
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].Basis); err != nil {
+			return err
+		}
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].BasisExpSigma); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ReadDump reads a ProvingKey from a dump written by WriteDump.
+// This is platform dependent and very unsafe (no checks, no endianness translation, etc.)
+func (pk *ProvingKey) ReadDump(r io.Reader) error {
+	// read the marker to fail early in case of malformed input
+	if err := unsafe.ReadMarker(r); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.ReadFrom(r); err != nil {
+		return err
+	}
+
+	dec := curve.NewDecoder(r, curve.NoSubgroupChecks())
+
+	var nbWires uint64
+	var nbCommitments uint32
+
+	toDecode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// &pk.G1.A,
+		// &pk.G1.B,
+		// &pk.G1.Z,
+		// &pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// &pk.G2.B,
+		&nbWires,
+		&pk.NbInfinityA,
+		&pk.NbInfinityB,
+	}
+
+	for _, v := range toDecode {
+		if err := dec.Decode(v); err != nil {
+			return err
+		}
+	}
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+
+	if err := dec.Decode(&pk.InfinityA); err != nil {
+		return err
+	}
+	if err := dec.Decode(&pk.InfinityB); err != nil {
+		return err
+	}
+	if err := dec.Decode(&nbCommitments); err != nil {
+		return err
+	}
+
+	// read slices of points
+	var err error
+	pk.G1.A, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.B, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.Z, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.K, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G2.B, _, err = unsafe.ReadSlice[[]curve.G2Affine](r)
+	if err != nil {
+		return err
+	}
+
+	pk.CommitmentKeys = make([]pedersen.ProvingKey, nbCommitments)
+	for i := range pk.CommitmentKeys {
+		pk.CommitmentKeys[i].Basis, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+		pk.CommitmentKeys[i].BasisExpSigma, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
 }

--- a/backend/groth16/bn254/marshal_test.go
+++ b/backend/groth16/bn254/marshal_test.go
@@ -187,9 +187,16 @@ func TestProvingKeySerialization(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) })
-			return err == nil
+			if err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
 
+			if err := io.DumpRoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
+			return true
 		},
 		GenG1(),
 		GenG2(),

--- a/backend/groth16/bw6-633/marshal_test.go
+++ b/backend/groth16/bw6-633/marshal_test.go
@@ -187,9 +187,16 @@ func TestProvingKeySerialization(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) })
-			return err == nil
+			if err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
 
+			if err := io.DumpRoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
+			return true
 		},
 		GenG1(),
 		GenG2(),

--- a/backend/groth16/bw6-761/marshal.go
+++ b/backend/groth16/bw6-761/marshal.go
@@ -20,6 +20,7 @@ import (
 	curve "github.com/consensys/gnark-crypto/ecc/bw6-761"
 
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/pedersen"
+	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
 	"io"
 )
@@ -371,4 +372,166 @@ func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) 
 	}
 
 	return n + dec.BytesRead(), nil
+}
+
+// WriteDump behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+// Output is compatible with ReadDump, with the caveat that, not only the points are not checked for
+// correctness, but the raw bytes are platform dependent (endianness, etc.)
+func (pk *ProvingKey) WriteDump(w io.Writer) error {
+	// it behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+
+	// start by writing an unsafe marker to fail early.
+	if err := unsafe.WriteMarker(w); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.WriteTo(w); err != nil {
+		return err
+	}
+
+	enc := curve.NewEncoder(w, curve.RawEncoding())
+	nbWires := uint64(len(pk.InfinityA))
+
+	toEncode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// pk.G1.A,
+		// pk.G1.B,
+		// pk.G1.Z,
+		// pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// pk.G2.B,
+		nbWires,
+		pk.NbInfinityA,
+		pk.NbInfinityB,
+		pk.InfinityA,
+		pk.InfinityB,
+		uint32(len(pk.CommitmentKeys)),
+	}
+
+	for _, v := range toEncode {
+		if err := enc.Encode(v); err != nil {
+			return err
+		}
+	}
+
+	// dump slices of points
+	if err := unsafe.WriteSlice(w, pk.G1.A); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.B); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.Z); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.K); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G2.B); err != nil {
+		return err
+	}
+
+	for i := range pk.CommitmentKeys {
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].Basis); err != nil {
+			return err
+		}
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].BasisExpSigma); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ReadDump reads a ProvingKey from a dump written by WriteDump.
+// This is platform dependent and very unsafe (no checks, no endianness translation, etc.)
+func (pk *ProvingKey) ReadDump(r io.Reader) error {
+	// read the marker to fail early in case of malformed input
+	if err := unsafe.ReadMarker(r); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.ReadFrom(r); err != nil {
+		return err
+	}
+
+	dec := curve.NewDecoder(r, curve.NoSubgroupChecks())
+
+	var nbWires uint64
+	var nbCommitments uint32
+
+	toDecode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// &pk.G1.A,
+		// &pk.G1.B,
+		// &pk.G1.Z,
+		// &pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// &pk.G2.B,
+		&nbWires,
+		&pk.NbInfinityA,
+		&pk.NbInfinityB,
+	}
+
+	for _, v := range toDecode {
+		if err := dec.Decode(v); err != nil {
+			return err
+		}
+	}
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+
+	if err := dec.Decode(&pk.InfinityA); err != nil {
+		return err
+	}
+	if err := dec.Decode(&pk.InfinityB); err != nil {
+		return err
+	}
+	if err := dec.Decode(&nbCommitments); err != nil {
+		return err
+	}
+
+	// read slices of points
+	var err error
+	pk.G1.A, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.B, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.Z, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.K, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G2.B, _, err = unsafe.ReadSlice[[]curve.G2Affine](r)
+	if err != nil {
+		return err
+	}
+
+	pk.CommitmentKeys = make([]pedersen.ProvingKey, nbCommitments)
+	for i := range pk.CommitmentKeys {
+		pk.CommitmentKeys[i].Basis, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+		pk.CommitmentKeys[i].BasisExpSigma, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
 }

--- a/backend/groth16/bw6-761/marshal_test.go
+++ b/backend/groth16/bw6-761/marshal_test.go
@@ -187,9 +187,16 @@ func TestProvingKeySerialization(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) })
-			return err == nil
+			if err := io.RoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
 
+			if err := io.DumpRoundTripCheck(&pk, func() any { return new(ProvingKey) }); err != nil {
+				t.Log(err)
+				return false
+			}
+			return true
 		},
 		GenG1(),
 		GenG2(),

--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -74,6 +74,7 @@ type Proof interface {
 type ProvingKey interface {
 	groth16Object
 	gnarkio.UnsafeReaderFrom
+	gnarkio.BinaryDumper
 
 	// NbG1 returns the number of G1 elements in the ProvingKey
 	NbG1() int

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/bavard v0.1.13
 	github.com/consensys/compress v0.2.5
-	github.com/consensys/gnark-crypto v0.12.2-0.20240503014124-f9fac6259545
+	github.com/consensys/gnark-crypto v0.12.2-0.20240504013751-564b6f724c3b
 	github.com/fxamacker/cbor/v2 v2.5.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/bavard v0.1.13
 	github.com/consensys/compress v0.2.5
-	github.com/consensys/gnark-crypto v0.12.2-0.20240423164836-7edca0e476c5
+	github.com/consensys/gnark-crypto v0.12.2-0.20240503014124-f9fac6259545
 	github.com/fxamacker/cbor/v2 v2.5.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,8 @@ github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/Yj
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/compress v0.2.5 h1:gJr1hKzbOD36JFsF1AN8lfXz1yevnJi1YolffY19Ntk=
 github.com/consensys/compress v0.2.5/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
-github.com/consensys/gnark-crypto v0.12.2-0.20240423164836-7edca0e476c5 h1:qdtFrv6MlqK4IBrlm56ZQRiDK2sfPRXXvgmkvjzFiSI=
-github.com/consensys/gnark-crypto v0.12.2-0.20240423164836-7edca0e476c5/go.mod h1:wKqwsieaKPThcFkHe0d0zMsbHEUWFmZcG7KBCse210o=
-github.com/consensys/gnark-crypto v0.12.2-0.20240503014124-f9fac6259545 h1:uQLAWNM+vwVx+BxuTMySzqhYbzotVqOu79m3bMgwOmQ=
-github.com/consensys/gnark-crypto v0.12.2-0.20240503014124-f9fac6259545/go.mod h1:wKqwsieaKPThcFkHe0d0zMsbHEUWFmZcG7KBCse210o=
+github.com/consensys/gnark-crypto v0.12.2-0.20240504013751-564b6f724c3b h1:tu0NaVr64o6vXzy9rYSK/LCZXmS+u/k9eP1F8OtRUWQ=
+github.com/consensys/gnark-crypto v0.12.2-0.20240504013751-564b6f724c3b/go.mod h1:wKqwsieaKPThcFkHe0d0zMsbHEUWFmZcG7KBCse210o=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/consensys/compress v0.2.5 h1:gJr1hKzbOD36JFsF1AN8lfXz1yevnJi1YolffY19
 github.com/consensys/compress v0.2.5/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
 github.com/consensys/gnark-crypto v0.12.2-0.20240423164836-7edca0e476c5 h1:qdtFrv6MlqK4IBrlm56ZQRiDK2sfPRXXvgmkvjzFiSI=
 github.com/consensys/gnark-crypto v0.12.2-0.20240423164836-7edca0e476c5/go.mod h1:wKqwsieaKPThcFkHe0d0zMsbHEUWFmZcG7KBCse210o=
+github.com/consensys/gnark-crypto v0.12.2-0.20240503014124-f9fac6259545 h1:uQLAWNM+vwVx+BxuTMySzqhYbzotVqOu79m3bMgwOmQ=
+github.com/consensys/gnark-crypto v0.12.2-0.20240503014124-f9fac6259545/go.mod h1:wKqwsieaKPThcFkHe0d0zMsbHEUWFmZcG7KBCse210o=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.marshal.go.tmpl
@@ -2,6 +2,7 @@ import (
 	{{ template "import_curve" . }}
 	{{ template "import_pedersen" . }}
 	"github.com/consensys/gnark/internal/utils"
+	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"io"
 )
 
@@ -361,3 +362,164 @@ func (pk *ProvingKey) readFrom(r io.Reader, decOptions ...func(*curve.Decoder)) 
 }
 
 
+// WriteDump behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+// Output is compatible with ReadDump, with the caveat that, not only the points are not checked for 
+// correctness, but the raw bytes are platform dependent (endianness, etc.)
+func (pk *ProvingKey) WriteDump(w io.Writer) error {
+	// it behaves like WriteRawTo, excepts, the slices of points are "dumped" using gnark-crypto/utils/unsafe
+
+	// start by writing an unsafe marker to fail early.
+	if err := unsafe.WriteMarker(w); err != nil {
+		return err
+	}
+	
+	if _, err := pk.Domain.WriteTo(w); err != nil {
+		return err 
+	}
+
+	enc := curve.NewEncoder(w, curve.RawEncoding())
+	nbWires := uint64(len(pk.InfinityA))
+	
+	toEncode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// pk.G1.A,
+		// pk.G1.B,
+		// pk.G1.Z,
+		// pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// pk.G2.B,
+		nbWires,
+		pk.NbInfinityA,
+		pk.NbInfinityB,
+		pk.InfinityA,
+		pk.InfinityB,
+		uint32(len(pk.CommitmentKeys)),
+	}
+
+	for _, v := range toEncode {
+		if err := enc.Encode(v); err != nil {
+			return err
+		}
+	}
+
+	// dump slices of points
+	if err := unsafe.WriteSlice(w, pk.G1.A); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.B); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.Z); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G1.K); err != nil {
+		return err
+	}
+	if err := unsafe.WriteSlice(w, pk.G2.B); err != nil {
+		return err
+	}
+
+	for i := range pk.CommitmentKeys {
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].Basis); err != nil {
+			return err
+		}
+		if err := unsafe.WriteSlice(w, pk.CommitmentKeys[i].BasisExpSigma); err != nil {
+			return err
+		}
+	}	
+
+	return  nil
+}
+
+// ReadDump reads a ProvingKey from a dump written by WriteDump.
+// This is platform dependent and very unsafe (no checks, no endianness translation, etc.)
+func (pk *ProvingKey) ReadDump(r io.Reader) error {
+	// read the marker to fail early in case of malformed input
+	if err := unsafe.ReadMarker(r); err != nil {
+		return err
+	}
+
+	if _, err := pk.Domain.ReadFrom(r); err != nil {
+		return err 
+	}
+
+	dec := curve.NewDecoder(r, curve.NoSubgroupChecks())
+
+	var nbWires uint64 
+	var nbCommitments uint32
+
+	toDecode := []interface{}{
+		&pk.G1.Alpha,
+		&pk.G1.Beta,
+		&pk.G1.Delta,
+		// &pk.G1.A,
+		// &pk.G1.B,
+		// &pk.G1.Z,
+		// &pk.G1.K,
+		&pk.G2.Beta,
+		&pk.G2.Delta,
+		// &pk.G2.B,
+		&nbWires, 
+		&pk.NbInfinityA,
+		&pk.NbInfinityB,
+	}
+
+	for _, v := range toDecode {
+		if err := dec.Decode(v); err != nil {
+			return err
+		}
+	}
+	pk.InfinityA = make([]bool, nbWires)
+	pk.InfinityB = make([]bool, nbWires)
+
+	if err := dec.Decode(&pk.InfinityA); err != nil {
+		return err
+	}
+	if err := dec.Decode(&pk.InfinityB); err != nil {
+		return err
+	}
+	if err := dec.Decode(&nbCommitments); err != nil {
+		return err
+	}
+
+	// read slices of points
+	var err error
+	pk.G1.A, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.B, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.Z, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G1.K, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+	if err != nil {
+		return err
+	}
+	pk.G2.B, _, err = unsafe.ReadSlice[[]curve.G2Affine](r)
+	if err != nil {
+		return err
+	}
+
+	pk.CommitmentKeys = make([]pedersen.ProvingKey, nbCommitments)
+	for i := range pk.CommitmentKeys {
+		pk.CommitmentKeys[i].Basis, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+		pk.CommitmentKeys[i].BasisExpSigma, _, err = unsafe.ReadSlice[[]curve.G1Affine](r)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.marshal.go.tmpl
@@ -173,9 +173,16 @@ func TestProvingKeySerialization(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := io.RoundTripCheck(&pk, func() any {return new(ProvingKey)})
-			return err == nil 
+			if err := io.RoundTripCheck(&pk, func() any {return new(ProvingKey)}); err != nil {
+				t.Log(err)
+				return false
+			}
 
+			if err := io.DumpRoundTripCheck(&pk, func() any {return new(ProvingKey)}); err != nil {
+				t.Log(err)
+				return false
+			}
+			return true
 		},
 		GenG1(),
 		GenG2(),

--- a/io/io.go
+++ b/io/io.go
@@ -39,3 +39,11 @@ type WriterRawTo interface {
 type UnsafeReaderFrom interface {
 	UnsafeReadFrom(r io.Reader) (int64, error)
 }
+
+// BinaryDumper is the interface that wraps the WriteDump and ReadDump methods.
+// WriteDump writes the object to w, ReadDump reads the object from r.
+// The object is serialized in binary format, in a very fast, very unsafe way.
+type BinaryDumper interface {
+	WriteDump(w io.Writer) error
+	ReadDump(r io.Reader) error
+}

--- a/io/roundtrip.go
+++ b/io/roundtrip.go
@@ -73,3 +73,20 @@ func RoundTripCheck(from any, to func() any) error {
 
 	return nil
 }
+
+func DumpRoundTripCheck(from any, to func() any) error {
+	var buf bytes.Buffer
+
+	if err := from.(BinaryDumper).WriteDump(&buf); err != nil {
+		return err
+	}
+
+	r := to().(BinaryDumper)
+	if err := r.ReadDump(bytes.NewReader(buf.Bytes())); err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(from, r) {
+		return errors.New("reconstructed object don't match original (ReadDump)")
+	}
+	return nil
+}


### PR DESCRIPTION
Sister PR to https://github.com/Consensys/gnark-crypto/pull/501 .

Essentially, addresses the issue of slow deserialization for (large) proving keys. `ReadFrom` and `UnsafeReadFrom` can take many seconds (if not minutes) due to subgroup checks, point decompression and "safe" point reconstruction (involve at least converting `[]byte` canonical field elements into Montgomery repr).

This PR introduces `pk.WriteDump` and `pk.ReadDump` for scenarios where want to minimize loading time, don't need portability (uses `unsafe`; `pk.ReadDump` must read a stream generated by `pk.WriteDump` on a similar architecture: 32/64 bit little/big endian (most popular platforms these days are 64bits little endian)), and don't need to perform any sanity checks.

A quick bench for a medium sized `groth16.ProvingKey` for bls12-377; divides by 100x decoding time 🔥 (but since we use `unsafe` we are io bound, here we ... kind of benchmark `memcopy` for 80% of the pk).

```
BenchmarkSerialization/deserialize_pk_from_dump
BenchmarkSerialization/deserialize_pk_from_dump-10                     6         213271979 ns/op        2314815138 B/op      141 allocs/op
BenchmarkSerialization/deserialize_pk_unsafereadfrom
BenchmarkSerialization/deserialize_pk_unsafereadfrom-10                1        19682179709 ns/op       3226044160 B/op 14597433 allocs/op
```