### PR TITLE
fix: avoid malicious hint in BN254 final exp check

### DIFF
--- a/std/algebra/emulated/fields_bn254/e12_pairing.go
+++ b/std/algebra/emulated/fields_bn254/e12_pairing.go
@@ -447,17 +447,14 @@ func (e Ext12) FinalExponentiationCheck(x *E12) *E12 {
 			B2: E2{A0: *res[10], A1: *res[11]},
 		},
 	}
+	// constrain cubicNonResiduePower to be in Fp6
 	cubicNonResiduePower := E12{
 		C0: E6{
 			B0: E2{A0: *res[12], A1: *res[13]},
 			B1: E2{A0: *res[14], A1: *res[15]},
 			B2: E2{A0: *res[16], A1: *res[17]},
 		},
-		C1: E6{
-			B0: E2{A0: *res[18], A1: *res[19]},
-			B1: E2{A0: *res[20], A1: *res[21]},
-			B2: E2{A0: *res[22], A1: *res[23]},
-		},
+		C1: (*e.Ext6.Zero()),
 	}
 
 	// Check that  x * cubicNonResiduePower == residueWitness^λ

--- a/std/algebra/emulated/sw_bn254/hints.go
+++ b/std/algebra/emulated/sw_bn254/hints.go
@@ -1,6 +1,7 @@
 package sw_bn254
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254"
@@ -47,6 +48,10 @@ func millerLoopAndCheckFinalExpHint(nativeMod *big.Int, nativeInputs, nativeOutp
 			previous.C1.B1.A1.SetBigInt(inputs[15])
 			previous.C1.B2.A0.SetBigInt(inputs[16])
 			previous.C1.B2.A1.SetBigInt(inputs[17])
+
+			if previous.IsZero() {
+				return errors.New("previous Miller loop result is zero")
+			}
 
 			lines := bn254.PrecomputeLines(Q)
 			millerLoop, err := bn254.MillerLoopFixedQ(

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -709,17 +709,14 @@ func (pr Pairing) MillerLoopAndFinalExpCheck(P *G1Affine, Q *G2Affine, previous 
 			B2: fields_bn254.E2{A0: *hint[10], A1: *hint[11]},
 		},
 	}
+	// constrain cubicNonResiduePower to be in Fp6
 	cubicNonResiduePower := fields_bn254.E12{
 		C0: fields_bn254.E6{
 			B0: fields_bn254.E2{A0: *hint[12], A1: *hint[13]},
 			B1: fields_bn254.E2{A0: *hint[14], A1: *hint[15]},
 			B2: fields_bn254.E2{A0: *hint[16], A1: *hint[17]},
 		},
-		C1: fields_bn254.E6{
-			B0: fields_bn254.E2{A0: *hint[18], A1: *hint[19]},
-			B1: fields_bn254.E2{A0: *hint[20], A1: *hint[21]},
-			B2: fields_bn254.E2{A0: *hint[22], A1: *hint[23]},
-		},
+		C1: (*pr.Ext6.Zero()),
 	}
 
 	// residueWitnessInv = 1 / residueWitness


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Fixes #1213 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

Same tests.

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

no change.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

