### PR TITLE
feat: capture O variable in gate for external range checker

### DIFF
--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -729,12 +729,10 @@ func (builder *builder) GetWireConstraints(wires []frontend.Variable, addMissing
 		if _, ok := lookup[int(c.XA)]; ok {
 			res = append(res, [2]int{nbPub + constraintIdx, 0})
 			delete(lookup, int(c.XA))
-			continue
 		}
 		if _, ok := lookup[int(c.XB)]; ok {
 			res = append(res, [2]int{nbPub + constraintIdx, 1})
 			delete(lookup, int(c.XB))
-			continue
 		}
 		if len(lookup) == 0 {
 			// we can break early if we found constraints for all the wires

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -734,6 +734,10 @@ func (builder *builder) GetWireConstraints(wires []frontend.Variable, addMissing
 			res = append(res, [2]int{nbPub + constraintIdx, 1})
 			delete(lookup, int(c.XB))
 		}
+		if _, ok := lookup[int(c.XC)]; ok {
+			res = append(res, [2]int{nbPub + constraintIdx, 2})
+			delete(lookup, int(c.XC))
+		}
 		if len(lookup) == 0 {
 			// we can break early if we found constraints for all the wires
 			break


### PR DESCRIPTION
# Description

Previously, we only checked if the variable to be range checked externally was at L xor R locations in the gate. In this PR we remove the restrictions that we can use a gate only a single variable range check. Additionally, we also output now if the variable is in the O location in the gate.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?

In downstream usage

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

