### PR TITLE
optim: avoid div in millerLoopAndFinalExpResult

### DIFF
--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -753,8 +753,8 @@ func (pr Pairing) millerLoopAndFinalExpResult(P *G1Affine, Q *G2Affine, previous
 	t2 := pr.Ext12.Mul(&cubicNonResiduePower, res)
 
 	t1 := pr.FrobeniusCube(residueWitnessInv)
-	t0 := pr.FrobeniusSquare(residueWitnessInv)
-	t1 = pr.Ext12.DivUnchecked(t1, t0)
+	t0 := pr.FrobeniusSquare(residueWitness)
+	t1 = pr.Ext12.Mul(t1, t0)
 	t0 = pr.Frobenius(residueWitnessInv)
 	t1 = pr.Ext12.Mul(t1, t0)
 


### PR DESCRIPTION
# Description

Super minor optimisation to replace a div with a mul, for exponentiation by `λ' = q^3 - q^2 + q`. We already have the inv so we can just exp the inverse by `q^2` and mul (instead of exp and div).

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] Ran all the tests and benches