### PR TITLE
fix(uints): constrain valueOf

### DIFF
--- a/std/math/uints/uint8.go
+++ b/std/math/uints/uint8.go
@@ -173,10 +173,18 @@ func (bf *BinaryField[T]) ValueOf(a frontend.Variable) T {
 	if err != nil {
 		panic(err)
 	}
-	// TODO: add constraint which ensures that map back to
-	for i := range bts {
+
+	var checker frontend.Variable = 0x00
+	for i := len(bts) - 1; i >= 0; i-- {
 		r[i] = bf.ByteValueOf(bts[i])
+
+		// Reconstruct the value of a
+		checker = bf.api.Add(bf.api.Mul(checker, 256), r[i].Val)
+
 	}
+
+	bf.api.AssertIsEqual(checker, a)
+
 	return r
 }
 

--- a/std/math/uints/uint8.go
+++ b/std/math/uints/uint8.go
@@ -175,7 +175,7 @@ func (bf *BinaryField[T]) ValueOf(a frontend.Variable) T {
 		panic(err)
 	}
 
-	for i := len(bts) - 1; i >= 0; i-- {
+	for i := range bts {
 		r[i] = bf.ByteValueOf(bts[i])
 	}
 	expectedValue := bf.ToValue(r)

--- a/std/math/uints/uint8.go
+++ b/std/math/uints/uint8.go
@@ -174,16 +174,11 @@ func (bf *BinaryField[T]) ValueOf(a frontend.Variable) T {
 		panic(err)
 	}
 
-	var checker frontend.Variable = 0x00
 	for i := len(bts) - 1; i >= 0; i-- {
 		r[i] = bf.ByteValueOf(bts[i])
-
-		// Reconstruct the value of a
-		checker = bf.api.Add(bf.api.Mul(checker, 256), r[i].Val)
-
 	}
-
-	bf.api.AssertIsEqual(checker, a)
+	expectedValue := bf.ToValue(r)
+	bf.api.AssertIsEqual(a, expectedValue)
 
 	return r
 }

--- a/std/math/uints/uint8.go
+++ b/std/math/uints/uint8.go
@@ -185,7 +185,7 @@ func (bf *BinaryField[T]) ValueOf(a frontend.Variable) T {
 }
 
 func (bf *BinaryField[T]) ToValue(a T) frontend.Variable {
-	v := make([]frontend.Variable, len(a))
+	v := make([]frontend.Variable, bf.lenBts())
 	for i := range v {
 		v[i] = bf.api.Mul(a[i].Val, 1<<(i*8))
 	}
@@ -210,8 +210,8 @@ func (bf *BinaryField[T]) PackLSB(a ...U8) T {
 }
 
 func (bf *BinaryField[T]) UnpackMSB(a T) []U8 {
-	ret := make([]U8, len(a))
-	for i := 0; i < len(a); i++ {
+	ret := make([]U8, bf.lenBts())
+	for i := 0; i < len(ret); i++ {
 		ret[len(a)-i-1] = a[i]
 	}
 	return ret
@@ -219,8 +219,8 @@ func (bf *BinaryField[T]) UnpackMSB(a T) []U8 {
 
 func (bf *BinaryField[T]) UnpackLSB(a T) []U8 {
 	// cannot deduce that a can be cast to []U8
-	ret := make([]U8, len(a))
-	for i := 0; i < len(a); i++ {
+	ret := make([]U8, bf.lenBts())
+	for i := 0; i < len(ret); i++ {
 		ret[i] = a[i]
 	}
 	return ret
@@ -274,7 +274,7 @@ func (bf *BinaryField[T]) Add(a ...T) T {
 }
 
 func (bf *BinaryField[T]) Lrot(a T, c int) T {
-	l := len(a)
+	l := bf.lenBts()
 	if c < 0 {
 		c = l*8 + c
 	}
@@ -301,23 +301,24 @@ func (bf *BinaryField[T]) Lrot(a T, c int) T {
 }
 
 func (bf *BinaryField[T]) Rshift(a T, c int) T {
+	lenB := bf.lenBts()
 	shiftBl := c / 8
 	shiftBt := c % 8
-	partitioned := make([][2]frontend.Variable, len(a)-shiftBl)
+	partitioned := make([][2]frontend.Variable, lenB-shiftBl)
 	for i := range partitioned {
 		lower, upper := bitslice.Partition(bf.api, a[i+shiftBl].Val, uint(shiftBt), bitslice.WithNbDigits(8))
 		partitioned[i] = [2]frontend.Variable{lower, upper}
 	}
 	var ret T
-	for i := 0; i < len(a)-shiftBl-1; i++ {
+	for i := 0; i < bf.lenBts()-shiftBl-1; i++ {
 		if shiftBt != 0 {
 			ret[i].Val = bf.api.Add(partitioned[i][1], bf.api.Mul(1<<(8-shiftBt), partitioned[i+1][0]))
 		} else {
 			ret[i].Val = partitioned[i][1]
 		}
 	}
-	ret[len(a)-shiftBl-1].Val = partitioned[len(a)-shiftBl-1][1]
-	for i := len(a) - shiftBl; i < len(ret); i++ {
+	ret[lenB-shiftBl-1].Val = partitioned[lenB-shiftBl-1][1]
+	for i := lenB - shiftBl; i < lenB; i++ {
 		ret[i] = NewU8(0)
 	}
 	return ret
@@ -328,7 +329,7 @@ func (bf *BinaryField[T]) ByteAssertEq(a, b U8) {
 }
 
 func (bf *BinaryField[T]) AssertEq(a, b T) {
-	for i := 0; i < len(a); i++ {
+	for i := 0; i < bf.lenBts(); i++ {
 		bf.ByteAssertEq(a[i], b[i])
 	}
 }

--- a/std/math/uints/uint8_test.go
+++ b/std/math/uints/uint8_test.go
@@ -105,3 +105,24 @@ func TestValueOf(t *testing.T) {
 	err = test.IsSolved(&valueOfCircuit[U32]{}, &valueOfCircuit[U32]{In: 0x1234567812345678, Expected: [4]U8{NewU8(0x78), NewU8(0x56), NewU8(0x34), NewU8(0x12)}}, ecc.BN254.ScalarField())
 	assert.Error(err)
 }
+
+type addCircuit struct {
+	In       [2]U32
+	Expected U32
+}
+
+func (c *addCircuit) Define(api frontend.API) error {
+	uapi, err := New[U32](api)
+	if err != nil {
+		return err
+	}
+	res := uapi.Add(c.In[0], c.In[1])
+	uapi.AssertEq(res, c.Expected)
+	return nil
+}
+
+func TestAdd(t *testing.T) {
+	assert := test.NewAssert(t)
+	err := test.IsSolved(&addCircuit{}, &addCircuit{In: [2]U32{NewU32(^uint32(0)), NewU32(2)}, Expected: NewU32(1)}, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}

--- a/std/math/uints/uint8_test.go
+++ b/std/math/uints/uint8_test.go
@@ -79,3 +79,29 @@ func TestRshift(t *testing.T) {
 	err = test.IsSolved(&rshiftCircuit{Shift: 11}, &rshiftCircuit{Shift: 11, In: NewU32(0x12345678), Expected: NewU32(0x12345678 >> 11)}, ecc.BN254.ScalarField())
 	assert.NoError(err)
 }
+
+type valueOfCircuit[T U32 | U64] struct {
+	In       frontend.Variable
+	Expected T
+}
+
+func (c *valueOfCircuit[T]) Define(api frontend.API) error {
+	uapi, err := New[T](api)
+	if err != nil {
+		return err
+	}
+	res := uapi.ValueOf(c.In)
+	uapi.AssertEq(res, c.Expected)
+	return nil
+}
+
+func TestValueOf(t *testing.T) {
+	assert := test.NewAssert(t)
+	var err error
+	err = test.IsSolved(&valueOfCircuit[U64]{}, &valueOfCircuit[U64]{In: 0x12345678, Expected: [8]U8{NewU8(0x78), NewU8(0x56), NewU8(0x34), NewU8(0x12), NewU8(0), NewU8(0), NewU8(0), NewU8(0)}}, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	err = test.IsSolved(&valueOfCircuit[U32]{}, &valueOfCircuit[U32]{In: 0x12345678, Expected: [4]U8{NewU8(0x78), NewU8(0x56), NewU8(0x34), NewU8(0x12)}}, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	err = test.IsSolved(&valueOfCircuit[U32]{}, &valueOfCircuit[U32]{In: 0x1234567812345678, Expected: [4]U8{NewU8(0x78), NewU8(0x56), NewU8(0x34), NewU8(0x12)}}, ecc.BN254.ScalarField())
+	assert.Error(err)
+}

--- a/std/math/uints/uint8_test.go
+++ b/std/math/uints/uint8_test.go
@@ -80,7 +80,7 @@ func TestRshift(t *testing.T) {
 	assert.NoError(err)
 }
 
-type valueOfCircuit[T U32 | U64] struct {
+type valueOfCircuit[T Long] struct {
 	In       frontend.Variable
 	Expected T
 }


### PR DESCRIPTION
# Description

As stated in the TODO, `uints8.ValueOf` is not constrained. This commit constrains the output of ValueOf. 

I am jumping in on the deep end with circuit development, so would appreciate as much feedback as possible. Especially would appreciate guidance on testing constraints for intermediate values, the overflow was the only technique I could think of that works in a unit test.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?

Added a unit test that if added to the current master branch will fail. The third test case should return an error as the input exceeds the output size.

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

