### PR TITLE
Feat/switch groth16 key

### DIFF
--- a/std/algebra/emulated/sw_bls12381/pairing.go
+++ b/std/algebra/emulated/sw_bls12381/pairing.go
@@ -186,11 +186,117 @@ func (pr Pairing) AssertIsEqual(x, y *GTEl) {
 }
 
 func (pr Pairing) MuxG2(sel frontend.Variable, inputs ...*G2Affine) *G2Affine {
-	panic("not implemented")
+	if len(inputs) == 0 {
+		return nil
+	}
+	if len(inputs) == 1 {
+		pr.api.AssertIsEqual(sel, 0)
+		return inputs[0]
+	}
+	for i := 1; i < len(inputs); i++ {
+		if (inputs[0].Lines == nil) != (inputs[i].Lines == nil) {
+			panic("muxing points with and without precomputed lines")
+		}
+	}
+	var ret G2Affine
+	XA0 := make([]*emulated.Element[BaseField], len(inputs))
+	XA1 := make([]*emulated.Element[BaseField], len(inputs))
+	YA0 := make([]*emulated.Element[BaseField], len(inputs))
+	YA1 := make([]*emulated.Element[BaseField], len(inputs))
+	for i := range inputs {
+		XA0[i] = &inputs[i].P.X.A0
+		XA1[i] = &inputs[i].P.X.A1
+		YA0[i] = &inputs[i].P.Y.A0
+		YA1[i] = &inputs[i].P.Y.A1
+	}
+	ret.P.X.A0 = *pr.curveF.Mux(sel, XA0...)
+	ret.P.X.A1 = *pr.curveF.Mux(sel, XA1...)
+	ret.P.Y.A0 = *pr.curveF.Mux(sel, YA0...)
+	ret.P.Y.A1 = *pr.curveF.Mux(sel, YA1...)
+
+	if inputs[0].Lines == nil {
+		return &ret
+	}
+
+	// switch precomputed lines
+	ret.Lines = new(lineEvaluations)
+	for j := range inputs[0].Lines[0] {
+		lineR0A0 := make([]*emulated.Element[BaseField], len(inputs))
+		lineR0A1 := make([]*emulated.Element[BaseField], len(inputs))
+		lineR1A0 := make([]*emulated.Element[BaseField], len(inputs))
+		lineR1A1 := make([]*emulated.Element[BaseField], len(inputs))
+		for k := 0; k < 2; k++ {
+			for i := range inputs {
+				lineR0A0[i] = &inputs[i].Lines[k][j].R0.A0
+				lineR0A1[i] = &inputs[i].Lines[k][j].R0.A1
+				lineR1A0[i] = &inputs[i].Lines[k][j].R1.A0
+				lineR1A1[i] = &inputs[i].Lines[k][j].R1.A1
+			}
+			le := &lineEvaluation{
+				R0: fields_bls12381.E2{
+					A0: *pr.curveF.Mux(sel, lineR0A0...),
+					A1: *pr.curveF.Mux(sel, lineR0A1...),
+				},
+				R1: fields_bls12381.E2{
+					A0: *pr.curveF.Mux(sel, lineR1A0...),
+					A1: *pr.curveF.Mux(sel, lineR1A1...),
+				},
+			}
+			ret.Lines[k][j] = le
+		}
+	}
+
+	return &ret
 }
 
 func (pr Pairing) MuxGt(sel frontend.Variable, inputs ...*GTEl) *GTEl {
-	panic("not implemented")
+	if len(inputs) == 0 {
+		return nil
+	}
+	if len(inputs) == 1 {
+		pr.api.AssertIsEqual(sel, 0)
+		return inputs[0]
+	}
+	var ret GTEl
+	A0s := make([]*emulated.Element[BaseField], len(inputs))
+	A1s := make([]*emulated.Element[BaseField], len(inputs))
+	A2s := make([]*emulated.Element[BaseField], len(inputs))
+	A3s := make([]*emulated.Element[BaseField], len(inputs))
+	A4s := make([]*emulated.Element[BaseField], len(inputs))
+	A5s := make([]*emulated.Element[BaseField], len(inputs))
+	A6s := make([]*emulated.Element[BaseField], len(inputs))
+	A7s := make([]*emulated.Element[BaseField], len(inputs))
+	A8s := make([]*emulated.Element[BaseField], len(inputs))
+	A9s := make([]*emulated.Element[BaseField], len(inputs))
+	A10s := make([]*emulated.Element[BaseField], len(inputs))
+	A11s := make([]*emulated.Element[BaseField], len(inputs))
+	for i := range inputs {
+		A0s[i] = &inputs[i].A0
+		A1s[i] = &inputs[i].A1
+		A2s[i] = &inputs[i].A2
+		A3s[i] = &inputs[i].A3
+		A4s[i] = &inputs[i].A4
+		A5s[i] = &inputs[i].A5
+		A6s[i] = &inputs[i].A6
+		A7s[i] = &inputs[i].A7
+		A8s[i] = &inputs[i].A8
+		A9s[i] = &inputs[i].A9
+		A10s[i] = &inputs[i].A10
+		A11s[i] = &inputs[i].A11
+	}
+	ret.A0 = *pr.curveF.Mux(sel, A0s...)
+	ret.A1 = *pr.curveF.Mux(sel, A1s...)
+	ret.A2 = *pr.curveF.Mux(sel, A2s...)
+	ret.A3 = *pr.curveF.Mux(sel, A3s...)
+	ret.A4 = *pr.curveF.Mux(sel, A4s...)
+	ret.A5 = *pr.curveF.Mux(sel, A5s...)
+	ret.A6 = *pr.curveF.Mux(sel, A6s...)
+	ret.A7 = *pr.curveF.Mux(sel, A7s...)
+	ret.A8 = *pr.curveF.Mux(sel, A8s...)
+	ret.A9 = *pr.curveF.Mux(sel, A9s...)
+	ret.A10 = *pr.curveF.Mux(sel, A10s...)
+	ret.A11 = *pr.curveF.Mux(sel, A11s...)
+	return &ret
 }
 
 func (pr Pairing) AssertIsOnCurve(P *G1Affine) {

--- a/std/algebra/emulated/sw_bls12381/pairing.go
+++ b/std/algebra/emulated/sw_bls12381/pairing.go
@@ -185,6 +185,14 @@ func (pr Pairing) AssertIsEqual(x, y *GTEl) {
 	pr.Ext12.AssertIsEqual(x, y)
 }
 
+func (pr Pairing) MuxG2(sel frontend.Variable, inputs ...*G2Affine) *G2Affine {
+	panic("not implemented")
+}
+
+func (pr Pairing) MuxGt(sel frontend.Variable, inputs ...*GTEl) *GTEl {
+	panic("not implemented")
+}
+
 func (pr Pairing) AssertIsOnCurve(P *G1Affine) {
 	pr.curve.AssertIsOnCurve(P)
 }

--- a/std/algebra/emulated/sw_bls12381/pairing_test.go
+++ b/std/algebra/emulated/sw_bls12381/pairing_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -300,6 +301,96 @@ func TestGroupMembershipSolve(t *testing.T) {
 	}
 	err := test.IsSolved(&GroupMembershipCircuit{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
+}
+
+type MuxesCircuits struct {
+	InG2       []G2Affine
+	InGt       []GTEl
+	SelG2      frontend.Variable
+	SelGt      frontend.Variable
+	ExpectedG2 G2Affine
+	ExpectedGt GTEl
+}
+
+func (c *MuxesCircuits) Define(api frontend.API) error {
+	g2api := NewG2(api)
+	pairing, err := NewPairing(api)
+	if err != nil {
+		return fmt.Errorf("new pairing: %w", err)
+	}
+	var inG2 []*G2Affine
+	for i := range c.InG2 {
+		inG2 = append(inG2, &c.InG2[i])
+	}
+	var inGt []*GTEl
+	for i := range c.InGt {
+		inGt = append(inGt, &c.InGt[i])
+	}
+	g2 := pairing.MuxG2(c.SelG2, inG2...)
+	gt := pairing.MuxGt(c.SelGt, inGt...)
+	if len(c.InG2) == 0 {
+		if g2 != nil {
+			return fmt.Errorf("mux G2: expected nil, got %v", g2)
+		}
+	} else {
+		g2api.AssertIsEqual(g2, &c.ExpectedG2)
+	}
+	if len(c.InGt) == 0 {
+		if gt != nil {
+			return fmt.Errorf("mux Gt: expected nil, got %v", gt)
+		}
+	} else {
+		pairing.AssertIsEqual(gt, &c.ExpectedGt)
+	}
+	return nil
+}
+
+func TestPairingMuxes(t *testing.T) {
+	assert := test.NewAssert(t)
+	var err error
+	for _, nbPairs := range []int{0, 1, 2, 3, 4, 5} {
+		assert.Run(func(assert *test.Assert) {
+			g2s := make([]bls12381.G2Affine, nbPairs)
+			gts := make([]bls12381.GT, nbPairs)
+			var p bls12381.G1Affine
+			witG2s := make([]G2Affine, nbPairs)
+			witGts := make([]GTEl, nbPairs)
+			for i := range nbPairs {
+				p, g2s[i] = randomG1G2Affines()
+				gts[i], err = bls12381.Pair([]bls12381.G1Affine{p}, []bls12381.G2Affine{g2s[i]})
+				assert.NoError(err)
+				witG2s[i] = NewG2Affine(g2s[i])
+				witGts[i] = NewGTEl(gts[i])
+			}
+			circuit := MuxesCircuits{InG2: make([]G2Affine, nbPairs), InGt: make([]GTEl, nbPairs)}
+			var witness MuxesCircuits
+			if nbPairs > 0 {
+				selG2, err := rand.Int(rand.Reader, big.NewInt(int64(nbPairs)))
+				assert.NoError(err)
+				selGt, err := rand.Int(rand.Reader, big.NewInt(int64(nbPairs)))
+				assert.NoError(err)
+				expectedG2 := witG2s[selG2.Int64()]
+				expectedGt := witGts[selGt.Int64()]
+				witness = MuxesCircuits{
+					InG2:       witG2s,
+					InGt:       witGts,
+					SelG2:      selG2,
+					SelGt:      selGt,
+					ExpectedG2: expectedG2,
+					ExpectedGt: expectedGt,
+				}
+			} else {
+				witness = MuxesCircuits{
+					InG2:  witG2s,
+					InGt:  witGts,
+					SelG2: big.NewInt(0),
+					SelGt: big.NewInt(0),
+				}
+			}
+			err = test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+			assert.NoError(err)
+		}, fmt.Sprintf("nbPairs=%d", nbPairs))
+	}
 }
 
 // bench

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -386,44 +386,44 @@ func (pr Pairing) MuxGt(sel frontend.Variable, inputs ...*GTEl) *GTEl {
 		return inputs[0]
 	}
 	var ret GTEl
-	C0B0A0s := make([]*emulated.Element[BaseField], len(inputs))
-	C0B0A1s := make([]*emulated.Element[BaseField], len(inputs))
-	C0B1A0s := make([]*emulated.Element[BaseField], len(inputs))
-	C0B1A1s := make([]*emulated.Element[BaseField], len(inputs))
-	C0B2A0s := make([]*emulated.Element[BaseField], len(inputs))
-	C0B2A1s := make([]*emulated.Element[BaseField], len(inputs))
-	C1B0A0s := make([]*emulated.Element[BaseField], len(inputs))
-	C1B0A1s := make([]*emulated.Element[BaseField], len(inputs))
-	C1B1A0s := make([]*emulated.Element[BaseField], len(inputs))
-	C1B1A1s := make([]*emulated.Element[BaseField], len(inputs))
-	C1B2A0s := make([]*emulated.Element[BaseField], len(inputs))
-	C1B2A1s := make([]*emulated.Element[BaseField], len(inputs))
+	A0s := make([]*emulated.Element[BaseField], len(inputs))
+	A1s := make([]*emulated.Element[BaseField], len(inputs))
+	A2s := make([]*emulated.Element[BaseField], len(inputs))
+	A3s := make([]*emulated.Element[BaseField], len(inputs))
+	A4s := make([]*emulated.Element[BaseField], len(inputs))
+	A5s := make([]*emulated.Element[BaseField], len(inputs))
+	A6s := make([]*emulated.Element[BaseField], len(inputs))
+	A7s := make([]*emulated.Element[BaseField], len(inputs))
+	A8s := make([]*emulated.Element[BaseField], len(inputs))
+	A9s := make([]*emulated.Element[BaseField], len(inputs))
+	A10s := make([]*emulated.Element[BaseField], len(inputs))
+	A11s := make([]*emulated.Element[BaseField], len(inputs))
 	for i := range inputs {
-		C0B0A0s[i] = &inputs[i].C0.B0.A0
-		C0B0A1s[i] = &inputs[i].C0.B0.A1
-		C0B1A0s[i] = &inputs[i].C0.B1.A0
-		C0B1A1s[i] = &inputs[i].C0.B1.A1
-		C0B2A0s[i] = &inputs[i].C0.B2.A0
-		C0B2A1s[i] = &inputs[i].C0.B2.A1
-		C1B0A0s[i] = &inputs[i].C1.B0.A0
-		C1B0A1s[i] = &inputs[i].C1.B0.A1
-		C1B1A0s[i] = &inputs[i].C1.B1.A0
-		C1B1A1s[i] = &inputs[i].C1.B1.A1
-		C1B2A0s[i] = &inputs[i].C1.B2.A0
-		C1B2A1s[i] = &inputs[i].C1.B2.A1
+		A0s[i] = &inputs[i].A0
+		A1s[i] = &inputs[i].A1
+		A2s[i] = &inputs[i].A2
+		A3s[i] = &inputs[i].A3
+		A4s[i] = &inputs[i].A4
+		A5s[i] = &inputs[i].A5
+		A6s[i] = &inputs[i].A6
+		A7s[i] = &inputs[i].A7
+		A8s[i] = &inputs[i].A8
+		A9s[i] = &inputs[i].A9
+		A10s[i] = &inputs[i].A10
+		A11s[i] = &inputs[i].A11
 	}
-	ret.C0.B0.A0 = *pr.curveF.Mux(sel, C0B0A0s...)
-	ret.C0.B0.A1 = *pr.curveF.Mux(sel, C0B0A1s...)
-	ret.C0.B1.A0 = *pr.curveF.Mux(sel, C0B1A0s...)
-	ret.C0.B1.A1 = *pr.curveF.Mux(sel, C0B1A1s...)
-	ret.C0.B2.A0 = *pr.curveF.Mux(sel, C0B2A0s...)
-	ret.C0.B2.A1 = *pr.curveF.Mux(sel, C0B2A1s...)
-	ret.C1.B0.A0 = *pr.curveF.Mux(sel, C1B0A0s...)
-	ret.C1.B0.A1 = *pr.curveF.Mux(sel, C1B0A1s...)
-	ret.C1.B1.A0 = *pr.curveF.Mux(sel, C1B1A0s...)
-	ret.C1.B1.A1 = *pr.curveF.Mux(sel, C1B1A1s...)
-	ret.C1.B2.A0 = *pr.curveF.Mux(sel, C1B2A0s...)
-	ret.C1.B2.A1 = *pr.curveF.Mux(sel, C1B2A1s...)
+	ret.A0 = *pr.curveF.Mux(sel, A0s...)
+	ret.A1 = *pr.curveF.Mux(sel, A1s...)
+	ret.A2 = *pr.curveF.Mux(sel, A2s...)
+	ret.A3 = *pr.curveF.Mux(sel, A3s...)
+	ret.A4 = *pr.curveF.Mux(sel, A4s...)
+	ret.A5 = *pr.curveF.Mux(sel, A5s...)
+	ret.A6 = *pr.curveF.Mux(sel, A6s...)
+	ret.A7 = *pr.curveF.Mux(sel, A7s...)
+	ret.A8 = *pr.curveF.Mux(sel, A8s...)
+	ret.A9 = *pr.curveF.Mux(sel, A9s...)
+	ret.A10 = *pr.curveF.Mux(sel, A10s...)
+	ret.A11 = *pr.curveF.Mux(sel, A11s...)
 	return &ret
 }
 

--- a/std/algebra/emulated/sw_bn254/pairing_test.go
+++ b/std/algebra/emulated/sw_bn254/pairing_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -465,6 +466,96 @@ func TestIsMillerLoopAndFinalExpCircuitTestSolve(t *testing.T) {
 	}
 	err = test.IsSolved(&IsMillerLoopAndFinalExpCircuit{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
+}
+
+type MuxesCircuits struct {
+	InG2       []G2Affine
+	InGt       []GTEl
+	SelG2      frontend.Variable
+	SelGt      frontend.Variable
+	ExpectedG2 G2Affine
+	ExpectedGt GTEl
+}
+
+func (c *MuxesCircuits) Define(api frontend.API) error {
+	g2api := NewG2(api)
+	pairing, err := NewPairing(api)
+	if err != nil {
+		return fmt.Errorf("new pairing: %w", err)
+	}
+	var inG2 []*G2Affine
+	for i := range c.InG2 {
+		inG2 = append(inG2, &c.InG2[i])
+	}
+	var inGt []*GTEl
+	for i := range c.InGt {
+		inGt = append(inGt, &c.InGt[i])
+	}
+	g2 := pairing.MuxG2(c.SelG2, inG2...)
+	gt := pairing.MuxGt(c.SelGt, inGt...)
+	if len(c.InG2) == 0 {
+		if g2 != nil {
+			return fmt.Errorf("mux G2: expected nil, got %v", g2)
+		}
+	} else {
+		g2api.AssertIsEqual(g2, &c.ExpectedG2)
+	}
+	if len(c.InGt) == 0 {
+		if gt != nil {
+			return fmt.Errorf("mux Gt: expected nil, got %v", gt)
+		}
+	} else {
+		pairing.AssertIsEqual(gt, &c.ExpectedGt)
+	}
+	return nil
+}
+
+func TestPairingMuxes(t *testing.T) {
+	assert := test.NewAssert(t)
+	var err error
+	for _, nbPairs := range []int{0, 1, 2, 3, 4, 5} {
+		assert.Run(func(assert *test.Assert) {
+			g2s := make([]bn254.G2Affine, nbPairs)
+			gts := make([]bn254.GT, nbPairs)
+			var p bn254.G1Affine
+			witG2s := make([]G2Affine, nbPairs)
+			witGts := make([]GTEl, nbPairs)
+			for i := range nbPairs {
+				p, g2s[i] = randomG1G2Affines()
+				gts[i], err = bn254.Pair([]bn254.G1Affine{p}, []bn254.G2Affine{g2s[i]})
+				assert.NoError(err)
+				witG2s[i] = NewG2Affine(g2s[i])
+				witGts[i] = NewGTEl(gts[i])
+			}
+			circuit := MuxesCircuits{InG2: make([]G2Affine, nbPairs), InGt: make([]GTEl, nbPairs)}
+			var witness MuxesCircuits
+			if nbPairs > 0 {
+				selG2, err := rand.Int(rand.Reader, big.NewInt(int64(nbPairs)))
+				assert.NoError(err)
+				selGt, err := rand.Int(rand.Reader, big.NewInt(int64(nbPairs)))
+				assert.NoError(err)
+				expectedG2 := witG2s[selG2.Int64()]
+				expectedGt := witGts[selGt.Int64()]
+				witness = MuxesCircuits{
+					InG2:       witG2s,
+					InGt:       witGts,
+					SelG2:      selG2,
+					SelGt:      selGt,
+					ExpectedG2: expectedG2,
+					ExpectedGt: expectedGt,
+				}
+			} else {
+				witness = MuxesCircuits{
+					InG2:  witG2s,
+					InGt:  witGts,
+					SelG2: big.NewInt(0),
+					SelGt: big.NewInt(0),
+				}
+			}
+			err = test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+			assert.NoError(err)
+		}, fmt.Sprintf("nbPairs=%d", nbPairs))
+	}
 }
 
 // bench

--- a/std/algebra/emulated/sw_bw6761/pairing.go
+++ b/std/algebra/emulated/sw_bw6761/pairing.go
@@ -227,6 +227,14 @@ func (pr Pairing) AssertIsEqual(x, y *GTEl) {
 	pr.Ext6.AssertIsEqual(x, y)
 }
 
+func (pr Pairing) MuxG2(sel frontend.Variable, inputs ...*G2Affine) *G2Affine {
+	panic("not implemented")
+}
+
+func (pr Pairing) MuxGt(sel frontend.Variable, inputs ...*GTEl) *GTEl {
+	panic("not implemented")
+}
+
 func (pr Pairing) AssertIsOnCurve(P *G1Affine) {
 	pr.curve.AssertIsOnCurve(P)
 }

--- a/std/algebra/emulated/sw_bw6761/pairing.go
+++ b/std/algebra/emulated/sw_bw6761/pairing.go
@@ -228,11 +228,83 @@ func (pr Pairing) AssertIsEqual(x, y *GTEl) {
 }
 
 func (pr Pairing) MuxG2(sel frontend.Variable, inputs ...*G2Affine) *G2Affine {
-	panic("not implemented")
+	if len(inputs) == 0 {
+		return nil
+	}
+	if len(inputs) == 1 {
+		pr.api.AssertIsEqual(sel, 0)
+		return inputs[0]
+	}
+	for i := 1; i < len(inputs); i++ {
+		if (inputs[0].Lines == nil) != (inputs[i].Lines == nil) {
+			panic("muxing points with and without precomputed lines")
+		}
+	}
+	var ret G2Affine
+	Xs := make([]*emulated.Element[BaseField], len(inputs))
+	Ys := make([]*emulated.Element[BaseField], len(inputs))
+	for i := range inputs {
+		Xs[i] = &inputs[i].P.X
+		Ys[i] = &inputs[i].P.Y
+	}
+	ret.P.X = *pr.curveF.Mux(sel, Xs...)
+	ret.P.Y = *pr.curveF.Mux(sel, Ys...)
+
+	if inputs[0].Lines == nil {
+		return &ret
+	}
+
+	// switch precomputed lines
+	ret.Lines = new(lineEvaluations)
+	for j := range inputs[0].Lines[0] {
+		lineR0s := make([]*emulated.Element[BaseField], len(inputs))
+		lineR1s := make([]*emulated.Element[BaseField], len(inputs))
+		for k := 0; k < 2; k++ {
+			for i := range inputs {
+				lineR0s[i] = &inputs[i].Lines[k][j].R0
+				lineR1s[i] = &inputs[i].Lines[k][j].R1
+			}
+			le := &lineEvaluation{
+				R0: *pr.curveF.Mux(sel, lineR0s...),
+				R1: *pr.curveF.Mux(sel, lineR1s...),
+			}
+			ret.Lines[k][j] = le
+		}
+	}
+
+	return &ret
 }
 
 func (pr Pairing) MuxGt(sel frontend.Variable, inputs ...*GTEl) *GTEl {
-	panic("not implemented")
+	if len(inputs) == 0 {
+		return nil
+	}
+	if len(inputs) == 1 {
+		pr.api.AssertIsEqual(sel, 0)
+		return inputs[0]
+	}
+	var ret GTEl
+	A0s := make([]*emulated.Element[BaseField], len(inputs))
+	A1s := make([]*emulated.Element[BaseField], len(inputs))
+	A2s := make([]*emulated.Element[BaseField], len(inputs))
+	A3s := make([]*emulated.Element[BaseField], len(inputs))
+	A4s := make([]*emulated.Element[BaseField], len(inputs))
+	A5s := make([]*emulated.Element[BaseField], len(inputs))
+	for i := range inputs {
+		A0s[i] = &inputs[i].A0
+		A1s[i] = &inputs[i].A1
+		A2s[i] = &inputs[i].A2
+		A3s[i] = &inputs[i].A3
+		A4s[i] = &inputs[i].A4
+		A5s[i] = &inputs[i].A5
+	}
+	ret.A0 = *pr.curveF.Mux(sel, A0s...)
+	ret.A1 = *pr.curveF.Mux(sel, A1s...)
+	ret.A2 = *pr.curveF.Mux(sel, A2s...)
+	ret.A3 = *pr.curveF.Mux(sel, A3s...)
+	ret.A4 = *pr.curveF.Mux(sel, A4s...)
+	ret.A5 = *pr.curveF.Mux(sel, A5s...)
+	return &ret
 }
 
 func (pr Pairing) AssertIsOnCurve(P *G1Affine) {

--- a/std/algebra/emulated/sw_bw6761/pairing_test.go
+++ b/std/algebra/emulated/sw_bw6761/pairing_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -264,6 +265,99 @@ func TestGroupMembershipSolve(t *testing.T) {
 	}
 	err := test.IsSolved(&GroupMembershipCircuit{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
+}
+
+type MuxesCircuits struct {
+	InG2       []G2Affine
+	InGt       []GTEl
+	SelG2      frontend.Variable
+	SelGt      frontend.Variable
+	ExpectedG2 G2Affine
+	ExpectedGt GTEl
+}
+
+func (c *MuxesCircuits) Define(api frontend.API) error {
+	g2api, err := NewG2(api)
+	if err != nil {
+		return fmt.Errorf("new G2: %w", err)
+	}
+	pairing, err := NewPairing(api)
+	if err != nil {
+		return fmt.Errorf("new pairing: %w", err)
+	}
+	var inG2 []*G2Affine
+	for i := range c.InG2 {
+		inG2 = append(inG2, &c.InG2[i])
+	}
+	var inGt []*GTEl
+	for i := range c.InGt {
+		inGt = append(inGt, &c.InGt[i])
+	}
+	g2 := pairing.MuxG2(c.SelG2, inG2...)
+	gt := pairing.MuxGt(c.SelGt, inGt...)
+	if len(c.InG2) == 0 {
+		if g2 != nil {
+			return fmt.Errorf("mux G2: expected nil, got %v", g2)
+		}
+	} else {
+		g2api.AssertIsEqual(g2, &c.ExpectedG2)
+	}
+	if len(c.InGt) == 0 {
+		if gt != nil {
+			return fmt.Errorf("mux Gt: expected nil, got %v", gt)
+		}
+	} else {
+		pairing.AssertIsEqual(gt, &c.ExpectedGt)
+	}
+	return nil
+}
+
+func TestPairingMuxes(t *testing.T) {
+	assert := test.NewAssert(t)
+	var err error
+	for _, nbPairs := range []int{0, 1, 2, 3, 4, 5} {
+		assert.Run(func(assert *test.Assert) {
+			g2s := make([]bw6761.G2Affine, nbPairs)
+			gts := make([]bw6761.GT, nbPairs)
+			var p bw6761.G1Affine
+			witG2s := make([]G2Affine, nbPairs)
+			witGts := make([]GTEl, nbPairs)
+			for i := range nbPairs {
+				p, g2s[i] = randomG1G2Affines()
+				gts[i], err = bw6761.Pair([]bw6761.G1Affine{p}, []bw6761.G2Affine{g2s[i]})
+				assert.NoError(err)
+				witG2s[i] = NewG2Affine(g2s[i])
+				witGts[i] = NewGTEl(gts[i])
+			}
+			circuit := MuxesCircuits{InG2: make([]G2Affine, nbPairs), InGt: make([]GTEl, nbPairs)}
+			var witness MuxesCircuits
+			if nbPairs > 0 {
+				selG2, err := rand.Int(rand.Reader, big.NewInt(int64(nbPairs)))
+				assert.NoError(err)
+				selGt, err := rand.Int(rand.Reader, big.NewInt(int64(nbPairs)))
+				assert.NoError(err)
+				expectedG2 := witG2s[selG2.Int64()]
+				expectedGt := witGts[selGt.Int64()]
+				witness = MuxesCircuits{
+					InG2:       witG2s,
+					InGt:       witGts,
+					SelG2:      selG2,
+					SelGt:      selGt,
+					ExpectedG2: expectedG2,
+					ExpectedGt: expectedGt,
+				}
+			} else {
+				witness = MuxesCircuits{
+					InG2:  witG2s,
+					InGt:  witGts,
+					SelG2: big.NewInt(0),
+					SelGt: big.NewInt(0),
+				}
+			}
+			err = test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+			assert.NoError(err)
+		}, fmt.Sprintf("nbPairs=%d", nbPairs))
+	}
 }
 
 // bench

--- a/std/algebra/interfaces.go
+++ b/std/algebra/interfaces.go
@@ -106,6 +106,13 @@ type Pairing[G1El G1ElementT, G2El G2ElementT, GtEl GtElementT] interface {
 	// AssertIsOnG2 asserts that the input is on the G2 curve.
 	AssertIsOnG2(*G2El)
 
+	// MuxG2 performs a lookup from the G2 inputs and returns inputs[sel]. It is
+	// most efficient for power of two lengths of the inputs, but works for any
+	// number of inputs.
 	MuxG2(sel frontend.Variable, inputs ...*G2El) *G2El
+
+	// MuxGt performs a lookup from the Gt inputs and returns inputs[sel]. It is
+	// most efficient for power of two lengths of the inputs, but works for any
+	// number of inputs.
 	MuxGt(sel frontend.Variable, inputs ...*GtEl) *GtEl
 }

--- a/std/algebra/interfaces.go
+++ b/std/algebra/interfaces.go
@@ -105,4 +105,7 @@ type Pairing[G1El G1ElementT, G2El G2ElementT, GtEl GtElementT] interface {
 
 	// AssertIsOnG2 asserts that the input is on the G2 curve.
 	AssertIsOnG2(*G2El)
+
+	MuxG2(sel frontend.Variable, inputs ...*G2El) *G2El
+	MuxGt(sel frontend.Variable, inputs ...*GtEl) *GtEl
 }

--- a/std/algebra/native/sw_bls12377/pairing2_test.go
+++ b/std/algebra/native/sw_bls12377/pairing2_test.go
@@ -2,6 +2,7 @@ package sw_bls12377
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -12,13 +13,31 @@ import (
 	"github.com/consensys/gnark/test"
 )
 
-type MuxCircuitTest struct {
+func randomG1G2Affines() (bls12377.G1Affine, bls12377.G2Affine) {
+	_, _, G1AffGen, G2AffGen := bls12377.Generators()
+	mod := bls12377.ID.ScalarField()
+	s1, err := rand.Int(rand.Reader, mod)
+	if err != nil {
+		panic(err)
+	}
+	s2, err := rand.Int(rand.Reader, mod)
+	if err != nil {
+		panic(err)
+	}
+	var p bls12377.G1Affine
+	p.ScalarMultiplication(&G1AffGen, s1)
+	var q bls12377.G2Affine
+	q.ScalarMultiplication(&G2AffGen, s2)
+	return p, q
+}
+
+type MuxG1CircuitTest struct {
 	Selector frontend.Variable
 	Inputs   [8]G1Affine
 	Expected G1Affine
 }
 
-func (c *MuxCircuitTest) Define(api frontend.API) error {
+func (c *MuxG1CircuitTest) Define(api frontend.API) error {
 	cr, err := NewCurve(api)
 	if err != nil {
 		return err
@@ -32,9 +51,9 @@ func (c *MuxCircuitTest) Define(api frontend.API) error {
 	return nil
 }
 
-func TestMux(t *testing.T) {
+func TestMuxG1(t *testing.T) {
 	assert := test.NewAssert(t)
-	circuit := MuxCircuitTest{}
+	circuit := MuxG1CircuitTest{}
 	r := make([]fr_bls12377.Element, len(circuit.Inputs))
 	for i := range r {
 		r[i].SetRandom()
@@ -42,7 +61,7 @@ func TestMux(t *testing.T) {
 	selector, _ := rand.Int(rand.Reader, big.NewInt(int64(len(r))))
 	expectedR := r[selector.Int64()]
 	expected := new(bls12377.G1Affine).ScalarMultiplicationBase(expectedR.BigInt(new(big.Int)))
-	witness := MuxCircuitTest{
+	witness := MuxG1CircuitTest{
 		Selector: selector,
 		Expected: NewG1Affine(*expected),
 	}
@@ -52,4 +71,92 @@ func TestMux(t *testing.T) {
 	}
 	err := test.IsSolved(&circuit, &witness, ecc.BW6_761.ScalarField())
 	assert.NoError(err)
+}
+
+type MuxG2GtCircuit struct {
+	InG2       []G2Affine
+	InGt       []GT
+	SelG2      frontend.Variable
+	SelGt      frontend.Variable
+	ExpectedG2 G2Affine
+	ExpectedGt GT
+}
+
+func (c *MuxG2GtCircuit) Define(api frontend.API) error {
+	pairing := NewPairing(api)
+	var inG2 []*G2Affine
+	for i := range c.InG2 {
+		inG2 = append(inG2, &c.InG2[i])
+	}
+	var inGt []*GT
+	for i := range c.InGt {
+		inGt = append(inGt, &c.InGt[i])
+	}
+	g2 := pairing.MuxG2(c.SelG2, inG2...)
+	gt := pairing.MuxGt(c.SelGt, inGt...)
+	if len(c.InG2) == 0 {
+		if g2 != nil {
+			return fmt.Errorf("mux G2: expected nil, got %v", g2)
+		}
+	} else {
+		c.ExpectedG2.P.AssertIsEqual(api, g2.P)
+	}
+	if len(c.InGt) == 0 {
+		if gt != nil {
+			return fmt.Errorf("mux Gt: expected nil, got %v", gt)
+		}
+	} else {
+		pairing.AssertIsEqual(gt, &c.ExpectedGt)
+	}
+	return nil
+}
+
+func TestPairingMuxes(t *testing.T) {
+	assert := test.NewAssert(t)
+	var err error
+	for _, nbPairs := range []int{0, 1, 2, 3, 4, 5} {
+		assert.Run(func(assert *test.Assert) {
+			g2s := make([]bls12377.G2Affine, nbPairs)
+			gts := make([]bls12377.GT, nbPairs)
+			var p bls12377.G1Affine
+			witG2s := make([]G2Affine, nbPairs)
+			witGts := make([]GT, nbPairs)
+			for i := range nbPairs {
+				p, g2s[i] = randomG1G2Affines()
+				gts[i], err = bls12377.Pair([]bls12377.G1Affine{p}, []bls12377.G2Affine{g2s[i]})
+				assert.NoError(err)
+				witG2s[i] = NewG2Affine(g2s[i])
+				witGts[i] = NewGTEl(gts[i])
+			}
+			circuit := MuxG2GtCircuit{InG2: make([]G2Affine, nbPairs), InGt: make([]GT, nbPairs)}
+			var witness MuxG2GtCircuit
+			if nbPairs > 0 {
+				selG2, err := rand.Int(rand.Reader, big.NewInt(int64(nbPairs)))
+				assert.NoError(err)
+				selGt, err := rand.Int(rand.Reader, big.NewInt(int64(nbPairs)))
+				assert.NoError(err)
+				expectedG2 := witG2s[selG2.Int64()]
+				expectedGt := witGts[selGt.Int64()]
+				witness = MuxG2GtCircuit{
+					InG2:       witG2s,
+					InGt:       witGts,
+					SelG2:      selG2,
+					SelGt:      selGt,
+					ExpectedG2: expectedG2,
+					ExpectedGt: expectedGt,
+				}
+			} else {
+				witness = MuxG2GtCircuit{
+					InG2:       witG2s,
+					InGt:       witGts,
+					SelG2:      big.NewInt(0),
+					SelGt:      big.NewInt(0),
+					ExpectedG2: NewG2Affine(bls12377.G2Affine{}),
+					ExpectedGt: NewGTEl(bls12377.GT{}),
+				}
+			}
+			err = test.IsSolved(&circuit, &witness, ecc.BW6_761.ScalarField())
+			assert.NoError(err)
+		}, fmt.Sprintf("nbPairs=%d", nbPairs))
+	}
 }

--- a/std/algebra/native/sw_bls24315/pairing2.go
+++ b/std/algebra/native/sw_bls24315/pairing2.go
@@ -343,8 +343,8 @@ func (pr Pairing) MuxG2(sel frontend.Variable, inputs ...*G2Affine) *G2Affine {
 	for i := range inputs {
 		XB0A0[i] = inputs[i].P.X.B0.A0
 		XB0A1[i] = inputs[i].P.X.B0.A1
-		XB1A0[i] = inputs[i].P.Y.B1.A0
-		XB1A1[i] = inputs[i].P.Y.B1.A1
+		XB1A0[i] = inputs[i].P.X.B1.A0
+		XB1A1[i] = inputs[i].P.X.B1.A1
 		YB0A0[i] = inputs[i].P.Y.B0.A0
 		YB0A1[i] = inputs[i].P.Y.B0.A1
 		YB1A0[i] = inputs[i].P.Y.B1.A0

--- a/std/algebra/native/sw_bls24315/pairing2.go
+++ b/std/algebra/native/sw_bls24315/pairing2.go
@@ -318,13 +318,187 @@ func (p *Pairing) PairingCheck(P []*G1Affine, Q []*G2Affine) error {
 func (p *Pairing) AssertIsEqual(e1, e2 *GT) {
 	e1.AssertIsEqual(p.api, *e2)
 }
-
 func (pr Pairing) MuxG2(sel frontend.Variable, inputs ...*G2Affine) *G2Affine {
-	panic("not implemented")
+	if len(inputs) == 0 {
+		return nil
+	}
+	if len(inputs) == 1 {
+		pr.api.AssertIsEqual(sel, 0)
+		return inputs[0]
+	}
+	for i := 1; i < len(inputs); i++ {
+		if (inputs[0].Lines == nil) != (inputs[i].Lines == nil) {
+			panic("muxing points with and without precomputed lines")
+		}
+	}
+	var ret G2Affine
+	XB0A0 := make([]frontend.Variable, len(inputs))
+	XB0A1 := make([]frontend.Variable, len(inputs))
+	XB1A0 := make([]frontend.Variable, len(inputs))
+	XB1A1 := make([]frontend.Variable, len(inputs))
+	YB0A0 := make([]frontend.Variable, len(inputs))
+	YB0A1 := make([]frontend.Variable, len(inputs))
+	YB1A0 := make([]frontend.Variable, len(inputs))
+	YB1A1 := make([]frontend.Variable, len(inputs))
+	for i := range inputs {
+		XB0A0[i] = inputs[i].P.X.B0.A0
+		XB0A1[i] = inputs[i].P.X.B0.A1
+		XB1A0[i] = inputs[i].P.Y.B1.A0
+		XB1A1[i] = inputs[i].P.Y.B1.A1
+		YB0A0[i] = inputs[i].P.Y.B0.A0
+		YB0A1[i] = inputs[i].P.Y.B0.A1
+		YB1A0[i] = inputs[i].P.Y.B1.A0
+		YB1A1[i] = inputs[i].P.Y.B1.A1
+	}
+	ret.P.X.B0.A0 = selector.Mux(pr.api, sel, XB0A0...)
+	ret.P.X.B0.A1 = selector.Mux(pr.api, sel, XB0A1...)
+	ret.P.X.B1.A0 = selector.Mux(pr.api, sel, XB1A0...)
+	ret.P.X.B1.A1 = selector.Mux(pr.api, sel, XB1A1...)
+	ret.P.Y.B0.A0 = selector.Mux(pr.api, sel, YB0A0...)
+	ret.P.Y.B0.A1 = selector.Mux(pr.api, sel, YB0A1...)
+	ret.P.Y.B1.A0 = selector.Mux(pr.api, sel, YB1A0...)
+	ret.P.Y.B1.A1 = selector.Mux(pr.api, sel, YB1A1...)
+
+	if inputs[0].Lines == nil {
+		return &ret
+	}
+
+	// switch precomputed lines
+	ret.Lines = new(lineEvaluations)
+	for j := range inputs[0].Lines[0] {
+		lineR0B0A0 := make([]frontend.Variable, len(inputs))
+		lineR0B0A1 := make([]frontend.Variable, len(inputs))
+		lineR0B1A0 := make([]frontend.Variable, len(inputs))
+		lineR0B1A1 := make([]frontend.Variable, len(inputs))
+		lineR1B0A0 := make([]frontend.Variable, len(inputs))
+		lineR1B0A1 := make([]frontend.Variable, len(inputs))
+		lineR1B1A0 := make([]frontend.Variable, len(inputs))
+		lineR1B1A1 := make([]frontend.Variable, len(inputs))
+		for k := 0; k < 2; k++ {
+			for i := range inputs {
+				lineR0B0A0[i] = inputs[i].Lines[k][j].R0.B0.A0
+				lineR0B0A1[i] = inputs[i].Lines[k][j].R0.B0.A1
+				lineR0B1A0[i] = inputs[i].Lines[k][j].R0.B1.A0
+				lineR0B1A1[i] = inputs[i].Lines[k][j].R0.B1.A1
+				lineR1B0A0[i] = inputs[i].Lines[k][j].R1.B0.A0
+				lineR1B0A1[i] = inputs[i].Lines[k][j].R1.B0.A1
+				lineR1B1A0[i] = inputs[i].Lines[k][j].R1.B1.A0
+				lineR1B1A1[i] = inputs[i].Lines[k][j].R1.B1.A1
+			}
+			le := &lineEvaluation{
+				R0: fields_bls24315.E4{
+					B0: fields_bls24315.E2{
+						A0: selector.Mux(pr.api, sel, lineR0B0A0...),
+						A1: selector.Mux(pr.api, sel, lineR0B0A1...),
+					},
+					B1: fields_bls24315.E2{
+						A0: selector.Mux(pr.api, sel, lineR0B1A0...),
+						A1: selector.Mux(pr.api, sel, lineR0B1A1...),
+					},
+				},
+				R1: fields_bls24315.E4{
+					B0: fields_bls24315.E2{
+						A0: selector.Mux(pr.api, sel, lineR1B0A0...),
+						A1: selector.Mux(pr.api, sel, lineR1B0A1...),
+					},
+					B1: fields_bls24315.E2{
+						A0: selector.Mux(pr.api, sel, lineR1B1A0...),
+						A1: selector.Mux(pr.api, sel, lineR1B1A1...),
+					},
+				},
+			}
+			ret.Lines[k][j] = le
+		}
+	}
+
+	return &ret
 }
 
 func (pr Pairing) MuxGt(sel frontend.Variable, inputs ...*GT) *GT {
-	panic("not implemented")
+	if len(inputs) == 0 {
+		return nil
+	}
+	if len(inputs) == 1 {
+		pr.api.AssertIsEqual(sel, 0)
+		return inputs[0]
+	}
+	var ret GT
+	D0C0B0A0 := make([]frontend.Variable, len(inputs))
+	D0C0B0A1 := make([]frontend.Variable, len(inputs))
+	D0C0B1A0 := make([]frontend.Variable, len(inputs))
+	D0C0B1A1 := make([]frontend.Variable, len(inputs))
+	D0C1B0A0 := make([]frontend.Variable, len(inputs))
+	D0C1B0A1 := make([]frontend.Variable, len(inputs))
+	D0C1B1A0 := make([]frontend.Variable, len(inputs))
+	D0C1B1A1 := make([]frontend.Variable, len(inputs))
+	D0C2B0A0 := make([]frontend.Variable, len(inputs))
+	D0C2B0A1 := make([]frontend.Variable, len(inputs))
+	D0C2B1A0 := make([]frontend.Variable, len(inputs))
+	D0C2B1A1 := make([]frontend.Variable, len(inputs))
+	D1C0B0A0 := make([]frontend.Variable, len(inputs))
+	D1C0B0A1 := make([]frontend.Variable, len(inputs))
+	D1C0B1A0 := make([]frontend.Variable, len(inputs))
+	D1C0B1A1 := make([]frontend.Variable, len(inputs))
+	D1C1B0A0 := make([]frontend.Variable, len(inputs))
+	D1C1B0A1 := make([]frontend.Variable, len(inputs))
+	D1C1B1A0 := make([]frontend.Variable, len(inputs))
+	D1C1B1A1 := make([]frontend.Variable, len(inputs))
+	D1C2B0A0 := make([]frontend.Variable, len(inputs))
+	D1C2B0A1 := make([]frontend.Variable, len(inputs))
+	D1C2B1A0 := make([]frontend.Variable, len(inputs))
+	D1C2B1A1 := make([]frontend.Variable, len(inputs))
+	for i := range inputs {
+		D0C0B0A0[i] = inputs[i].D0.C0.B0.A0
+		D0C0B0A1[i] = inputs[i].D0.C0.B0.A1
+		D0C0B1A0[i] = inputs[i].D0.C0.B1.A0
+		D0C0B1A1[i] = inputs[i].D0.C0.B1.A1
+		D0C1B0A0[i] = inputs[i].D0.C1.B0.A0
+		D0C1B0A1[i] = inputs[i].D0.C1.B0.A1
+		D0C1B1A0[i] = inputs[i].D0.C1.B1.A0
+		D0C1B1A1[i] = inputs[i].D0.C1.B1.A1
+		D0C2B0A0[i] = inputs[i].D0.C2.B0.A0
+		D0C2B0A1[i] = inputs[i].D0.C2.B0.A1
+		D0C2B1A0[i] = inputs[i].D0.C2.B1.A0
+		D0C2B1A1[i] = inputs[i].D0.C2.B1.A1
+		D1C0B0A0[i] = inputs[i].D1.C0.B0.A0
+		D1C0B0A1[i] = inputs[i].D1.C0.B0.A1
+		D1C0B1A0[i] = inputs[i].D1.C0.B1.A0
+		D1C0B1A1[i] = inputs[i].D1.C0.B1.A1
+		D1C1B0A0[i] = inputs[i].D1.C1.B0.A0
+		D1C1B0A1[i] = inputs[i].D1.C1.B0.A1
+		D1C1B1A0[i] = inputs[i].D1.C1.B1.A0
+		D1C1B1A1[i] = inputs[i].D1.C1.B1.A1
+		D1C2B0A0[i] = inputs[i].D1.C2.B0.A0
+		D1C2B0A1[i] = inputs[i].D1.C2.B0.A1
+		D1C2B1A0[i] = inputs[i].D1.C2.B1.A0
+		D1C2B1A1[i] = inputs[i].D1.C2.B1.A1
+	}
+	ret.D0.C0.B0.A0 = selector.Mux(pr.api, sel, D0C0B0A0...)
+	ret.D0.C0.B0.A1 = selector.Mux(pr.api, sel, D0C0B0A1...)
+	ret.D0.C0.B1.A0 = selector.Mux(pr.api, sel, D0C0B1A0...)
+	ret.D0.C0.B1.A1 = selector.Mux(pr.api, sel, D0C0B1A1...)
+	ret.D0.C1.B0.A0 = selector.Mux(pr.api, sel, D0C1B0A0...)
+	ret.D0.C1.B0.A1 = selector.Mux(pr.api, sel, D0C1B0A1...)
+	ret.D0.C1.B1.A0 = selector.Mux(pr.api, sel, D0C1B1A0...)
+	ret.D0.C1.B1.A1 = selector.Mux(pr.api, sel, D0C1B1A1...)
+	ret.D0.C2.B0.A0 = selector.Mux(pr.api, sel, D0C2B0A0...)
+	ret.D0.C2.B0.A1 = selector.Mux(pr.api, sel, D0C2B0A1...)
+	ret.D0.C2.B1.A0 = selector.Mux(pr.api, sel, D0C2B1A0...)
+	ret.D0.C2.B1.A1 = selector.Mux(pr.api, sel, D0C2B1A1...)
+	ret.D1.C0.B0.A0 = selector.Mux(pr.api, sel, D1C0B0A0...)
+	ret.D1.C0.B0.A1 = selector.Mux(pr.api, sel, D1C0B0A1...)
+	ret.D1.C0.B1.A0 = selector.Mux(pr.api, sel, D1C0B1A0...)
+	ret.D1.C0.B1.A1 = selector.Mux(pr.api, sel, D1C0B1A1...)
+	ret.D1.C1.B0.A0 = selector.Mux(pr.api, sel, D1C1B0A0...)
+	ret.D1.C1.B0.A1 = selector.Mux(pr.api, sel, D1C1B0A1...)
+	ret.D1.C1.B1.A0 = selector.Mux(pr.api, sel, D1C1B1A0...)
+	ret.D1.C1.B1.A1 = selector.Mux(pr.api, sel, D1C1B1A1...)
+	ret.D1.C2.B0.A0 = selector.Mux(pr.api, sel, D1C2B0A0...)
+	ret.D1.C2.B0.A1 = selector.Mux(pr.api, sel, D1C2B0A1...)
+	ret.D1.C2.B1.A0 = selector.Mux(pr.api, sel, D1C2B1A0...)
+	ret.D1.C2.B1.A1 = selector.Mux(pr.api, sel, D1C2B1A1...)
+
+	return &ret
 }
 
 func (p *Pairing) AssertIsOnG1(P *G1Affine) {

--- a/std/algebra/native/sw_bls24315/pairing2.go
+++ b/std/algebra/native/sw_bls24315/pairing2.go
@@ -319,6 +319,14 @@ func (p *Pairing) AssertIsEqual(e1, e2 *GT) {
 	e1.AssertIsEqual(p.api, *e2)
 }
 
+func (pr Pairing) MuxG2(sel frontend.Variable, inputs ...*G2Affine) *G2Affine {
+	panic("not implemented")
+}
+
+func (pr Pairing) MuxGt(sel frontend.Variable, inputs ...*GT) *GT {
+	panic("not implemented")
+}
+
 func (p *Pairing) AssertIsOnG1(P *G1Affine) {
 	panic("not implemented")
 }

--- a/std/algebra/native/sw_bls24315/pairing2_test.go
+++ b/std/algebra/native/sw_bls24315/pairing2_test.go
@@ -2,6 +2,7 @@ package sw_bls24315
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -11,6 +12,24 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/test"
 )
+
+func randomG1G2Affines() (bls24315.G1Affine, bls24315.G2Affine) {
+	_, _, G1AffGen, G2AffGen := bls24315.Generators()
+	mod := bls24315.ID.ScalarField()
+	s1, err := rand.Int(rand.Reader, mod)
+	if err != nil {
+		panic(err)
+	}
+	s2, err := rand.Int(rand.Reader, mod)
+	if err != nil {
+		panic(err)
+	}
+	var p bls24315.G1Affine
+	p.ScalarMultiplication(&G1AffGen, s1)
+	var q bls24315.G2Affine
+	q.ScalarMultiplication(&G2AffGen, s2)
+	return p, q
+}
 
 type MuxCircuitTest struct {
 	Selector frontend.Variable
@@ -52,4 +71,92 @@ func TestMux(t *testing.T) {
 	}
 	err := test.IsSolved(&circuit, &witness, ecc.BW6_761.ScalarField())
 	assert.NoError(err)
+}
+
+type MuxG2GtCircuit struct {
+	InG2       []G2Affine
+	InGt       []GT
+	SelG2      frontend.Variable
+	SelGt      frontend.Variable
+	ExpectedG2 G2Affine
+	ExpectedGt GT
+}
+
+func (c *MuxG2GtCircuit) Define(api frontend.API) error {
+	pairing := NewPairing(api)
+	var inG2 []*G2Affine
+	for i := range c.InG2 {
+		inG2 = append(inG2, &c.InG2[i])
+	}
+	var inGt []*GT
+	for i := range c.InGt {
+		inGt = append(inGt, &c.InGt[i])
+	}
+	g2 := pairing.MuxG2(c.SelG2, inG2...)
+	gt := pairing.MuxGt(c.SelGt, inGt...)
+	if len(c.InG2) == 0 {
+		if g2 != nil {
+			return fmt.Errorf("mux G2: expected nil, got %v", g2)
+		}
+	} else {
+		c.ExpectedG2.P.AssertIsEqual(api, g2.P)
+	}
+	if len(c.InGt) == 0 {
+		if gt != nil {
+			return fmt.Errorf("mux Gt: expected nil, got %v", gt)
+		}
+	} else {
+		pairing.AssertIsEqual(gt, &c.ExpectedGt)
+	}
+	return nil
+}
+
+func TestPairingMuxes(t *testing.T) {
+	assert := test.NewAssert(t)
+	var err error
+	for _, nbPairs := range []int{0, 1, 2, 3, 4, 5} {
+		assert.Run(func(assert *test.Assert) {
+			g2s := make([]bls24315.G2Affine, nbPairs)
+			gts := make([]bls24315.GT, nbPairs)
+			var p bls24315.G1Affine
+			witG2s := make([]G2Affine, nbPairs)
+			witGts := make([]GT, nbPairs)
+			for i := range nbPairs {
+				p, g2s[i] = randomG1G2Affines()
+				gts[i], err = bls24315.Pair([]bls24315.G1Affine{p}, []bls24315.G2Affine{g2s[i]})
+				assert.NoError(err)
+				witG2s[i] = NewG2Affine(g2s[i])
+				witGts[i] = NewGTEl(gts[i])
+			}
+			circuit := MuxG2GtCircuit{InG2: make([]G2Affine, nbPairs), InGt: make([]GT, nbPairs)}
+			var witness MuxG2GtCircuit
+			if nbPairs > 0 {
+				selG2, err := rand.Int(rand.Reader, big.NewInt(int64(nbPairs)))
+				assert.NoError(err)
+				selGt, err := rand.Int(rand.Reader, big.NewInt(int64(nbPairs)))
+				assert.NoError(err)
+				expectedG2 := witG2s[selG2.Int64()]
+				expectedGt := witGts[selGt.Int64()]
+				witness = MuxG2GtCircuit{
+					InG2:       witG2s,
+					InGt:       witGts,
+					SelG2:      selG2,
+					SelGt:      selGt,
+					ExpectedG2: expectedG2,
+					ExpectedGt: expectedGt,
+				}
+			} else {
+				witness = MuxG2GtCircuit{
+					InG2:       witG2s,
+					InGt:       witGts,
+					SelG2:      big.NewInt(0),
+					SelGt:      big.NewInt(0),
+					ExpectedG2: NewG2Affine(bls24315.G2Affine{}),
+					ExpectedGt: NewGTEl(bls24315.GT{}),
+				}
+			}
+			err = test.IsSolved(&circuit, &witness, ecc.BW6_761.ScalarField())
+			assert.NoError(err)
+		}, fmt.Sprintf("nbPairs=%d", nbPairs))
+	}
 }

--- a/std/recursion/groth16/verifier.go
+++ b/std/recursion/groth16/verifier.go
@@ -731,6 +731,7 @@ func (v *Verifier[FR, G1El, G2El, GtEl]) SwitchVerificationKey(idx frontend.Vari
 			cmtBexs[j] = &vks[j].CommitmentKeys[i].GSigmaNeg
 		}
 		ret.CommitmentKeys[i].G = *v.pairing.MuxG2(idx, cmtBss...)
+		ret.CommitmentKeys[i].GSigmaNeg = *v.pairing.MuxG2(idx, cmtBexs...)
 	}
 	// switch E
 	Es := make([]*GtEl, len(vks))

--- a/std/recursion/groth16/verifier.go
+++ b/std/recursion/groth16/verifier.go
@@ -219,6 +219,7 @@ func ValueOfVerifyingKey[G1El algebra.G1ElementT, G2El algebra.G2ElementT, GtEl 
 				return ret, fmt.Errorf("commitment key[%d]: %w", i, err)
 			}
 		}
+		ret.PublicAndCommitmentCommitted = tVk.PublicAndCommitmentCommitted
 	case *VerifyingKey[sw_bls12377.G1Affine, sw_bls12377.G2Affine, sw_bls12377.GT]:
 		tVk, ok := vk.(*groth16backend_bls12377.VerifyingKey)
 		if !ok {
@@ -246,6 +247,7 @@ func ValueOfVerifyingKey[G1El algebra.G1ElementT, G2El algebra.G2ElementT, GtEl 
 				return ret, fmt.Errorf("commitment key[%d]: %w", i, err)
 			}
 		}
+		ret.PublicAndCommitmentCommitted = tVk.PublicAndCommitmentCommitted
 	case *VerifyingKey[sw_bls12381.G1Affine, sw_bls12381.G2Affine, sw_bls12381.GTEl]:
 		tVk, ok := vk.(*groth16backend_bls12381.VerifyingKey)
 		if !ok {
@@ -273,6 +275,7 @@ func ValueOfVerifyingKey[G1El algebra.G1ElementT, G2El algebra.G2ElementT, GtEl 
 				return ret, fmt.Errorf("commitment key[%d]: %w", i, err)
 			}
 		}
+		ret.PublicAndCommitmentCommitted = tVk.PublicAndCommitmentCommitted
 	case *VerifyingKey[sw_bls24315.G1Affine, sw_bls24315.G2Affine, sw_bls24315.GT]:
 		tVk, ok := vk.(*groth16backend_bls24315.VerifyingKey)
 		if !ok {
@@ -300,6 +303,7 @@ func ValueOfVerifyingKey[G1El algebra.G1ElementT, G2El algebra.G2ElementT, GtEl 
 				return ret, fmt.Errorf("commitment key[%d]: %w", i, err)
 			}
 		}
+		ret.PublicAndCommitmentCommitted = tVk.PublicAndCommitmentCommitted
 	case *VerifyingKey[sw_bw6761.G1Affine, sw_bw6761.G2Affine, sw_bw6761.GTEl]:
 		tVk, ok := vk.(*groth16backend_bw6761.VerifyingKey)
 		if !ok {
@@ -327,6 +331,7 @@ func ValueOfVerifyingKey[G1El algebra.G1ElementT, G2El algebra.G2ElementT, GtEl 
 				return ret, fmt.Errorf("commitment key[%d]: %w", i, err)
 			}
 		}
+		ret.PublicAndCommitmentCommitted = tVk.PublicAndCommitmentCommitted
 	default:
 		return ret, fmt.Errorf("unknown parametric type combination")
 	}

--- a/std/recursion/groth16/verifier.go
+++ b/std/recursion/groth16/verifier.go
@@ -687,3 +687,82 @@ func (v *Verifier[FR, G1El, G2El, GtEl]) AssertProof(vk VerifyingKey[G1El, G2El,
 	v.pairing.AssertIsEqual(pairing, &vk.E)
 	return nil
 }
+
+func (v *Verifier[FR, G1El, G2El, GtEl]) SwitchVerificationKey(idx frontend.Variable, vks []VerifyingKey[G1El, G2El, GtEl]) (VerifyingKey[G1El, G2El, GtEl], error) {
+	var ret VerifyingKey[G1El, G2El, GtEl]
+	if len(vks) == 0 {
+		return ret, fmt.Errorf("no verifying keys provided")
+	}
+	if len(vks) == 1 {
+		v.api.AssertIsEqual(idx, 0)
+		return vks[0], nil
+	}
+	// commitment info
+	for i := 1; i < len(vks); i++ {
+		if len(vks[i].PublicAndCommitmentCommitted) != len(vks[0].PublicAndCommitmentCommitted) {
+			return ret, fmt.Errorf("invalid number of commitments")
+		}
+		for j := range vks[i].PublicAndCommitmentCommitted {
+			if len(vks[i].PublicAndCommitmentCommitted[j]) != len(vks[0].PublicAndCommitmentCommitted[j]) {
+				return ret, fmt.Errorf("invalid number of public committed variables")
+			}
+			for k := range vks[i].PublicAndCommitmentCommitted[j] {
+				if vks[i].PublicAndCommitmentCommitted[j][k] != vks[0].PublicAndCommitmentCommitted[j][k] {
+					return ret, fmt.Errorf("invalid public committed variable index")
+				}
+			}
+		}
+		if len(vks[i].CommitmentKeys) != len(vks[0].CommitmentKeys) {
+			return ret, fmt.Errorf("invalid number of commitment keys")
+		}
+	}
+	ret.PublicAndCommitmentCommitted = make([][]int, len(vks[0].PublicAndCommitmentCommitted))
+	for i := range vks[0].PublicAndCommitmentCommitted {
+		ret.PublicAndCommitmentCommitted[i] = make([]int, len(vks[0].PublicAndCommitmentCommitted[i]))
+		copy(ret.PublicAndCommitmentCommitted[i], vks[0].PublicAndCommitmentCommitted[i])
+	}
+
+	ret.CommitmentKeys = make([]pedersen.VerifyingKey[G2El], len(vks[0].CommitmentKeys))
+	for i := range ret.CommitmentKeys {
+		cmtBss := make([]*G2El, len(vks))
+		cmtBexs := make([]*G2El, len(vks))
+		for j := range vks {
+			cmtBss[j] = &vks[j].CommitmentKeys[i].G
+			cmtBexs[j] = &vks[j].CommitmentKeys[i].GSigmaNeg
+		}
+		ret.CommitmentKeys[i].G = *v.pairing.MuxG2(idx, cmtBss...)
+	}
+	// switch E
+	Es := make([]*GtEl, len(vks))
+	for i := range vks {
+		Es[i] = &vks[i].E
+	}
+	ret.E = *v.pairing.MuxGt(idx, Es...)
+
+	// Switch K
+	for i := 1; i < len(vks); i++ {
+		if len(vks[i].G1.K) != len(vks[0].G1.K) {
+			return ret, fmt.Errorf("invalid number of K elements")
+		}
+	}
+	ret.G1.K = make([]G1El, len(vks[0].G1.K))
+	for i := range ret.G1.K {
+		Ks := make([]*G1El, len(vks))
+		for j := range vks {
+			Ks[j] = &vks[j].G1.K[i]
+		}
+		ret.G1.K[i] = *v.curve.Mux(idx, Ks...)
+	}
+
+	// Switch G2
+	gammaNegs := make([]*G2El, len(vks))
+	deltaNegs := make([]*G2El, len(vks))
+	for i := range vks {
+		gammaNegs[i] = &vks[i].G2.GammaNeg
+		deltaNegs[i] = &vks[i].G2.DeltaNeg
+	}
+	ret.G2.GammaNeg = *v.pairing.MuxG2(idx, gammaNegs...)
+	ret.G2.DeltaNeg = *v.pairing.MuxG2(idx, deltaNegs...)
+
+	return ret, nil
+}

--- a/std/recursion/groth16/verifier.go
+++ b/std/recursion/groth16/verifier.go
@@ -688,6 +688,9 @@ func (v *Verifier[FR, G1El, G2El, GtEl]) AssertProof(vk VerifyingKey[G1El, G2El,
 	return nil
 }
 
+// SwitchVerification key switches the verification key based on the provided
+// index idx. Can be used for recursive verification based on the verification
+// key index.
 func (v *Verifier[FR, G1El, G2El, GtEl]) SwitchVerificationKey(idx frontend.Variable, vks []VerifyingKey[G1El, G2El, GtEl]) (VerifyingKey[G1El, G2El, GtEl], error) {
 	var ret VerifyingKey[G1El, G2El, GtEl]
 	if len(vks) == 0 {

--- a/std/recursion/plonk/verifier.go
+++ b/std/recursion/plonk/verifier.go
@@ -1221,6 +1221,8 @@ func (v *Verifier[FR, G1El, G2El, GtEl]) SwitchVerificationKey(bvk BaseVerifying
 		return ret, fmt.Errorf("no circuit verification keys given")
 	}
 	if len(cvks) == 1 {
+		// we don't need to switch. But the index needs to be 0.
+		v.api.AssertIsEqual(idx, 0)
 		return VerifyingKey[FR, G1El, G2El]{
 			BaseVerifyingKey:    bvk,
 			CircuitVerifyingKey: cvks[0],


### PR DESCRIPTION
# Description

This PR implements `SwitchVerificationKey` for groth16 recursion. By including two verification keys for similar circuits, it allows recursive verification of multiple proofs for both circuits, seamlessly switching between their corresponding verification keys as needed.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

There are three similar tests that verify that two proofs from two different circuits are in the third circuit. Each test uses different curves for the inner and outer circuits:

- [x] Test [`TestMultipleBN254InBN254`](https://github.com/lucasmenendez/gnark/blob/becbd0e43531ea2cd0c4b23d0da60f4852db5398/std/recursion/groth16/verifier_test.go#L546)
- [x] Test [`TestMultipleBLS12InBW6`](https://github.com/lucasmenendez/gnark/blob/becbd0e43531ea2cd0c4b23d0da60f4852db5398/std/recursion/groth16/verifier_test.go#L591)
- [x] Test [`TestMultipleBW6InBN254`](https://github.com/lucasmenendez/gnark/blob/becbd0e43531ea2cd0c4b23d0da60f4852db5398/std/recursion/groth16/verifier_test.go#L637)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

