### PR TITLE
bump gnark-crypto version and match interface changes

### DIFF
--- a/backend/groth16/bls12-377/marshal_test.go
+++ b/backend/groth16/bls12-377/marshal_test.go
@@ -109,7 +109,7 @@ func TestVerifyingKeySerialization(t *testing.T) {
 						elem.Add(&elem, &p1)
 					}
 				}
-				_, vk.CommitmentKey, err = pedersen.Setup(bases...)
+				_, vk.CommitmentKey, err = pedersen.Setup(bases)
 				assert.NoError(t, err)
 			}
 
@@ -183,7 +183,7 @@ func TestProvingKeySerialization(t *testing.T) {
 			}
 			{
 				var err error
-				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases...)
+				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases)
 				require.NoError(t, err)
 			}
 

--- a/backend/groth16/bls12-377/prove.go
+++ b/backend/groth16/bls12-377/prove.go
@@ -123,8 +123,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	for i := range commitmentInfo {
 		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[commitmentInfo[i].CommitmentIndex].Marshal())
 	}
-
-	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, challenge[0]); err != nil {
 		return nil, err
 	}
 

--- a/backend/groth16/bls12-377/setup.go
+++ b/backend/groth16/bls12-377/setup.go
@@ -287,7 +287,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		return errors.New("didn't consume all G1 points") // TODO @Tabaie Remove this
 	}
 
-	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 		}
 	}
 
-	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}

--- a/backend/groth16/bls12-377/verify.go
+++ b/backend/groth16/bls12-377/verify.go
@@ -98,8 +98,11 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		publicWitness = append(publicWitness, res)
 		copy(commitmentsSerialized[i*fr.Bytes:], res.Marshal())
 	}
-
-	if folded, err := pedersen.FoldCommitments(proof.Commitments, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return err
+	}
+	if folded, err := pedersen.FoldCommitments(proof.Commitments, challenge[0]); err != nil {
 		return err
 	} else {
 		if err = vk.CommitmentKey.Verify(folded, proof.CommitmentPok); err != nil {

--- a/backend/groth16/bls12-381/marshal_test.go
+++ b/backend/groth16/bls12-381/marshal_test.go
@@ -109,7 +109,7 @@ func TestVerifyingKeySerialization(t *testing.T) {
 						elem.Add(&elem, &p1)
 					}
 				}
-				_, vk.CommitmentKey, err = pedersen.Setup(bases...)
+				_, vk.CommitmentKey, err = pedersen.Setup(bases)
 				assert.NoError(t, err)
 			}
 
@@ -183,7 +183,7 @@ func TestProvingKeySerialization(t *testing.T) {
 			}
 			{
 				var err error
-				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases...)
+				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases)
 				require.NoError(t, err)
 			}
 

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -123,8 +123,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	for i := range commitmentInfo {
 		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[commitmentInfo[i].CommitmentIndex].Marshal())
 	}
-
-	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, challenge[0]); err != nil {
 		return nil, err
 	}
 

--- a/backend/groth16/bls12-381/setup.go
+++ b/backend/groth16/bls12-381/setup.go
@@ -287,7 +287,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		return errors.New("didn't consume all G1 points") // TODO @Tabaie Remove this
 	}
 
-	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 		}
 	}
 
-	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}

--- a/backend/groth16/bls12-381/verify.go
+++ b/backend/groth16/bls12-381/verify.go
@@ -98,8 +98,11 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		publicWitness = append(publicWitness, res)
 		copy(commitmentsSerialized[i*fr.Bytes:], res.Marshal())
 	}
-
-	if folded, err := pedersen.FoldCommitments(proof.Commitments, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return err
+	}
+	if folded, err := pedersen.FoldCommitments(proof.Commitments, challenge[0]); err != nil {
 		return err
 	} else {
 		if err = vk.CommitmentKey.Verify(folded, proof.CommitmentPok); err != nil {

--- a/backend/groth16/bls24-315/marshal_test.go
+++ b/backend/groth16/bls24-315/marshal_test.go
@@ -109,7 +109,7 @@ func TestVerifyingKeySerialization(t *testing.T) {
 						elem.Add(&elem, &p1)
 					}
 				}
-				_, vk.CommitmentKey, err = pedersen.Setup(bases...)
+				_, vk.CommitmentKey, err = pedersen.Setup(bases)
 				assert.NoError(t, err)
 			}
 
@@ -183,7 +183,7 @@ func TestProvingKeySerialization(t *testing.T) {
 			}
 			{
 				var err error
-				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases...)
+				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases)
 				require.NoError(t, err)
 			}
 

--- a/backend/groth16/bls24-315/prove.go
+++ b/backend/groth16/bls24-315/prove.go
@@ -123,8 +123,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	for i := range commitmentInfo {
 		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[commitmentInfo[i].CommitmentIndex].Marshal())
 	}
-
-	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, challenge[0]); err != nil {
 		return nil, err
 	}
 

--- a/backend/groth16/bls24-315/setup.go
+++ b/backend/groth16/bls24-315/setup.go
@@ -287,7 +287,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		return errors.New("didn't consume all G1 points") // TODO @Tabaie Remove this
 	}
 
-	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 		}
 	}
 
-	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}

--- a/backend/groth16/bls24-315/verify.go
+++ b/backend/groth16/bls24-315/verify.go
@@ -98,8 +98,11 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		publicWitness = append(publicWitness, res)
 		copy(commitmentsSerialized[i*fr.Bytes:], res.Marshal())
 	}
-
-	if folded, err := pedersen.FoldCommitments(proof.Commitments, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return err
+	}
+	if folded, err := pedersen.FoldCommitments(proof.Commitments, challenge[0]); err != nil {
 		return err
 	} else {
 		if err = vk.CommitmentKey.Verify(folded, proof.CommitmentPok); err != nil {

--- a/backend/groth16/bls24-317/marshal_test.go
+++ b/backend/groth16/bls24-317/marshal_test.go
@@ -109,7 +109,7 @@ func TestVerifyingKeySerialization(t *testing.T) {
 						elem.Add(&elem, &p1)
 					}
 				}
-				_, vk.CommitmentKey, err = pedersen.Setup(bases...)
+				_, vk.CommitmentKey, err = pedersen.Setup(bases)
 				assert.NoError(t, err)
 			}
 
@@ -183,7 +183,7 @@ func TestProvingKeySerialization(t *testing.T) {
 			}
 			{
 				var err error
-				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases...)
+				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases)
 				require.NoError(t, err)
 			}
 

--- a/backend/groth16/bls24-317/prove.go
+++ b/backend/groth16/bls24-317/prove.go
@@ -123,8 +123,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	for i := range commitmentInfo {
 		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[commitmentInfo[i].CommitmentIndex].Marshal())
 	}
-
-	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, challenge[0]); err != nil {
 		return nil, err
 	}
 

--- a/backend/groth16/bls24-317/setup.go
+++ b/backend/groth16/bls24-317/setup.go
@@ -287,7 +287,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		return errors.New("didn't consume all G1 points") // TODO @Tabaie Remove this
 	}
 
-	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 		}
 	}
 
-	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}

--- a/backend/groth16/bls24-317/verify.go
+++ b/backend/groth16/bls24-317/verify.go
@@ -98,8 +98,11 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		publicWitness = append(publicWitness, res)
 		copy(commitmentsSerialized[i*fr.Bytes:], res.Marshal())
 	}
-
-	if folded, err := pedersen.FoldCommitments(proof.Commitments, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return err
+	}
+	if folded, err := pedersen.FoldCommitments(proof.Commitments, challenge[0]); err != nil {
 		return err
 	} else {
 		if err = vk.CommitmentKey.Verify(folded, proof.CommitmentPok); err != nil {

--- a/backend/groth16/bn254/marshal_test.go
+++ b/backend/groth16/bn254/marshal_test.go
@@ -109,7 +109,7 @@ func TestVerifyingKeySerialization(t *testing.T) {
 						elem.Add(&elem, &p1)
 					}
 				}
-				_, vk.CommitmentKey, err = pedersen.Setup(bases...)
+				_, vk.CommitmentKey, err = pedersen.Setup(bases)
 				assert.NoError(t, err)
 			}
 
@@ -183,7 +183,7 @@ func TestProvingKeySerialization(t *testing.T) {
 			}
 			{
 				var err error
-				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases...)
+				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases)
 				require.NoError(t, err)
 			}
 

--- a/backend/groth16/bn254/prove.go
+++ b/backend/groth16/bn254/prove.go
@@ -123,8 +123,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	for i := range commitmentInfo {
 		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[commitmentInfo[i].CommitmentIndex].Marshal())
 	}
-
-	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, challenge[0]); err != nil {
 		return nil, err
 	}
 

--- a/backend/groth16/bn254/setup.go
+++ b/backend/groth16/bn254/setup.go
@@ -287,7 +287,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		return errors.New("didn't consume all G1 points") // TODO @Tabaie Remove this
 	}
 
-	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 		}
 	}
 
-	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}

--- a/backend/groth16/bn254/verify.go
+++ b/backend/groth16/bn254/verify.go
@@ -101,8 +101,11 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		publicWitness = append(publicWitness, res)
 		copy(commitmentsSerialized[i*fr.Bytes:], res.Marshal())
 	}
-
-	if folded, err := pedersen.FoldCommitments(proof.Commitments, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return err
+	}
+	if folded, err := pedersen.FoldCommitments(proof.Commitments, challenge[0]); err != nil {
 		return err
 	} else {
 		if err = vk.CommitmentKey.Verify(folded, proof.CommitmentPok); err != nil {

--- a/backend/groth16/bw6-633/marshal_test.go
+++ b/backend/groth16/bw6-633/marshal_test.go
@@ -109,7 +109,7 @@ func TestVerifyingKeySerialization(t *testing.T) {
 						elem.Add(&elem, &p1)
 					}
 				}
-				_, vk.CommitmentKey, err = pedersen.Setup(bases...)
+				_, vk.CommitmentKey, err = pedersen.Setup(bases)
 				assert.NoError(t, err)
 			}
 
@@ -183,7 +183,7 @@ func TestProvingKeySerialization(t *testing.T) {
 			}
 			{
 				var err error
-				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases...)
+				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases)
 				require.NoError(t, err)
 			}
 

--- a/backend/groth16/bw6-633/prove.go
+++ b/backend/groth16/bw6-633/prove.go
@@ -123,8 +123,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	for i := range commitmentInfo {
 		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[commitmentInfo[i].CommitmentIndex].Marshal())
 	}
-
-	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, challenge[0]); err != nil {
 		return nil, err
 	}
 

--- a/backend/groth16/bw6-633/setup.go
+++ b/backend/groth16/bw6-633/setup.go
@@ -287,7 +287,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		return errors.New("didn't consume all G1 points") // TODO @Tabaie Remove this
 	}
 
-	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 		}
 	}
 
-	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}

--- a/backend/groth16/bw6-633/verify.go
+++ b/backend/groth16/bw6-633/verify.go
@@ -98,8 +98,11 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		publicWitness = append(publicWitness, res)
 		copy(commitmentsSerialized[i*fr.Bytes:], res.Marshal())
 	}
-
-	if folded, err := pedersen.FoldCommitments(proof.Commitments, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return err
+	}
+	if folded, err := pedersen.FoldCommitments(proof.Commitments, challenge[0]); err != nil {
 		return err
 	} else {
 		if err = vk.CommitmentKey.Verify(folded, proof.CommitmentPok); err != nil {

--- a/backend/groth16/bw6-761/marshal_test.go
+++ b/backend/groth16/bw6-761/marshal_test.go
@@ -109,7 +109,7 @@ func TestVerifyingKeySerialization(t *testing.T) {
 						elem.Add(&elem, &p1)
 					}
 				}
-				_, vk.CommitmentKey, err = pedersen.Setup(bases...)
+				_, vk.CommitmentKey, err = pedersen.Setup(bases)
 				assert.NoError(t, err)
 			}
 
@@ -183,7 +183,7 @@ func TestProvingKeySerialization(t *testing.T) {
 			}
 			{
 				var err error
-				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases...)
+				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases)
 				require.NoError(t, err)
 			}
 

--- a/backend/groth16/bw6-761/prove.go
+++ b/backend/groth16/bw6-761/prove.go
@@ -123,8 +123,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	for i := range commitmentInfo {
 		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[commitmentInfo[i].CommitmentIndex].Marshal())
 	}
-
-	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, challenge[0]); err != nil {
 		return nil, err
 	}
 

--- a/backend/groth16/bw6-761/setup.go
+++ b/backend/groth16/bw6-761/setup.go
@@ -287,7 +287,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		return errors.New("didn't consume all G1 points") // TODO @Tabaie Remove this
 	}
 
-	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 		}
 	}
 
-	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, _, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}

--- a/backend/groth16/bw6-761/verify.go
+++ b/backend/groth16/bw6-761/verify.go
@@ -98,8 +98,11 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		publicWitness = append(publicWitness, res)
 		copy(commitmentsSerialized[i*fr.Bytes:], res.Marshal())
 	}
-
-	if folded, err := pedersen.FoldCommitments(proof.Commitments, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return err
+	}
+	if folded, err := pedersen.FoldCommitments(proof.Commitments, challenge[0]); err != nil {
 		return err
 	} else {
 		if err = vk.CommitmentKey.Verify(folded, proof.CommitmentPok); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/bavard v0.1.13
 	github.com/consensys/compress v0.2.5
-	github.com/consensys/gnark-crypto v0.12.2-0.20240703135258-5d8b5fab1afb
+	github.com/consensys/gnark-crypto v0.13.1-0.20240802214859-ff4c0ddbe1ef
 	github.com/fxamacker/cbor/v2 v2.5.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/Yj
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/compress v0.2.5 h1:gJr1hKzbOD36JFsF1AN8lfXz1yevnJi1YolffY19Ntk=
 github.com/consensys/compress v0.2.5/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
-github.com/consensys/gnark-crypto v0.12.2-0.20240703135258-5d8b5fab1afb h1:LMfC1GSeYv1TKp3zNIuwYNEqb9RCVrMkCV4Y9k5ZJ6o=
-github.com/consensys/gnark-crypto v0.12.2-0.20240703135258-5d8b5fab1afb/go.mod h1:wKqwsieaKPThcFkHe0d0zMsbHEUWFmZcG7KBCse210o=
+github.com/consensys/gnark-crypto v0.13.1-0.20240802214859-ff4c0ddbe1ef h1:4DaS1IYXk0vKcCdguGjkHVyN43YqmKUmpYDxb90VBnU=
+github.com/consensys/gnark-crypto v0.13.1-0.20240802214859-ff4c0ddbe1ef/go.mod h1:wKqwsieaKPThcFkHe0d0zMsbHEUWFmZcG7KBCse210o=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.prove.go.tmpl
@@ -107,8 +107,11 @@ func Prove(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 	for i := range commitmentInfo {
 		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[commitmentInfo[i].CommitmentIndex].Marshal())
 	}
-
-	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if proof.CommitmentPok, err = pedersen.BatchProve(pk.CommitmentKeys, privateCommittedValues, challenge[0]); err != nil {
 		return nil, err
 	}
 

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.setup.go.tmpl
@@ -269,7 +269,7 @@ func Setup(r1cs *cs.R1CS, pk *ProvingKey, vk *VerifyingKey) error {
 		return errors.New("didn't consume all G1 points") // TODO @Tabaie Remove this
 	}
 
-	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys, vk.CommitmentKey, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}
@@ -545,7 +545,7 @@ func DummySetup(r1cs *cs.R1CS, pk *ProvingKey) error {
 		}
 	}
 
-	pk.CommitmentKeys,_, err = pedersen.Setup(commitmentBases...)
+	pk.CommitmentKeys,_, err = pedersen.Setup(commitmentBases)
 	if err != nil {
 		return err
 	}

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.verify.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.verify.go.tmpl
@@ -85,8 +85,11 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		publicWitness = append(publicWitness, res)
 		copy(commitmentsSerialized[i*fr.Bytes:], res.Marshal())
 	}
-
-	if folded, err := pedersen.FoldCommitments(proof.Commitments, commitmentsSerialized); err != nil {
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return err
+	}
+	if folded, err := pedersen.FoldCommitments(proof.Commitments, challenge[0]); err != nil {
 		return err
 	} else {
 		if err = vk.CommitmentKey.Verify(folded, proof.CommitmentPok); err != nil {

--- a/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/tests/groth16.marshal.go.tmpl
@@ -93,7 +93,7 @@ func TestVerifyingKeySerialization(t *testing.T) {
 						elem.Add(&elem, &p1)
 					}
 				}
-				_, vk.CommitmentKey, err = pedersen.Setup(bases...)
+				_, vk.CommitmentKey, err = pedersen.Setup(bases)
 				assert.NoError(t, err)
 			}
 		
@@ -169,7 +169,7 @@ func TestProvingKeySerialization(t *testing.T) {
 			}
 			{
 			var err error
-				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases...)
+				pk.CommitmentKeys, _, err = pedersen.Setup(pedersenBases)
 				require.NoError(t, err)
 			}
 


### PR DESCRIPTION
This PR updates the Groth16 BSB22 Commitments module to match [recent gnark-crypto changes](https://github.com/Consensys/gnark-crypto/pull/517).

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

