### PR TITLE
fix: shift constraint indices by nb of public vars

### DIFF
--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -736,6 +736,10 @@ func (builder *builder) GetWireConstraints(wires []frontend.Variable, addMissing
 			delete(lookup, int(c.XB))
 			continue
 		}
+		if len(lookup) == 0 {
+			// we can break early if we found constraints for all the wires
+			break
+		}
 	}
 	if addMissing {
 		nbWitnessWires := builder.cs.GetNbPublicVariables() + builder.cs.GetNbSecretVariables()

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -722,16 +722,17 @@ func (builder *builder) GetWireConstraints(wires []frontend.Variable, addMissing
 		}
 		lookup[ww.WireID()] = struct{}{}
 	}
+	nbPub := builder.cs.GetNbPublicVariables()
 	res := make([][2]int, 0, len(wires))
 	iterator := builder.cs.GetSparseR1CIterator()
 	for c, constraintIdx := iterator.Next(), 0; c != nil; c, constraintIdx = iterator.Next(), constraintIdx+1 {
 		if _, ok := lookup[int(c.XA)]; ok {
-			res = append(res, [2]int{constraintIdx, 0})
+			res = append(res, [2]int{nbPub + constraintIdx, 0})
 			delete(lookup, int(c.XA))
 			continue
 		}
 		if _, ok := lookup[int(c.XB)]; ok {
-			res = append(res, [2]int{constraintIdx, 1})
+			res = append(res, [2]int{nbPub + constraintIdx, 1})
 			delete(lookup, int(c.XB))
 			continue
 		}
@@ -748,7 +749,7 @@ func (builder *builder) GetWireConstraints(wires []frontend.Variable, addMissing
 				QL: constraint.CoeffIdOne,
 				QO: constraint.CoeffIdMinusOne,
 			}, builder.genericGate)
-			res = append(res, [2]int{constraintIdx, 0})
+			res = append(res, [2]int{nbPub + constraintIdx, 0})
 			delete(lookup, k)
 		}
 	}


### PR DESCRIPTION
# Description

When extracting the constraint indices for range checking, we didn't take into account the added constraints rows in the traces which account for the public inputs. We now shift the constraint indices by the number of public variables.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

In zkevm repo.

# How has this been benchmarked?

Not benchmarked. But added an optimization to break the loop early when all results have been found.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

