### PR TITLE
feat: emulated AssertIsDifferent

### DIFF
--- a/std/math/emulated/field_assert.go
+++ b/std/math/emulated/field_assert.go
@@ -153,6 +153,14 @@ func (f *Field[T]) IsZero(a *Element[T]) frontend.Variable {
 	return f.api.Or(res0, resP)
 }
 
+// AssertIsDifferent asserts that a and b are different.
+func (f *Field[T]) AssertIsDifferent(a, b *Element[T]) {
+	// we skip conditional width checking as it is done in [Sub] below
+	diff := f.Sub(a, b)
+	diffIsZero := f.IsZero(diff)
+	f.api.AssertIsEqual(diffIsZero, 0)
+}
+
 // // Cmp returns:
 // //   - -1 if a < b
 // //   - 0 if a = b
@@ -171,19 +179,4 @@ func (f *Field[T]) IsZero(a *Element[T]) frontend.Variable {
 // 		res = f.api.Select(f.api.IsZero(res), lmbCmp, res)
 // 	}
 // 	return res
-// }
-
-// TODO(@ivokub)
-// func (f *Field[T]) AssertIsDifferent(a, b *Element[T]) {
-// 	ca := f.Reduce(a)
-// 	f.AssertIsInRange(ca)
-// 	cb := f.Reduce(b)
-// 	f.AssertIsInRange(cb)
-// 	var res frontend.Variable = 0
-// 	for i := 0; i < int(f.fParams.NbLimbs()); i++ {
-// 		cmp := f.api.Cmp(ca.Limbs[i], cb.Limbs[i])
-// 		cmpsq := f.api.Mul(cmp, cmp)
-// 		res = f.api.Add(res, cmpsq)
-// 	}
-// 	f.api.AssertIsDifferent(res, 0)
 // }


### PR DESCRIPTION
# Description

Even though we were able to assert emulated element difference previously quite easily, then add a dedicated method so that in case we have some optimizations in the future it could be applied automatically.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestAssertIsDifferent


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

