### PR TITLE
fix: sanitize groth16 verification key reading

### DIFF
--- a/backend/groth16/bls12-377/marshal.go
+++ b/backend/groth16/bls12-377/marshal.go
@@ -22,6 +22,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
+
+	"fmt"
 	"io"
 )
 
@@ -196,35 +198,39 @@ func (vk *VerifyingKey) readFrom(r io.Reader, raw bool) (int64, error) {
 		&nbCommitments,
 	}
 
-	for _, v := range toDecode {
+	for i, v := range toDecode {
 		if err := dec.Decode(v); err != nil {
-			return dec.BytesRead(), err
+			return dec.BytesRead(), fmt.Errorf("read field %d: %w", i, err)
 		}
 	}
 
 	vk.PublicAndCommitmentCommitted = utils.Uint64SliceSliceToIntSliceSlice(publicCommitted)
 
-	vk.CommitmentKeys = make([]pedersen.VerifyingKey, nbCommitments)
 	var n int64
-	for i := range vk.CommitmentKeys {
+	for i := 0; i < int(nbCommitments); i++ {
 		var (
 			m   int64
 			err error
 		)
+		commitmentKey := pedersen.VerifyingKey{}
 		if raw {
-			m, err = vk.CommitmentKeys[i].UnsafeReadFrom(r)
+			m, err = commitmentKey.UnsafeReadFrom(r)
 		} else {
-			m, err = vk.CommitmentKeys[i].ReadFrom(r)
+			m, err = commitmentKey.ReadFrom(r)
 		}
 		n += m
 		if err != nil {
-			return n + dec.BytesRead(), err
+			return n + dec.BytesRead(), fmt.Errorf("read commitment key %d: %w", i, err)
 		}
+		vk.CommitmentKeys = append(vk.CommitmentKeys, commitmentKey)
+	}
+	if len(vk.CommitmentKeys) != int(nbCommitments) {
+		return n + dec.BytesRead(), fmt.Errorf("invalid number of commitment keys. Expected %d got %d", nbCommitments, len(vk.CommitmentKeys))
 	}
 
 	// recompute vk.e (e(α, β)) and  -[δ]2, -[γ]2
 	if err := vk.Precompute(); err != nil {
-		return n + dec.BytesRead(), err
+		return n + dec.BytesRead(), fmt.Errorf("precompute: %w", err)
 	}
 
 	return n + dec.BytesRead(), nil

--- a/backend/groth16/bls12-381/marshal.go
+++ b/backend/groth16/bls12-381/marshal.go
@@ -22,6 +22,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
+
+	"fmt"
 	"io"
 )
 
@@ -196,35 +198,39 @@ func (vk *VerifyingKey) readFrom(r io.Reader, raw bool) (int64, error) {
 		&nbCommitments,
 	}
 
-	for _, v := range toDecode {
+	for i, v := range toDecode {
 		if err := dec.Decode(v); err != nil {
-			return dec.BytesRead(), err
+			return dec.BytesRead(), fmt.Errorf("read field %d: %w", i, err)
 		}
 	}
 
 	vk.PublicAndCommitmentCommitted = utils.Uint64SliceSliceToIntSliceSlice(publicCommitted)
 
-	vk.CommitmentKeys = make([]pedersen.VerifyingKey, nbCommitments)
 	var n int64
-	for i := range vk.CommitmentKeys {
+	for i := 0; i < int(nbCommitments); i++ {
 		var (
 			m   int64
 			err error
 		)
+		commitmentKey := pedersen.VerifyingKey{}
 		if raw {
-			m, err = vk.CommitmentKeys[i].UnsafeReadFrom(r)
+			m, err = commitmentKey.UnsafeReadFrom(r)
 		} else {
-			m, err = vk.CommitmentKeys[i].ReadFrom(r)
+			m, err = commitmentKey.ReadFrom(r)
 		}
 		n += m
 		if err != nil {
-			return n + dec.BytesRead(), err
+			return n + dec.BytesRead(), fmt.Errorf("read commitment key %d: %w", i, err)
 		}
+		vk.CommitmentKeys = append(vk.CommitmentKeys, commitmentKey)
+	}
+	if len(vk.CommitmentKeys) != int(nbCommitments) {
+		return n + dec.BytesRead(), fmt.Errorf("invalid number of commitment keys. Expected %d got %d", nbCommitments, len(vk.CommitmentKeys))
 	}
 
 	// recompute vk.e (e(α, β)) and  -[δ]2, -[γ]2
 	if err := vk.Precompute(); err != nil {
-		return n + dec.BytesRead(), err
+		return n + dec.BytesRead(), fmt.Errorf("precompute: %w", err)
 	}
 
 	return n + dec.BytesRead(), nil

--- a/backend/groth16/bls24-317/marshal.go
+++ b/backend/groth16/bls24-317/marshal.go
@@ -22,6 +22,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls24-317/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
+
+	"fmt"
 	"io"
 )
 
@@ -196,35 +198,39 @@ func (vk *VerifyingKey) readFrom(r io.Reader, raw bool) (int64, error) {
 		&nbCommitments,
 	}
 
-	for _, v := range toDecode {
+	for i, v := range toDecode {
 		if err := dec.Decode(v); err != nil {
-			return dec.BytesRead(), err
+			return dec.BytesRead(), fmt.Errorf("read field %d: %w", i, err)
 		}
 	}
 
 	vk.PublicAndCommitmentCommitted = utils.Uint64SliceSliceToIntSliceSlice(publicCommitted)
 
-	vk.CommitmentKeys = make([]pedersen.VerifyingKey, nbCommitments)
 	var n int64
-	for i := range vk.CommitmentKeys {
+	for i := 0; i < int(nbCommitments); i++ {
 		var (
 			m   int64
 			err error
 		)
+		commitmentKey := pedersen.VerifyingKey{}
 		if raw {
-			m, err = vk.CommitmentKeys[i].UnsafeReadFrom(r)
+			m, err = commitmentKey.UnsafeReadFrom(r)
 		} else {
-			m, err = vk.CommitmentKeys[i].ReadFrom(r)
+			m, err = commitmentKey.ReadFrom(r)
 		}
 		n += m
 		if err != nil {
-			return n + dec.BytesRead(), err
+			return n + dec.BytesRead(), fmt.Errorf("read commitment key %d: %w", i, err)
 		}
+		vk.CommitmentKeys = append(vk.CommitmentKeys, commitmentKey)
+	}
+	if len(vk.CommitmentKeys) != int(nbCommitments) {
+		return n + dec.BytesRead(), fmt.Errorf("invalid number of commitment keys. Expected %d got %d", nbCommitments, len(vk.CommitmentKeys))
 	}
 
 	// recompute vk.e (e(α, β)) and  -[δ]2, -[γ]2
 	if err := vk.Precompute(); err != nil {
-		return n + dec.BytesRead(), err
+		return n + dec.BytesRead(), fmt.Errorf("precompute: %w", err)
 	}
 
 	return n + dec.BytesRead(), nil

--- a/backend/groth16/bn254/marshal.go
+++ b/backend/groth16/bn254/marshal.go
@@ -22,6 +22,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
+
+	"fmt"
 	"io"
 )
 
@@ -196,35 +198,39 @@ func (vk *VerifyingKey) readFrom(r io.Reader, raw bool) (int64, error) {
 		&nbCommitments,
 	}
 
-	for _, v := range toDecode {
+	for i, v := range toDecode {
 		if err := dec.Decode(v); err != nil {
-			return dec.BytesRead(), err
+			return dec.BytesRead(), fmt.Errorf("read field %d: %w", i, err)
 		}
 	}
 
 	vk.PublicAndCommitmentCommitted = utils.Uint64SliceSliceToIntSliceSlice(publicCommitted)
 
-	vk.CommitmentKeys = make([]pedersen.VerifyingKey, nbCommitments)
 	var n int64
-	for i := range vk.CommitmentKeys {
+	for i := 0; i < int(nbCommitments); i++ {
 		var (
 			m   int64
 			err error
 		)
+		commitmentKey := pedersen.VerifyingKey{}
 		if raw {
-			m, err = vk.CommitmentKeys[i].UnsafeReadFrom(r)
+			m, err = commitmentKey.UnsafeReadFrom(r)
 		} else {
-			m, err = vk.CommitmentKeys[i].ReadFrom(r)
+			m, err = commitmentKey.ReadFrom(r)
 		}
 		n += m
 		if err != nil {
-			return n + dec.BytesRead(), err
+			return n + dec.BytesRead(), fmt.Errorf("read commitment key %d: %w", i, err)
 		}
+		vk.CommitmentKeys = append(vk.CommitmentKeys, commitmentKey)
+	}
+	if len(vk.CommitmentKeys) != int(nbCommitments) {
+		return n + dec.BytesRead(), fmt.Errorf("invalid number of commitment keys. Expected %d got %d", nbCommitments, len(vk.CommitmentKeys))
 	}
 
 	// recompute vk.e (e(α, β)) and  -[δ]2, -[γ]2
 	if err := vk.Precompute(); err != nil {
-		return n + dec.BytesRead(), err
+		return n + dec.BytesRead(), fmt.Errorf("precompute: %w", err)
 	}
 
 	return n + dec.BytesRead(), nil

--- a/backend/groth16/bw6-633/marshal.go
+++ b/backend/groth16/bw6-633/marshal.go
@@ -22,6 +22,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-633/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
+
+	"fmt"
 	"io"
 )
 
@@ -196,35 +198,39 @@ func (vk *VerifyingKey) readFrom(r io.Reader, raw bool) (int64, error) {
 		&nbCommitments,
 	}
 
-	for _, v := range toDecode {
+	for i, v := range toDecode {
 		if err := dec.Decode(v); err != nil {
-			return dec.BytesRead(), err
+			return dec.BytesRead(), fmt.Errorf("read field %d: %w", i, err)
 		}
 	}
 
 	vk.PublicAndCommitmentCommitted = utils.Uint64SliceSliceToIntSliceSlice(publicCommitted)
 
-	vk.CommitmentKeys = make([]pedersen.VerifyingKey, nbCommitments)
 	var n int64
-	for i := range vk.CommitmentKeys {
+	for i := 0; i < int(nbCommitments); i++ {
 		var (
 			m   int64
 			err error
 		)
+		commitmentKey := pedersen.VerifyingKey{}
 		if raw {
-			m, err = vk.CommitmentKeys[i].UnsafeReadFrom(r)
+			m, err = commitmentKey.UnsafeReadFrom(r)
 		} else {
-			m, err = vk.CommitmentKeys[i].ReadFrom(r)
+			m, err = commitmentKey.ReadFrom(r)
 		}
 		n += m
 		if err != nil {
-			return n + dec.BytesRead(), err
+			return n + dec.BytesRead(), fmt.Errorf("read commitment key %d: %w", i, err)
 		}
+		vk.CommitmentKeys = append(vk.CommitmentKeys, commitmentKey)
+	}
+	if len(vk.CommitmentKeys) != int(nbCommitments) {
+		return n + dec.BytesRead(), fmt.Errorf("invalid number of commitment keys. Expected %d got %d", nbCommitments, len(vk.CommitmentKeys))
 	}
 
 	// recompute vk.e (e(α, β)) and  -[δ]2, -[γ]2
 	if err := vk.Precompute(); err != nil {
-		return n + dec.BytesRead(), err
+		return n + dec.BytesRead(), fmt.Errorf("precompute: %w", err)
 	}
 
 	return n + dec.BytesRead(), nil

--- a/backend/groth16/bw6-761/marshal.go
+++ b/backend/groth16/bw6-761/marshal.go
@@ -22,6 +22,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bw6-761/fr/pedersen"
 	"github.com/consensys/gnark-crypto/utils/unsafe"
 	"github.com/consensys/gnark/internal/utils"
+
+	"fmt"
 	"io"
 )
 
@@ -196,35 +198,39 @@ func (vk *VerifyingKey) readFrom(r io.Reader, raw bool) (int64, error) {
 		&nbCommitments,
 	}
 
-	for _, v := range toDecode {
+	for i, v := range toDecode {
 		if err := dec.Decode(v); err != nil {
-			return dec.BytesRead(), err
+			return dec.BytesRead(), fmt.Errorf("read field %d: %w", i, err)
 		}
 	}
 
 	vk.PublicAndCommitmentCommitted = utils.Uint64SliceSliceToIntSliceSlice(publicCommitted)
 
-	vk.CommitmentKeys = make([]pedersen.VerifyingKey, nbCommitments)
 	var n int64
-	for i := range vk.CommitmentKeys {
+	for i := 0; i < int(nbCommitments); i++ {
 		var (
 			m   int64
 			err error
 		)
+		commitmentKey := pedersen.VerifyingKey{}
 		if raw {
-			m, err = vk.CommitmentKeys[i].UnsafeReadFrom(r)
+			m, err = commitmentKey.UnsafeReadFrom(r)
 		} else {
-			m, err = vk.CommitmentKeys[i].ReadFrom(r)
+			m, err = commitmentKey.ReadFrom(r)
 		}
 		n += m
 		if err != nil {
-			return n + dec.BytesRead(), err
+			return n + dec.BytesRead(), fmt.Errorf("read commitment key %d: %w", i, err)
 		}
+		vk.CommitmentKeys = append(vk.CommitmentKeys, commitmentKey)
+	}
+	if len(vk.CommitmentKeys) != int(nbCommitments) {
+		return n + dec.BytesRead(), fmt.Errorf("invalid number of commitment keys. Expected %d got %d", nbCommitments, len(vk.CommitmentKeys))
 	}
 
 	// recompute vk.e (e(α, β)) and  -[δ]2, -[γ]2
 	if err := vk.Precompute(); err != nil {
-		return n + dec.BytesRead(), err
+		return n + dec.BytesRead(), fmt.Errorf("precompute: %w", err)
 	}
 
 	return n + dec.BytesRead(), nil

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.marshal.go.tmpl
@@ -180,9 +180,9 @@ func (vk *VerifyingKey) readFrom(r io.Reader, raw bool) (int64, error) {
 		&nbCommitments,
 	}
 
-	for _, v := range toDecode {
+	for i, v := range toDecode {
 		if err := dec.Decode(v); err != nil {
-			return dec.BytesRead(), err
+			return dec.BytesRead(), fmt.Errorf("read field %d: %w", i, err)
 		}
 	}
 
@@ -202,17 +202,17 @@ func (vk *VerifyingKey) readFrom(r io.Reader, raw bool) (int64, error) {
 		}
 		n += m
 		if err != nil {
-			return n + dec.BytesRead(), err
+			return n + dec.BytesRead(), fmt.Errorf("read commitment key %d: %w", i, err)
 		}
 		vk.CommitmentKeys = append(vk.CommitmentKeys, commitmentKey)
 	}
 	if len(vk.CommitmentKeys) != int(nbCommitments) {
-		return n + dec.BytesRead(), fmt.Errorf("invalid number of commitment keys")
+		return n + dec.BytesRead(), fmt.Errorf("invalid number of commitment keys. Expected %d got %d", nbCommitments, len(vk.CommitmentKeys))
 	}
 
 	// recompute vk.e (e(α, β)) and  -[δ]2, -[γ]2
 	if err := vk.Precompute(); err != nil {
-		return n + dec.BytesRead(), err
+		return n + dec.BytesRead(), fmt.Errorf("precompute: %w", err)
 	}
 
 	return n + dec.BytesRead(), nil

--- a/internal/generator/backend/template/zkpschemes/groth16/groth16.marshal.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/groth16.marshal.go.tmpl
@@ -3,6 +3,8 @@ import (
 	{{ template "import_pedersen" . }}
 	"github.com/consensys/gnark/internal/utils"
 	"github.com/consensys/gnark-crypto/utils/unsafe"
+
+	"fmt"
 	"io"
 )
 
@@ -186,22 +188,26 @@ func (vk *VerifyingKey) readFrom(r io.Reader, raw bool) (int64, error) {
 
 	vk.PublicAndCommitmentCommitted = utils.Uint64SliceSliceToIntSliceSlice(publicCommitted)
 	
-	vk.CommitmentKeys = make([]pedersen.VerifyingKey, nbCommitments)
 	var n int64
-	for i := range vk.CommitmentKeys {
+	for i := 0; i < int(nbCommitments); i++ {
 		var (
 			m   int64
 			err error
 		)
+		commitmentKey := pedersen.VerifyingKey{}
 		if raw {
-			m, err = vk.CommitmentKeys[i].UnsafeReadFrom(r)
+			m, err = commitmentKey.UnsafeReadFrom(r)
 		} else {
-			m, err = vk.CommitmentKeys[i].ReadFrom(r)
+			m, err = commitmentKey.ReadFrom(r)
 		}
 		n += m
 		if err != nil {
 			return n + dec.BytesRead(), err
 		}
+		vk.CommitmentKeys = append(vk.CommitmentKeys, commitmentKey)
+	}
+	if len(vk.CommitmentKeys) != int(nbCommitments) {
+		return n + dec.BytesRead(), fmt.Errorf("invalid number of commitment keys")
 	}
 
 	// recompute vk.e (e(α, β)) and  -[δ]2, -[γ]2


### PR DESCRIPTION
# Description

See the related security advisory https://github.com/Consensys/gnark/security/advisories/GHSA-cph5-3pgr-c82g (will publish once PR has been reviewed and tested) for full description and POC.

The main issue is that serialized Groth16 verification key includes in a header number of expected Pedersen verification keys which is used for initializing a slice. When modifying the serialized file, we may allocate huge slice, leading to OOM.

In this PR instead of allocating the slice beforehand, we instead try to read all the existing commitment keys in the file and then compare that the number of read commitment keys corresponds to the expected. This prevents using heuristics on the number of commitment keys and bounds the size of the in-memory full verification key to the serialized file size.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Tested against the POC in the advisory. Does not OOM anymore.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

