### PR TITLE
feat: add BN254 on NewPoseidon2

### DIFF
--- a/std/permutation/poseidon2/poseidon2.go
+++ b/std/permutation/poseidon2/poseidon2.go
@@ -50,8 +50,11 @@ func NewPoseidon2(api frontend.API) (*Permutation, error) {
 	switch utils.FieldToCurve(api.Compiler().Field()) { // TODO: assumes pairing based builder, reconsider when supporting other backends
 	case ecc.BLS12_377:
 		params := poseidonbls12377.GetDefaultParameters()
-		return NewPoseidon2FromParameters(api, 2, params.NbFullRounds, params.NbPartialRounds)
+		return NewPoseidon2FromParameters(api, params.Width, params.NbFullRounds, params.NbPartialRounds)
 	// TODO: we don't have default parameters for other curves yet. Update this when we do.
+	case ecc.BN254:
+		params := poseidonbls12377.GetDefaultParameters()
+		return NewPoseidon2FromParameters(api, params.Width, params.NbFullRounds, params.NbPartialRounds)
 	default:
 		return nil, fmt.Errorf("field %s not supported", api.Compiler().Field().String())
 	}


### PR DESCRIPTION
add BN254 on NewPoseidon2 (params same with gnark-crypto NewPoseidon2)
use params.Width on BLS12_377

# Description

add BN254 on NewPoseidon2
use params.Width on BLS12_377

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

