### PR TITLE
perf: avoid commiting to table and queries in log-derivative argument

### DIFF
--- a/internal/stats/latest_stats.csv
+++ b/internal/stats/latest_stats.csv
@@ -132,13 +132,13 @@ math/emulated/secp256k1_64,bls24_315,groth16,1070,1950
 math/emulated/secp256k1_64,bls24_317,groth16,1070,1950
 math/emulated/secp256k1_64,bw6_761,groth16,1070,1950
 math/emulated/secp256k1_64,bw6_633,groth16,1070,1950
-math/emulated/secp256k1_64,bn254,plonk,4497,4388
-math/emulated/secp256k1_64,bls12_377,plonk,4497,4388
-math/emulated/secp256k1_64,bls12_381,plonk,4497,4388
-math/emulated/secp256k1_64,bls24_315,plonk,4497,4388
-math/emulated/secp256k1_64,bls24_317,plonk,4497,4388
-math/emulated/secp256k1_64,bw6_761,plonk,4497,4388
-math/emulated/secp256k1_64,bw6_633,plonk,4497,4388
+math/emulated/secp256k1_64,bn254,plonk,3873,4388
+math/emulated/secp256k1_64,bls12_377,plonk,3873,4388
+math/emulated/secp256k1_64,bls12_381,plonk,3873,4388
+math/emulated/secp256k1_64,bls24_315,plonk,3873,4388
+math/emulated/secp256k1_64,bls24_317,plonk,3873,4388
+math/emulated/secp256k1_64,bw6_761,plonk,3873,4388
+math/emulated/secp256k1_64,bw6_633,plonk,3873,4388
 pairing_bls12377,bn254,groth16,0,0
 pairing_bls12377,bls12_377,groth16,0,0
 pairing_bls12377,bls12_381,groth16,0,0
@@ -160,7 +160,7 @@ pairing_bls12381,bls24_315,groth16,0,0
 pairing_bls12381,bls24_317,groth16,0,0
 pairing_bls12381,bw6_761,groth16,0,0
 pairing_bls12381,bw6_633,groth16,0,0
-pairing_bls12381,bn254,plonk,5629807,5285448
+pairing_bls12381,bn254,plonk,4896933,5285448
 pairing_bls12381,bls12_377,plonk,0,0
 pairing_bls12381,bls12_381,plonk,0,0
 pairing_bls12381,bls24_315,plonk,0,0
@@ -188,7 +188,7 @@ pairing_bn254,bls24_315,groth16,0,0
 pairing_bn254,bls24_317,groth16,0,0
 pairing_bn254,bw6_761,groth16,0,0
 pairing_bn254,bw6_633,groth16,0,0
-pairing_bn254,bn254,plonk,3798583,3560759
+pairing_bn254,bn254,plonk,3304850,3560759
 pairing_bn254,bls12_377,plonk,0,0
 pairing_bn254,bls12_381,plonk,0,0
 pairing_bn254,bls24_315,plonk,0,0
@@ -202,7 +202,7 @@ pairing_bw6761,bls24_315,groth16,0,0
 pairing_bw6761,bls24_317,groth16,0,0
 pairing_bw6761,bw6_761,groth16,0,0
 pairing_bw6761,bw6_633,groth16,0,0
-pairing_bw6761,bn254,plonk,11486969,10777222
+pairing_bw6761,bn254,plonk,9919350,10777222
 pairing_bw6761,bls12_377,plonk,0,0
 pairing_bw6761,bls12_381,plonk,0,0
 pairing_bw6761,bls24_315,plonk,0,0
@@ -216,7 +216,7 @@ scalar_mul_G1_bn254,bls24_315,groth16,0,0
 scalar_mul_G1_bn254,bls24_317,groth16,0,0
 scalar_mul_G1_bn254,bw6_761,groth16,0,0
 scalar_mul_G1_bn254,bw6_633,groth16,0,0
-scalar_mul_G1_bn254,bn254,plonk,278909,261995
+scalar_mul_G1_bn254,bn254,plonk,242129,261995
 scalar_mul_G1_bn254,bls12_377,plonk,0,0
 scalar_mul_G1_bn254,bls12_381,plonk,0,0
 scalar_mul_G1_bn254,bls24_315,plonk,0,0
@@ -230,7 +230,7 @@ scalar_mul_P256,bls24_315,groth16,0,0
 scalar_mul_P256,bls24_317,groth16,0,0
 scalar_mul_P256,bw6_761,groth16,0,0
 scalar_mul_P256,bw6_633,groth16,0,0
-scalar_mul_P256,bn254,plonk,385060,359805
+scalar_mul_P256,bn254,plonk,329932,359805
 scalar_mul_P256,bls12_377,plonk,0,0
 scalar_mul_P256,bls12_381,plonk,0,0
 scalar_mul_P256,bls24_315,plonk,0,0
@@ -244,7 +244,7 @@ scalar_mul_secp256k1,bls24_315,groth16,0,0
 scalar_mul_secp256k1,bls24_317,groth16,0,0
 scalar_mul_secp256k1,bw6_761,groth16,0,0
 scalar_mul_secp256k1,bw6_633,groth16,0,0
-scalar_mul_secp256k1,bn254,plonk,281870,264753
+scalar_mul_secp256k1,bn254,plonk,244652,264753
 scalar_mul_secp256k1,bls12_377,plonk,0,0
 scalar_mul_secp256k1,bls12_381,plonk,0,0
 scalar_mul_secp256k1,bls24_315,plonk,0,0

--- a/std/internal/logderivarg/logderivarg.go
+++ b/std/internal/logderivarg/logderivarg.go
@@ -77,18 +77,10 @@ func Build(api frontend.API, table Table, queries Table) error {
 		return fmt.Errorf("table empty")
 	}
 	nbRow := len(table[0])
-	constTable := true
 	countInputs := []frontend.Variable{len(table), nbRow}
 	for i := range table {
 		if len(table[i]) != nbRow {
 			return fmt.Errorf("table row length mismatch")
-		}
-		if constTable {
-			for j := range table[i] {
-				if _, isConst := api.Compiler().ConstantValue(table[i][j]); !isConst {
-					constTable = false
-				}
-			}
 		}
 		countInputs = append(countInputs, table[i]...)
 	}
@@ -104,11 +96,6 @@ func Build(api frontend.API, table Table, queries Table) error {
 	}
 
 	var toCommit []frontend.Variable
-	if !constTable {
-		for i := range table {
-			toCommit = append(toCommit, table[i]...)
-		}
-	}
 	for i := range queries {
 		toCommit = append(toCommit, queries[i]...)
 	}

--- a/std/internal/logderivarg/logderivarg.go
+++ b/std/internal/logderivarg/logderivarg.go
@@ -96,8 +96,13 @@ func Build(api frontend.API, table Table, queries Table) error {
 	}
 
 	var toCommit []frontend.Variable
-	for i := range queries {
-		toCommit = append(toCommit, queries[i]...)
+
+	// if table is single-column, then we don't need to sample coefficients
+	// for the random linear combination.
+	if nbRow > 1 {
+		for i := range queries {
+			toCommit = append(toCommit, queries[i]...)
+		}
 	}
 	toCommit = append(toCommit, exps...)
 


### PR DESCRIPTION
# Description

In the log-derivative argument check `F \in T` the prover provides the histogram of the occurrences `M` of the elements `F` in `T`. We then check `\sum_i m_i/(X - t_i) == \sum_j 1/(X - f_j)`.

Previously we always committed to `F, T, M` to obtain the random challenge `r` which we used for checking the equality. But as the left-hand side is always known and the equality doesn't hold for invalid `M` except for negligible probability, then we can avoid committing to `F` and `T`.

However, when the table entries and queries are vectors, then we need to challenge the random coefficients for the random linear combination, so we still commit to the queries then.

Doesn't affect Groth16 as there we compute the commitment as a Pedersen vector commitment. But for PLONK as we need to align the committed values to the commitment column and it saves the number of constraints significantly. Depending on the circuit it may be 10-15%.

# How has this been benchmarked?

See the updated stats

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

