### PR TITLE
fix(math/bitslice): fix partition upper part range check width

### DIFF
--- a/std/math/bitslice/opts.go
+++ b/std/math/bitslice/opts.go
@@ -17,8 +17,14 @@ func parseOpts(opts ...Option) (*opt, error) {
 	return o, nil
 }
 
+// Option allows to customize the behavior of functions in this package. See
+// [WithNbDigits] and [WithUnconstrainedOutputs] for examples.
 type Option func(*opt) error
 
+// WithNbDigits sets the bound on the number of digits the input can have. If
+// this is not set, then we use standard binary decomposition of the input. If
+// it is set and it is less than the width of the native field, then we use
+// lookup table based method for bounding the inputs which is more efficient.
 func WithNbDigits(nbDigits int) Option {
 	return func(o *opt) error {
 		if nbDigits < 1 {
@@ -29,6 +35,8 @@ func WithNbDigits(nbDigits int) Option {
 	}
 }
 
+// WithUnconstrainedOutputs allows to skip the output decomposition and outputs
+// width checks. Can be used when these are performed by the caller.
 func WithUnconstrainedOutputs() Option {
 	return func(o *opt) error {
 		o.nocheck = true

--- a/std/math/bitslice/partition.go
+++ b/std/math/bitslice/partition.go
@@ -1,3 +1,4 @@
+// Package bitslice allows partitioning variables.
 package bitslice
 
 import (

--- a/std/math/bitslice/partition.go
+++ b/std/math/bitslice/partition.go
@@ -58,7 +58,7 @@ func Partition(api frontend.API, v frontend.Variable, split uint, opts ...Option
 	if opt.digits > 0 {
 		upperBound = opt.digits
 	}
-	rh.Check(upper, upperBound)
+	rh.Check(upper, upperBound-int(split))
 	rh.Check(lower, int(split))
 
 	m := big.NewInt(1)


### PR DESCRIPTION
# Description

Fixes #1153.

Also handle separately case when `nbDigits >= Fr width` as we need to check that we do not overflow and use unique decomposition. There isn't a better way beyond doing bit-by-by comparison against the modulus, so this case is deferred to `math/bits` package.

Added some package documentation.

Shouldn't affect current usage of the implementation as we call everywhere with `nbDigits` small.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestIssue1153

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

