### PR TITLE
Fix typos in comments for clarity and grammatical correctness

### DIFF
--- a/frontend/builder.go
+++ b/frontend/builder.go
@@ -14,7 +14,7 @@ type NewBuilder func(*big.Int, CompileConfig) (Builder, error)
 type Compiler interface {
 	constraint.CustomizableSystem
 
-	// MarkBoolean sets (but do not constraint!) v to be boolean
+	// MarkBoolean sets (but does not constrain!) v to be boolean
 	// This is useful in scenarios where a variable is known to be boolean through a constraint
 	// that is not api.AssertIsBoolean. If v is a constant, this is a no-op.
 	MarkBoolean(v Variable)

--- a/frontend/variable.go
+++ b/frontend/variable.go
@@ -26,7 +26,7 @@ import (
 type Variable interface{}
 
 // IsCanonical returns true if the Variable has been normalized in a (internal) LinearExpression
-// by one of the constraint system builder. In other words, if the Variable is a circuit input OR
+// by one of the constraint system builders. In other words, if the Variable is a circuit input OR
 // returned by the API.
 func IsCanonical(v Variable) bool {
 	switch v.(type) {


### PR DESCRIPTION
**Changes:**

1. **In `frontend/builder.go`:**
   - Fixed the grammatical error in the comment for the `MarkBoolean` method. The original comment was:
     > "MarkBoolean sets (but do not constraint!) v to be boolean"
   - Corrected to:
     > "MarkBoolean sets (but does not constrain!) v to be boolean"
   - **Explanation**: The word "constraint" was used incorrectly. The verb should be "constrain" as it follows the auxiliary verb "does" which requires the infinitive form.

2. **In `frontend/variable.go`:**
   - Fixed the plural form of "builder" in the comment for the `IsCanonical` function. The original comment was:
     > "by one of the constraint system builder."
   - Corrected to:
     > "by one of the constraint system builders."
   - **Explanation**: The sentence refers to multiple potential builders, so the correct form is "builders" (plural).

These changes improve the grammatical accuracy and clarity of the comments, ensuring the documentation aligns with standard English usage.


- [x] Bug fix (non-breaking change which fixes an issue)


