### PR TITLE
feat: direct multivariate polynomial evaluation in non-native

### DIFF
--- a/std/math/emulated/doc.go
+++ b/std/math/emulated/doc.go
@@ -111,6 +111,17 @@ identity at a random point:
 where e(X) is a polynomial used for carrying the overflows of the left- and
 right-hand side of the above equation.
 
+This approachs can be extended to the case when the left hand side is not a
+simple multiplication, but rather any evaluation of a multivariate polynomial.
+So in essence we can check the correctness of any polynomial evaluation modulo
+r:
+
+	F(x_1, x_2, ..., x_n) = c + z*r
+
+through the following identity:
+
+	F(x_1(X), x_2(X), ..., x_n(X)) = c(X) + z(X) * r(X) + (2^w' - X) e(X).
+
 # Subtraction
 
 We perform subtraction limb-wise between the elements x and y. However, we have

--- a/std/math/emulated/doc.go
+++ b/std/math/emulated/doc.go
@@ -111,7 +111,7 @@ identity at a random point:
 where e(X) is a polynomial used for carrying the overflows of the left- and
 right-hand side of the above equation.
 
-This approachs can be extended to the case when the left hand side is not a
+This approach can be extended to the case when the left hand side is not a
 simple multiplication, but rather any evaluation of a multivariate polynomial.
 So in essence we can check the correctness of any polynomial evaluation modulo
 r:

--- a/std/math/emulated/element_test.go
+++ b/std/math/emulated/element_test.go
@@ -1281,7 +1281,7 @@ func TestIsZeroEdgeCases(t *testing.T) {
 type PolyEvalCircuit[T FieldParams] struct {
 	Inputs   []Element[T]
 	Terms    [][]int
-	Coeffs   []*big.Int
+	Coeffs   []int
 	Expected Element[T]
 }
 
@@ -1307,7 +1307,7 @@ func (c *PolyEvalCircuit[T]) Define(api frontend.API) error {
 		for j := range term {
 			termVal = f.Mul(termVal, &c.Inputs[term[j]])
 		}
-		addTerms[i] = f.MulConst(termVal, c.Coeffs[i])
+		addTerms[i] = f.MulConst(termVal, big.NewInt(int64(c.Coeffs[i])))
 	}
 	resSum := f.Sum(addTerms...)
 
@@ -1318,7 +1318,7 @@ func (c *PolyEvalCircuit[T]) Define(api frontend.API) error {
 		for j := range term {
 			termVal = f.MulNoReduce(termVal, &c.Inputs[term[j]])
 		}
-		addTerms2[i] = f.MulConst(termVal, c.Coeffs[i])
+		addTerms2[i] = f.MulConst(termVal, big.NewInt(int64(c.Coeffs[i])))
 	}
 	resNoReduce := f.Sum(addTerms2...)
 	resReduced := f.Reduce(resNoReduce)
@@ -1345,7 +1345,7 @@ func testPolyEval[T FieldParams](t *testing.T) {
 	var err error
 	// 2*x^3 + 3*x^2 y + 4*x y^2 + 5*y^3
 	terms := [][]int{{0, 0, 0}, {0, 0, 1}, {0, 1, 1}, {1, 1, 1}}
-	coefficients := []*big.Int{big.NewInt(2), big.NewInt(3), big.NewInt(4), big.NewInt(5)}
+	coefficients := []int{2, 3, 4, 5}
 	inputs := make([]*big.Int, nbInputs)
 	assignmentInput := make([]Element[T], nbInputs)
 	for i := range inputs {
@@ -1357,7 +1357,7 @@ func testPolyEval[T FieldParams](t *testing.T) {
 	}
 	expected := new(big.Int)
 	for i, term := range terms {
-		termVal := new(big.Int).Set(coefficients[i])
+		termVal := new(big.Int).SetInt64(int64(coefficients[i]))
 		for j := range term {
 			termVal.Mul(termVal, inputs[term[j]])
 		}
@@ -1383,7 +1383,7 @@ func (c *PolyEvalNegativeCoefficient[T]) Define(api frontend.API) error {
 		return err
 	}
 	// x - y
-	coefficients := []*big.Int{big.NewInt(1), big.NewInt(-1)}
+	coefficients := []int{1, -1}
 	res := f.Eval([][]*Element[T]{{&c.Inputs[0]}, {&c.Inputs[1]}}, coefficients)
 	f.AssertIsEqual(res, &c.Res)
 	return nil

--- a/std/math/emulated/field.go
+++ b/std/math/emulated/field.go
@@ -282,3 +282,15 @@ func max[T constraints.Ordered](a ...T) T {
 	}
 	return m
 }
+
+func sum[T constraints.Ordered](a ...T) T {
+	if len(a) == 0 {
+		var f T
+		return f
+	}
+	m := a[0]
+	for _, v := range a[1:] {
+		m += v
+	}
+	return m
+}

--- a/std/math/emulated/field.go
+++ b/std/math/emulated/field.go
@@ -47,7 +47,7 @@ type Field[T FieldParams] struct {
 	constrainedLimbs map[[16]byte]struct{}
 	checker          frontend.Rangechecker
 
-	mulChecks []mulCheck[T]
+	deferredChecks []deferredChecker
 }
 
 type ctxKey[T FieldParams] struct{}
@@ -103,7 +103,7 @@ func NewField[T FieldParams](native frontend.API) (*Field[T], error) {
 		return nil, fmt.Errorf("elements with limb length %d does not fit into scalar field", f.fParams.BitsPerLimb())
 	}
 
-	native.Compiler().Defer(f.performMulChecks)
+	native.Compiler().Defer(f.performDeferredChecks)
 	if storer, ok := native.(kvstore.Store); ok {
 		storer.SetKeyValue(ctxKey[T]{}, f)
 	}

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -355,16 +355,12 @@ func (f *Field[T]) callMulHint(a, b *Element[T], isMulMod bool, customMod *Eleme
 	nbCarryLimbs := max(nbMultiplicationResLimbs(len(a.Limbs), len(b.Limbs)), nbMultiplicationResLimbs(int(nbQuoLimbs), int(nbLimbs))) - 1
 	// we encode the computed parameters and widths to the hint function so can
 	// know how many limbs to expect.
-	hintInputs := []frontend.Variable{
-		nbBits,
-		nbLimbs,
-		len(a.Limbs),
-		nbQuoLimbs,
-	}
 	modulusLimbs := f.Modulus().Limbs
 	if customMod != nil {
 		modulusLimbs = customMod.Limbs
 	}
+	hintInputs := make([]frontend.Variable, 0, 4+len(modulusLimbs)+len(a.Limbs)+len(b.Limbs))
+	hintInputs = append(hintInputs, nbBits, nbLimbs, len(a.Limbs), nbQuoLimbs)
 	hintInputs = append(hintInputs, modulusLimbs...)
 	hintInputs = append(hintInputs, a.Limbs...)
 	hintInputs = append(hintInputs, b.Limbs...)
@@ -699,15 +695,12 @@ func (f *Field[T]) callPolyMvHint(mv *multivariate[T], at []*Element[T]) (quo, r
 	nbRemLimbs := nbLimbs
 	nbCarryLimbs := nbMultiplicationResLimbs(int(nbQuoLimbs), int(nbLimbs)) - 1
 
-	hintInputs := []frontend.Variable{
-		nbBits,
-		nbLimbs,
-		len(mv.Terms),
-		len(at),
-		nbQuoLimbs,
-		nbRemLimbs,
-		nbCarryLimbs,
+	nbHintInputs := 7 + len(at)*len(mv.Terms) + len(mv.Coefficients) + len(f.Modulus().Limbs)
+	for i := range at {
+		nbHintInputs += len(at[i].Limbs) + 1
 	}
+	hintInputs := make([]frontend.Variable, 0, nbHintInputs)
+	hintInputs = append(hintInputs, nbBits, nbLimbs, len(mv.Terms), len(at), nbQuoLimbs, nbRemLimbs, nbCarryLimbs)
 	// store the terms in the hint input. First the exponents
 	for i := range mv.Terms {
 		for j := range mv.Terms[i] {

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -636,7 +636,7 @@ func (f *Field[T]) Eval(at [][]*Element[T], coefs []int) *Element[T] {
 		}
 	}
 	// we already know all different inputs. We now count the number of
-	// occurences in every term.
+	// occurrences in every term.
 	terms := make([][]int, 0, len(at))
 	for i := range at {
 		term := make([]int, len(allElems))
@@ -684,7 +684,7 @@ func (f *Field[T]) Eval(at [][]*Element[T], coefs []int) *Element[T] {
 
 // callPolyMvHint computes the multivariate evaluation given by mv at at. It
 // returns the remainder (reduced result), the quotient and the carries. The
-// computation is performed inside a hint, so it is the callers responsibilty to
+// computation is performed inside a hint, so it is the callers responsibility to
 // perform the deferred multiplication check.
 func (f *Field[T]) callPolyMvHint(mv *multivariate[T], at []*Element[T]) (quo, rem, carries *Element[T], err error) {
 	// first compute the length of the result so that we know how many bits we need for the quotient.

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -110,7 +110,11 @@ type mulCheck[T FieldParams] struct {
 }
 
 func (mc *mulCheck[T]) toCommit() []frontend.Variable {
-	var toCommit []frontend.Variable
+	nbToCommit := len(mc.a.Limbs) + len(mc.b.Limbs) + len(mc.r.Limbs) + len(mc.k.Limbs) + len(mc.c.Limbs)
+	if mc.p != nil {
+		nbToCommit += len(mc.p.Limbs)
+	}
+	toCommit := make([]frontend.Variable, 0, nbToCommit)
 	toCommit = append(toCommit, mc.a.Limbs...)
 	toCommit = append(toCommit, mc.b.Limbs...)
 	toCommit = append(toCommit, mc.r.Limbs...)
@@ -747,7 +751,11 @@ type mvCheck[T FieldParams] struct {
 }
 
 func (mc *mvCheck[T]) toCommit() []frontend.Variable {
-	var toCommit []frontend.Variable
+	nbToCommit := len(mc.r.Limbs) + len(mc.k.Limbs) + len(mc.c.Limbs)
+	for j := range mc.vals {
+		nbToCommit += len(mc.vals[j].Limbs)
+	}
+	toCommit := make([]frontend.Variable, 0, nbToCommit)
 	toCommit = append(toCommit, mc.r.Limbs...)
 	toCommit = append(toCommit, mc.k.Limbs...)
 	toCommit = append(toCommit, mc.c.Limbs...)

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -552,6 +552,12 @@ type multivariate[T FieldParams] struct {
 //
 // NB! This is experimental API. It does not support negative coefficients. It
 // does not check that computing the term wouldn't overflow the field.
+//
+// For example, for computing the expression x^2 + 2xy + y^2 we would call
+//
+//	f.Eval([][]*Element[T]{{x,x}, {x,y}, {y,y}}, []int{1, 2, 1})
+//
+// The method returns the result of the evaluation.
 func (f *Field[T]) Eval(at [][]*Element[T], coefs []int) *Element[T] {
 	if len(at) != len(coefs) {
 		panic("terms and coefficients mismatch")

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -520,6 +520,27 @@ func (f *Field[T]) Exp(base, exp *Element[T]) *Element[T] {
 // multivariate represents a multivariate polynomial. It is a list of terms
 // where each term is a list of exponents for each variable. The coefficients
 // are stored in the same order as the terms.
+//
+// For example, if there are two inputs x and y and we compute the polynomial
+//
+//	x^2 + 2xy + y^2
+//
+// then we have the terms
+//
+//	[[2, 0], [1, 1], [0, 2]]
+//
+// and coefficients
+//
+//	[1, 1, 1].
+//
+// These definitions differ from how we expose the method in the [Field.Eval]
+// method - there as we use pointers to the variables themselves, then we can
+// allow to give the inputs directly a la
+//
+//	f.Eval([][]*Element[T]{{x,x}, {x,y}, {y,y}}, []int{1, 1, 1}),
+//
+// but we cannot use the references inside the hint function as we work with
+// solved values.
 type multivariate[T FieldParams] struct {
 	Terms        [][]int
 	Coefficients []int

--- a/std/math/emulated/hints.go
+++ b/std/math/emulated/hints.go
@@ -24,7 +24,7 @@ func GetHints() []solver.Hint {
 		SqrtHint,
 		mulHint,
 		subPaddingHint,
-		polyHint,
+		polyMvHint,
 	}
 }
 

--- a/std/math/emulated/hints.go
+++ b/std/math/emulated/hints.go
@@ -24,6 +24,7 @@ func GetHints() []solver.Hint {
 		SqrtHint,
 		mulHint,
 		subPaddingHint,
+		polyHint,
 	}
 }
 


### PR DESCRIPTION
# Description

This PR adds direct multivariate polynomial evaluation using non-native arithmetic. It can be used to perform direct extension computation, used in pairing computation (BW6, BN254, BLS12-377).

The idea is very similar to the multiplication approach, but when we do the evaluation check then we can work with arbitrary multivariate polynomials. This is really beneficial as the most of the cost is in range checking the result and the quotient, so when we can amortize multiple operations.

Another PR using it in BW6 evaluation is incoming, but it saves more than 50% of constraints in the Miller loop computation.

NB! One thing which I haven't figure out is how to allow negative coefficients. For example for BW6 we need to multiply by the non residue -4 for which we currently use a non-native value. But this changes the carry computation and SZ check which still isn't fully functional. But I think I'll keep it for the future to get working.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestPolyEval

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

