### PR TITLE
feat: add IsOnG2 for BN254

### DIFF
--- a/std/algebra/emulated/fields_bn254/e2.go
+++ b/std/algebra/emulated/fields_bn254/e2.go
@@ -296,6 +296,14 @@ func (e Ext2) AssertIsEqual(x, y *E2) {
 	e.fp.AssertIsEqual(&x.A1, &y.A1)
 }
 
+func (e Ext2) IsEqual(x, y *E2) frontend.Variable {
+	xDiff := e.fp.Sub(&x.A0, &y.A0)
+	yDiff := e.fp.Sub(&x.A1, &y.A1)
+	xIsZero := e.fp.IsZero(xDiff)
+	yIsZero := e.fp.IsZero(yDiff)
+	return e.api.And(xIsZero, yIsZero)
+}
+
 func FromE2(y *bn254.E2) E2 {
 	return E2{
 		A0: emulated.ValueOf[emulated.BN254Fp](y.A0),

--- a/std/algebra/emulated/sw_bn254/g2.go
+++ b/std/algebra/emulated/sw_bn254/g2.go
@@ -10,6 +10,7 @@ import (
 )
 
 type G2 struct {
+	api frontend.API
 	*fields_bn254.Ext2
 	w    *emulated.Element[BaseField]
 	u, v *fields_bn254.E2
@@ -49,6 +50,7 @@ func NewG2(api frontend.API) *G2 {
 		A1: emulated.ValueOf[BaseField]("3505843767911556378687030309984248845540243509899259641013678093033130930403"),
 	}
 	return &G2{
+		api:  api,
 		Ext2: fields_bn254.NewExt2(api),
 		w:    &w,
 		u:    &u,
@@ -261,4 +263,10 @@ func (g2 G2) doubleAndAdd(p, q *G2Affine) *G2Affine {
 func (g2 *G2) AssertIsEqual(p, q *G2Affine) {
 	g2.Ext2.AssertIsEqual(&p.P.X, &q.P.X)
 	g2.Ext2.AssertIsEqual(&p.P.Y, &q.P.Y)
+}
+
+func (g2 *G2) IsEqual(p, q *G2Affine) frontend.Variable {
+	xEqual := g2.Ext2.IsEqual(&p.P.X, &q.P.X)
+	yEqual := g2.Ext2.IsEqual(&p.P.Y, &q.P.Y)
+	return g2.api.And(xEqual, yEqual)
 }

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -306,7 +306,7 @@ func (pr Pairing) AssertIsOnG1(P *G1Affine) {
 	pr.AssertIsOnCurve(P)
 }
 
-func (pr Pairing) computeSubgroupEquation(Q *G2Affine) (_Q *G2Affine) {
+func (pr Pairing) computeG2ShortVector(Q *G2Affine) (_Q *G2Affine) {
 	// [x₀]Q
 	xQ := pr.g2.scalarMulBySeed(Q)
 	// ψ([x₀]Q)
@@ -329,7 +329,7 @@ func (pr Pairing) AssertIsOnG2(Q *G2Affine) {
 	pr.AssertIsOnTwist(Q)
 
 	// 2- Check Q has the right subgroup order
-	_Q := pr.computeSubgroupEquation(Q)
+	_Q := pr.computeG2ShortVector(Q)
 	// [r]Q == 0 <==>  _Q == Q
 	pr.g2.AssertIsEqual(Q, _Q)
 }
@@ -341,7 +341,7 @@ func (pr Pairing) IsOnG2(Q *G2Affine) frontend.Variable {
 	// 1 - is Q on curve
 	isOnCurve := pr.IsOnTwist(Q)
 	// 2 - is Q in the subgroup
-	_Q := pr.computeSubgroupEquation(Q)
+	_Q := pr.computeG2ShortVector(Q)
 	isInSubgroup := pr.g2.IsEqual(Q, _Q)
 	return pr.api.And(isOnCurve, isInSubgroup)
 }

--- a/std/algebra/emulated/sw_bn254/pairing_test.go
+++ b/std/algebra/emulated/sw_bn254/pairing_test.go
@@ -308,6 +308,69 @@ func TestIsOnTwistSolve(t *testing.T) {
 	assert.NoError(err)
 }
 
+type IsOnG2Circuit struct {
+	Q        G2Affine
+	Expected frontend.Variable
+}
+
+func (c *IsOnG2Circuit) Define(api frontend.API) error {
+	pairing, err := NewPairing(api)
+	if err != nil {
+		return fmt.Errorf("new pairing: %w", err)
+	}
+	res := pairing.IsOnG2(&c.Q)
+	api.AssertIsEqual(res, c.Expected)
+	return nil
+}
+
+func TestIsOnG2Solve(t *testing.T) {
+	assert := test.NewAssert(t)
+	// test for a point not on the curve
+	var Q bn254.G2Affine
+	_, err := Q.X.A0.SetString("0x119606e6d3ea97cea4eff54433f5c7dbc026b8d0670ddfbe6441e31225028d31")
+	assert.NoError(err)
+	_, err = Q.X.A1.SetString("0x1d3df5be6084324da6333a6ad1367091ca9fbceb70179ec484543a58b8cb5d63")
+	assert.NoError(err)
+	_, err = Q.Y.A0.SetString("0x1b9a36ea373fe2c5b713557042ce6deb2907d34e12be595f9bbe84c144de86ef")
+	assert.NoError(err)
+	_, err = Q.Y.A1.SetString("0x49fe60975e8c78b7b31a6ed16a338ac8b28cf6a065cfd2ca47e9402882518ba0")
+	assert.NoError(err)
+	assert.False(Q.IsOnCurve())
+	witness := IsOnG2Circuit{
+		Q:        NewG2Affine(Q),
+		Expected: 0,
+	}
+	err = test.IsSolved(&IsOnG2Circuit{}, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	// test for a point on curve not in G2
+	_, err = Q.X.A0.SetString("0x07192b9fd0e2a32e3e1caa8e59462b757326d48f641924e6a1d00d66478913eb")
+	assert.NoError(err)
+	_, err = Q.X.A1.SetString("0x15ce93f1b1c4946dd6cfbb3d287d9c9a1cdedb264bda7aada0844416d8a47a63")
+	assert.NoError(err)
+	_, err = Q.Y.A0.SetString("0x0fa65a9b48ba018361ed081e3b9e958451de5d9e8ae0bd251833ebb4b2fafc96")
+	assert.NoError(err)
+	_, err = Q.Y.A1.SetString("0x06e1f5e20f68f6dfa8a91a3bea048df66d9eaf56cc7f11215401f7e05027e0c6")
+	assert.NoError(err)
+	assert.True(Q.IsOnCurve())
+	assert.False(Q.IsInSubGroup())
+	witness = IsOnG2Circuit{
+		Q:        NewG2Affine(Q),
+		Expected: 0,
+	}
+	err = test.IsSolved(&IsOnG2Circuit{}, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	// test for a point in G2
+	_, Q = randomG1G2Affines()
+	assert.True(Q.IsOnCurve())
+	assert.True(Q.IsInSubGroup())
+	witness = IsOnG2Circuit{
+		Q:        NewG2Affine(Q),
+		Expected: 1,
+	}
+	err = test.IsSolved(&IsOnG2Circuit{}, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}
+
 // bench
 func BenchmarkPairing(b *testing.B) {
 


### PR DESCRIPTION
# Description

This method allows to check for non-membership. In case we need to assert membership it is still more efficient to use `AssertIsOnG2` as then we don't have to call `IsZero` for non-native elements which is more expensive that `AssertIsEqual`.

@yelhousni - can you recommend better naming for the methods? I think this could generalize to other curves, but right now needed for Linea, so omitted the implementation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestIsOnTwistSolve
- [x] TestIsOnG2Solve



# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

