### PR TITLE
fix: remove unconstrained and unused variables

### DIFF
--- a/std/algebra/emulated/sw_bn254/hints.go
+++ b/std/algebra/emulated/sw_bn254/hints.go
@@ -157,12 +157,6 @@ func millerLoopAndCheckFinalExpHint(nativeMod *big.Int, nativeInputs, nativeOutp
 			cubicNonResiduePower.C0.B1.A1.BigInt(outputs[15])
 			cubicNonResiduePower.C0.B2.A0.BigInt(outputs[16])
 			cubicNonResiduePower.C0.B2.A1.BigInt(outputs[17])
-			cubicNonResiduePower.C1.B0.A0.BigInt(outputs[18])
-			cubicNonResiduePower.C1.B0.A1.BigInt(outputs[19])
-			cubicNonResiduePower.C1.B1.A0.BigInt(outputs[20])
-			cubicNonResiduePower.C1.B1.A1.BigInt(outputs[21])
-			cubicNonResiduePower.C1.B2.A0.BigInt(outputs[22])
-			cubicNonResiduePower.C1.B2.A1.BigInt(outputs[23])
 
 			return nil
 		})

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -688,7 +688,7 @@ func (pr Pairing) MillerLoopAndMul(P *G1Affine, Q *G2Affine, previous *GTEl) (*G
 func (pr Pairing) millerLoopAndFinalExpResult(P *G1Affine, Q *G2Affine, previous *GTEl) *GTEl {
 
 	// hint the non-residue witness
-	hint, err := pr.curveF.NewHint(millerLoopAndCheckFinalExpHint, 24, &P.X, &P.Y, &Q.P.X.A0, &Q.P.X.A1, &Q.P.Y.A0, &Q.P.Y.A1, &previous.C0.B0.A0, &previous.C0.B0.A1, &previous.C0.B1.A0, &previous.C0.B1.A1, &previous.C0.B2.A0, &previous.C0.B2.A1, &previous.C1.B0.A0, &previous.C1.B0.A1, &previous.C1.B1.A0, &previous.C1.B1.A1, &previous.C1.B2.A0, &previous.C1.B2.A1)
+	hint, err := pr.curveF.NewHint(millerLoopAndCheckFinalExpHint, 18, &P.X, &P.Y, &Q.P.X.A0, &Q.P.X.A1, &Q.P.Y.A0, &Q.P.Y.A1, &previous.C0.B0.A0, &previous.C0.B0.A1, &previous.C0.B1.A0, &previous.C0.B1.A1, &previous.C0.B2.A0, &previous.C0.B2.A1, &previous.C1.B0.A0, &previous.C1.B0.A1, &previous.C1.B1.A0, &previous.C1.B1.A1, &previous.C1.B2.A0, &previous.C1.B2.A1)
 	if err != nil {
 		// err is non-nil only for invalid number of inputs
 		panic(err)


### PR DESCRIPTION
# Description

PR #1214 removed usage of possible malicious hint value from the circuit. However, we still output the variables in circuit which are then enforced to be range checked. In gnark it leads to unnecessary constraints and in zkevm it creates problem with the external range checker as we're looking for constraints where this variables are used.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Current CI. Only cosmetic change.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

