### PR TITLE
Fix typo Update logger.go

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -29,7 +29,7 @@ func SetOutput(w io.Writer) {
 	logger = logger.Output(w)
 }
 
-// Set allow a gnark user to overhide the global logger
+// Set allows a gnark user to overhide the global logger
 func Set(l zerolog.Logger) {
 	logger = l
 }


### PR DESCRIPTION
# Description

In the comment for the `Set` function, there is a typo. The original comment reads:

```go
// Set allow a gnark user to overhide the global logger
```

**Fixed version:**

```go
// Set allows a gnark user to override the global logger
```

**Explanation of the fix:**

- The verb **"allow"** should be **"allows"** since the subject of the sentence is the function name `Set`, which is singular. 
- The word **"overhide"** is incorrect. The correct term here is **"override"**, which is commonly used to refer to replacing or modifying the behavior of an existing function or setting.

This fix ensures that the comment is grammatically correct and clearly communicates the intended meaning.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

