### PR TITLE
fix: add G2 membership check for constant points

### DIFF
--- a/std/algebra/emulated/sw_bn254/g2.go
+++ b/std/algebra/emulated/sw_bn254/g2.go
@@ -74,6 +74,15 @@ func NewG2Affine(v bn254.G2Affine) G2Affine {
 // NewG2AffineFixed returns witness of v with precomputations for efficient
 // pairing computation.
 func NewG2AffineFixed(v bn254.G2Affine) G2Affine {
+	if !v.IsInSubGroup() {
+		// for the pairing check we check that G2 point is already in the
+		// subgroup when we compute the lines in circuit. However, when the
+		// point is given as a constant, then we already precompute the lines at
+		// circuit compile time without explicitly checking the G2 membership.
+		// So, we need to check that the point is in the subgroup before we
+		// compute the lines.
+		panic("given point is not in the G2 subgroup")
+	}
 	lines := precomputeLines(v)
 	return G2Affine{
 		P:     newG2AffP(v),


### PR DESCRIPTION
# Description

PR #1387 introduced implicit G2 membership check during lines computation. This allows to avoid separate G2 membership test.

However, when the G2 points is given as a constant (i.e. embedded in the circuit description), for example in recursive proof verification, then we don't explicitly check the G2 membership for the constant point. This PR adds this check.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Existing tests pass

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

