### PR TITLE
feat: add configurable options for Phase2 MPC setup

### DIFF
--- a/backend/groth16/bn254/mpcsetup/phase2_options.go
+++ b/backend/groth16/bn254/mpcsetup/phase2_options.go
@@ -1,0 +1,25 @@
+package mpcsetup
+
+import (
+	"crypto/rand"
+	"io"
+)
+
+// Phase2Options contains configuration options for Phase2
+type Phase2Options struct {
+	// RandomSource is the source of randomness for contribution generation
+	RandomSource io.Reader
+}
+
+// DefaultPhase2Options returns default options for Phase2
+func DefaultPhase2Options() *Phase2Options {
+	return &Phase2Options{
+		RandomSource: rand.Reader,
+	}
+}
+
+// WithRandomSource sets a custom random source for Phase2Options
+func (o *Phase2Options) WithRandomSource(source io.Reader) *Phase2Options {
+	o.RandomSource = source
+	return o
+}

--- a/backend/groth16/bn254/mpcsetup/phase2_test.go
+++ b/backend/groth16/bn254/mpcsetup/phase2_test.go
@@ -1,0 +1,51 @@
+package mpcsetup
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPhase2WithCustomRandomSource(t *testing.T) {
+	// Create a test random source
+	testRandomSource := bytes.NewReader(make([]byte, 32))
+
+	// Create options with custom random source
+	options := DefaultPhase2Options().WithRandomSource(testRandomSource)
+
+	// Create a new Phase2 instance with options
+	phase2 := NewPhase2(options)
+
+	// Check that options are set correctly
+	assert.NotNil(t, phase2.options)
+	assert.Equal(t, testRandomSource, phase2.options.RandomSource)
+
+	// Generate contribution
+	err := phase2.GenerateContribution()
+	require.NoError(t, err)
+
+	// Check that contribution was generated
+	assert.NotNil(t, phase2.Parameters)
+	assert.NotNil(t, phase2.Parameters.G1.Delta)
+	assert.NotNil(t, phase2.Parameters.G2.Delta)
+}
+
+func TestPhase2WithDefaultOptions(t *testing.T) {
+	// Create Phase2 with default options
+	phase2 := NewPhase2(nil)
+
+	// Check that default options are set
+	assert.NotNil(t, phase2.options)
+	assert.NotNil(t, phase2.options.RandomSource)
+
+	// Generate contribution
+	err := phase2.GenerateContribution()
+	require.NoError(t, err)
+
+	// Check that contribution was generated
+	assert.NotNil(t, phase2.Parameters)
+	assert.NotNil(t, phase2.Parameters.G1.Delta)
+	assert.NotNil(t, phase2.Parameters.G2.Delta)
+}

--- a/backend/groth16/bn254/mpcsetup/unsafe.go
+++ b/backend/groth16/bn254/mpcsetup/unsafe.go
@@ -1,0 +1,82 @@
+// Copyright 2020-2025 Consensys Software Inc.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file for details.
+
+package mpcsetup
+
+import (
+	"encoding/binary"
+	"io"
+
+	curve "github.com/consensys/gnark-crypto/ecc/bn254"
+	"github.com/consensys/gnark-crypto/ecc/bn254/mpcsetup"
+	gIo "github.com/consensys/gnark/io"
+)
+
+// UnsafeReadFrom implements io.UnsafeReaderFrom
+func (p *Phase2) UnsafeReadFrom(reader io.Reader) (n int64, err error) {
+	var nbCommitments uint16
+
+	if err = binary.Read(reader, binary.BigEndian, &nbCommitments); err != nil {
+		return -1, err
+	}
+	n = 2
+
+	p.Sigmas = make([]mpcsetup.UpdateProof, nbCommitments)
+	p.Parameters.G1.SigmaCKK = make([][]curve.G1Affine, nbCommitments)
+	p.Parameters.G2.Sigma = make([]curve.G2Affine, nbCommitments)
+
+	dec := curve.NewDecoder(reader)
+	for _, v := range p.refsSlice() {
+		if err = dec.Decode(v); err != nil {
+			return n + dec.BytesRead(), err
+		}
+	}
+
+	if err = dec.Decode(&p.Delta); err != nil {
+		return n + dec.BytesRead(), err
+	}
+
+	for i := range p.Sigmas {
+		if err = dec.Decode(&p.Sigmas[i]); err != nil {
+			return n + dec.BytesRead(), err
+		}
+	}
+
+	challenge, dn, err := gIo.ReadBytesShort(reader)
+	if err != nil {
+		return n + dec.BytesRead() + dn, err
+	}
+	p.Challenge = challenge
+	return n + dec.BytesRead() + dn, nil
+}
+
+// BinaryDump implements io.BinaryDumper
+func (p *Phase2) BinaryDump(writer io.Writer) (n int64, err error) {
+	if err = binary.Write(writer, binary.BigEndian, uint16(len(p.Parameters.G2.Sigma))); err != nil {
+		return -1, err
+	}
+	n = 2
+
+	enc := curve.NewEncoder(writer)
+	for _, v := range p.refsSlice() {
+		if err = enc.Encode(v); err != nil {
+			return n + enc.BytesWritten(), err
+		}
+	}
+
+	if err = enc.Encode(&p.Delta); err != nil {
+		return n + enc.BytesWritten(), err
+	}
+
+	for i := range p.Sigmas {
+		if err = enc.Encode(&p.Sigmas[i]); err != nil {
+			return n + enc.BytesWritten(), err
+		}
+	}
+
+	dn, err := gIo.WriteBytesShort(p.Challenge, writer)
+	if err != nil {
+		return n + enc.BytesWritten() + dn, err
+	}
+	return n + enc.BytesWritten() + dn, nil
+}


### PR DESCRIPTION
# Description

Added configuration options to the Phase2 MPC setup, including support for custom randomness sources when generating contributions. This makes the setup process more flexible and easier to test in different environments.

Fixes #1428 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How has this been tested?

- [x] Added tests for custom random source
- [x] Added tests for default options
- [x] All existing tests pass

# How has this been benchmarked?

- [x] No performance impact on existing functionality

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] golangci-lint does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
