### PR TITLE
Fix: Build on 32-bit arch would raise int overflow

### DIFF
--- a/std/rangecheck/rangecheck_commit.go
+++ b/std/rangecheck/rangecheck_commit.go
@@ -154,10 +154,10 @@ func (c *commitChecker) getOptimalBasewidth(api frontend.API) int {
 }
 
 func optimalWidth(countFn func(baseLength int, collected []checkedVariable) int, collected []checkedVariable) int {
-	min := math.MaxInt64
+	min := int64(math.MaxInt64)
 	minVal := 0
 	for j := 2; j < 18; j++ {
-		current := countFn(j, collected)
+		current := int64(countFn(j, collected))
 		if current < min {
 			min = current
 			minVal = j


### PR DESCRIPTION
# Description

Fixes https://github.com/Consensys/gnark/issues/1192

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- [x] Test on Ubuntu 22.04
```
GOOS=linux GOARCH=arm go build
GOOS=linux GOARCH=386 go build
```
- [x] Test on MacBook M1 Pro. 
  - Before this PR and after this PR, `go build` always success. 
  - This PR would fix gomobile Android binding https://github.com/Consensys/gnark/issues/1192#issuecomment-2221872640


Btw, some unit tests would also raise int overflow under 32-bit Arch
```bash
➜  gnark git:(master) GOOS=linux GOARCH=arm /usr/local/go/bin/go test
# github.com/consensys/gnark/internal/backend/circuits [github.com/consensys/gnark.test]
internal/backend/circuits/div.go:17:24: cannot use 2387287246 (untyped int constant) as int value in argument to api.DivUnchecked (overflows)
internal/backend/circuits/inv.go:17:19: cannot use 2387287246 (untyped int constant) as int value in argument to api.Inverse (overflows)
internal/backend/circuits/mul.go:30:11: cannot use 92149106544 (untyped int constant) as int value in assignment (overflows)
internal/backend/circuits/sub.go:14:15: cannot use 23820938283 (untyped int constant) as int value in argument to api.Sub (overflows)
internal/backend/circuits/sub.go:31:11: cannot use 23820938283 (untyped int constant) as int value in assignment (overflows)
internal/backend/circuits/sub.go:32:13: cannot use 23820935805 (untyped int constant) as int value in assignment (overflows)
internal/backend/circuits/sub.go:38:10: cannot use 23820938283 (untyped int constant) as int value in assignment (overflows)
FAIL    github.com/consensys/gnark [build failed]
```

# How has this been benchmarked?

No

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

