### PR TITLE
fix: expmod precompile if modulus is 1

### DIFF
--- a/std/evmprecompiles/05-expmod_test.go
+++ b/std/evmprecompiles/05-expmod_test.go
@@ -69,7 +69,7 @@ func TestEdgeCases(t *testing.T) {
 		base, exp, modulus, result *big.Int
 	}{
 		{big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0)},     // 0^0 = 0 mod 0
-		{big.NewInt(0), big.NewInt(0), big.NewInt(1), big.NewInt(1)},     // 0^0 = 1 mod 1
+		{big.NewInt(0), big.NewInt(0), big.NewInt(1), big.NewInt(0)},     // 0^0 = 0 mod 1
 		{big.NewInt(0), big.NewInt(0), big.NewInt(123), big.NewInt(1)},   // 0^0 = 1 mod 123
 		{big.NewInt(123), big.NewInt(123), big.NewInt(0), big.NewInt(0)}, // 123^123 = 0 mod 0
 		{big.NewInt(123), big.NewInt(123), big.NewInt(0), big.NewInt(0)}, // 123^123 = 0 mod 1


### PR DESCRIPTION
# Description

Even though EVM yellow paper defines 0^0=1, then this holds only if modulus is not 0 or 1. In either such case any exponentiation is 0.

Fixes LA audit Issue G

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- [x] TestEdgeCases - changed the edge case test


# How has this been benchmarked?

Not benchmarked

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

