### PR TITLE
Fix typo Update api.go

### DIFF
--- a/frontend/api.go
+++ b/frontend/api.go
@@ -37,7 +37,7 @@ type API interface {
 	// doing:
 	//
 	//     acopy := api.Mul(a, 1)
-	//     acopy = MulAcc(acopy, b, c)
+	//     acopy = api.MulAcc(acopy, b, c)
 	//
 	// ! But it may not modify a, always use MulAcc(...) result for correctness.
 	MulAcc(a, b, c Variable) Variable


### PR DESCRIPTION
**Description:**  
This pull request fixes a typo in the documentation of the `MulAcc` method in the `API` interface.  

### Problem  
In the documentation, the example for the `MulAcc` method currently reads:  
```  
acopy = MulAcc(acopy, b, c)  
```  
This is inconsistent with other examples in the documentation, which explicitly reference the API object using the `api.` prefix. The omission of `api.` in this example could confuse readers, particularly those new to the interface, as they might not realize that `MulAcc` is intended to be invoked as a method of the `API` object.  

### Fix  
The corrected line is:  
```  
acopy = api.MulAcc(acopy, b, c)  
```  

### Importance  
- **Clarity:** Ensures consistency in the documentation, aligning this example with other examples.  
- **Accuracy:** Prevents potential confusion for developers interpreting the documentation.  
- **User Experience:** Enhances the overall readability and usability of the API documentation.  

Please review and merge.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


