### PR TITLE
fix: variable modulus subtraction padding

### DIFF
--- a/std/math/emulated/custommod.go
+++ b/std/math/emulated/custommod.go
@@ -48,6 +48,13 @@ func (f *Field[T]) modSub(a, b *Element[T], modulus *Element[T]) *Element[T] {
 	// instead of assuming T as a constant. And when doing as a hint, then need
 	// to assert that the padding is a multiple of the modulus (done inside callSubPaddingHint)
 	nextOverflow := max(b.overflow+1, a.overflow) + 1
+	if nextOverflow > f.maxOverflow() {
+		// TODO: in general we should handle it more gracefully, but this method
+		// is only used in ModAssertIsEqual which in turn is only used in tests,
+		// then for now we avoid automatic overflow handling (like we have for fixed modulus case).
+		// We only panic here so that the user would know to manually handle the overflow.
+		panic("next overflow would overflow the native field")
+	}
 	nbLimbs := max(len(a.Limbs), len(b.Limbs))
 	limbs := make([]frontend.Variable, nbLimbs)
 	padding := f.computeSubPaddingHint(b.overflow, uint(nbLimbs), modulus)

--- a/std/math/emulated/hints.go
+++ b/std/math/emulated/hints.go
@@ -203,15 +203,12 @@ func (f *Field[T]) computeSubPaddingHint(overflow uint, nbLimbs uint, modulus *E
 	maxLimb := new(big.Int).Lsh(big.NewInt(1), fp.BitsPerLimb()+overflow)
 	maxLimb.Sub(maxLimb, big.NewInt(1))
 	for i := range res {
-		// ensure that condition 3 always holds. As we compute the padding hint
-		// depending on the overflow of the inputs, then can use the maximum
-		// possible value
-		f.checker.Check(res[i], int(fp.BitsPerLimb()+overflow+1))
-		// to ensure that condition 2 holds we subtract the maximum possible
-		// value from the padding and check that the result is small (fits into
-		// expected range). If we would have underflow then the result would
-		// underflow the native field otherwise and the range check wouldn't
-		// hold.
+		// we can check conditions 2 and 3 together by subtracting the maximum
+		// value which can be subtracted from the padding. The result should not
+		// underflow (in which case the width of the subtraction result could be
+		// at least native_width-overflow) and should be nbBits+overflow+1 bits
+		// wide (as expected padding is one bit wider than the maximum allowed
+		// subtraction limb).
 		f.checker.Check(f.api.Sub(res[i], maxLimb), int(fp.BitsPerLimb()+overflow+1))
 	}
 

--- a/std/math/emulated/hints.go
+++ b/std/math/emulated/hints.go
@@ -198,7 +198,7 @@ func (f *Field[T]) computeSubPaddingHint(overflow uint, nbLimbs uint, modulus *E
 	for i := range res {
 		f.checker.Check(res[i], int(fp.BitsPerLimb()+overflow+1))
 	}
-	padding := f.newInternalElement(res, fp.BitsPerLimb()+overflow+1)
+	padding := f.newInternalElement(res, overflow+1)
 	f.checkZero(padding, modulus)
 	return padding
 }

--- a/std/math/emulated/hints.go
+++ b/std/math/emulated/hints.go
@@ -200,7 +200,8 @@ func (f *Field[T]) computeSubPaddingHint(overflow uint, nbLimbs uint, modulus *E
 	if err != nil {
 		panic(fmt.Sprintf("sub padding hint: %v", err))
 	}
-	maxLimb := (1 << (int(fp.BitsPerLimb()) + int(overflow))) - 1
+	maxLimb := new(big.Int).Lsh(big.NewInt(1), fp.BitsPerLimb()+overflow)
+	maxLimb.Sub(maxLimb, big.NewInt(1))
 	for i := range res {
 		// ensure that condition 3 always holds. As we compute the padding hint
 		// depending on the overflow of the inputs, then can use the maximum


### PR DESCRIPTION
# Description

This PR fixes some of the methods used in testing the variable modulus case in field emulation:
* correctly set the next overflow
* assert that the subtraction padding is big enough
* check that the next overflow wouldn't the native field

We currently only panic when the next overflow would overflow the native field, in contrast to the behaviour with fixed emulated modulus where we then would mod-reduce the value automatically. As `modSub` is not directly exposed and used in equality assertion (which is then only used in tests), then it should be sufficient for now.

Fixes #1152

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Existing tests pass.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

