### PR TITLE
refactor: remove TODOs, improve error handling, clarify AssignmentOffsets docs, and clean up test assertions

### DIFF
--- a/constraint/gkr.go
+++ b/constraint/gkr.go
@@ -49,15 +49,29 @@ func (w GkrWire) IsOutput() bool {
 	return w.NbUniqueOutputs == 0
 }
 
-// AssignmentOffsets returns the index of the first value assigned to a wire TODO: Explain clearly
+// AssignmentOffsets calculates and returns an array where each element represents
+// the index of the first value assigned to a specific wire in the circuit.
+//
+// - `res[i]`: Represents the **starting index** of values assigned to wire `i`.
+// - `res[i+1]`: Represents the **starting index** of values assigned to the next wire (`i+1`).
+// - If a wire is an **independent input**, its assigned values are determined directly.
+//   However, if it **depends on other wires**, the number of assignments is adjusted
+//   based on the dependencies (`nbExplicitAssignments` calculation).
+//
+//  This function ensures that each wire in the `Circuit` has a correctly assigned
+//    starting index for its values, helping track assignments efficiently.
+
 func (d *GkrInfo) AssignmentOffsets() []int {
 	c := d.Circuit
-	res := make([]int, len(c)+1)
+	res := make([]int, len(c)+1) // One extra element for easier boundary calculations.
 	for i := range c {
 		nbExplicitAssignments := 0
+		// If the wire is an independent input
 		if c[i].IsInput() {
+			// Determine the number of non-dependent instances
 			nbExplicitAssignments = d.NbInstances - len(c[i].Dependencies)
 		}
+		// Compute the offset by adding to the previous index
 		res[i+1] = res[i] + nbExplicitAssignments
 	}
 	return res

--- a/internal/generator/backend/main.go
+++ b/internal/generator/backend/main.go
@@ -163,14 +163,14 @@ func main() {
 				{File: filepath.Join(groth16Dir, "marshal_test.go"), Templates: []string{"groth16/tests/groth16.marshal.go.tmpl", importCurve}},
 			}
 			if err := bgen.Generate(d, "groth16", "./template/zkpschemes/", entries...); err != nil {
-				panic(err) // TODO handle
+				log.Fatalf("Failed to generate Groth16 files: %v", err)
 			}
 
 			entries = []bavard.Entry{
 				{File: filepath.Join(groth16Dir, "commitment_test.go"), Templates: []string{"groth16/tests/groth16.commitment.go.tmpl", importCurve}},
 			}
 			if err := bgen.Generate(d, "groth16_test", "./template/zkpschemes/", entries...); err != nil {
-				panic(err) // TODO handle
+				log.Fatalf("Failed to generate Groth16 test files: %v", err)
 			}
 
 			// groth16 mpcsetup
@@ -184,7 +184,7 @@ func main() {
 			}
 
 			if err := bgen.Generate(d, "mpcsetup", "./template/zkpschemes/", entries...); err != nil {
-				panic(err) // TODO handle
+				log.Fatalf("Failed to generate Groth16 MPC setup files: %v", err)
 			}
 
 			// plonk

--- a/std/gkr/gkr_test.go
+++ b/std/gkr/gkr_test.go
@@ -342,7 +342,6 @@ func TestTopSortSingleGate(t *testing.T) {
 	c[0].Inputs = []*Wire{&c[1], &c[2]}
 	sorted := topologicalSort(c)
 	expected := []*Wire{&c[1], &c[2], &c[0]}
-	assert.True(t, SliceEqual(sorted, expected)) //TODO: Remove
 	AssertSliceEqual(t, sorted, expected)
 	assert.Equal(t, c[0].nbUniqueOutputs, 0)
 	assert.Equal(t, c[1].nbUniqueOutputs, 1)


### PR DESCRIPTION
# Description
### `internal/generator/backend/main.go`
- Replaced `panic(err)` with `log.Fatalf("Failed to generate ... files: %v", err)`.
- Removed `TODO handle` comments and added clearer error messages.

### `constraint/gkr.go`
- Clarified the `AssignmentOffsets` function by replacing the `TODO: Explain clearly` comment with a detailed explanation.
- Improved overall readability and clarity of comments.

### `std/gkr/gkr_test.go`
- Removed redundant test assertion `assert.True(t, SliceEqual(...))` since `AssertSliceEqual` already serves the same purpose.
- Removed `TODO`.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# Checklist:
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I did not modify files generated from templates
- [X] `golangci-lint` does not output errors locally
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
