### PR TITLE
feat test engine friendly GKR

### DIFF
--- a/constraint/bls12-377/gkr.go
+++ b/constraint/bls12-377/gkr.go
@@ -217,3 +217,27 @@ func GetHashBuilder(name string) (func() hash.Hash, error) {
 	}
 	return builder, nil
 }
+
+// For testing purposes
+type ConstPseudoHash int
+
+func (c ConstPseudoHash) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (c ConstPseudoHash) Sum([]byte) []byte {
+	var x fr.Element
+	x.SetInt64(int64(c))
+	res := x.Bytes()
+	return res[:]
+}
+
+func (c ConstPseudoHash) Reset() {}
+
+func (c ConstPseudoHash) Size() int {
+	return fr.Bytes
+}
+
+func (c ConstPseudoHash) BlockSize() int {
+	return fr.Bytes
+}

--- a/constraint/bls12-381/gkr.go
+++ b/constraint/bls12-381/gkr.go
@@ -217,3 +217,27 @@ func GetHashBuilder(name string) (func() hash.Hash, error) {
 	}
 	return builder, nil
 }
+
+// For testing purposes
+type ConstPseudoHash int
+
+func (c ConstPseudoHash) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (c ConstPseudoHash) Sum([]byte) []byte {
+	var x fr.Element
+	x.SetInt64(int64(c))
+	res := x.Bytes()
+	return res[:]
+}
+
+func (c ConstPseudoHash) Reset() {}
+
+func (c ConstPseudoHash) Size() int {
+	return fr.Bytes
+}
+
+func (c ConstPseudoHash) BlockSize() int {
+	return fr.Bytes
+}

--- a/constraint/bls24-315/gkr.go
+++ b/constraint/bls24-315/gkr.go
@@ -217,3 +217,27 @@ func GetHashBuilder(name string) (func() hash.Hash, error) {
 	}
 	return builder, nil
 }
+
+// For testing purposes
+type ConstPseudoHash int
+
+func (c ConstPseudoHash) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (c ConstPseudoHash) Sum([]byte) []byte {
+	var x fr.Element
+	x.SetInt64(int64(c))
+	res := x.Bytes()
+	return res[:]
+}
+
+func (c ConstPseudoHash) Reset() {}
+
+func (c ConstPseudoHash) Size() int {
+	return fr.Bytes
+}
+
+func (c ConstPseudoHash) BlockSize() int {
+	return fr.Bytes
+}

--- a/constraint/bls24-317/gkr.go
+++ b/constraint/bls24-317/gkr.go
@@ -217,3 +217,27 @@ func GetHashBuilder(name string) (func() hash.Hash, error) {
 	}
 	return builder, nil
 }
+
+// For testing purposes
+type ConstPseudoHash int
+
+func (c ConstPseudoHash) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (c ConstPseudoHash) Sum([]byte) []byte {
+	var x fr.Element
+	x.SetInt64(int64(c))
+	res := x.Bytes()
+	return res[:]
+}
+
+func (c ConstPseudoHash) Reset() {}
+
+func (c ConstPseudoHash) Size() int {
+	return fr.Bytes
+}
+
+func (c ConstPseudoHash) BlockSize() int {
+	return fr.Bytes
+}

--- a/constraint/bn254/gkr.go
+++ b/constraint/bn254/gkr.go
@@ -217,3 +217,27 @@ func GetHashBuilder(name string) (func() hash.Hash, error) {
 	}
 	return builder, nil
 }
+
+// For testing purposes
+type ConstPseudoHash int
+
+func (c ConstPseudoHash) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (c ConstPseudoHash) Sum([]byte) []byte {
+	var x fr.Element
+	x.SetInt64(int64(c))
+	res := x.Bytes()
+	return res[:]
+}
+
+func (c ConstPseudoHash) Reset() {}
+
+func (c ConstPseudoHash) Size() int {
+	return fr.Bytes
+}
+
+func (c ConstPseudoHash) BlockSize() int {
+	return fr.Bytes
+}

--- a/constraint/bw6-633/gkr.go
+++ b/constraint/bw6-633/gkr.go
@@ -217,3 +217,27 @@ func GetHashBuilder(name string) (func() hash.Hash, error) {
 	}
 	return builder, nil
 }
+
+// For testing purposes
+type ConstPseudoHash int
+
+func (c ConstPseudoHash) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (c ConstPseudoHash) Sum([]byte) []byte {
+	var x fr.Element
+	x.SetInt64(int64(c))
+	res := x.Bytes()
+	return res[:]
+}
+
+func (c ConstPseudoHash) Reset() {}
+
+func (c ConstPseudoHash) Size() int {
+	return fr.Bytes
+}
+
+func (c ConstPseudoHash) BlockSize() int {
+	return fr.Bytes
+}

--- a/constraint/bw6-761/gkr.go
+++ b/constraint/bw6-761/gkr.go
@@ -217,3 +217,27 @@ func GetHashBuilder(name string) (func() hash.Hash, error) {
 	}
 	return builder, nil
 }
+
+// For testing purposes
+type ConstPseudoHash int
+
+func (c ConstPseudoHash) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (c ConstPseudoHash) Sum([]byte) []byte {
+	var x fr.Element
+	x.SetInt64(int64(c))
+	res := x.Bytes()
+	return res[:]
+}
+
+func (c ConstPseudoHash) Reset() {}
+
+func (c ConstPseudoHash) Size() int {
+	return fr.Bytes
+}
+
+func (c ConstPseudoHash) BlockSize() int {
+	return fr.Bytes
+}

--- a/internal/generator/backend/template/representations/gkr.go.tmpl
+++ b/internal/generator/backend/template/representations/gkr.go.tmpl
@@ -199,3 +199,28 @@ func GetHashBuilder(name string) (func() hash.Hash, error) {
 	}
 	return builder, nil
 }
+
+
+// For testing purposes
+type ConstPseudoHash int
+
+func (c ConstPseudoHash) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (c ConstPseudoHash) Sum([]byte) []byte {
+	var x fr.Element
+	x.SetInt64(int64(c))
+	res := x.Bytes()
+	return res[:]
+}
+
+func (c ConstPseudoHash) Reset() {}
+
+func (c ConstPseudoHash) Size() int {
+	return fr.Bytes
+}
+
+func (c ConstPseudoHash) BlockSize() int {
+	return fr.Bytes
+}

--- a/std/gkr/api_test.go
+++ b/std/gkr/api_test.go
@@ -2,6 +2,13 @@ package gkr
 
 import (
 	"fmt"
+	bls12377 "github.com/consensys/gnark/constraint/bls12-377"
+	bls12381 "github.com/consensys/gnark/constraint/bls12-381"
+	bls24315 "github.com/consensys/gnark/constraint/bls24-315"
+	bls24317 "github.com/consensys/gnark/constraint/bls24-317"
+	bw6633 "github.com/consensys/gnark/constraint/bw6-633"
+	bw6761 "github.com/consensys/gnark/constraint/bw6-761"
+	"github.com/consensys/gnark/test"
 	"hash"
 	"math/rand"
 	"strconv"
@@ -10,7 +17,7 @@ import (
 
 	"github.com/consensys/gnark-crypto/kzg"
 	"github.com/consensys/gnark/backend/plonk"
-	bn254r1cs "github.com/consensys/gnark/constraint/bn254"
+	bn254 "github.com/consensys/gnark/constraint/bn254"
 	"github.com/stretchr/testify/require"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -74,8 +81,8 @@ func TestDoubleNoDependencyCircuit(t *testing.T) {
 			assignment := doubleNoDependencyCircuit{X: xValues}
 			circuit := doubleNoDependencyCircuit{X: make([]frontend.Variable, len(xValues)), hashName: hashName}
 
-			testGroth16(t, &circuit, &assignment)
-			testPlonk(t, &circuit, &assignment)
+			test.NewAssert(t).CheckCircuit(&circuit, test.WithValidAssignment(&assignment))
+
 		}
 	}
 }
@@ -427,7 +434,7 @@ func testPlonk(t *testing.T, circuit, assignment frontend.Circuit) {
 }
 
 func registerMiMC() {
-	bn254r1cs.RegisterHashBuilder("mimc", func() hash.Hash {
+	bn254.RegisterHashBuilder("mimc", func() hash.Hash {
 		return bn254MiMC.NewMiMC()
 	})
 	stdHash.Register("mimc", func(api frontend.API) (stdHash.FieldHasher, error) {
@@ -438,11 +445,31 @@ func registerMiMC() {
 
 func registerConstant(c int) {
 	name := strconv.Itoa(c)
-	bn254r1cs.RegisterHashBuilder(name, func() hash.Hash {
-		return constHashBn254(c)
+	bls12377.RegisterHashBuilder(name, func() hash.Hash {
+		return bls12377.ConstPseudoHash(c)
 	})
+
+	bls12381.RegisterHashBuilder(name, func() hash.Hash {
+		return bls12381.ConstPseudoHash(c)
+	})
+	bls24315.RegisterHashBuilder(name, func() hash.Hash {
+		return bls24315.ConstPseudoHash(c)
+	})
+	bls24317.RegisterHashBuilder(name, func() hash.Hash {
+		return bls24317.ConstPseudoHash(c)
+	})
+	bn254.RegisterHashBuilder(name, func() hash.Hash {
+		return bn254.ConstPseudoHash(c)
+	})
+	bw6633.RegisterHashBuilder(name, func() hash.Hash {
+		return bw6633.ConstPseudoHash(c)
+	})
+	bw6761.RegisterHashBuilder(name, func() hash.Hash {
+		return bw6761.ConstPseudoHash(c)
+	})
+
 	stdHash.Register(name, func(frontend.API) (stdHash.FieldHasher, error) {
-		return constHash(c), nil
+		return constPseudoHash(c), nil
 	})
 }
 
@@ -458,38 +485,15 @@ func registerMiMCGate() {
 	gkr.Gates["mimc"] = mimcCipherGate{}
 }
 
-type constHashBn254 int // TODO @Tabaie move to gnark-crypto
+type constPseudoHash int
 
-func (c constHashBn254) Write(p []byte) (int, error) {
-	return len(p), nil
-}
-
-func (c constHashBn254) Sum([]byte) []byte {
-	var x fr.Element
-	x.SetInt64(int64(c))
-	res := x.Bytes()
-	return res[:]
-}
-
-func (c constHashBn254) Reset() {}
-
-func (c constHashBn254) Size() int {
-	return fr.Bytes
-}
-
-func (c constHashBn254) BlockSize() int {
-	return fr.Bytes
-}
-
-type constHash int
-
-func (c constHash) Sum() frontend.Variable {
+func (c constPseudoHash) Sum() frontend.Variable {
 	return int(c)
 }
 
-func (c constHash) Write(...frontend.Variable) {}
+func (c constPseudoHash) Write(...frontend.Variable) {}
 
-func (c constHash) Reset() {}
+func (c constPseudoHash) Reset() {}
 
 var mimcFrTotalCalls = 0
 

--- a/std/gkr/compile.go
+++ b/std/gkr/compile.go
@@ -2,7 +2,6 @@ package gkr
 
 import (
 	"fmt"
-	"math/big"
 	"math/bits"
 
 	"github.com/consensys/gnark/constraint"
@@ -124,8 +123,9 @@ func (api *API) Solve(parentApi frontend.API) (Solution, error) {
 		}
 	}
 
-	outsSerialized, err := parentApi.Compiler().NewHint(SolveHintPlaceholder, solveHintNOut, ins...)
-	api.toStore.SolveHintID = solver.GetHintID(SolveHintPlaceholder)
+	solveHintPlaceholder := SolveHintPlaceholder(api.toStore)
+	outsSerialized, err := parentApi.Compiler().NewHint(solveHintPlaceholder, solveHintNOut, ins...)
+	api.toStore.SolveHintID = solver.GetHintID(solveHintPlaceholder)
 	if err != nil {
 		return Solution{}, err
 	}
@@ -176,11 +176,12 @@ func (s Solution) Verify(hashName string, initialChallenges ...frontend.Variable
 	}
 	copy(hintIns[1:], initialChallenges)
 
+	proveHintPlaceholder := ProveHintPlaceholder(hashName)
 	if proofSerialized, err = s.parentApi.Compiler().NewHint(
-		ProveHintPlaceholder, ProofSize(forSnark.circuit, logNbInstances), hintIns...); err != nil {
+		proveHintPlaceholder, ProofSize(forSnark.circuit, logNbInstances), hintIns...); err != nil {
 		return err
 	}
-	s.toStore.ProveHintID = solver.GetHintID(ProveHintPlaceholder)
+	s.toStore.ProveHintID = solver.GetHintID(proveHintPlaceholder)
 
 	forSnarkSorted := algo_utils.MapRange(0, len(s.toStore.Circuit), slicePtrAt(forSnark.circuit))
 
@@ -200,14 +201,6 @@ func (s Solution) Verify(hashName string, initialChallenges ...frontend.Variable
 	}
 
 	return s.parentApi.Compiler().SetGkrInfo(s.toStore)
-}
-
-func SolveHintPlaceholder(*big.Int, []*big.Int, []*big.Int) error { // TODO @Tabaie Add implementation for testing
-	return fmt.Errorf("placeholder - not meant to be called")
-}
-
-func ProveHintPlaceholder(*big.Int, []*big.Int, []*big.Int) error { // TODO @Tabaie Add implementation for testing
-	return fmt.Errorf("placeholder - not meant to be called")
 }
 
 func slicePtrAt[T any](slice []T) func(int) *T {

--- a/std/gkr/hints.go
+++ b/std/gkr/hints.go
@@ -1,0 +1,102 @@
+package gkr
+
+import (
+	"errors"
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/constraint"
+	bls12377 "github.com/consensys/gnark/constraint/bls12-377"
+	bls12381 "github.com/consensys/gnark/constraint/bls12-381"
+	bls24315 "github.com/consensys/gnark/constraint/bls24-315"
+	bls24317 "github.com/consensys/gnark/constraint/bls24-317"
+	bn254 "github.com/consensys/gnark/constraint/bn254"
+	bw6633 "github.com/consensys/gnark/constraint/bw6-633"
+	bw6761 "github.com/consensys/gnark/constraint/bw6-761"
+	"github.com/consensys/gnark/constraint/solver"
+	"math/big"
+)
+
+var testEngineGkrSolvingData = make(map[string]any)
+
+func modKey(mod *big.Int) string {
+	return mod.Text(32)
+}
+
+func SolveHintPlaceholder(gkrInfo constraint.GkrInfo) solver.Hint {
+	return func(mod *big.Int, ins []*big.Int, outs []*big.Int) error {
+
+		// TODO @Tabaie autogenerate this or decide not to
+		if mod.Cmp(ecc.BLS12_377.ScalarField()) == 0 {
+			var data bls12377.GkrSolvingData
+			testEngineGkrSolvingData[modKey(mod)] = &data
+			return bls12377.GkrSolveHint(gkrInfo, &data)(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BLS12_381.ScalarField()) == 0 {
+			var data bls12381.GkrSolvingData
+			testEngineGkrSolvingData[modKey(mod)] = &data
+			return bls12381.GkrSolveHint(gkrInfo, &data)(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BLS24_315.ScalarField()) == 0 {
+			var data bls24315.GkrSolvingData
+			testEngineGkrSolvingData[modKey(mod)] = &data
+			return bls24315.GkrSolveHint(gkrInfo, &data)(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BLS24_317.ScalarField()) == 0 {
+			var data bls24317.GkrSolvingData
+			testEngineGkrSolvingData[modKey(mod)] = &data
+			return bls24317.GkrSolveHint(gkrInfo, &data)(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BN254.ScalarField()) == 0 {
+			var data bn254.GkrSolvingData
+			testEngineGkrSolvingData[modKey(mod)] = &data
+			return bn254.GkrSolveHint(gkrInfo, &data)(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BW6_633.ScalarField()) == 0 {
+			var data bw6633.GkrSolvingData
+			testEngineGkrSolvingData[modKey(mod)] = &data
+			return bw6633.GkrSolveHint(gkrInfo, &data)(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BW6_761.ScalarField()) == 0 {
+			var data bw6761.GkrSolvingData
+			testEngineGkrSolvingData[modKey(mod)] = &data
+			return bw6761.GkrSolveHint(gkrInfo, &data)(mod, ins, outs)
+		}
+
+		return errors.New("unsupported modulus")
+	}
+}
+
+func ProveHintPlaceholder(hashName string) solver.Hint {
+	return func(mod *big.Int, ins, outs []*big.Int) error {
+		k := modKey(mod)
+		data, ok := testEngineGkrSolvingData[k]
+		if !ok {
+			return errors.New("solving data not found")
+		}
+		delete(testEngineGkrSolvingData, k)
+
+		// TODO @Tabaie autogenerate this or decide not to
+		if mod.Cmp(ecc.BLS12_377.ScalarField()) == 0 {
+			return bls12377.GkrProveHint(hashName, data.(*bls12377.GkrSolvingData))(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BLS12_381.ScalarField()) == 0 {
+			return bls12381.GkrProveHint(hashName, data.(*bls12381.GkrSolvingData))(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BLS24_315.ScalarField()) == 0 {
+			return bls24315.GkrProveHint(hashName, data.(*bls24315.GkrSolvingData))(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BLS24_317.ScalarField()) == 0 {
+			return bls24317.GkrProveHint(hashName, data.(*bls24317.GkrSolvingData))(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BN254.ScalarField()) == 0 {
+			return bn254.GkrProveHint(hashName, data.(*bn254.GkrSolvingData))(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BW6_633.ScalarField()) == 0 {
+			return bw6633.GkrProveHint(hashName, data.(*bw6633.GkrSolvingData))(mod, ins, outs)
+		}
+		if mod.Cmp(ecc.BW6_761.ScalarField()) == 0 {
+			return bw6761.GkrProveHint(hashName, data.(*bw6761.GkrSolvingData))(mod, ins, outs)
+		}
+
+		return errors.New("unsupported modulus")
+	}
+}

--- a/test/engine.go
+++ b/test/engine.go
@@ -755,7 +755,7 @@ func (e *engine) ToCanonicalVariable(v frontend.Variable) frontend.CanonicalVari
 }
 
 func (e *engine) SetGkrInfo(info constraint.GkrInfo) error {
-	return fmt.Errorf("not implemented")
+	return nil
 }
 
 // MustBeLessOrEqCst implements method comparing value given by its bits aBits


### PR DESCRIPTION
Currently, GKR cannot run under the test engine. This PR changes that by implementing hints that delegate to the appropriate curve-specific ones used in the solver.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

