### PR TITLE
chore: up gnark-crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/bavard v0.1.13
 	github.com/consensys/compress v0.2.5
-	github.com/consensys/gnark-crypto v0.14.0
+	github.com/consensys/gnark-crypto v0.14.1-0.20240909142611-e6b99e74cec1
 	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/Yj
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
 github.com/consensys/compress v0.2.5 h1:gJr1hKzbOD36JFsF1AN8lfXz1yevnJi1YolffY19Ntk=
 github.com/consensys/compress v0.2.5/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
-github.com/consensys/gnark-crypto v0.14.0 h1:DDBdl4HaBtdQsq/wfMwJvZNE80sHidrK3Nfrefatm0E=
-github.com/consensys/gnark-crypto v0.14.0/go.mod h1:CU4UijNPsHawiVGNxe9co07FkzCeWHHrb1li/n1XoU0=
+github.com/consensys/gnark-crypto v0.14.1-0.20240909142611-e6b99e74cec1 h1:xsKDyn8I+lnrLFsJL6bbDavs7xTrmKeQE/xe/htVt3I=
+github.com/consensys/gnark-crypto v0.14.1-0.20240909142611-e6b99e74cec1/go.mod h1:CU4UijNPsHawiVGNxe9co07FkzCeWHHrb1li/n1XoU0=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/std/recursion/wrapped_hash.go
+++ b/std/recursion/wrapped_hash.go
@@ -46,9 +46,6 @@ func NewShort(current, target *big.Int) (hash.Hash, error) {
 	case ecc.BLS12_377.ScalarField().String():
 		h = cryptomimc.MIMC_BLS12_377
 		bitBlockSize = ecc.BLS12_377.ScalarField().BitLen()
-	case ecc.BLS12_378.ScalarField().String():
-		h = cryptomimc.MIMC_BLS12_378
-		bitBlockSize = ecc.BLS12_378.ScalarField().BitLen()
 	case ecc.BW6_761.ScalarField().String():
 		h = cryptomimc.MIMC_BW6_761
 		bitBlockSize = ecc.BW6_761.ScalarField().BitLen()
@@ -61,9 +58,6 @@ func NewShort(current, target *big.Int) (hash.Hash, error) {
 	case ecc.BW6_633.ScalarField().String():
 		h = cryptomimc.MIMC_BW6_633
 		bitBlockSize = ecc.BW6_633.ScalarField().BitLen()
-	case ecc.BW6_756.ScalarField().String():
-		h = cryptomimc.MIMC_BW6_756
-		bitBlockSize = ecc.BW6_756.ScalarField().BitLen()
 	default:
 		return nil, fmt.Errorf("no default mimc for scalar field: %s", current.String())
 	}


### PR DESCRIPTION
# Description

update gnark-crypto to latest which removes support of BLS12-378 and BW6-756 curves

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

`wrapped_hash_test.go` in std/recursion passes.

# How has this been benchmarked?

N/A

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

