### PR TITLE
fix: non-native zero IsZero edge case

### DIFF
--- a/std/math/emulated/element_test.go
+++ b/std/math/emulated/element_test.go
@@ -917,6 +917,9 @@ func (c *IsZeroCircuit[T]) Define(api frontend.API) error {
 	}
 	R := f.Add(&c.X, &c.Y)
 	api.AssertIsEqual(c.Zero, f.IsZero(R))
+
+	isZero := f.IsZero(f.Zero())
+	api.AssertIsEqual(isZero, 1)
 	return nil
 }
 

--- a/std/math/emulated/field_assert.go
+++ b/std/math/emulated/field_assert.go
@@ -103,6 +103,11 @@ func (f *Field[T]) AssertIsInRange(a *Element[T]) {
 // method internally reduces the element and asserts that the value is less than
 // the modulus.
 func (f *Field[T]) IsZero(a *Element[T]) frontend.Variable {
+	// fast path - when the element is on zero limbs, then it is always zero
+	if len(a.Limbs) == 0 {
+		return 1
+	}
+
 	// to avoid using strict reduction (which is expensive as requires binary
 	// assertion that value is less than modulus), we use ordinary reduction but
 	// in this case the result can be either 0 or p (if it is zero).

--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -193,6 +193,10 @@ func (mc *mulCheck[T]) cleanEvaluations() {
 // mulMod returns a*b mod r. In practice it computes the result using a hint and
 // defers the actual multiplication check.
 func (f *Field[T]) mulMod(a, b *Element[T], _ uint, p *Element[T]) *Element[T] {
+	// fast path - if one of the inputs is on zero limbs (it is zero), then the result is also zero
+	if len(a.Limbs) == 0 || len(b.Limbs) == 0 {
+		return f.Zero()
+	}
 	f.enforceWidthConditional(a)
 	f.enforceWidthConditional(b)
 	f.enforceWidthConditional(p)

--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -11,7 +11,7 @@ import (
 
 // Div computes a/b and returns it. It uses [DivHint] as a hint function.
 func (f *Field[T]) Div(a, b *Element[T]) *Element[T] {
-	// fast path when dividing by 0
+	// fast path when dividing 0
 	if len(a.Limbs) == 0 {
 		return f.Zero()
 	}


### PR DESCRIPTION
# Description

When the compiler can deduce that non-native element is constant zero, then we represent it on zero limbs. However in `IsZero` method we initialized the accumulator from first limb without range checking. This PR adds fast path for constant zero.

Fixes #1412 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] Improved `IsZeroCircuit` test to include the regression

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

