### PR TITLE
Update golangci-lint-action to v8.0.0 (engine v2.1.6)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,9 +26,9 @@ jobs:
         if [[ -n $(git status --porcelain) ]]; then echo "git repo is dirty after running go generate -- please don't modify generated files"; echo $(git diff);echo $(git status --porcelain); exit 1; fi
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
-          version: v1.60
+          version: v2.1.6
           args: -v --timeout=5m
   
   test:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,9 +29,9 @@ jobs:
         if [[ -n $(git status --porcelain) ]]; then echo "git repo is dirty after running go generate -- please don't modify generated files"; echo $(git diff);echo $(git status --porcelain); exit 1; fi
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
-          version: v1.60
+          version: v2.1.6
           args: -v --timeout=5m
   
   test:


### PR DESCRIPTION
# Description


This PR bumps our `golangci-lint-action` to **v8.0.0** and pins the lint engine at **v2.1.6**, bringing two key benefits:

* **Absolute `working-directory` resolution**
  Ensures all paths are resolved from the repo root, eliminating “file not found” errors in monorepos or nested directories.
* **Modern lint engine requirement**
  By pinning to **golangci-lint v2.1.6** (v8’s minimum is v2.1.0), we get the latest rules, bug fixes, and performance improvements.

Together these changes make our CI linting more reliable and ensure we’re running on a fully supported linting toolchain.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [ ] Test A
- [ ] Test B

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

- [ ] Benchmark A, on Macbook pro M1, 32GB RAM
- [ ] Benchmark B, on x86 Intel xxx, 16GB RAM

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

