### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/profile/internal/graph/dotgraph.go
+++ b/profile/internal/graph/dotgraph.go
@@ -291,10 +291,10 @@ func (b *builder) addEdge(edge *Edge, from, to int, hasNodelets bool) {
 	attr := fmt.Sprintf(`label=" %s%s"`, w, inline)
 	if b.config.Total != 0 {
 		// Note: edge.weight > b.config.Total is possible for profile diffs.
-		if weight := 1 + int(min64(abs64(edge.WeightValue()*100/b.config.Total), 100)); weight > 1 {
+		if weight := 1 + int(min(abs64(edge.WeightValue()*100/b.config.Total), 100)); weight > 1 {
 			attr = fmt.Sprintf(`%s weight=%d`, attr, weight)
 		}
-		if width := 1 + int(min64(abs64(edge.WeightValue()*5/b.config.Total), 5)); width > 1 {
+		if width := 1 + int(min(abs64(edge.WeightValue()*5/b.config.Total), 5)); width > 1 {
 			attr = fmt.Sprintf(`%s penwidth=%d`, attr, width)
 		}
 		attr = fmt.Sprintf(`%s color="%s"`, attr,
@@ -468,13 +468,6 @@ func (b *builder) tagGroupLabel(g []*Tag) (label string, flat, cum int64) {
 	// much smaller than other values which appear, so the range of tag sizes
 	// sometimes would appear to be "0..0" when scaled to the selected output unit.
 	return measurement.Label(min.Value, min.Unit) + ".." + measurement.Label(max.Value, max.Unit), f, c
-}
-
-func min64(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 // escapeAllForDot applies escapeForDot to all strings in the given slice.

--- a/std/compress/io.go
+++ b/std/compress/io.go
@@ -2,12 +2,13 @@ package compress
 
 import (
 	"errors"
+	"hash"
+	"math/big"
+
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/compress/internal/plonk"
 	"github.com/consensys/gnark/std/hash/mimc"
 	"github.com/consensys/gnark/std/lookup/logderivlookup"
-	"hash"
-	"math/big"
 )
 
 // Pack packs the words as tightly as possible, and works Big Endian: i.e. the first word is the most significant in the packed elem
@@ -247,11 +248,4 @@ func (nr *NumReader) next(v frontend.Variable) frontend.Variable {
 
 	nr.toRead = nr.toRead[1:]
 	return nr.last
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/std/gkr/gkr.go
+++ b/std/gkr/gkr.go
@@ -224,13 +224,6 @@ func ProofSize(c Circuit, logNbInstances int) int {
 	return nbUniqueInputs + nbPartialEvalPolys*logNbInstances
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func ChallengeNames(sorted []*Wire, logNbInstances int, prefix string) []string {
 
 	// Pre-compute the size TODO: Consider not doing this and just grow the list by appending


### PR DESCRIPTION
# Description

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Refactor

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [ ] Test A
- [ ] Test B

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

