### PR TITLE
fix: groth16 solidity templates

### DIFF
--- a/backend/groth16/bls12-377/verify.go
+++ b/backend/groth16/bls12-377/verify.go
@@ -19,7 +19,6 @@ package groth16
 import (
 	"errors"
 	"fmt"
-	"github.com/consensys/gnark/backend/solidity"
 	"io"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/logger"
 )

--- a/backend/groth16/bls12-381/verify.go
+++ b/backend/groth16/bls12-381/verify.go
@@ -19,7 +19,6 @@ package groth16
 import (
 	"errors"
 	"fmt"
-	"github.com/consensys/gnark/backend/solidity"
 	"io"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/logger"
 )

--- a/backend/groth16/bls24-315/verify.go
+++ b/backend/groth16/bls24-315/verify.go
@@ -19,7 +19,6 @@ package groth16
 import (
 	"errors"
 	"fmt"
-	"github.com/consensys/gnark/backend/solidity"
 	"io"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-315/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/logger"
 )

--- a/backend/groth16/bls24-317/verify.go
+++ b/backend/groth16/bls24-317/verify.go
@@ -19,7 +19,6 @@ package groth16
 import (
 	"errors"
 	"fmt"
-	"github.com/consensys/gnark/backend/solidity"
 	"io"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/logger"
 )

--- a/backend/groth16/bn254/solidity.go
+++ b/backend/groth16/bn254/solidity.go
@@ -75,49 +75,49 @@ contract Verifier {
     uint256 constant EXP_SQRT_FP = 0xC19139CB84C680A6E14116DA060561765E05AA45A1C72A34F082305B61F3F52; // (P + 1) / 4;
 
     // Groth16 alpha point in G1
-    uint256 constant ALPHA_X = {{.Vk.G1.Alpha.X.String}};
-    uint256 constant ALPHA_Y = {{.Vk.G1.Alpha.Y.String}};
+    uint256 constant ALPHA_X = {{ (fpstr .Vk.G1.Alpha.X) }};
+    uint256 constant ALPHA_Y = {{ (fpstr .Vk.G1.Alpha.Y) }};
 
     // Groth16 beta point in G2 in powers of i
-    uint256 constant BETA_NEG_X_0 = {{.Vk.G2.Beta.X.A0.String}};
-    uint256 constant BETA_NEG_X_1 = {{.Vk.G2.Beta.X.A1.String}};
-    uint256 constant BETA_NEG_Y_0 = {{.Vk.G2.Beta.Y.A0.String}};
-    uint256 constant BETA_NEG_Y_1 = {{.Vk.G2.Beta.Y.A1.String}};
+    uint256 constant BETA_NEG_X_0 = {{ (fpstr .Vk.G2.Beta.X.A0) }};
+    uint256 constant BETA_NEG_X_1 = {{ (fpstr .Vk.G2.Beta.X.A1) }};
+    uint256 constant BETA_NEG_Y_0 = {{ (fpstr .Vk.G2.Beta.Y.A0) }};
+    uint256 constant BETA_NEG_Y_1 = {{ (fpstr .Vk.G2.Beta.Y.A1) }};
 
     // Groth16 gamma point in G2 in powers of i
-    uint256 constant GAMMA_NEG_X_0 = {{.Vk.G2.Gamma.X.A0.String}};
-    uint256 constant GAMMA_NEG_X_1 = {{.Vk.G2.Gamma.X.A1.String}};
-    uint256 constant GAMMA_NEG_Y_0 = {{.Vk.G2.Gamma.Y.A0.String}};
-    uint256 constant GAMMA_NEG_Y_1 = {{.Vk.G2.Gamma.Y.A1.String}};
+    uint256 constant GAMMA_NEG_X_0 = {{ (fpstr .Vk.G2.Gamma.X.A0) }};
+    uint256 constant GAMMA_NEG_X_1 = {{ (fpstr .Vk.G2.Gamma.X.A1) }};
+    uint256 constant GAMMA_NEG_Y_0 = {{ (fpstr .Vk.G2.Gamma.Y.A0) }};
+    uint256 constant GAMMA_NEG_Y_1 = {{ (fpstr .Vk.G2.Gamma.Y.A1) }};
 
     // Groth16 delta point in G2 in powers of i
-    uint256 constant DELTA_NEG_X_0 = {{.Vk.G2.Delta.X.A0.String}};
-    uint256 constant DELTA_NEG_X_1 = {{.Vk.G2.Delta.X.A1.String}};
-    uint256 constant DELTA_NEG_Y_0 = {{.Vk.G2.Delta.Y.A0.String}};
-    uint256 constant DELTA_NEG_Y_1 = {{.Vk.G2.Delta.Y.A1.String}};
+    uint256 constant DELTA_NEG_X_0 = {{ (fpstr .Vk.G2.Delta.X.A0) }};
+    uint256 constant DELTA_NEG_X_1 = {{ (fpstr .Vk.G2.Delta.X.A1) }};
+    uint256 constant DELTA_NEG_Y_0 = {{ (fpstr .Vk.G2.Delta.Y.A0) }};
+    uint256 constant DELTA_NEG_Y_1 = {{ (fpstr .Vk.G2.Delta.Y.A1) }};
 
     {{- if gt $numCommitments 0 }}
     // Pedersen G point in G2 in powers of i
-    uint256 constant PEDERSEN_G_X_0 = {{.Vk.CommitmentKey.G.X.A0.String}};
-    uint256 constant PEDERSEN_G_X_1 = {{.Vk.CommitmentKey.G.X.A1.String}};
-    uint256 constant PEDERSEN_G_Y_0 = {{.Vk.CommitmentKey.G.Y.A0.String}};
-    uint256 constant PEDERSEN_G_Y_1 = {{.Vk.CommitmentKey.G.Y.A1.String}};
+    uint256 constant PEDERSEN_G_X_0 = {{ (fpstr .Vk.CommitmentKey.G.X.A0) }};
+    uint256 constant PEDERSEN_G_X_1 = {{ (fpstr .Vk.CommitmentKey.G.X.A1) }};
+    uint256 constant PEDERSEN_G_Y_0 = {{ (fpstr .Vk.CommitmentKey.G.Y.A0) }};
+    uint256 constant PEDERSEN_G_Y_1 = {{ (fpstr .Vk.CommitmentKey.G.Y.A1) }};
 
     // Pedersen GRootSigmaNeg point in G2 in powers of i
-    uint256 constant PEDERSEN_GROOTSIGMANEG_X_0 = {{.Vk.CommitmentKey.GRootSigmaNeg.X.A0.String}};
-    uint256 constant PEDERSEN_GROOTSIGMANEG_X_1 = {{.Vk.CommitmentKey.GRootSigmaNeg.X.A1.String}};
-    uint256 constant PEDERSEN_GROOTSIGMANEG_Y_0 = {{.Vk.CommitmentKey.GRootSigmaNeg.Y.A0.String}};
-    uint256 constant PEDERSEN_GROOTSIGMANEG_Y_1 = {{.Vk.CommitmentKey.GRootSigmaNeg.Y.A1.String}};
+    uint256 constant PEDERSEN_GROOTSIGMANEG_X_0 = {{ (fpstr .Vk.CommitmentKey.GRootSigmaNeg.X.A0) }};
+    uint256 constant PEDERSEN_GROOTSIGMANEG_X_1 = {{ (fpstr .Vk.CommitmentKey.GRootSigmaNeg.X.A1) }};
+    uint256 constant PEDERSEN_GROOTSIGMANEG_Y_0 = {{ (fpstr .Vk.CommitmentKey.GRootSigmaNeg.Y.A0) }};
+    uint256 constant PEDERSEN_GROOTSIGMANEG_Y_1 = {{ (fpstr .Vk.CommitmentKey.GRootSigmaNeg.Y.A1) }};
     {{- end }}
 
     // Constant and public input points
     {{- $k0 := index .Vk.G1.K 0}}
-    uint256 constant CONSTANT_X = {{$k0.X.String}};
-    uint256 constant CONSTANT_Y = {{$k0.Y.String}};
+    uint256 constant CONSTANT_X = {{ (fpstr $k0.X) }};
+    uint256 constant CONSTANT_Y = {{ (fpstr $k0.Y) }};
     {{- range $i, $ki := .Vk.G1.K }}
         {{- if gt $i 0 }}
-    uint256 constant PUB_{{sub $i 1}}_X = {{$ki.X.String}};
-    uint256 constant PUB_{{sub $i 1}}_Y = {{$ki.Y.String}};
+    uint256 constant PUB_{{sub $i 1}}_X = {{ (fpstr $ki.X) }};
+    uint256 constant PUB_{{sub $i 1}}_Y = {{ (fpstr $ki.Y) }};
         {{- end }}
     {{- end }}
 

--- a/backend/groth16/bn254/verify.go
+++ b/backend/groth16/bn254/verify.go
@@ -19,8 +19,9 @@ package groth16
 import (
 	"errors"
 	"fmt"
-	"github.com/consensys/gnark/backend/solidity"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
 	"io"
+	"math/big"
 	"text/template"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/logger"
 )
@@ -162,6 +164,11 @@ func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.Expor
 				out[i] = i
 			}
 			return out
+		},
+		"fpstr": func(x fp.Element) string {
+			bv := new(big.Int)
+			x.BigInt(bv)
+			return bv.String()
 		},
 	}
 

--- a/backend/groth16/bw6-633/verify.go
+++ b/backend/groth16/bw6-633/verify.go
@@ -19,7 +19,6 @@ package groth16
 import (
 	"errors"
 	"fmt"
-	"github.com/consensys/gnark/backend/solidity"
 	"io"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/logger"
 )

--- a/backend/groth16/bw6-761/verify.go
+++ b/backend/groth16/bw6-761/verify.go
@@ -19,7 +19,6 @@ package groth16
 import (
 	"errors"
 	"fmt"
-	"github.com/consensys/gnark/backend/solidity"
 	"io"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/logger"
 )

--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -94,6 +94,10 @@ type ProvingKey interface {
 type VerifyingKey interface {
 	groth16Object
 	gnarkio.UnsafeReaderFrom
+	// VerifyingKey are the methods required for generating the Solidity
+	// verifier contract from the VerifyingKey. This will return an error if not
+	// supported on the CurveID().
+	solidity.VerifyingKey
 
 	// NbPublicWitness returns number of elements expected in the public witness
 	NbPublicWitness() int

--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -108,10 +108,6 @@ type VerifyingKey interface {
 	// NbG2 returns the number of G2 elements in the VerifyingKey
 	NbG2() int
 
-	// ExportSolidity writes a solidity Verifier contract from the VerifyingKey
-	// this will return an error if not supported on the CurveID()
-	ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error
-
 	IsDifferent(interface{}) bool
 }
 

--- a/backend/plonk/plonk.go
+++ b/backend/plonk/plonk.go
@@ -92,8 +92,10 @@ type VerifyingKey interface {
 	io.ReaderFrom
 	gnarkio.WriterRawTo
 	gnarkio.UnsafeReaderFrom
-	NbPublicWitness() int // number of elements expected in the public witness
-	ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error
+	// VerifyingKey are the methods required for generating the Solidity
+	// verifier contract from the VerifyingKey. This will return an error if not
+	// supported on the CurveID().
+	solidity.VerifyingKey
 }
 
 // Setup prepares the public data associated to a circuit + public inputs.

--- a/backend/solidity/solidity.go
+++ b/backend/solidity/solidity.go
@@ -24,7 +24,7 @@ func NewExportConfig(opts ...ExportOption) (ExportConfig, error) {
 	return config, nil
 }
 
-// WithPragmaVersion changes the pragma version used in the solidit verifier.
+// WithPragmaVersion changes the pragma version used in the solidity verifier.
 func WithPragmaVersion(version string) ExportOption {
 	return func(cfg *ExportConfig) error {
 		cfg.PragmaVersion = version

--- a/backend/solidity/verifyingkey.go
+++ b/backend/solidity/verifyingkey.go
@@ -1,0 +1,9 @@
+package solidity
+
+import "io"
+
+// VerifyingKey is the interface for verifying keys in the Solidity backend.
+type VerifyingKey interface {
+	NbPublicWitness() int
+	ExportSolidity(io.Writer, ...ExportOption) error
+}

--- a/internal/generator/backend/template/imports.go.tmpl
+++ b/internal/generator/backend/template/imports.go.tmpl
@@ -6,6 +6,15 @@
 	{{- end}}
 {{- end }}
 
+{{- define "import_fp" }}
+	{{- if eq .Curve "tinyfield"}}
+	fr "github.com/consensys/gnark/internal/tinyfield"
+	{{- else}}
+	"github.com/consensys/gnark-crypto/ecc/{{toLower .Curve}}/fp"
+	{{- end}}
+{{- end }}
+
+
 {{- define "import_fri" }}
 	"github.com/consensys/gnark-crypto/ecc/{{toLower .Curve}}/fr/fri"
 {{- end}}

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.verify.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.verify.go.tmpl
@@ -2,9 +2,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"github.com/consensys/gnark/backend/solidity"
 	{{- if eq .Curve "BN254"}}
+	"math/big"
 	"text/template"
+	{{- template "import_fp" . }}
 	{{- end}}
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	{{- template "import_hash_to_field" . }}
 	"github.com/consensys/gnark-crypto/utils"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/logger"
 )
@@ -148,6 +150,11 @@ func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.Expor
 				out[i] = i
 			}
 			return out
+		},
+		"fpstr": func(x fp.Element) string {
+			bv := new(big.Int)
+			x.BigInt(bv)
+			return bv.String()
 		},
 	}
 

--- a/test/assert_checkcircuit.go
+++ b/test/assert_checkcircuit.go
@@ -7,6 +7,7 @@ import (
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/backend/plonk"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/backend/witness"
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/frontend"
@@ -139,7 +140,7 @@ func (assert *Assert) CheckCircuit(circuit frontend.Circuit, opts ...TestingOpti
 
 							if checkSolidity {
 								// check that the proof can be verified by gnark-solidity-checker
-								if _vk, ok := vk.(verifyingKey); ok {
+								if _vk, ok := vk.(solidity.VerifyingKey); ok {
 									assert.Run(func(assert *Assert) {
 										assert.solidityVerification(b, _vk, proof, w.public)
 									}, "solidity")

--- a/test/assert_checkcircuit.go
+++ b/test/assert_checkcircuit.go
@@ -142,7 +142,7 @@ func (assert *Assert) CheckCircuit(circuit frontend.Circuit, opts ...TestingOpti
 								// check that the proof can be verified by gnark-solidity-checker
 								if _vk, ok := vk.(solidity.VerifyingKey); ok {
 									assert.Run(func(assert *Assert) {
-										assert.solidityVerification(b, _vk, proof, w.public)
+										assert.solidityVerification(b, _vk, proof, w.public, opt.solidityOpts)
 									}, "solidity")
 								}
 							}

--- a/test/assert_options.go
+++ b/test/assert_options.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
 )
@@ -20,6 +21,7 @@ type testingConfig struct {
 	proverOpts   []backend.ProverOption
 	verifierOpts []backend.VerifierOption
 	compileOpts  []frontend.CompileOption
+	solidityOpts []solidity.ExportOption
 
 	validAssignments   []frontend.Circuit
 	invalidAssignments []frontend.Circuit
@@ -173,6 +175,15 @@ func WithCompileOpts(compileOpts ...frontend.CompileOption) TestingOption {
 func WithVerifierOpts(verifierOpts ...backend.VerifierOption) TestingOption {
 	return func(tc *testingConfig) error {
 		tc.verifierOpts = append(tc.verifierOpts, verifierOpts...)
+		return nil
+	}
+}
+
+// WithSolidityExportOptions is a testing option which uses the given solidityOpts when
+// calling ExportSolidity method on the verification key.
+func WithSolidityExportOptions(solidityOpts ...solidity.ExportOption) TestingOption {
+	return func(tc *testingConfig) error {
+		tc.solidityOpts = solidityOpts
 		return nil
 	}
 }

--- a/test/assert_solidity.go
+++ b/test/assert_solidity.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"encoding/hex"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,18 +9,14 @@ import (
 
 	fr_bn254 "github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/backend/solidity"
 	"github.com/consensys/gnark/backend/witness"
 )
-
-type verifyingKey interface {
-	NbPublicWitness() int
-	ExportSolidity(io.Writer) error
-}
 
 // solidityVerification checks that the exported solidity contract can verify the proof
 // and that the proof is valid.
 // It uses gnark-solidity-checker see test.WithSolidity option.
-func (assert *Assert) solidityVerification(b backend.ID, vk verifyingKey,
+func (assert *Assert) solidityVerification(b backend.ID, vk solidity.VerifyingKey,
 	proof any,
 	validPublicWitness witness.Witness) {
 	if !SolcCheck || len(validPublicWitness.Vector().(fr_bn254.Vector)) == 0 {


### PR DESCRIPTION
# Description

PR https://github.com/Consensys/gnark/pull/1138 changed the implementation of `VerifyingKey.ExportSolidity` and due to that the CI tests for Solidity started to fail.

This PR resolves the interface definition

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

(ran full test suite locally to ensure Solidity verifier is run)



# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

