### PR TITLE
Make ExpMod work with parametric fields parameters

### DIFF
--- a/std/evmprecompiles/05-expmod.go
+++ b/std/evmprecompiles/05-expmod.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/math/emulated"
-	"github.com/consensys/gnark/std/math/emulated/emparams"
 )
 
 // Expmod implements [MODEXP] precompile contract at address 0x05.
@@ -15,10 +14,10 @@ import (
 // the actual length of the inputs.
 //
 // [MODEXP]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/expmod/index.html
-func Expmod(api frontend.API, base, exp, modulus *emulated.Element[emparams.Mod1e4096]) *emulated.Element[emparams.Mod1e4096] {
+func Expmod[P emulated.FieldParams](api frontend.API, base, exp, modulus *emulated.Element[P]) *emulated.Element[P] {
 	// x^0 = 1
 	// x mod 0 = 0
-	f, err := emulated.NewField[emparams.Mod1e4096](api)
+	f, err := emulated.NewField[P](api)
 	if err != nil {
 		panic(fmt.Sprintf("new field: %v", err))
 	}

--- a/std/math/emulated/emparams/emparams.go
+++ b/std/math/emulated/emparams/emparams.go
@@ -319,3 +319,22 @@ func (Mod1e512) Modulus() *big.Int {
 	val, _ := new(big.Int).SetString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
 	return val
 }
+
+// Mod1e256 provides type parametrization for emulated aritmetic:
+//   - limbs: 4
+//   - limb width: 64 bits
+//
+// The modulus for type parametrisation is 2^256-1.
+//
+// This is non-prime modulus. It is mainly targeted for using variable-modulus
+// operations (ModAdd, ModMul, ModExp, ModAssertIsEqual) for variable modulus
+// arithmetic.
+type Mod1e256 struct{}
+
+func (Mod1e256) NbLimbs() uint     { return 4 }
+func (Mod1e256) BitsPerLimb() uint { return 64 }
+func (Mod1e256) IsPrime() bool     { return false }
+func (Mod1e256) Modulus() *big.Int {
+	val, _ := new(big.Int).SetString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+	return val
+}


### PR DESCRIPTION
# Description

The PR allows the caller of ExpMod to specify which field parameter to use for the circuit generation as the current implemenentation fixes a size of 4096.

The PR also adds the 256 bit variant of Mod1e512

This is required for the integration in the prover. 

The changes did not break existing calling code.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

No test have been added specifically for the changes

# How has this been benchmarked?

No benchmark have been done.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

