### PR TITLE
optimize paddingFixedWidth of sha3 using divmod hint

### DIFF
--- a/std/hash/sha3/sha3.go
+++ b/std/hash/sha3/sha3.go
@@ -41,12 +41,6 @@ func (d *digest) Sum() []uints.U8 {
 }
 
 func (d *digest) FixedLengthSum(length frontend.Variable) []uints.U8 {
-	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(len(d.in))), false)
-	// in case the lower bound on the length of input is given, check that the input is long enough
-	if d.minimalLength > 0 {
-		comparator.AssertIsLessEq(d.minimalLength, length)
-	}
-
 	padded, numberOfBlocks := d.paddingFixedWidth(length)
 
 	blocks := d.composeBlocks(padded)
@@ -87,6 +81,10 @@ func (d *digest) paddingFixedWidth(length frontend.Variable) (padded []uints.U8,
 	padded = append(padded, uints.NewU8Array(make([]uint8, maxPaddingCount))...)
 
 	comparator := cmp.NewBoundedComparator(d.api, big.NewInt(int64(maxTotalLen)), false)
+	// in case the lower bound on the length of input is given, check that the input is long enough
+	if d.minimalLength > 0 {
+		comparator.AssertIsLessEq(d.minimalLength, length)
+	}
 
 	// When i < minLen or i > maxLen, padding dsbyte is completely unnecessary
 	for i := d.minimalLength; i <= maxLen; i++ {

--- a/std/hash/sha3/sha3.go
+++ b/std/hash/sha3/sha3.go
@@ -76,7 +76,7 @@ func (d *digest) padding() []uints.U8 {
 }
 
 func (d *digest) paddingFixedWidth(length frontend.Variable) (padded []uints.U8, numberOfBlocks frontend.Variable) {
-	numberOfBlocks, remainder := arith.DivMod(d.api, length, uint(d.rate))
+	quotient, modulus := arith.DivMod(d.api, length, uint(d.rate))
 
 	maxLen := len(d.in)
 	maxPaddingCount := d.rate - maxLen%d.rate
@@ -100,7 +100,7 @@ func (d *digest) paddingFixedWidth(length frontend.Variable) (padded []uints.U8,
 		padded[i].Val = d.api.Select(isPaddingPos, 0, padded[i].Val)
 	}
 
-	paddingCount := d.api.Sub(d.rate, remainder)
+	paddingCount := d.api.Sub(d.rate, modulus)
 	totalLen := d.api.Add(length, paddingCount)
 	lastPaddingPos := d.api.Sub(totalLen, 1)
 
@@ -113,7 +113,7 @@ func (d *digest) paddingFixedWidth(length frontend.Variable) (padded []uints.U8,
 		padded[i].Val = d.api.Select(isLastPaddingPos, lastPaddedByte, padded[i].Val)
 	}
 
-	return padded, numberOfBlocks
+	return padded, d.api.Add(quotient, 1)
 }
 
 func (d *digest) composeBlocks(padded []uints.U8) [][]uints.U64 {

--- a/std/math/arith/divmod.go
+++ b/std/math/arith/divmod.go
@@ -8,7 +8,7 @@ import (
 )
 
 // DivMod returns quotient = x / y and modulus = x % y
-// If y == 0, a division-by-zero run-time panic occurs.
+// If y == 0, a error compile-time panic occurs.
 //
 // DivMod implements Euclidean division and modulus:
 //

--- a/std/math/arith/divmod.go
+++ b/std/math/arith/divmod.go
@@ -1,0 +1,45 @@
+package arith
+
+import (
+	"math/big"
+
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/cmp"
+)
+
+// DivMod returns quotient = x / y and modulus = x % y
+// If y == 0, a division-by-zero run-time panic occurs.
+//
+// DivMod implements Euclidean division and modulus:
+//
+//	q = x div y  such that
+//	m = x - y*q  with 0 <= m < y
+//
+// The method enforces that modulus < y, and quotient*y + modulus == x.
+func DivMod(api frontend.API, x frontend.Variable, y uint) (quotient, modulus frontend.Variable) {
+	if y == 1 {
+		return x, 0
+	}
+
+	div := big.NewInt(int64(y))
+
+	// handle constant case
+	if xc, ok := api.Compiler().ConstantValue(x); ok {
+		q, m := new(big.Int), new(big.Int)
+		q.DivMod(xc, div, m)
+		return q, m
+	}
+
+	ret, err := api.Compiler().NewHint(divmodHint, 2, x, y)
+	if err != nil {
+		panic(err)
+	}
+
+	quotient = ret[0]
+	modulus = ret[1]
+
+	cmp.NewBoundedComparator(api, div, false).AssertIsLess(modulus, y)
+	composed := api.Add(modulus, api.Mul(quotient, div))
+	api.AssertIsEqual(composed, x)
+	return
+}

--- a/std/math/arith/divmod_test.go
+++ b/std/math/arith/divmod_test.go
@@ -1,0 +1,35 @@
+package arith
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/scs"
+	"github.com/consensys/gnark/test"
+)
+
+type divmodCircuit struct {
+	Div                   uint
+	In, Quotient, Modulus frontend.Variable
+}
+
+func (c *divmodCircuit) Define(api frontend.API) error {
+	quotient, modulus := DivMod(api, c.In, c.Div)
+	api.AssertIsEqual(quotient, c.Quotient)
+	api.AssertIsEqual(modulus, c.Modulus)
+	return nil
+}
+
+func TestDivMod(t *testing.T) {
+	assert := test.NewAssert(t)
+	_, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &divmodCircuit{Div: 0})
+	assert.Error(err)
+
+	assert.ProverSucceeded(&divmodCircuit{Div: 1}, &divmodCircuit{In: 0, Quotient: 0, Modulus: 0})
+	assert.ProverSucceeded(&divmodCircuit{Div: 2}, &divmodCircuit{In: 1, Quotient: 0, Modulus: 1})
+	assert.ProverSucceeded(&divmodCircuit{Div: 3}, &divmodCircuit{In: 5, Quotient: 1, Modulus: 2})
+
+	assert.ProverSucceeded(&divmodCircuit{Div: 4}, &divmodCircuit{In: 8, Quotient: 2, Modulus: 0})
+	assert.ProverFailed(&divmodCircuit{Div: 4}, &divmodCircuit{In: 8, Quotient: 1, Modulus: 4})
+}

--- a/std/math/arith/hints.go
+++ b/std/math/arith/hints.go
@@ -1,0 +1,29 @@
+package arith
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/consensys/gnark/constraint/solver"
+)
+
+func init() {
+	solver.RegisterHint(GetHints()...)
+}
+
+func GetHints() []solver.Hint {
+	return []solver.Hint{
+		divmodHint,
+	}
+}
+
+func divmodHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	if len(inputs) != 2 {
+		return errors.New("expecting two inputs")
+	}
+	if len(outputs) != 2 {
+		return errors.New("expecting two outputs")
+	}
+	outputs[0].DivMod(inputs[0], inputs[1], outputs[1])
+	return nil
+}


### PR DESCRIPTION
# Description

In this pr, a divmod function is implemented with hint, and it is used to optimize the paddingFixedWidth of sha3 to reduce the number of selects in the process of padding data and calculating numberOfBlocks.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

- [x] TestSHA2FixedLengthSum
- [x] TestSHA3FixedLengthSum

# How has this been benchmarked?

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
