### PR TITLE
fix: edge case with PLONK backend when 1 constraint

### DIFF
--- a/std/math/emulated/element_test.go
+++ b/std/math/emulated/element_test.go
@@ -1120,6 +1120,10 @@ func (c *ReduceStrictCircuit[T]) Define(api frontend.API) error {
 	for i := range elR.Limbs {
 		api.AssertIsEqual(elR.Limbs[i], c.Expected[i])
 	}
+
+	// TODO: dummy constraint to have at least two constraints in the circuit.
+	// Otherwise PLONK setup phase fails.
+	api.AssertIsEqual(c.Expected[0], elR.Limbs[0])
 	return nil
 }
 


### PR DESCRIPTION
# Description

Fixes big CI error. In Reduce test when emulating Goldilocks we only had a single constraint, but PLONK setup phase assumes circuit of size at least two.

The circuit size check is already defined in several issues: https://github.com/Consensys/gnark/issues/864, https://github.com/Consensys/gnark/issues/967. I also have locally open branch to add more helpful errors in case the circuit size is 0 or 1.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

CI


