### PR TITLE
fix: fix OR computation in case one input is constant and other variable

### DIFF
--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -351,9 +351,6 @@ func (builder *builder) Or(a, b frontend.Variable) frontend.Variable {
 		return 0
 	}
 
-	res := builder.newInternalVariable()
-	builder.MarkBoolean(res)
-
 	// if one input is constant, ensure we put it in b
 	if aConstant {
 		a, b = b, a
@@ -362,20 +359,14 @@ func (builder *builder) Or(a, b frontend.Variable) frontend.Variable {
 	}
 
 	if bConstant {
-		xa := a.(expr.Term)
-		// b = b - 1
-		qL := _b
-		qL = builder.cs.Sub(qL, builder.tOne)
-		qL = builder.cs.Mul(qL, xa.Coeff)
-		// a * (b-1) + res == 0
-		builder.addPlonkConstraint(sparseR1C{
-			xa: xa.VID,
-			xc: res.VID,
-			qL: qL,
-			qO: builder.tOne,
-		})
-		return res
+		if builder.cs.IsOne(_b) {
+			return 1
+		} else {
+			return a
+		}
 	}
+	res := builder.newInternalVariable()
+	builder.MarkBoolean(res)
 	xa := a.(expr.Term)
 	xb := b.(expr.Term)
 	// -a - b + ab + res == 0


### PR DESCRIPTION
# Description

See the added regression tests. If we had
```go
api.Or(x, 1)
```
then the result was incorrectly computed for both `x=0` and `x=1`. This was because we used `a*(1-b)` for computation not `a+b-ab` for OR. Furthermore, if we know that one input is constant then we do not have to add constraints as the result is always constant `1` if constant input is `1` and `x` if constant input is `0`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestRegressionOr

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

