### PR TITLE
fix: poseidon2 compression didn't include feed-forward

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ toolchain go1.22.6
 require (
 	github.com/bits-and-blooms/bitset v1.20.0
 	github.com/blang/semver/v4 v4.0.0
-	github.com/consensys/bavard v0.1.29
+	github.com/consensys/bavard v0.1.31-0.20250314194434-b30d4344e6d4
 	github.com/consensys/compress v0.2.5
-	github.com/consensys/gnark-crypto v0.16.1-0.20250217214835-5ed804970f85
+	github.com/consensys/gnark-crypto v0.17.1-0.20250324200108-53c5047f69d5
 	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8

--- a/go.sum
+++ b/go.sum
@@ -57,12 +57,12 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/consensys/bavard v0.1.29 h1:fobxIYksIQ+ZSrTJUuQgu+HIJwclrAPcdXqd7H2hh1k=
-github.com/consensys/bavard v0.1.29/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
+github.com/consensys/bavard v0.1.31-0.20250314194434-b30d4344e6d4 h1:0J+ppRic2ZXsQE+Y+Lr9miam+RQVcWqwqe3SeiggR6s=
+github.com/consensys/bavard v0.1.31-0.20250314194434-b30d4344e6d4/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
 github.com/consensys/compress v0.2.5 h1:gJr1hKzbOD36JFsF1AN8lfXz1yevnJi1YolffY19Ntk=
 github.com/consensys/compress v0.2.5/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
-github.com/consensys/gnark-crypto v0.16.1-0.20250217214835-5ed804970f85 h1:3ht4gGH3smFGVLFhpFTKvDbEdagC6eSaPXnHjCQGh94=
-github.com/consensys/gnark-crypto v0.16.1-0.20250217214835-5ed804970f85/go.mod h1:A2URlMHUT81ifJ0UlLzSlm7TmnE3t7VxEThApdMukJw=
+github.com/consensys/gnark-crypto v0.17.1-0.20250324200108-53c5047f69d5 h1:1E/Omf6m9+gPZaz/E02j8LteugnMMGLT5VQyraW7lmg=
+github.com/consensys/gnark-crypto v0.17.1-0.20250324200108-53c5047f69d5/go.mod h1:uV1HwfBwGRj50DGK3LbDLeCvq0RX/vFXST3CRSAu0Fs=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/std/hash/poseidon2/poseidon2_test.go
+++ b/std/hash/poseidon2/poseidon2_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr/poseidon2"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/test"
+
+	fr_bn254 "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	bn254_poseidon2 "github.com/consensys/gnark-crypto/ecc/bn254/fr/poseidon2"
+	gchash "github.com/consensys/gnark-crypto/hash"
+	"github.com/consensys/gnark/std/hash"
+	gprmp2 "github.com/consensys/gnark/std/permutation/poseidon2"
 )
 
 type Poseidon2Circuit struct {
@@ -38,4 +44,53 @@ func TestPoseidon2Hash(t *testing.T) {
 	}
 	res := h.Sum(nil)
 	assert.CheckCircuit(&Poseidon2Circuit{Input: make([]frontend.Variable, nbInputs)}, test.WithValidAssignment(&Poseidon2Circuit{Input: circInput, Expected: res}), test.WithCurves(ecc.BLS12_377)) // we have parametrized currently only for BLS12-377
+}
+
+type Poseidon2BN254Circuit struct {
+	Input    []frontend.Variable
+	Expected frontend.Variable `gnark:",public"`
+
+	width, nbFull, nbPartialRounds int
+}
+
+func (c *Poseidon2BN254Circuit) Define(api frontend.API) error {
+	p, err := gprmp2.NewPoseidon2FromParameters(api, c.width, c.nbFull, c.nbPartialRounds)
+	if err != nil {
+		return err
+	}
+	h := hash.NewMerkleDamgardHasher(api, p, 0)
+	h.Write(c.Input...)
+	dgst := h.Sum()
+	api.AssertIsEqual(dgst, c.Expected)
+	return nil
+}
+
+// TestPoseidon2Custom tests the Poseidon2 permutation with custom parameters.
+// Exemplifies how to use the Poseidon2 hasher in case default parameters are
+// not defined
+func TestPoseidon2Custom(t *testing.T) {
+	assert := test.NewAssert(t)
+
+	p := bn254_poseidon2.NewPermutation(2, 6, 50)
+	h := gchash.NewMerkleDamgardHasher(p, make([]byte, fr_bn254.Bytes))
+
+	inputs := []int{1, 2, 3, 4, 5}
+	varInputs := make([]frontend.Variable, len(inputs))
+	for i := range inputs {
+		var v fr_bn254.Element
+		v.SetUint64(uint64(inputs[i]))
+		vb := v.Bytes()
+		_, err := h.Write(vb[:])
+		assert.NoError(err)
+		varInputs[i] = inputs[i]
+	}
+
+	res := h.Sum(nil)
+	assert.CheckCircuit(
+		&Poseidon2BN254Circuit{
+			Input: make([]frontend.Variable, len(inputs)),
+			width: 2, nbFull: 6, nbPartialRounds: 50,
+		},
+		test.WithValidAssignment(&Poseidon2BN254Circuit{Input: varInputs, Expected: res}),
+		test.WithCurves(ecc.BN254))
 }

--- a/std/permutation/poseidon2/poseidon2.go
+++ b/std/permutation/poseidon2/poseidon2.go
@@ -328,5 +328,6 @@ func (h *Permutation) Compress(left, right frontend.Variable) frontend.Variable 
 	if err := h.Permutation(vars[:]); err != nil {
 		panic(err) // this would never happen
 	}
-	return vars[1]
+	res := h.api.Add(vars[1], right)
+	return res
 }


### PR DESCRIPTION
# Description

The compression function of Poseidon2 permutation differs between gnark and gnark-crypto. gnark-crypto includes right side feed-forward in the result but gnark not. This made the results differ.

Also added example test for non-default parameters to see that instance generation matches between gnark and gnark-crypto

Strangely - this was tested before but CI didn't fail? I don't see any obvious reasons, @gbotrel maybe you have ideas? I think it is somehow related which curves we test - currently the test was only for BLS12-377 as we don't have default parameters for other curves yet, but I think that for some test configuration it completely discarded testing.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Added new test. Current test works locally. Strangely the test should have had failed in CI before, but didn't?

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

