### PR TITLE
fix: branch with unchecked cast could panic at compile time

### DIFF
--- a/frontend/cs/scs/api_assertions.go
+++ b/frontend/cs/scs/api_assertions.go
@@ -87,8 +87,10 @@ func (builder *builder) AssertIsEqual(i1, i2 frontend.Variable) {
 // AssertIsDifferent fails if i1 == i2
 func (builder *builder) AssertIsDifferent(i1, i2 frontend.Variable) {
 	s := builder.Sub(i1, i2)
-	if c, ok := builder.constantValue(s); ok && c.IsZero() {
-		panic("AssertIsDifferent(x,x) will never be satisfied")
+	if c, ok := builder.constantValue(s); ok {
+		if c.IsZero() {
+			panic("AssertIsDifferent(x,x) will never be satisfied")
+		}
 	} else if t := s.(expr.Term); t.Coeff.IsZero() {
 		panic("AssertIsDifferent(x,x) will never be satisfied")
 	}


### PR DESCRIPTION
branch with unchecked cast could panic at compile time, thanks to @wuestholz  for reporting.