### PR TITLE
optimize FixedLengthSum of hash with minLen

### DIFF
--- a/std/hash/hash.go
+++ b/std/hash/hash.go
@@ -89,6 +89,29 @@ type BinaryFixedLengthHasher interface {
 	FixedLengthSum(length frontend.Variable) []uints.U8
 }
 
+// HasherConfig allows to configure the behavior of the hash constructors. Do
+// not initialize the configuration directly but rather use the [Option]
+// functions which perform correct initializations. This configuration is
+// exported for importing in hash implementations.
+type HasherConfig struct {
+	MinimalLength int
+}
+
+// Option allows configuring the hash functions.
+type Option func(*HasherConfig) error
+
+// WithMinimalLength hints the minimal length of the input to the hash function.
+// This allows to optimize the constraint count when calling
+// [BinaryFixedLengthHasher.FixedLengthSum] as we can avoid selecting between
+// the dummy padding and actual padding. If this option is not provided, then we
+// assume the minimal length is 0.
+func WithMinimalLength(minimalLength int) Option {
+	return func(cfg *HasherConfig) error {
+		cfg.MinimalLength = minimalLength
+		return nil
+	}
+}
+
 // Compressor is a 2-1 one-way function. It takes two inputs and compresses
 // them into one output.
 //

--- a/std/hash/hash.go
+++ b/std/hash/hash.go
@@ -85,7 +85,7 @@ type BinaryHasher interface {
 type BinaryFixedLengthHasher interface {
 	BinaryHasher
 	// FixedLengthSum returns digest of the first length bytes. See the
-	// [WithMinimalLength] option for setting lower cound on length.
+	// [WithMinimalLength] option for setting lower bound on length.
 	FixedLengthSum(length frontend.Variable) []uints.U8
 }
 

--- a/std/hash/hash.go
+++ b/std/hash/hash.go
@@ -85,6 +85,7 @@ type BinaryHasher interface {
 type BinaryFixedLengthHasher interface {
 	BinaryHasher
 	// FixedLengthSum returns digest of the first length bytes.
+	// the minLen is the minimum length of the input.
 	FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 }
 

--- a/std/hash/hash.go
+++ b/std/hash/hash.go
@@ -85,7 +85,7 @@ type BinaryHasher interface {
 type BinaryFixedLengthHasher interface {
 	BinaryHasher
 	// FixedLengthSum returns digest of the first length bytes.
-	FixedLengthSum(length frontend.Variable) []uints.U8
+	FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 }
 
 // Compressor is a 2-1 one-way function. It takes two inputs and compresses

--- a/std/hash/hash.go
+++ b/std/hash/hash.go
@@ -85,8 +85,8 @@ type BinaryHasher interface {
 type BinaryFixedLengthHasher interface {
 	BinaryHasher
 	// FixedLengthSum returns digest of the first length bytes.
-	// the minLen is the minimum length of the input.
-	FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
+	// the minLen is the minimum length of the input to be hashed.
+	FixedLengthSum(length frontend.Variable, minLenOpt ...int) []uints.U8
 }
 
 // Compressor is a 2-1 one-way function. It takes two inputs and compresses

--- a/std/hash/hash.go
+++ b/std/hash/hash.go
@@ -85,8 +85,8 @@ type BinaryHasher interface {
 type BinaryFixedLengthHasher interface {
 	BinaryHasher
 	// FixedLengthSum returns digest of the first length bytes.
-	// the minLen is the minimum length of the input to be hashed.
-	FixedLengthSum(length frontend.Variable, minLenOpt ...int) []uints.U8
+	// the minLen is the minimum length of the input.
+	FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 }
 
 // Compressor is a 2-1 one-way function. It takes two inputs and compresses

--- a/std/hash/hash.go
+++ b/std/hash/hash.go
@@ -84,9 +84,9 @@ type BinaryHasher interface {
 // the length of the input is the total number of bytes written.
 type BinaryFixedLengthHasher interface {
 	BinaryHasher
-	// FixedLengthSum returns digest of the first length bytes.
-	// the minLen is the minimum length of the input.
-	FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
+	// FixedLengthSum returns digest of the first length bytes. See the
+	// [WithMinimalLength] option for setting lower cound on length.
+	FixedLengthSum(length frontend.Variable) []uints.U8
 }
 
 // Compressor is a 2-1 one-way function. It takes two inputs and compresses

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -87,15 +87,16 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 	// idea - have a mask for blocks where 1 is only for the block we want to
 	// use.
 
-	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(len(d.in)+64+8)), false)
+	maxLen := len(d.in)
+	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(maxLen+64+8)), false)
 	comparator.AssertIsLessEq(minLen, length)
 
-	data := make([]uints.U8, len(d.in))
+	data := make([]uints.U8, maxLen)
 	copy(data, d.in)
 	data = append(data, uints.NewU8Array(make([]uint8, 64+8))...)
 
-	// When i < minLen and i < len(data)-8, padding 1 or 0 is completely unnecessary
-	for i := minLen; i < len(data)-8; i++ {
+	// When i < minLen and i >= len(d.in)+1, padding 0x80 is completely unnecessary
+	for i := minLen; i < maxLen+1; i++ {
 		isPaddingStartPos := cmp.IsEqual(d.api, i, length)
 		data[i].Val = d.api.Select(isPaddingStartPos, 0x80, data[i].Val)
 

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -81,7 +81,7 @@ func (d *digest) unpackU8digest(digest [8]uints.U32) []uints.U8 {
 	return ret
 }
 
-func (d *digest) FixedLengthSum(length frontend.Variable, minLenOpt ...int) []uints.U8 {
+func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8 {
 	// we need to do two things here -- first the padding has to be put to the
 	// right place. For that we need to know how many blocks we have used. We
 	// need to fit at least 9 more bytes (padding byte and 8 bytes for input
@@ -93,12 +93,7 @@ func (d *digest) FixedLengthSum(length frontend.Variable, minLenOpt ...int) []ui
 
 	maxLen := len(d.in)
 	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(maxLen+64+8)), false)
-
-	minLen := 0
-	if len(minLenOpt) == 1 {
-		minLen = minLenOpt[0]
-		comparator.AssertIsLessEq(minLen, length)
-	}
+	comparator.AssertIsLessEq(minLen, length)
 
 	data := make([]uints.U8, maxLen)
 	copy(data, d.in)

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -111,8 +111,8 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 	var dataLenBtyes [8]frontend.Variable
 	d.bigEndianPutUint64(dataLenBtyes[:], d.api.Mul(length, 8))
 
-	// When i < minLen and i >= len(d.in)+1, padding 1 0r 0 is completely unnecessary
-	for i := minLen; i < maxLen+1; i++ {
+	// When i < minLen or i > maxLen, padding 1 0r 0 is completely unnecessary
+	for i := minLen; i <= maxLen; i++ {
 		isPaddingStartPos := cmp.IsEqual(d.api, i, length)
 		padded[i].Val = d.api.Select(isPaddingStartPos, 0x80, padded[i].Val)
 

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -70,9 +70,13 @@ func (d *digest) Sum() []uints.U8 {
 		runningDigest = sha2.Permute(d.uapi, runningDigest, buf)
 	}
 
+	return d.unpackU8digest(runningDigest)
+}
+
+func (d *digest) unpackU8digest(digest [8]uints.U32) []uints.U8 {
 	var ret []uints.U8
-	for i := range runningDigest {
-		ret = append(ret, d.uapi.UnpackMSB(runningDigest[i])...)
+	for i := range digest {
+		ret = append(ret, d.uapi.UnpackMSB(digest[i])...)
 	}
 	return ret
 }
@@ -95,7 +99,7 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 	copy(data, d.in)
 	data = append(data, uints.NewU8Array(make([]uint8, 64+8))...)
 
-	// When i < minLen and i >= len(d.in)+1, padding 0x80 is completely unnecessary
+	// When i < minLen and i >= len(d.in)+1, padding 1 0r 0 is completely unnecessary
 	for i := minLen; i < maxLen+1; i++ {
 		isPaddingStartPos := cmp.IsEqual(d.api, i, length)
 		data[i].Val = d.api.Select(isPaddingStartPos, 0x80, data[i].Val)
@@ -151,11 +155,7 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 		}
 	}
 
-	var ret []uints.U8
-	for i := range resultDigest {
-		ret = append(ret, d.uapi.UnpackMSB(resultDigest[i])...)
-	}
-	return ret
+	return d.unpackU8digest(resultDigest)
 }
 
 func (d *digest) Reset() {

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -95,9 +95,9 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(maxLen+64+8)), false)
 	comparator.AssertIsLessEq(minLen, length)
 
-	data := make([]uints.U8, maxLen)
-	copy(data, d.in)
-	data = append(data, uints.NewU8Array(make([]uint8, 64+8))...)
+	padded := make([]uints.U8, maxLen)
+	copy(padded, d.in)
+	padded = append(padded, uints.NewU8Array(make([]uint8, 64+8))...)
 
 	lenMod64 := d.mod64(length)
 	lenMod64Less56 := comparator.IsLess(lenMod64, 56)
@@ -114,18 +114,18 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 	// When i < minLen and i >= len(d.in)+1, padding 1 0r 0 is completely unnecessary
 	for i := minLen; i < maxLen+1; i++ {
 		isPaddingStartPos := cmp.IsEqual(d.api, i, length)
-		data[i].Val = d.api.Select(isPaddingStartPos, 0x80, data[i].Val)
+		padded[i].Val = d.api.Select(isPaddingStartPos, 0x80, padded[i].Val)
 
 		isPaddingPos := comparator.IsLess(length, i)
-		data[i].Val = d.api.Select(isPaddingPos, 0, data[i].Val)
+		padded[i].Val = d.api.Select(isPaddingPos, 0, padded[i].Val)
 	}
 
 	// When i <= minLen, padding length is completely unnecessary
-	for i := minLen + 1; i < len(data); i++ {
+	for i := minLen + 1; i < len(padded); i++ {
 		isLast8BytesPos := cmp.IsEqual(d.api, i, last8BytesPos)
 		for j := 0; j < 8; j++ {
-			if i+j < len(data) {
-				data[i+j].Val = d.api.Select(isLast8BytesPos, dataLenBtyes[j], data[i+j].Val)
+			if i+j < len(padded) {
+				padded[i+j].Val = d.api.Select(isLast8BytesPos, dataLenBtyes[j], padded[i+j].Val)
 			}
 		}
 	}
@@ -135,8 +135,8 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 	var buf [64]uints.U8
 	copy(runningDigest[:], _seed)
 
-	for i := 0; i < len(data)/64; i++ {
-		copy(buf[:], data[i*64:(i+1)*64])
+	for i := 0; i < len(padded)/64; i++ {
+		copy(buf[:], padded[i*64:(i+1)*64])
 		runningDigest = sha2.Permute(d.uapi, runningDigest, buf)
 
 		// When i < minLen/64, runningDigest cannot be resultDigest, and proceed to the next loop directly

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -70,10 +70,10 @@ func (d *digest) Sum() []uints.U8 {
 		runningDigest = sha2.Permute(d.uapi, runningDigest, buf)
 	}
 
-	return d.unpackU8digest(runningDigest)
+	return d.unpackU8Digest(runningDigest)
 }
 
-func (d *digest) unpackU8digest(digest [8]uints.U32) []uints.U8 {
+func (d *digest) unpackU8Digest(digest [8]uints.U32) []uints.U8 {
 	var ret []uints.U8
 	for i := range digest {
 		ret = append(ret, d.uapi.UnpackMSB(digest[i])...)
@@ -160,7 +160,7 @@ func (d *digest) FixedLengthSum(length frontend.Variable, minLenOpt ...int) []ui
 		}
 	}
 
-	return d.unpackU8digest(resultDigest)
+	return d.unpackU8Digest(resultDigest)
 }
 
 func (d *digest) Reset() {

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -81,7 +81,7 @@ func (d *digest) unpackU8digest(digest [8]uints.U32) []uints.U8 {
 	return ret
 }
 
-func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8 {
+func (d *digest) FixedLengthSum(length frontend.Variable, minLenOpt ...int) []uints.U8 {
 	// we need to do two things here -- first the padding has to be put to the
 	// right place. For that we need to know how many blocks we have used. We
 	// need to fit at least 9 more bytes (padding byte and 8 bytes for input
@@ -93,7 +93,12 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 
 	maxLen := len(d.in)
 	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(maxLen+64+8)), false)
-	comparator.AssertIsLessEq(minLen, length)
+
+	minLen := 0
+	if len(minLenOpt) == 1 {
+		minLen = minLenOpt[0]
+		comparator.AssertIsLessEq(minLen, length)
+	}
 
 	data := make([]uints.U8, maxLen)
 	copy(data, d.in)

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -78,10 +78,10 @@ func (d *digest) Sum() []uints.U8 {
 		runningDigest = sha2.Permute(d.uapi, runningDigest, buf)
 	}
 
-	return d.unpackU8digest(runningDigest)
+	return d.unpackU8Digest(runningDigest)
 }
 
-func (d *digest) unpackU8digest(digest [8]uints.U32) []uints.U8 {
+func (d *digest) unpackU8Digest(digest [8]uints.U32) []uints.U8 {
 	var ret []uints.U8
 	for i := range digest {
 		ret = append(ret, d.uapi.UnpackMSB(digest[i])...)
@@ -167,7 +167,7 @@ func (d *digest) FixedLengthSum(length frontend.Variable) []uints.U8 {
 		}
 	}
 
-	return d.unpackU8digest(resultDigest)
+	return d.unpackU8Digest(resultDigest)
 }
 
 func (d *digest) Reset() {

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -70,10 +70,10 @@ func (d *digest) Sum() []uints.U8 {
 		runningDigest = sha2.Permute(d.uapi, runningDigest, buf)
 	}
 
-	return d.unpackU8Digest(runningDigest)
+	return d.unpackU8digest(runningDigest)
 }
 
-func (d *digest) unpackU8Digest(digest [8]uints.U32) []uints.U8 {
+func (d *digest) unpackU8digest(digest [8]uints.U32) []uints.U8 {
 	var ret []uints.U8
 	for i := range digest {
 		ret = append(ret, d.uapi.UnpackMSB(digest[i])...)
@@ -160,7 +160,7 @@ func (d *digest) FixedLengthSum(length frontend.Variable, minLenOpt ...int) []ui
 		}
 	}
 
-	return d.unpackU8Digest(resultDigest)
+	return d.unpackU8digest(resultDigest)
 }
 
 func (d *digest) Reset() {

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -129,7 +129,6 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 	var resultDigest [8]uints.U32
 	var buf [64]uints.U8
 	copy(runningDigest[:], _seed)
-	copy(resultDigest[:], _seed)
 
 	for i := 0; i < len(data)/64; i++ {
 		copy(buf[:], data[i*64:(i+1)*64])
@@ -137,6 +136,9 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 
 		// When i < minLen/64, runningDigest cannot be resultDigest, and proceed to the next loop directly
 		if i < minLen/64 {
+			continue
+		} else if i == minLen/64 { // init resultDigests
+			copy(resultDigest[:], runningDigest[:])
 			continue
 		}
 

--- a/std/hash/sha2/sha2.go
+++ b/std/hash/sha2/sha2.go
@@ -60,14 +60,16 @@ func (d *digest) padded(bytesLen int) []uints.U8 {
 }
 
 func (d *digest) Sum() []uints.U8 {
+	padded := d.padded(len(d.in))
+
 	var runningDigest [8]uints.U32
 	var buf [64]uints.U8
 	copy(runningDigest[:], _seed)
-	padded := d.padded(len(d.in))
 	for i := 0; i < len(padded)/64; i++ {
 		copy(buf[:], padded[i*64:(i+1)*64])
 		runningDigest = sha2.Permute(d.uapi, runningDigest, buf)
 	}
+
 	var ret []uints.U8
 	for i := range runningDigest {
 		ret = append(ret, d.uapi.UnpackMSB(runningDigest[i])...)
@@ -133,7 +135,7 @@ func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8
 		copy(buf[:], data[i*64:(i+1)*64])
 		runningDigest = sha2.Permute(d.uapi, runningDigest, buf)
 
-		// When i < minLen/64, it must be in the range, so we use runningDigest directly
+		// When i < minLen/64, runningDigest cannot be resultDigest, and proceed to the next loop directly
 		if i < minLen/64 {
 			continue
 		}

--- a/std/hash/sha2/sha2_test.go
+++ b/std/hash/sha2/sha2_test.go
@@ -122,7 +122,7 @@ func (c *sha2FixedLengthWithMinLenCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func TestSHA2FixedLengthWithMinLenSumWithMinLen(t *testing.T) {
+func TestSHA2FixedLengthSumWithMinLen(t *testing.T) {
 	assert := test.NewAssert(t)
 	circuit := &sha2FixedLengthWithMinLenCircuit{In: make([]uints.U8, maxLen)}
 	bts := make([]byte, maxLen)

--- a/std/hash/sha2/sha2_test.go
+++ b/std/hash/sha2/sha2_test.go
@@ -65,7 +65,7 @@ func (c *sha2FixedLengthCircuit) Define(api frontend.API) error {
 		return err
 	}
 	h.Write(c.In)
-	res := h.FixedLengthSum(c.Length)
+	res := h.FixedLengthSum(0, c.Length)
 	if len(res) != 32 {
 		return fmt.Errorf("not 32 bytes")
 	}

--- a/std/hash/sha2/sha2_test.go
+++ b/std/hash/sha2/sha2_test.go
@@ -122,7 +122,7 @@ func (c *sha2FixedLengthWithMinLenCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-func TestSHA2FixedLengthSumWithMinLen(t *testing.T) {
+func TestSHA2FixedLengthWithMinLenSumWithMinLen(t *testing.T) {
 	assert := test.NewAssert(t)
 	circuit := &sha2FixedLengthWithMinLenCircuit{In: make([]uints.U8, maxLen)}
 	bts := make([]byte, maxLen)

--- a/std/hash/sha2/sha2_test.go
+++ b/std/hash/sha2/sha2_test.go
@@ -56,6 +56,11 @@ type sha2FixedLengthCircuit struct {
 	Expected [32]uints.U8
 }
 
+const (
+	minLen = 56
+	maxLen = 144
+)
+
 func (c *sha2FixedLengthCircuit) Define(api frontend.API) error {
 	h, err := New(api)
 	if err != nil {
@@ -66,7 +71,7 @@ func (c *sha2FixedLengthCircuit) Define(api frontend.API) error {
 		return err
 	}
 	h.Write(c.In)
-	res := h.FixedLengthSum(c.Length)
+	res := h.FixedLengthSum(minLen, c.Length)
 	if len(res) != 32 {
 		return fmt.Errorf("not 32 bytes")
 	}
@@ -77,54 +82,8 @@ func (c *sha2FixedLengthCircuit) Define(api frontend.API) error {
 }
 
 func TestSHA2FixedLengthSum(t *testing.T) {
-	bts := make([]byte, 144)
-	length := 56
-	dgst := sha256.Sum256(bts[:length])
-	witness := sha2FixedLengthCircuit{
-		In:     uints.NewU8Array(bts),
-		Length: length,
-	}
-	copy(witness.Expected[:], uints.NewU8Array(dgst[:]))
-	err := test.IsSolved(&sha2FixedLengthCircuit{In: make([]uints.U8, len(bts))}, &witness, ecc.BN254.ScalarField())
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-type sha2FixedLengthWithMinLenCircuit struct {
-	In       []uints.U8
-	Length   frontend.Variable
-	Expected [32]uints.U8
-}
-
-const (
-	minLen = 56
-	maxLen = 144
-)
-
-func (c *sha2FixedLengthWithMinLenCircuit) Define(api frontend.API) error {
-	h, err := New(api)
-	if err != nil {
-		return err
-	}
-	uapi, err := uints.New[uints.U32](api)
-	if err != nil {
-		return err
-	}
-	h.Write(c.In)
-	res := h.FixedLengthSum(c.Length, minLen)
-	if len(res) != 32 {
-		return fmt.Errorf("not 32 bytes")
-	}
-	for i := range c.Expected {
-		uapi.ByteAssertEq(c.Expected[i], res[i])
-	}
-	return nil
-}
-
-func TestSHA2FixedLengthWithMinLenSumWithMinLen(t *testing.T) {
 	assert := test.NewAssert(t)
-	circuit := &sha2FixedLengthWithMinLenCircuit{In: make([]uints.U8, maxLen)}
+	circuit := &sha2FixedLengthCircuit{In: make([]uints.U8, maxLen)}
 	bts := make([]byte, maxLen)
 	_, err := rand.Reader.Read(bts)
 	assert.NoError(err)
@@ -132,7 +91,7 @@ func TestSHA2FixedLengthWithMinLenSumWithMinLen(t *testing.T) {
 	for length := minLen; length <= maxLen; length++ {
 		assert.Run(func(assert *test.Assert) {
 			dgst := sha256.Sum256(bts[:length])
-			witness := &sha2FixedLengthWithMinLenCircuit{
+			witness := &sha2FixedLengthCircuit{
 				In:       uints.NewU8Array(bts),
 				Length:   length,
 				Expected: [32]uints.U8(uints.NewU8Array(dgst[:])),

--- a/std/hash/sha2/sha2_test.go
+++ b/std/hash/sha2/sha2_test.go
@@ -55,6 +55,11 @@ type sha2FixedLengthCircuit struct {
 	Expected [32]uints.U8
 }
 
+const (
+	minLen = 55
+	maxLen = 144
+)
+
 func (c *sha2FixedLengthCircuit) Define(api frontend.API) error {
 	h, err := New(api)
 	if err != nil {
@@ -65,7 +70,7 @@ func (c *sha2FixedLengthCircuit) Define(api frontend.API) error {
 		return err
 	}
 	h.Write(c.In)
-	res := h.FixedLengthSum(0, c.Length)
+	res := h.FixedLengthSum(minLen, c.Length)
 	if len(res) != 32 {
 		return fmt.Errorf("not 32 bytes")
 	}
@@ -76,7 +81,8 @@ func (c *sha2FixedLengthCircuit) Define(api frontend.API) error {
 }
 
 func TestSHA2FixedLengthSum(t *testing.T) {
-	bts := make([]byte, 144)
+	circuit := &sha2FixedLengthCircuit{In: make([]uints.U8, maxLen)}
+	bts := make([]byte, maxLen)
 	length := 56
 	dgst := sha256.Sum256(bts[:length])
 	witness := sha2FixedLengthCircuit{
@@ -84,7 +90,7 @@ func TestSHA2FixedLengthSum(t *testing.T) {
 		Length: length,
 	}
 	copy(witness.Expected[:], uints.NewU8Array(dgst[:]))
-	err := test.IsSolved(&sha2FixedLengthCircuit{In: make([]uints.U8, len(bts))}, &witness, ecc.BN254.ScalarField())
+	err := test.IsSolved(circuit, &witness, ecc.BN254.ScalarField())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/std/hash/sha3/hashes.go
+++ b/std/hash/sha3/hashes.go
@@ -1,99 +1,69 @@
 package sha3
 
 import (
+	"fmt"
+
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/hash"
 	"github.com/consensys/gnark/std/math/uints"
 )
 
+// newHash is a helper function to create a new SHA3 hash.
+func newHash(api frontend.API, dsByte byte, rate, outputLen int, opts ...hash.Option) (hash.BinaryFixedLengthHasher, error) {
+	cfg := new(hash.HasherConfig)
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return nil, fmt.Errorf("applying option: %w", err)
+		}
+	}
+	uapi, err := uints.New[uints.U64](api)
+	if err != nil {
+		return nil, fmt.Errorf("initializing uints: %w", err)
+	}
+	return &digest{
+		api:           api,
+		uapi:          uapi,
+		state:         newState(),
+		dsbyte:        dsByte,
+		rate:          rate,
+		outputLen:     outputLen,
+		minimalLength: cfg.MinimalLength,
+	}, nil
+}
+
 // New256 creates a new SHA3-256 hash.
 // Its generic security strength is 256 bits against preimage attacks,
 // and 128 bits against collision attacks.
-func New256(api frontend.API) (hash.BinaryFixedLengthHasher, error) {
-	uapi, err := uints.New[uints.U64](api)
-	if err != nil {
-		return nil, err
-	}
-	return &digest{
-		api:       api,
-		uapi:      uapi,
-		state:     newState(),
-		dsbyte:    0x06,
-		rate:      136,
-		outputLen: 32,
-	}, nil
+func New256(api frontend.API, opts ...hash.Option) (hash.BinaryFixedLengthHasher, error) {
+	return newHash(api, 0x06, 136, 32, opts...)
 }
 
 // New384 creates a new SHA3-384 hash.
 // Its generic security strength is 384 bits against preimage attacks,
 // and 192 bits against collision attacks.
-func New384(api frontend.API) (hash.BinaryFixedLengthHasher, error) {
-	uapi, err := uints.New[uints.U64](api)
-	if err != nil {
-		return nil, err
-	}
-	return &digest{
-		api:       api,
-		uapi:      uapi,
-		state:     newState(),
-		dsbyte:    0x06,
-		rate:      104,
-		outputLen: 48,
-	}, nil
+func New384(api frontend.API, opts ...hash.Option) (hash.BinaryFixedLengthHasher, error) {
+	return newHash(api, 0x06, 104, 48, opts...)
 }
 
 // New512 creates a new SHA3-512 hash.
 // Its generic security strength is 512 bits against preimage attacks,
 // and 256 bits against collision attacks.
-func New512(api frontend.API) (hash.BinaryFixedLengthHasher, error) {
-	uapi, err := uints.New[uints.U64](api)
-	if err != nil {
-		return nil, err
-	}
-	return &digest{
-		api:       api,
-		uapi:      uapi,
-		state:     newState(),
-		dsbyte:    0x06,
-		rate:      72,
-		outputLen: 64,
-	}, nil
+func New512(api frontend.API, opts ...hash.Option) (hash.BinaryFixedLengthHasher, error) {
+	return newHash(api, 0x06, 72, 64, opts...)
 }
 
 // NewLegacyKeccak256 creates a new Keccak-256 hash.
 //
 // Only use this function if you require compatibility with an existing cryptosystem
 // that uses non-standard padding. All other users should use New256 instead.
-func NewLegacyKeccak256(api frontend.API) (hash.BinaryFixedLengthHasher, error) {
-	uapi, err := uints.New[uints.U64](api)
-	if err != nil {
-		return nil, err
-	}
-	return &digest{
-		api:       api,
-		uapi:      uapi,
-		state:     newState(),
-		dsbyte:    0x01,
-		rate:      136,
-		outputLen: 32,
-	}, nil
+func NewLegacyKeccak256(api frontend.API, opts ...hash.Option) (hash.BinaryFixedLengthHasher, error) {
+	return newHash(api, 0x01, 136, 32, opts...)
 }
 
 // NewLegacyKeccak512 creates a new Keccak-512 hash.
 //
 // Only use this function if you require compatibility with an existing cryptosystem
 // that uses non-standard padding. All other users should use New512 instead.
-func NewLegacyKeccak512(api frontend.API) (hash.BinaryFixedLengthHasher, error) {
-	uapi, err := uints.New[uints.U64](api)
-	if err != nil {
-		return nil, err
-	}
-	return &digest{
-		api:       api,
-		uapi:      uapi,
-		state:     newState(),
-		dsbyte:    0x01,
-		rate:      72,
-		outputLen: 64,
-	}, nil
+func NewLegacyKeccak512(api frontend.API, opts ...hash.Option) (hash.BinaryFixedLengthHasher, error) {
+	return newHash(api, 0x01, 72, 64, opts...)
 }

--- a/std/hash/sha3/sha3.go
+++ b/std/hash/sha3/sha3.go
@@ -128,7 +128,6 @@ func (d *digest) absorbing(blocks [][]uints.U64) {
 func (d *digest) absorbingFixedWidth(minNbOfBlocks int, blocks [][]uints.U64, nbBlocks frontend.Variable) {
 	var state [25]uints.U64
 	var resultState [25]uints.U64
-	copy(resultState[:], d.state[:])
 	copy(state[:], d.state[:])
 
 	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(len(blocks))), false)
@@ -141,6 +140,9 @@ func (d *digest) absorbingFixedWidth(minNbOfBlocks int, blocks [][]uints.U64, nb
 
 		// When i < minNbOfBlocks, state cannot be resultState, and proceed to the next loop directly
 		if i < minNbOfBlocks {
+			continue
+		} else if i == minNbOfBlocks { // init resultState
+			copy(resultState[:], state[:])
 			continue
 		}
 

--- a/std/hash/sha3/sha3.go
+++ b/std/hash/sha3/sha3.go
@@ -10,13 +10,14 @@ import (
 )
 
 type digest struct {
-	api       frontend.API
-	uapi      *uints.BinaryField[uints.U64]
-	state     [25]uints.U64 // 1600 bits state: 25 x 64
-	in        []uints.U8    // input to be digested
-	dsbyte    byte          // dsbyte contains the "domain separation" bits and the first bit of the padding
-	rate      int           // the number of bytes of state to use
-	outputLen int           // the default output size in bytes
+	api           frontend.API
+	uapi          *uints.BinaryField[uints.U64]
+	state         [25]uints.U64 // 1600 bits state: 25 x 64
+	in            []uints.U8    // input to be digested
+	dsbyte        byte          // dsbyte contains the "domain separation" bits and the first bit of the padding
+	rate          int           // the number of bytes of state to use
+	outputLen     int           // the default output size in bytes
+	minimalLength int           // lower bound on the length of the input to optimize fixed length hashing
 }
 
 func (d *digest) Write(in []uints.U8) {
@@ -38,7 +39,7 @@ func (d *digest) Sum() []uints.U8 {
 	return d.squeezeBlocks()
 }
 
-func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8 {
+func (d *digest) FixedLengthSum(length frontend.Variable) []uints.U8 {
 	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(len(d.in))), false)
 	comparator.AssertIsLessEq(minLen, length)
 

--- a/std/hash/sha3/sha3.go
+++ b/std/hash/sha3/sha3.go
@@ -38,11 +38,17 @@ func (d *digest) Sum() []uints.U8 {
 	return d.squeezeBlocks()
 }
 
-func (d *digest) FixedLengthSum(length frontend.Variable) []uints.U8 {
-	padded, numberOfBlocks := d.paddingFixedWidth(length)
+func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8 {
+	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(len(d.in))), false)
+	comparator.AssertIsLessEq(minLen, length)
+
+	padded, numberOfBlocks := d.paddingFixedWidth(minLen, length)
 
 	blocks := d.composeBlocks(padded)
-	d.absorbingFixedWidth(blocks, numberOfBlocks)
+
+	minNbOfBlocks := minLen / d.rate
+	d.absorbingFixedWidth(minNbOfBlocks, blocks, numberOfBlocks)
+
 	return d.squeezeBlocks()
 }
 
@@ -65,13 +71,13 @@ func (d *digest) padding() []uints.U8 {
 	return padded
 }
 
-func (d *digest) paddingFixedWidth(length frontend.Variable) (padded []uints.U8, numberOfBlocks frontend.Variable) {
+func (d *digest) paddingFixedWidth(minLen int, length frontend.Variable) (padded []uints.U8, numberOfBlocks frontend.Variable) {
 	numberOfBlocks = frontend.Variable(0)
 	padded = make([]uints.U8, len(d.in))
 	copy(padded[:], d.in[:])
 	padded = append(padded, uints.NewU8Array(make([]uint8, d.rate))...)
 
-	for i := 0; i <= len(padded)-d.rate; i++ {
+	for i := minLen; i <= len(padded)-d.rate; i++ {
 		reachEnd := cmp.IsEqual(d.api, i, length)
 		switch q := d.rate - ((i) % d.rate); q {
 		case 1:
@@ -118,7 +124,7 @@ func (d *digest) absorbing(blocks [][]uints.U64) {
 	}
 }
 
-func (d *digest) absorbingFixedWidth(blocks [][]uints.U64, nbBlocks frontend.Variable) {
+func (d *digest) absorbingFixedWidth(minNbOfBlocks int, blocks [][]uints.U64, nbBlocks frontend.Variable) {
 	var state [25]uints.U64
 	var resultState [25]uints.U64
 	copy(resultState[:], d.state[:])
@@ -131,6 +137,10 @@ func (d *digest) absorbingFixedWidth(blocks [][]uints.U64, nbBlocks frontend.Var
 			state[j] = d.uapi.Xor(state[j], block[j])
 		}
 		state = keccakf.Permute(d.uapi, state)
+		if i < minNbOfBlocks {
+			continue
+		}
+
 		isInRange := comparator.IsLess(i, nbBlocks)
 		// only select blocks that are in range
 		for j := 0; j < 25; j++ {

--- a/std/hash/sha3/sha3.go
+++ b/std/hash/sha3/sha3.go
@@ -80,22 +80,22 @@ func (d *digest) paddingFixedWidth(minLen int, length frontend.Variable) (padded
 
 	// When i < minLen or i > maxLen, it is completely unnecessary
 	for i := minLen; i <= maxLen; i++ {
-		isPaddingStartPos := cmp.IsEqual(d.api, i, length)
+		reachEnd := cmp.IsEqual(d.api, i, length)
 		switch q := d.rate - ((i) % d.rate); q {
 		case 1:
-			padded[i].Val = d.api.Select(isPaddingStartPos, d.dsbyte^0x80, padded[i].Val)
-			numberOfBlocks = d.api.Select(isPaddingStartPos, (i+1)/d.rate, numberOfBlocks)
+			padded[i].Val = d.api.Select(reachEnd, d.dsbyte^0x80, padded[i].Val)
+			numberOfBlocks = d.api.Select(reachEnd, (i+1)/d.rate, numberOfBlocks)
 		case 2:
-			padded[i].Val = d.api.Select(isPaddingStartPos, d.dsbyte, padded[i].Val)
-			padded[i+1].Val = d.api.Select(isPaddingStartPos, 0x80, padded[i+1].Val)
-			numberOfBlocks = d.api.Select(isPaddingStartPos, (i+2)/d.rate, numberOfBlocks)
+			padded[i].Val = d.api.Select(reachEnd, d.dsbyte, padded[i].Val)
+			padded[i+1].Val = d.api.Select(reachEnd, 0x80, padded[i+1].Val)
+			numberOfBlocks = d.api.Select(reachEnd, (i+2)/d.rate, numberOfBlocks)
 		default:
-			padded[i].Val = d.api.Select(isPaddingStartPos, d.dsbyte, padded[i].Val)
+			padded[i].Val = d.api.Select(reachEnd, d.dsbyte, padded[i].Val)
 			for j := 0; j < q-2; j++ {
-				padded[i+1+j].Val = d.api.Select(isPaddingStartPos, 0, padded[i+1+j].Val)
+				padded[i+1+j].Val = d.api.Select(reachEnd, 0, padded[i+1+j].Val)
 			}
-			padded[i+q-1].Val = d.api.Select(isPaddingStartPos, 0x80, padded[i+q-1].Val)
-			numberOfBlocks = d.api.Select(isPaddingStartPos, (i+q)/d.rate, numberOfBlocks)
+			padded[i+q-1].Val = d.api.Select(reachEnd, 0x80, padded[i+q-1].Val)
+			numberOfBlocks = d.api.Select(reachEnd, (i+q)/d.rate, numberOfBlocks)
 		}
 	}
 	return padded, numberOfBlocks

--- a/std/hash/sha3/sha3.go
+++ b/std/hash/sha3/sha3.go
@@ -77,6 +77,7 @@ func (d *digest) paddingFixedWidth(minLen int, length frontend.Variable) (padded
 	copy(padded[:], d.in[:])
 	padded = append(padded, uints.NewU8Array(make([]uint8, d.rate))...)
 
+	// When i < minLen, it is completely unnecessary
 	for i := minLen; i <= len(padded)-d.rate; i++ {
 		reachEnd := cmp.IsEqual(d.api, i, length)
 		switch q := d.rate - ((i) % d.rate); q {
@@ -137,6 +138,8 @@ func (d *digest) absorbingFixedWidth(minNbOfBlocks int, blocks [][]uints.U64, nb
 			state[j] = d.uapi.Xor(state[j], block[j])
 		}
 		state = keccakf.Permute(d.uapi, state)
+
+		// When i < minNbOfBlocks, it must be in the range, so we use state directly
 		if i < minNbOfBlocks {
 			continue
 		}

--- a/std/hash/sha3/sha3.go
+++ b/std/hash/sha3/sha3.go
@@ -139,14 +139,14 @@ func (d *digest) absorbingFixedWidth(minNbOfBlocks int, blocks [][]uints.U64, nb
 		}
 		state = keccakf.Permute(d.uapi, state)
 
-		// When i < minNbOfBlocks, it must be in the range, so we use state directly
+		// When i < minNbOfBlocks, state cannot be resultState, and proceed to the next loop directly
 		if i < minNbOfBlocks {
 			continue
 		}
 
 		isInRange := comparator.IsLess(i, nbBlocks)
-		// only select blocks that are in range
-		for j := 0; j < 25; j++ {
+		// only select blocks that are in range. Only process the first outputLen data relevant to the result
+		for j := 0; j < d.outputLen/8; j++ {
 			for k := 0; k < 8; k++ {
 				resultState[j][k].Val = d.api.Select(isInRange, state[j][k].Val, resultState[j][k].Val)
 			}

--- a/std/hash/sha3/sha3.go
+++ b/std/hash/sha3/sha3.go
@@ -38,9 +38,13 @@ func (d *digest) Sum() []uints.U8 {
 	return d.squeezeBlocks()
 }
 
-func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8 {
-	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(len(d.in))), false)
-	comparator.AssertIsLessEq(minLen, length)
+func (d *digest) FixedLengthSum(length frontend.Variable, minLenOpt ...int) []uints.U8 {
+	minLen := 0
+	if len(minLenOpt) == 1 {
+		minLen = minLenOpt[0]
+		comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(len(d.in))), false)
+		comparator.AssertIsLessEq(minLen, length)
+	}
 
 	padded, numberOfBlocks := d.paddingFixedWidth(minLen, length)
 

--- a/std/hash/sha3/sha3.go
+++ b/std/hash/sha3/sha3.go
@@ -38,13 +38,9 @@ func (d *digest) Sum() []uints.U8 {
 	return d.squeezeBlocks()
 }
 
-func (d *digest) FixedLengthSum(length frontend.Variable, minLenOpt ...int) []uints.U8 {
-	minLen := 0
-	if len(minLenOpt) == 1 {
-		minLen = minLenOpt[0]
-		comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(len(d.in))), false)
-		comparator.AssertIsLessEq(minLen, length)
-	}
+func (d *digest) FixedLengthSum(minLen int, length frontend.Variable) []uints.U8 {
+	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(len(d.in))), false)
+	comparator.AssertIsLessEq(minLen, length)
 
 	padded, numberOfBlocks := d.paddingFixedWidth(minLen, length)
 

--- a/std/hash/sha3/sha3_test.go
+++ b/std/hash/sha3/sha3_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/frontend/cs/scs"
 	zkhash "github.com/consensys/gnark/std/hash"
 	"github.com/consensys/gnark/std/math/uints"
 	"github.com/consensys/gnark/test"
@@ -202,37 +201,5 @@ func TestSHA3FixedLengthSumWithMinLen(t *testing.T) {
 				}, fmt.Sprintf("length=%d", length))
 			}
 		}, fmt.Sprintf("hash=%s", name))
-	}
-}
-
-func Test_SHA3FixedLengthSum_WithMinLen_VS_Zero(t *testing.T) {
-	assert := test.NewAssert(t)
-
-	for name := range testCases {
-		name := name
-		strategy := testCases[name]
-		h := strategy.native()
-		sumLen := h.Size()
-
-		circuit1 := &sha3FixedLengthSumCircuit{
-			In:       make([]uints.U8, maxLen),
-			Expected: make([]uints.U8, sumLen),
-			hasher:   name,
-		}
-
-		cs1, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, circuit1)
-		assert.NoError(err)
-
-		circuit2 := &sha3FixedLengthSumWithMinLenCircuit{
-			In:       make([]uints.U8, maxLen),
-			Expected: make([]uints.U8, sumLen),
-			hasher:   name,
-		}
-
-		cs2, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, circuit2)
-		assert.NoError(err)
-
-		fmt.Printf("maxLen=%d, minLen=%d, hash=%s, nbConstraints: %d vs %d(withMinLen)\n",
-			maxLen, minLen, name, cs1.GetNbConstraints(), cs2.GetNbConstraints())
 	}
 }

--- a/std/hash/sha3/sha3_test.go
+++ b/std/hash/sha3/sha3_test.go
@@ -112,7 +112,7 @@ func (c *sha3FixedLengthSumCircuit) Define(api frontend.API) error {
 		return err
 	}
 	h.Write(c.In)
-	res := h.FixedLengthSum(c.Length)
+	res := h.FixedLengthSum(0, c.Length)
 
 	for i := range c.Expected {
 		uapi.ByteAssertEq(c.Expected[i], res[i])
@@ -184,7 +184,7 @@ func (c *sha3FixedLengthSumWithMinLenCircuit) Define(api frontend.API) error {
 		return err
 	}
 	h.Write(c.In)
-	res := h.FixedLengthSum(c.Length, minLen)
+	res := h.FixedLengthSum(minLen, c.Length)
 
 	for i := range c.Expected {
 		uapi.ByteAssertEq(c.Expected[i], res[i])

--- a/std/hash/sha3/sha3_test.go
+++ b/std/hash/sha3/sha3_test.go
@@ -112,7 +112,7 @@ func (c *sha3FixedLengthSumCircuit) Define(api frontend.API) error {
 		return err
 	}
 	h.Write(c.In)
-	res := h.FixedLengthSum(0, c.Length)
+	res := h.FixedLengthSum(c.Length)
 
 	for i := range c.Expected {
 		uapi.ByteAssertEq(c.Expected[i], res[i])
@@ -184,7 +184,7 @@ func (c *sha3FixedLengthSumWithMinLenCircuit) Define(api frontend.API) error {
 		return err
 	}
 	h.Write(c.In)
-	res := h.FixedLengthSum(minLen, c.Length)
+	res := h.FixedLengthSum(c.Length, minLen)
 
 	for i := range c.Expected {
 		uapi.ByteAssertEq(c.Expected[i], res[i])

--- a/std/hash/sha3/sha3_test.go
+++ b/std/hash/sha3/sha3_test.go
@@ -111,7 +111,7 @@ func (c *sha3FixedLengthSumCircuit) Define(api frontend.API) error {
 		return err
 	}
 	h.Write(c.In)
-	res := h.FixedLengthSum(c.Length)
+	res := h.FixedLengthSum(0, c.Length)
 
 	for i := range c.Expected {
 		uapi.ByteAssertEq(c.Expected[i], res[i])


### PR DESCRIPTION
# Description

Use minLen to reduce the times of selects and optimize the FixedLengthSum of hash.

In practice, the length of a piece of data to be hashed is variable, but its minimum value is rarely 0. In this case, if minLen is passed to FixedLengthSum, a lot of constraints can be saved. For example, in the project we are currently working on, one of the data lengths to be hashed ranges from 1680 to 1710. Using the new FixedLengthSum can reduce about 200,000 constraints, as shown in the results of Test_SHA3FixedLengthSum_WithMinLen_VS_Zero:

```
=== RUN   Test_SHA3FixedLengthSum_WithMinLen_VS_Zero
maxLen=1710, minLen=1680, hash=Keccak-512, nbConstraints: 6696856 vs 6555681(withMinLen)
maxLen=1710, minLen=1680, hash=SHA3-256, nbConstraints: 4040628 vs 3796970(withMinLen)
maxLen=1710, minLen=1680, hash=SHA3-384, nbConstraints: 4992172 vs 4800206(withMinLen)
maxLen=1710, minLen=1680, hash=SHA3-512, nbConstraints: 6696856 vs 6555681(withMinLen)
maxLen=1710, minLen=1680, hash=Keccak-256, nbConstraints: 4040628 vs 3796970(withMinLen)
--- PASS: Test_SHA3FixedLengthSum_WithMinLen_VS_Zero (47.33s)
```

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How has this been tested?

- [X] TestSHA2FixedLengthSum
- [X] TestSHA2FixedLengthSumWithMinLen
- [X] TestSHA3FixedLengthSum
- [X] TestSHA3FixedLengthSumWithMinLen
- [X] Test_SHA3FixedLengthSum_WithMinLen_VS_Zero

# How has this been benchmarked?

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I did not modify files generated from templates
- [X] `golangci-lint` does not output errors locally
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
