### PR TITLE
feat: use blake2 for variable hashcode

### DIFF
--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -58,7 +58,7 @@ type builder struct {
 	kvstore.Store
 
 	// map for recording boolean constrained variables (to not constrain them twice)
-	mtBooleans map[uint64][]expr.LinearExpression
+	mtBooleans map[[16]byte][]expr.LinearExpression
 
 	tOne        constraint.Element
 	eZero, eOne expr.LinearExpression
@@ -82,7 +82,7 @@ func newBuilder(field *big.Int, config frontend.CompileConfig) *builder {
 		macCapacity = config.CompressThreshold
 	}
 	builder := builder{
-		mtBooleans: make(map[uint64][]expr.LinearExpression, config.Capacity/10),
+		mtBooleans: make(map[[16]byte][]expr.LinearExpression, config.Capacity/10),
 		config:     config,
 		heap:       make(minHeap, 0, 100),
 		mbuf1:      make(expr.LinearExpression, 0, macCapacity),

--- a/std/math/emulated/field.go
+++ b/std/math/emulated/field.go
@@ -43,7 +43,7 @@ type Field[T FieldParams] struct {
 
 	log zerolog.Logger
 
-	constrainedLimbs map[uint64]struct{}
+	constrainedLimbs map[[16]byte]struct{}
 	checker          frontend.Rangechecker
 
 	mulChecks []mulCheck[T]
@@ -69,7 +69,7 @@ func NewField[T FieldParams](native frontend.API) (*Field[T], error) {
 	f := &Field[T]{
 		api:              native,
 		log:              logger.Logger(),
-		constrainedLimbs: make(map[uint64]struct{}),
+		constrainedLimbs: make(map[[16]byte]struct{}),
 		checker:          rangecheck.New(native),
 	}
 
@@ -216,7 +216,7 @@ func (f *Field[T]) enforceWidthConditional(a *Element[T]) (didConstrain bool) {
 			}
 			continue
 		}
-		if vv, ok := a.Limbs[i].(interface{ HashCode() uint64 }); ok {
+		if vv, ok := a.Limbs[i].(interface{ HashCode() [16]byte }); ok {
 			// okay, this is a canonical variable and it has a hashcode. We use
 			// it to see if the limb is already constrained.
 			h := vv.HashCode()


### PR DESCRIPTION
# Description

Fixes #1146.

Instead of a fast hash non-cryptographic hash use cryptographically secure hash. Previously it was possible for a malicious circuit designer to define a circuit in a way which would omit either boolean marking or non-native element range checking by creating collisions between variables. This PR avoids this by using a strong hash function instead.

NB! It uses as hash outputs only 16 bytes instead of full 32 bytes for saving some memory.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How has this been tested?

Existing tests pass

# How has this been benchmarked?

For example, I compiled the BW6-671 PLONK verifier in BN254 as one of the biggest circuits to get estimates in possible performance bottlenecks. Results:
```
# PRE patch

SCS:
* time 37.39810504s
* mem 32498MB

R1CS:
* time 46.508562287s
* mem 65606MB

# POST patch

SCS:
* time 37.215583182s
* mem 32430MB

R1CS:
* time 47.082183625s
* mem 66455MB
```

So it seems that for SCS it actually improves performance (but only very little). For R1CS we have approx 1% more memory allocations and 1% slower compiler. I think we could also try to optimize the hash code computation a little by using fixed buffers and hasher as the compiler is sequential anyway. And we can provide the destination to store the hash output instead of allocating new.

This makes the code a little less readable though, but may be worth it?

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

