### PR TITLE
refactor: rename TestCommitUniquenessZerosScs to TestCommitUniquenessZerosSCS

### DIFF
--- a/test/commitments_test.go
+++ b/test/commitments_test.go
@@ -170,8 +170,8 @@ func (c *commitUniquenessCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func TestCommitUniquenessZerosScs(t *testing.T) { // TODO @Tabaie Randomize Groth16 commitments for real
-
+// TODO @Tabaie Randomize Groth16 commitments for real
+func TestCommitUniquenessZerosSCS(t *testing.T) {
 	w, err := frontend.NewWitness(&commitUniquenessCircuit{[]frontend.Variable{0, 0}}, ecc.BN254.ScalarField())
 	assert.NoError(t, err)
 


### PR DESCRIPTION
- Fix test function name to use correct capitalization for SCS (Sparse Constraint System) abbreviation
- Move TODO comment to separate line for better readability