### PR TITLE
fix: use emulated arithmetic for GLV decomp

### DIFF
--- a/std/algebra/native/sw_bls24315/g1.go
+++ b/std/algebra/native/sw_bls24315/g1.go
@@ -188,7 +188,7 @@ func (P *G1Affine) varScalarMul(api frontend.API, Q G1Affine, s frontend.Variabl
 	// curve.
 	cc := getInnerCurveConfig(api.Compiler().Field())
 
-	s1, s2 := callDecomposeScalarG1Simple(api, s)
+	s1, s2 := callDecomposeScalar(api, s, true)
 
 	nbits := 127
 	s1bits := api.ToBinary(s1, nbits)
@@ -437,24 +437,8 @@ func (P *G1Affine) jointScalarMul(api frontend.API, Q, R G1Affine, s, t frontend
 // P = [s]Q + [t]R using Shamir's trick
 func (P *G1Affine) jointScalarMulUnsafe(api frontend.API, Q, R G1Affine, s, t frontend.Variable) *G1Affine {
 	cc := getInnerCurveConfig(api.Compiler().Field())
-
-	sd, err := api.Compiler().NewHint(decomposeScalarG1, 3, s)
-	if err != nil {
-		// err is non-nil only for invalid number of inputs
-		panic(err)
-	}
-	s1, s2 := sd[0], sd[1]
-
-	td, err := api.Compiler().NewHint(decomposeScalarG1, 3, t)
-	if err != nil {
-		// err is non-nil only for invalid number of inputs
-		panic(err)
-	}
-	t1, t2 := td[0], td[1]
-
-	api.AssertIsEqual(api.Add(s1, api.Mul(s2, cc.lambda)), api.Add(s, api.Mul(cc.fr, sd[2])))
-	api.AssertIsEqual(api.Add(t1, api.Mul(t2, cc.lambda)), api.Add(t, api.Mul(cc.fr, td[2])))
-
+	s1, s2 := callDecomposeScalar(api, s, false)
+	t1, t2 := callDecomposeScalar(api, t, false)
 	nbits := cc.lambda.BitLen() + 1
 
 	s1bits := api.ToBinary(s1, nbits)

--- a/std/algebra/native/sw_bls24315/g1.go
+++ b/std/algebra/native/sw_bls24315/g1.go
@@ -188,21 +188,7 @@ func (P *G1Affine) varScalarMul(api frontend.API, Q G1Affine, s frontend.Variabl
 	// curve.
 	cc := getInnerCurveConfig(api.Compiler().Field())
 
-	// the hints allow to decompose the scalar s into s1 and s2 such that
-	//     s1 + λ * s2 == s mod r,
-	// where λ is third root of one in 𝔽_r.
-	sd, err := api.Compiler().NewHint(decomposeScalarG1Simple, 3, s)
-	if err != nil {
-		// err is non-nil only for invalid number of inputs
-		panic(err)
-	}
-	s1, s2 := sd[0], sd[1]
-
-	// s1 + λ * s2 == s mod r
-	api.AssertIsEqual(
-		api.Add(s1, api.Mul(s2, cc.lambda)),
-		api.Add(s, api.Mul(cc.fr, sd[2])),
-	)
+	s1, s2 := callDecomposeScalarG1Simple(api, s)
 
 	nbits := 127
 	s1bits := api.ToBinary(s1, nbits)

--- a/std/algebra/native/sw_bls24315/g2.go
+++ b/std/algebra/native/sw_bls24315/g2.go
@@ -201,21 +201,7 @@ func (P *g2AffP) varScalarMul(api frontend.API, Q g2AffP, s frontend.Variable, o
 	// curve.
 	cc := getInnerCurveConfig(api.Compiler().Field())
 
-	// the hints allow to decompose the scalar s into s1 and s2 such that
-	//     s1 + λ * s2 == s mod r,
-	// where λ is third root of one in 𝔽_r.
-	sd, err := api.Compiler().NewHint(decomposeScalarG1Simple, 3, s)
-	if err != nil {
-		// err is non-nil only for invalid number of inputs
-		panic(err)
-	}
-	s1, s2 := sd[0], sd[1]
-
-	// s1 + λ * s2 == s mod r,
-	api.AssertIsEqual(
-		api.Add(s1, api.Mul(s2, cc.lambda)),
-		api.Add(s, api.Mul(cc.fr, sd[2])),
-	)
+	s1, s2 := callDecomposeScalarG1Simple(api, s)
 
 	nbits := 127
 	s1bits := api.ToBinary(s1, nbits)

--- a/std/algebra/native/sw_bls24315/g2.go
+++ b/std/algebra/native/sw_bls24315/g2.go
@@ -201,7 +201,7 @@ func (P *g2AffP) varScalarMul(api frontend.API, Q g2AffP, s frontend.Variable, o
 	// curve.
 	cc := getInnerCurveConfig(api.Compiler().Field())
 
-	s1, s2 := callDecomposeScalarG1Simple(api, s)
+	s1, s2 := callDecomposeScalar(api, s, true)
 
 	nbits := 127
 	s1bits := api.ToBinary(s1, nbits)

--- a/std/algebra/native/sw_bls24315/hints.go
+++ b/std/algebra/native/sw_bls24315/hints.go
@@ -6,13 +6,18 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/std/math/emulated/emparams"
 )
 
 func GetHints() []solver.Hint {
 	return []solver.Hint{
 		decomposeScalarG1,
-		decomposeScalarG1Simple,
 		decomposeScalarG2,
+
+		decomposeScalarG1SimpleEmulated,
+		decompose,
 	}
 }
 
@@ -20,22 +25,74 @@ func init() {
 	solver.RegisterHint(GetHints()...)
 }
 
-func decomposeScalarG1Simple(scalarField *big.Int, inputs []*big.Int, outputs []*big.Int) error {
-	if len(inputs) != 1 {
-		return fmt.Errorf("expecting one input")
-	}
-	if len(outputs) != 3 {
-		return fmt.Errorf("expecting three outputs")
-	}
-	cc := getInnerCurveConfig(scalarField)
-	sp := ecc.SplitScalar(inputs[0], cc.glvBasis)
-	outputs[0].Set(&(sp[0]))
-	outputs[1].Set(&(sp[1]))
-	// figure out how many times we have overflowed
-	outputs[2].Mul(outputs[1], cc.lambda).Add(outputs[2], outputs[0])
-	outputs[2].Sub(outputs[2], inputs[0])
-	outputs[2].Div(outputs[2], cc.fr)
+func decomposeScalarG1SimpleEmulated(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int) error {
+	return emulated.UnwrapHintWithNativeInput(nativeInputs, nativeOutputs, func(nnMod *big.Int, nninputs, nnOutputs []*big.Int) error {
+		if len(nninputs) != 1 {
+			return fmt.Errorf("expecting one input")
+		}
+		if len(nnOutputs) != 2 {
+			return fmt.Errorf("expecting three outputs")
+		}
+		cc := getInnerCurveConfig(nativeMod)
+		sp := ecc.SplitScalar(nninputs[0], cc.glvBasis)
+		nnOutputs[0].Set(&(sp[0]))
+		nnOutputs[1].Set(&(sp[1]))
 
+		return nil
+	})
+}
+
+func callDecomposeScalarG1Simple(api frontend.API, s frontend.Variable) (s1, s2 frontend.Variable) {
+	cc := getInnerCurveConfig(api.Compiler().Field())
+	sapi, err := emulated.NewField[emparams.BLS24315Fr](api)
+	if err != nil {
+		panic(err)
+	}
+	// compute the decomposition using a hint. We have to use the emulated
+	// version which takes native input and outputs non-native outputs.
+	//
+	// the hints allow to decompose the scalar s into s1 and s2 such that
+	//     s1 + λ * s2 == s mod r,
+	// where λ is third root of one in 𝔽_r.
+	sd, err := sapi.NewHintWithNativeInput(decomposeScalarG1SimpleEmulated, 2, s)
+	if err != nil {
+		panic(err)
+	}
+	// lambda as nonnative element
+	lambdaEmu := sapi.NewElement(cc.lambda)
+	// the scalar as nonnative element. We need to split at 64 bits.
+	limbs, err := api.NewHint(decompose, 4, s)
+	if err != nil {
+		panic(err)
+	}
+	semu := sapi.NewElement(limbs)
+	// s1 + λ * s2 == s mod r
+	lhs := sapi.Mul(sd[1], lambdaEmu)
+	lhs = sapi.Add(lhs, sd[0])
+
+	sapi.AssertIsEqual(lhs, semu)
+
+	s1 = 0
+	s2 = 0
+	b := big.NewInt(1)
+	for i := range sd[0].Limbs {
+		s1 = api.Add(s1, api.Mul(sd[0].Limbs[i], b))
+		s2 = api.Add(s2, api.Mul(sd[1].Limbs[i], b))
+		b.Lsh(b, 64)
+	}
+	return s1, s2
+}
+
+func decompose(mod *big.Int, inputs, outputs []*big.Int) error {
+	if len(inputs) != 1 && len(outputs) != 4 {
+		return fmt.Errorf("input/output length mismatch")
+	}
+	tmp := new(big.Int).Set(inputs[0])
+	mask := new(big.Int).SetUint64(^uint64(0))
+	for i := 0; i < 4; i++ {
+		outputs[i].And(tmp, mask)
+		tmp.Rsh(tmp, 64)
+	}
 	return nil
 }
 

--- a/std/algebra/native/sw_bls24315/pairing2.go
+++ b/std/algebra/native/sw_bls24315/pairing2.go
@@ -174,16 +174,7 @@ func (c *Curve) MultiScalarMul(P []*G1Affine, scalars []*Scalar, opts ...algopts
 		}
 		gamma := c.packScalarToVar(scalars[0])
 		// decompose gamma in the endomorphism eigenvalue basis and bit-decompose the sub-scalars
-		cc := getInnerCurveConfig(c.api.Compiler().Field())
-		sd, err := c.api.Compiler().NewHint(decomposeScalarG1Simple, 3, gamma)
-		if err != nil {
-			panic(err)
-		}
-		gamma1, gamma2 := sd[0], sd[1]
-		c.api.AssertIsEqual(
-			c.api.Add(gamma1, c.api.Mul(gamma2, cc.lambda)),
-			c.api.Add(gamma, c.api.Mul(cc.fr, sd[2])),
-		)
+		gamma1, gamma2 := callDecomposeScalarG1Simple(c.api, gamma)
 		nbits := 127
 		gamma1Bits := c.api.ToBinary(gamma1, nbits)
 		gamma2Bits := c.api.ToBinary(gamma2, nbits)

--- a/std/algebra/native/sw_bls24315/pairing2.go
+++ b/std/algebra/native/sw_bls24315/pairing2.go
@@ -174,7 +174,7 @@ func (c *Curve) MultiScalarMul(P []*G1Affine, scalars []*Scalar, opts ...algopts
 		}
 		gamma := c.packScalarToVar(scalars[0])
 		// decompose gamma in the endomorphism eigenvalue basis and bit-decompose the sub-scalars
-		gamma1, gamma2 := callDecomposeScalarG1Simple(c.api, gamma)
+		gamma1, gamma2 := callDecomposeScalar(c.api, gamma, true)
 		nbits := 127
 		gamma1Bits := c.api.ToBinary(gamma1, nbits)
 		gamma2Bits := c.api.ToBinary(gamma2, nbits)


### PR DESCRIPTION
# Description

We use GLV for scalar multiplication in 2-chains (BLS12-377 and BLS24-315). For the decomposition of scalar to be valid we have to check that `s1 + λ s2 = s` where `s` is the initial scalar and `s1`, `s2` are the decomposed values (width length 127 bits).

For BLS12-377 we can perform this check using native arithmetic as we constrain s1, s2, λ to all be 127 bits and we never overflow the outer curve scalar field (width 377 bits).

However, for BLS24-315 we have `λ` with `256` bits and in this case the check `s1 + λ s2 = s` may overflow the native field. We compensate for it by giving additional output from the hint which cancels out the overflowed value, but this gives the malicious prover some advantage for finding invalid inputs.

Safer approach would be to perform the arithmetic using non-native arithmetic, which this PR introduces.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Existing tests work.

# How has this been benchmarked?

- PLONK in PLONK before 454514 now 468122
- scalar multiplication in PLONK before 3588 now 4927 (VarScalarMul)
- scalar multiplication in R1CS before 1412 now 1721 (VarScalarMul)
- scalarmul edge cases (complete arithm) in R1CS before 2532 now 3079
- scalarmul edge cases (complete arithm) in PLONK before 6546 now 8959
- base mul R1CS before 1028 now 1337
- base mul PLONK before 2818 now 4157
- joint scalar mul in R1CS before 5100 now 5647
- joint scalar mul in PLONK before 12239 now 14651
- joint scalar mul edge cases in R1CS before 7628 now 8926
- joint scalar mul edge cases in PLONK before 19687 now 25293

No impact on pairing/ML/FE.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

