### PR TITLE
fix: NNA quotient length computation edge cases

### DIFF
--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -745,7 +745,7 @@ func (f *Field[T]) callPolyMvHint(mv *multivariate[T], at []*Element[T]) (quo, r
 		nbHintInputs += len(at[i].Limbs) + 1
 	}
 	hintInputs := make([]frontend.Variable, 0, nbHintInputs)
-	hintInputs = append(hintInputs, nbBits, nbLimbs, len(mv.Terms), len(at), nbQuoLimbs, nbRemLimbs, nbCarryLimbs)
+	hintInputs = append(hintInputs, nbBits, nbLimbs, len(mv.Terms), len(at), nbQuoLimbs, nbCarryLimbs)
 	// store the terms in the hint input. First the exponents
 	for i := range mv.Terms {
 		for j := range mv.Terms[i] {
@@ -893,8 +893,8 @@ func polyMvHint(mod *big.Int, inputs, outputs []*big.Int) error {
 		nbTerms      = int(inputs[2].Int64())
 		nbVars       = int(inputs[3].Int64())
 		nbQuoLimbs   = int(inputs[4].Int64())
-		nbRemLimbs   = int(inputs[5].Int64())
-		nbCarryLimbs = int(inputs[6].Int64())
+		nbRemLimbs   = nbLimbs
+		nbCarryLimbs = int(inputs[5].Int64())
 	)
 	if len(outputs) != nbQuoLimbs+nbRemLimbs+nbCarryLimbs {
 		return fmt.Errorf("output length mismatch")
@@ -906,7 +906,7 @@ func polyMvHint(mod *big.Int, inputs, outputs []*big.Int) error {
 	outPtr += nbRemLimbs
 	carryLimbs := outputs[outPtr : outPtr+nbCarryLimbs]
 	terms := make([][]int, nbTerms)
-	ptr := 7
+	ptr := 6
 	// read the terms
 	for i := range terms {
 		terms[i] = make([]int, nbVars)

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -347,10 +347,18 @@ func (f *Field[T]) callMulHint(a, b *Element[T], isMulMod bool, customMod *Eleme
 		// the quotient can be the total length of the multiplication result.
 		modbits = 0
 	}
-	nbQuoLimbs := (uint(nbMultiplicationResLimbs(len(a.Limbs), len(b.Limbs)))*nbBits + nextOverflow + 1 - //
-		modbits + //
-		nbBits - 1) /
-		nbBits
+	var nbQuoLimbs uint
+	if uint(nbMultiplicationResLimbs(len(a.Limbs), len(b.Limbs)))*nbBits+nextOverflow+nbBits > modbits {
+		// when the product of a*b is wider than the modulus, then we need
+		// non-zero limbs for the quotient. Otherwise the quotient is zero,
+		// represented on zero limbs. But we already handle cases when the
+		// quotient is zero in the calling functions, this is only for
+		// additional safety.
+		nbQuoLimbs = (uint(nbMultiplicationResLimbs(len(a.Limbs), len(b.Limbs)))*nbBits + nextOverflow + 1 - //
+			modbits + //
+			nbBits - 1) /
+			nbBits
+	}
 	// the remainder is always less than modulus so can represent on the same
 	// number of limbs as the modulus.
 	nbRemLimbs := nbLimbs

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -733,7 +733,10 @@ func (f *Field[T]) callPolyMvHint(mv *multivariate[T], at []*Element[T]) (quo, r
 	nbLimbs, nbBits := f.fParams.NbLimbs(), f.fParams.BitsPerLimb()
 	modBits := uint(f.fParams.Modulus().BitLen())
 	quoSize := f.polyMvEvalQuoSize(mv, at)
-	nbQuoLimbs := (uint(quoSize) - modBits + nbBits) / nbBits
+	var nbQuoLimbs uint
+	if quoSize+nbBits > modBits {
+		nbQuoLimbs = (quoSize - modBits + nbBits) / nbBits
+	}
 	nbRemLimbs := nbLimbs
 	nbCarryLimbs := nbMultiplicationResLimbs(int(nbQuoLimbs), int(nbLimbs)) - 1
 

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -1012,7 +1012,7 @@ func polyMvHint(mod *big.Int, inputs, outputs []*big.Int) error {
 	}
 
 	// compute the result as r + k*p on limbs
-	rhs := make([]*big.Int, nbMultiplicationResLimbs(nbQuoLimbs, nbLimbs))
+	rhs := make([]*big.Int, max(nbLimbs, nbMultiplicationResLimbs(nbQuoLimbs, nbLimbs)))
 	for i := range rhs {
 		rhs[i] = new(big.Int)
 	}


### PR DESCRIPTION
# Description

This PR fixes edge cases when computing the quotient length. We compute the product length in bits and then to get the quotient length, we subtract the modulus length. But as we work over uints then if the product length is less than the modulus (for example when inputs are short, on one limb), then we get underflow which due to rolling over leads to allocating huge slices. This crashes the prover.

Also fixed a potential edge case in carry computation.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Tested with #1339 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

