### PR TITLE
feat: add BN254 final exponentiation check with output

### DIFF
--- a/std/algebra/emulated/fields_bn254/e12.go
+++ b/std/algebra/emulated/fields_bn254/e12.go
@@ -173,6 +173,12 @@ func (e Ext12) CyclotomicSquare(x *E12) *E12 {
 	}
 }
 
+func (e Ext12) IsEqual(x, y *E12) frontend.Variable {
+	isC0Equal := e.Ext6.IsEqual(&x.C0, &y.C0)
+	isC1Equal := e.Ext6.IsEqual(&x.C1, &y.C1)
+	return e.api.And(isC0Equal, isC1Equal)
+}
+
 func (e Ext12) AssertIsEqual(x, y *E12) {
 	e.Ext6.AssertIsEqual(&x.C0, &y.C0)
 	e.Ext6.AssertIsEqual(&x.C1, &y.C1)

--- a/std/algebra/emulated/fields_bn254/e6.go
+++ b/std/algebra/emulated/fields_bn254/e6.go
@@ -382,6 +382,15 @@ func (e Ext6) FrobeniusSquare(x *E6) *E6 {
 	return &E6{B0: x.B0, B1: *z01, B2: *z02}
 }
 
+func (e Ext6) IsEqual(x, y *E6) frontend.Variable {
+	isB0Equal := e.Ext2.IsEqual(&x.B0, &y.B0)
+	isB1Equal := e.Ext2.IsEqual(&x.B1, &y.B1)
+	isB2Equal := e.Ext2.IsEqual(&x.B2, &y.B2)
+	res := e.api.And(isB0Equal, isB1Equal)
+	res = e.api.And(res, isB2Equal)
+	return res
+}
+
 func (e Ext6) AssertIsEqual(x, y *E6) {
 	e.Ext2.AssertIsEqual(&x.B0, &y.B0)
 	e.Ext2.AssertIsEqual(&x.B1, &y.B1)

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -683,9 +683,9 @@ func (pr Pairing) MillerLoopAndMul(P *G1Affine, Q *G2Affine, previous *GTEl) (*G
 	return res, err
 }
 
-// computeMillerLoopAndFinalExp computes the Miller loop between P and Q,
+// millerLoopAndFinalExpResult computes the Miller loop between P and Q,
 // multiplies it in 𝔽p¹² by previous and returns the result.
-func (pr Pairing) computeMillerLoopAndFinalExp(P *G1Affine, Q *G2Affine, previous *GTEl) *GTEl {
+func (pr Pairing) millerLoopAndFinalExpResult(P *G1Affine, Q *G2Affine, previous *GTEl) *GTEl {
 
 	// hint the non-residue witness
 	hint, err := pr.curveF.NewHint(millerLoopAndCheckFinalExpHint, 24, &P.X, &P.Y, &Q.P.X.A0, &Q.P.X.A1, &Q.P.Y.A0, &Q.P.Y.A1, &previous.C0.B0.A0, &previous.C0.B0.A1, &previous.C0.B1.A0, &previous.C0.B1.A1, &previous.C0.B2.A0, &previous.C0.B2.A1, &previous.C1.B0.A0, &previous.C1.B0.A1, &previous.C1.B1.A0, &previous.C1.B1.A1, &previous.C1.B2.A0, &previous.C1.B2.A1)
@@ -813,14 +813,14 @@ func (pr Pairing) computeMillerLoopAndFinalExp(P *G1Affine, Q *G2Affine, previou
 	return t2
 }
 
-func (pr Pairing) IsMillerLoopAndFinalExpCheck(P *G1Affine, Q *G2Affine, previous *GTEl) frontend.Variable {
-	t2 := pr.computeMillerLoopAndFinalExp(P, Q, previous)
+func (pr Pairing) IsMillerLoopAndFinalExpOne(P *G1Affine, Q *G2Affine, previous *GTEl) frontend.Variable {
+	t2 := pr.millerLoopAndFinalExpResult(P, Q, previous)
 
 	res := pr.IsEqual(t2, pr.One())
 	return res
 }
 
-// AssertMillerLoopAndFinalExpCheck computes the Miller loop between P and Q,
+// AssertMillerLoopAndFinalExpIsOne computes the Miller loop between P and Q,
 // multiplies it in 𝔽p¹² by previous and checks that the result lies in the
 // same equivalence class as the reduced pairing purported to be 1. This check
 // replaces the final exponentiation step in-circuit and follows Section 4 of
@@ -829,7 +829,7 @@ func (pr Pairing) IsMillerLoopAndFinalExpCheck(P *G1Affine, Q *G2Affine, previou
 // This method is needed for evmprecompiles/ecpair.
 //
 // [On Proving Pairings]: https://eprint.iacr.org/2024/640.pdf
-func (pr Pairing) AssertMillerLoopAndFinalExpCheck(P *G1Affine, Q *G2Affine, previous *GTEl) {
-	t2 := pr.computeMillerLoopAndFinalExp(P, Q, previous)
+func (pr Pairing) AssertMillerLoopAndFinalExpIsOne(P *G1Affine, Q *G2Affine, previous *GTEl) {
+	t2 := pr.millerLoopAndFinalExpResult(P, Q, previous)
 	pr.AssertIsEqual(t2, pr.One())
 }

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -813,6 +813,16 @@ func (pr Pairing) millerLoopAndFinalExpResult(P *G1Affine, Q *G2Affine, previous
 	return t2
 }
 
+// IsMillerLoopAndFinalExpOne computes the Miller loop between P and Q,
+// multiplies it in 𝔽p¹² by previous and and returns a boolean indicating if
+// the result lies in the same equivalence class as the reduced pairing
+// purported to be 1. This check replaces the final exponentiation step
+// in-circuit and follows Section 4 of [On Proving Pairings] paper by A.
+// Novakovic and L. Eagen.
+//
+// This method is needed for evmprecompiles/ecpair.
+//
+// [On Proving Pairings]: https://eprint.iacr.org/2024/640.pdf
 func (pr Pairing) IsMillerLoopAndFinalExpOne(P *G1Affine, Q *G2Affine, previous *GTEl) frontend.Variable {
 	t2 := pr.millerLoopAndFinalExpResult(P, Q, previous)
 

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -265,6 +265,10 @@ func (pr Pairing) PairingCheck(P []*G1Affine, Q []*G2Affine) error {
 	return nil
 }
 
+func (pr Pairing) IsEqual(x, y *GTEl) frontend.Variable {
+	return pr.Ext12.IsEqual(x, y)
+}
+
 func (pr Pairing) AssertIsEqual(x, y *GTEl) {
 	pr.Ext12.AssertIsEqual(x, y)
 }
@@ -679,16 +683,9 @@ func (pr Pairing) MillerLoopAndMul(P *G1Affine, Q *G2Affine, previous *GTEl) (*G
 	return res, err
 }
 
-// MillerLoopAndFinalExpCheck computes the Miller loop between P and Q,
-// multiplies it in 𝔽p¹² by previous and checks that the result lies in the
-// same equivalence class as the reduced pairing purported to be 1. This check
-// replaces the final exponentiation step in-circuit and follows Section 4 of
-// [On Proving Pairings] paper by A. Novakovic and L. Eagen.
-//
-// This method is needed for evmprecompiles/ecpair.
-//
-// [On Proving Pairings]: https://eprint.iacr.org/2024/640.pdf
-func (pr Pairing) MillerLoopAndFinalExpCheck(P *G1Affine, Q *G2Affine, previous *GTEl) error {
+// computeMillerLoopAndFinalExp computes the Miller loop between P and Q,
+// multiplies it in 𝔽p¹² by previous and returns the result.
+func (pr Pairing) computeMillerLoopAndFinalExp(P *G1Affine, Q *G2Affine, previous *GTEl) *GTEl {
 
 	// hint the non-residue witness
 	hint, err := pr.curveF.NewHint(millerLoopAndCheckFinalExpHint, 24, &P.X, &P.Y, &Q.P.X.A0, &Q.P.X.A1, &Q.P.Y.A0, &Q.P.Y.A1, &previous.C0.B0.A0, &previous.C0.B0.A1, &previous.C0.B1.A0, &previous.C0.B1.A1, &previous.C0.B2.A0, &previous.C0.B2.A1, &previous.C1.B0.A0, &previous.C1.B0.A1, &previous.C1.B1.A0, &previous.C1.B1.A1, &previous.C1.B2.A0, &previous.C1.B2.A1)
@@ -813,7 +810,26 @@ func (pr Pairing) MillerLoopAndFinalExpCheck(P *G1Affine, Q *G2Affine, previous 
 
 	t2 = pr.Mul(t2, t1)
 
-	pr.AssertIsEqual(t2, pr.One())
+	return t2
+}
 
-	return nil
+func (pr Pairing) IsMillerLoopAndFinalExpCheck(P *G1Affine, Q *G2Affine, previous *GTEl) frontend.Variable {
+	t2 := pr.computeMillerLoopAndFinalExp(P, Q, previous)
+
+	res := pr.IsEqual(t2, pr.One())
+	return res
+}
+
+// AssertMillerLoopAndFinalExpCheck computes the Miller loop between P and Q,
+// multiplies it in 𝔽p¹² by previous and checks that the result lies in the
+// same equivalence class as the reduced pairing purported to be 1. This check
+// replaces the final exponentiation step in-circuit and follows Section 4 of
+// [On Proving Pairings] paper by A. Novakovic and L. Eagen.
+//
+// This method is needed for evmprecompiles/ecpair.
+//
+// [On Proving Pairings]: https://eprint.iacr.org/2024/640.pdf
+func (pr Pairing) AssertMillerLoopAndFinalExpCheck(P *G1Affine, Q *G2Affine, previous *GTEl) {
+	t2 := pr.computeMillerLoopAndFinalExp(P, Q, previous)
+	pr.AssertIsEqual(t2, pr.One())
 }

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -776,7 +776,7 @@ func (pr Pairing) computeMillerLoopAndFinalExp(P *G1Affine, Q *G2Affine, previou
 			// (ℓ × ℓ) × res
 			res = pr.MulBy01234(res, prodLines)
 		default:
-			return nil
+			panic(fmt.Sprintf("invalid loop counter value %d", loopCounter[i]))
 		}
 	}
 

--- a/std/algebra/emulated/sw_bn254/pairing_test.go
+++ b/std/algebra/emulated/sw_bn254/pairing_test.go
@@ -428,7 +428,7 @@ func (c *IsMillerLoopAndFinalExpCircuit) Define(api frontend.API) error {
 	if err != nil {
 		return fmt.Errorf("new pairing: %w", err)
 	}
-	res := pairing.IsMillerLoopAndFinalExpCheck(&c.P, &c.Q, &c.Prev)
+	res := pairing.IsMillerLoopAndFinalExpOne(&c.P, &c.Q, &c.Prev)
 	api.AssertIsEqual(res, c.Expected)
 	return nil
 

--- a/std/evmprecompiles/08-bnpairing.go
+++ b/std/evmprecompiles/08-bnpairing.go
@@ -54,5 +54,5 @@ func ECPair(api frontend.API, P []*sw_bn254.G1Affine, Q []*sw_bn254.G2Affine) {
 	}
 
 	// fixed circuit 2
-	pair.MillerLoopAndFinalExpCheck(P[n-1], Q[n-1], ml)
+	pair.AssertMillerLoopAndFinalExpCheck(P[n-1], Q[n-1], ml)
 }

--- a/std/evmprecompiles/08-bnpairing.go
+++ b/std/evmprecompiles/08-bnpairing.go
@@ -54,5 +54,5 @@ func ECPair(api frontend.API, P []*sw_bn254.G1Affine, Q []*sw_bn254.G2Affine) {
 	}
 
 	// fixed circuit 2
-	pair.AssertMillerLoopAndFinalExpCheck(P[n-1], Q[n-1], ml)
+	pair.AssertMillerLoopAndFinalExpIsOne(P[n-1], Q[n-1], ml)
 }


### PR DESCRIPTION
# Description

In some cases we are interested to obtain the value if the final exponentiation resulted in 1 or not instead of asserting. Refactor and add such method.

With this, also renamed `FinalExpCheck` to `AssertFinalExpCheck` to better distinguish different methods.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?

- [x] TestIsMillerLoopAndFinalExpCircuitTestSolve
- [x] TestMillerLoopAndMulTestSolve

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

