### PR TITLE
fix: Ratio Verification on Groth16 MPC - Phase 1

### DIFF
--- a/backend/groth16/bls12-377/mpcsetup/phase1.go
+++ b/backend/groth16/bls12-377/mpcsetup/phase1.go
@@ -213,10 +213,10 @@ func (p *Phase1) Verify(next *Phase1) error {
 	}
 
 	return mpcsetup.SameRatioMany(
-		p.parameters.G1.Tau,
-		p.parameters.G2.Tau,
-		p.parameters.G1.AlphaTau,
-		p.parameters.G1.BetaTau,
+		next.parameters.G1.Tau,
+		next.parameters.G2.Tau,
+		next.parameters.G1.AlphaTau,
+		next.parameters.G1.BetaTau,
 	)
 }
 

--- a/backend/groth16/bls12-381/mpcsetup/phase1.go
+++ b/backend/groth16/bls12-381/mpcsetup/phase1.go
@@ -213,10 +213,10 @@ func (p *Phase1) Verify(next *Phase1) error {
 	}
 
 	return mpcsetup.SameRatioMany(
-		p.parameters.G1.Tau,
-		p.parameters.G2.Tau,
-		p.parameters.G1.AlphaTau,
-		p.parameters.G1.BetaTau,
+		next.parameters.G1.Tau,
+		next.parameters.G2.Tau,
+		next.parameters.G1.AlphaTau,
+		next.parameters.G1.BetaTau,
 	)
 }
 

--- a/backend/groth16/bls24-315/mpcsetup/phase1.go
+++ b/backend/groth16/bls24-315/mpcsetup/phase1.go
@@ -213,10 +213,10 @@ func (p *Phase1) Verify(next *Phase1) error {
 	}
 
 	return mpcsetup.SameRatioMany(
-		p.parameters.G1.Tau,
-		p.parameters.G2.Tau,
-		p.parameters.G1.AlphaTau,
-		p.parameters.G1.BetaTau,
+		next.parameters.G1.Tau,
+		next.parameters.G2.Tau,
+		next.parameters.G1.AlphaTau,
+		next.parameters.G1.BetaTau,
 	)
 }
 

--- a/backend/groth16/bls24-317/mpcsetup/phase1.go
+++ b/backend/groth16/bls24-317/mpcsetup/phase1.go
@@ -213,10 +213,10 @@ func (p *Phase1) Verify(next *Phase1) error {
 	}
 
 	return mpcsetup.SameRatioMany(
-		p.parameters.G1.Tau,
-		p.parameters.G2.Tau,
-		p.parameters.G1.AlphaTau,
-		p.parameters.G1.BetaTau,
+		next.parameters.G1.Tau,
+		next.parameters.G2.Tau,
+		next.parameters.G1.AlphaTau,
+		next.parameters.G1.BetaTau,
 	)
 }
 

--- a/backend/groth16/bn254/mpcsetup/phase1.go
+++ b/backend/groth16/bn254/mpcsetup/phase1.go
@@ -213,10 +213,10 @@ func (p *Phase1) Verify(next *Phase1) error {
 	}
 
 	return mpcsetup.SameRatioMany(
-		p.parameters.G1.Tau,
-		p.parameters.G2.Tau,
-		p.parameters.G1.AlphaTau,
-		p.parameters.G1.BetaTau,
+		next.parameters.G1.Tau,
+		next.parameters.G2.Tau,
+		next.parameters.G1.AlphaTau,
+		next.parameters.G1.BetaTau,
 	)
 }
 

--- a/backend/groth16/bw6-633/mpcsetup/phase1.go
+++ b/backend/groth16/bw6-633/mpcsetup/phase1.go
@@ -213,10 +213,10 @@ func (p *Phase1) Verify(next *Phase1) error {
 	}
 
 	return mpcsetup.SameRatioMany(
-		p.parameters.G1.Tau,
-		p.parameters.G2.Tau,
-		p.parameters.G1.AlphaTau,
-		p.parameters.G1.BetaTau,
+		next.parameters.G1.Tau,
+		next.parameters.G2.Tau,
+		next.parameters.G1.AlphaTau,
+		next.parameters.G1.BetaTau,
 	)
 }
 

--- a/backend/groth16/bw6-761/mpcsetup/phase1.go
+++ b/backend/groth16/bw6-761/mpcsetup/phase1.go
@@ -213,10 +213,10 @@ func (p *Phase1) Verify(next *Phase1) error {
 	}
 
 	return mpcsetup.SameRatioMany(
-		p.parameters.G1.Tau,
-		p.parameters.G2.Tau,
-		p.parameters.G1.AlphaTau,
-		p.parameters.G1.BetaTau,
+		next.parameters.G1.Tau,
+		next.parameters.G2.Tau,
+		next.parameters.G1.AlphaTau,
+		next.parameters.G1.BetaTau,
 	)
 }
 

--- a/internal/generator/backend/template/zkpschemes/groth16/mpcsetup/phase1.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/groth16/mpcsetup/phase1.go.tmpl
@@ -207,10 +207,10 @@ func (p *Phase1) Verify(next *Phase1) error {
 	}
 
 	return mpcsetup.SameRatioMany(
-		p.parameters.G1.Tau,
-		p.parameters.G2.Tau,
-		p.parameters.G1.AlphaTau,
-		p.parameters.G1.BetaTau,
+		next.parameters.G1.Tau,
+		next.parameters.G2.Tau,
+		next.parameters.G1.AlphaTau,
+		next.parameters.G1.BetaTau,
 	)
 }
 


### PR DESCRIPTION
Fixes a bug where `SameRatioMany` was run on `p` (previous contribution) rather than `next` (new contribution) which means the ratios on the very last contribution are not checked.