### PR TITLE
final exponentiation: select optimisation

### DIFF
--- a/std/algebra/emulated/sw_bls12381/pairing.go
+++ b/std/algebra/emulated/sw_bls12381/pairing.go
@@ -165,10 +165,7 @@ func (pr Pairing) finalExponentiation(e *GTEl, unsafe bool) *GTEl {
 		// the case, the result is 1 in the torus. We assign a dummy value (1) to e.C1
 		// and proceed further.
 		selector1 = pr.Ext6.IsZero(&e.C1)
-		e = &fields_bls12381.E12{
-			C0: e.C0,
-			C1: *pr.Ext6.Select(selector1, _dummy, &e.C1),
-		}
+		e.C1.B0.A0 = *pr.curveF.Select(selector1, pr.curveF.One(), &e.C1.B0.A0)
 	}
 
 	// Torus compression absorbed:

--- a/std/algebra/emulated/sw_bls12381/pairing_test.go
+++ b/std/algebra/emulated/sw_bls12381/pairing_test.go
@@ -295,3 +295,64 @@ func BenchmarkPairing(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkFinalExponentiation(b *testing.B) {
+	// e(a,2b) * e(-2a,b) == 1
+	var gt bls12381.GT
+	gt.SetRandom()
+	res := bls12381.FinalExponentiation(&gt)
+	witness := FinalExponentiationCircuit{
+		InGt: NewGTEl(gt),
+		Res:  NewGTEl(res),
+	}
+	w, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
+	if err != nil {
+		b.Fatal(err)
+	}
+	var ccs constraint.ConstraintSystem
+	b.Run("compile scs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if ccs, err = frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &FinalExponentiationCircuit{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	var buf bytes.Buffer
+	_, err = ccs.WriteTo(&buf)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Logf("scs size: %d (bytes), nb constraints %d, nbInstructions: %d", buf.Len(), ccs.GetNbConstraints(), ccs.GetNbInstructions())
+	b.Run("solve scs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := ccs.Solve(w); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("compile r1cs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if ccs, err = frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &FinalExponentiationCircuit{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	buf.Reset()
+	_, err = ccs.WriteTo(&buf)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Logf("r1cs size: %d (bytes), nb constraints %d, nbInstructions: %d", buf.Len(), ccs.GetNbConstraints(), ccs.GetNbInstructions())
+
+	b.Run("solve r1cs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := ccs.Solve(w); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -159,10 +159,7 @@ func (pr Pairing) finalExponentiation(e *GTEl, unsafe bool) *GTEl {
 		// the case, the result is 1 in the torus. We assign a dummy value (1) to e.C1
 		// and proceed further.
 		selector1 = pr.Ext6.IsZero(&e.C1)
-		e = &fields_bn254.E12{
-			C0: e.C0,
-			C1: *pr.Ext6.Select(selector1, _dummy, &e.C1),
-		}
+		e.C1.B0.A0 = *pr.curveF.Select(selector1, pr.curveF.One(), &e.C1.B0.A0)
 	}
 
 	// Torus compression absorbed:

--- a/std/algebra/emulated/sw_bn254/pairing_test.go
+++ b/std/algebra/emulated/sw_bn254/pairing_test.go
@@ -544,3 +544,65 @@ func BenchmarkPairing(b *testing.B) {
 		}
 	})
 }
+
+// bench
+func BenchmarkFinalExponentiation(b *testing.B) {
+	// e(a,2b) * e(-2a,b) == 1
+	var gt bn254.GT
+	gt.SetRandom()
+	res := bn254.FinalExponentiation(&gt)
+	witness := FinalExponentiationCircuit{
+		InGt: NewGTEl(gt),
+		Res:  NewGTEl(res),
+	}
+	w, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
+	if err != nil {
+		b.Fatal(err)
+	}
+	var ccs constraint.ConstraintSystem
+	b.Run("compile scs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if ccs, err = frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &FinalExponentiationCircuit{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	var buf bytes.Buffer
+	_, err = ccs.WriteTo(&buf)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Logf("scs size: %d (bytes), nb constraints %d, nbInstructions: %d", buf.Len(), ccs.GetNbConstraints(), ccs.GetNbInstructions())
+	b.Run("solve scs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := ccs.Solve(w); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("compile r1cs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if ccs, err = frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &FinalExponentiationCircuit{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	buf.Reset()
+	_, err = ccs.WriteTo(&buf)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Logf("r1cs size: %d (bytes), nb constraints %d, nbInstructions: %d", buf.Len(), ccs.GetNbConstraints(), ccs.GetNbInstructions())
+
+	b.Run("solve r1cs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := ccs.Solve(w); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

Replaces a select on Ext6 with one on just the first field element.
We check if the Ext6 is zero so we don't need to change all the elements and just the first one (from `0` to `1`) if all of them are `0`.

This saves a couple bunch of constraints. Added a benchmark to test number of constraints for final exponentiation.

```diff
➜  gnark git:(master) ✗ go test -benchmem -run=^$ -bench ^BenchmarkFinalExponentiation$ github.com/consensys/gnark/std/algebra/emulated/sw_bn254 -v
goos: darwin
goarch: arm64
pkg: github.com/consensys/gnark/std/algebra/emulated/sw_bn254
cpu: Apple M3 Pro
BenchmarkFinalExponentiation
BenchmarkFinalExponentiation/compile_scs
BenchmarkFinalExponentiation/compile_scs-12                    1        1936695834 ns/op        3169885256 B/op 20046059 allocs/op
-    pairing_test.go:576: scs size: 87215206 (bytes), nb constraints 3765050, nbInstructions: 3899230
+    pairing_test.go:576: scs size: 87208002 (bytes), nb constraints 3764854, nbInstructions: 3899034
BenchmarkFinalExponentiation/solve_scs
BenchmarkFinalExponentiation/solve_scs-12                      2         527410938 ns/op        735421012 B/op   4628026 allocs/op
BenchmarkFinalExponentiation/compile_r1cs
BenchmarkFinalExponentiation/compile_r1cs-12                   1        2443697500 ns/op        7939115440 B/op 33500835 allocs/op
-    pairing_test.go:598: r1cs size: 48421235 (bytes), nb constraints 961788, nbInstructions: 1100407
+    pairing_test.go:598: r1cs size: 48419241 (bytes), nb constraints 961756, nbInstructions: 1100375
BenchmarkFinalExponentiation/solve_r1cs
BenchmarkFinalExponentiation/solve_r1cs-12                     3         434831764 ns/op        352304069 B/op   4213308 allocs/op
PASS
ok      github.com/consensys/gnark/std/algebra/emulated/sw_bn254        9.024s
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
_Actually an optimisation_

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] Ran tests
- [x] Ran bench

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

- [x] Benchmark Final exponentiation, on Macbook pro M3, 36GB RAM

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] ~~Any dependent changes have been merged and published in downstream modules~~ _Not applicable_

