### PR TITLE
Fix: make GetWiresConstraint(Exact) deterministic

### DIFF
--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -825,7 +825,7 @@ func (builder *builder[E]) GetWiresConstraintExact(wires []frontend.Variable, ad
 	// benefit of making it simpler to read the LRO values.
 	//
 	// wireIDsSetOrdered stores the same values as wireIDsSet but in order
-	// of insertion. This is necessary to ensure
+	// of insertion. This is necessary to ensure the compilation is deterministic
 	var (
 		wireIDsSet = make(map[int]struct{})
 		wireTerms  = make([]expr.Term[E], len(wires))


### PR DESCRIPTION
# Description

In [GetWiresConstraint] and [GetWiresConstraintExact] there is a routine responsible for adding the variable that were not found in the constraints. However, this is done by iterating over a map and the order of insertion of the constraints is non-deterministic.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [ ] Test A
- [ ] Test B

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

