### PR TITLE
chore: Replace fmt.Printf calls with warning logs

### DIFF
--- a/frontend/schema/schema.go
+++ b/frontend/schema/schema.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/consensys/gnark/logger"
 )
 
 // Schema represents the structure of a gnark circuit (/ witness)
@@ -322,7 +324,8 @@ func parse(r []Field, input interface{}, target reflect.Type, parentFullName, pa
 	if tValue.Kind() == reflect.Slice || tValue.Kind() == reflect.Array {
 		if tValue.Len() == 0 {
 			if reflect.SliceOf(target) == tValue.Type() {
-				fmt.Printf("ignoring uninitialized slice: %s %s\n", parentGoName, reflect.SliceOf(target).String())
+				log := logger.Logger()
+				log.Warn().Str("slice name", parentGoName).Str("slice type", reflect.SliceOf(target).String()).Msg("ignoring uninitialized slice")
 			}
 			return r, nil
 		}

--- a/frontend/schema/walk.go
+++ b/frontend/schema/walk.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/consensys/gnark/frontend/schema/internal/reflectwalk"
+	"github.com/consensys/gnark/logger"
 )
 
 // Walk walks through the provided object and stops when it encounters objects of type tLeaf
@@ -82,7 +83,8 @@ func (w *walker) Pointer(value reflect.Value) error {
 func (w *walker) Slice(value reflect.Value) error {
 	if value.Type() == w.targetSlice {
 		if value.Len() == 0 {
-			fmt.Printf("ignoring uninitialized slice: %s %s\n", w.name(), reflect.SliceOf(w.target).String())
+			log := logger.Logger()
+			log.Warn().Str("slice name", w.name()).Str("slice type", reflect.SliceOf(w.target).String()).Msg("ignoring uninitialized slice")
 			return nil
 		}
 		return w.handleLeaves(value)


### PR DESCRIPTION
# Description

As far as I can tell, there's only two places (outside of tests) that still are using `fmt.Printf`/`fmt.Println` to print warnings to stdout, in the `frontend/schema` directory. This small PR replaces them with warning logs using the `logger` module.

If the severity of the message should be different from a warning, let me know so I can change it quickly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

I've tested this locally against a test case that triggers this message (specifically https://github.com/argumentcomputer/sphinx doing a Plonk BN254 proof verification, via an FFI wrapper at https://github.com/argumentcomputer/lurk-hs), and with this patch the messages are now logged at the proper level, as follows:

Before:
```
Testing fixture: "/home/w/dev/w/lurk-hs/assets/epoch_change.json"
ignoring uninitialized slice: Vars []frontend.Variable
ignoring uninitialized slice: Vars []frontend.Variable
ignoring uninitialized slice: Vars []frontend.Variable
Test completed for fixture: "/home/w/dev/w/lurk-hs/assets/epoch_change.json"
```
After:
```
Testing fixture: "/home/w/dev/w/lurk-hs/assets/epoch_change.json"
17:15:32 WRN ignoring uninitialized slice slice name=Vars slice type=[]frontend.Variable
17:15:32 WRN ignoring uninitialized slice slice name=Vars slice type=[]frontend.Variable
17:15:32 WRN ignoring uninitialized slice slice name=Vars slice type=[]frontend.Variable
Test completed for fixture: "/home/w/dev/w/lurk-hs/assets/epoch_change.json"
```

# How has this been benchmarked?

This change is minor and has not been benchmarked.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

