### PR TITLE
Feat: Bandersnatch 4D-GLV (GLV + fake GLV)

### DIFF
--- a/std/algebra/native/twistededwards/curve.go
+++ b/std/algebra/native/twistededwards/curve.go
@@ -46,7 +46,11 @@ func (c *curve) AssertIsOnCurve(p1 Point) {
 }
 func (c *curve) ScalarMul(p1 Point, scalar frontend.Variable) Point {
 	var p Point
-	p.scalarMul(c.api, &p1, scalar, c.params, c.endo)
+	if c.id == twistededwards.BLS12_381_BANDERSNATCH {
+		p.scalarMulGLVAndFakeGLV(c.api, &p1, scalar, c.params, c.endo)
+	} else {
+		p.scalarMulFakeGLV(c.api, &p1, scalar, c.params)
+	}
 	return p
 }
 func (c *curve) DoubleBaseScalarMul(p1, p2 Point, s1, s2 frontend.Variable) Point {

--- a/std/algebra/native/twistededwards/curve_test.go
+++ b/std/algebra/native/twistededwards/curve_test.go
@@ -8,6 +8,11 @@ import (
 	"math/big"
 	"testing"
 
+	"fmt"
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend/cs/scs"
+	"github.com/consensys/gnark/profile"
+
 	tbls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377/twistededwards"
 	tbls12381_bandersnatch "github.com/consensys/gnark-crypto/ecc/bls12-381/bandersnatch"
 	tbls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards"
@@ -428,4 +433,14 @@ func (circuit *varScalarMul) Define(api frontend.API) error {
 	api.AssertIsEqual(res.Y, circuit.R.Y)
 
 	return nil
+}
+
+// bench
+func BenchmarkSM(b *testing.B) {
+	var c varScalarMul
+	c.curveID = twistededwards.BLS12_381_BANDERSNATCH
+	p := profile.Start()
+	_, _ = frontend.Compile(ecc.BLS12_381.ScalarField(), scs.NewBuilder, &c)
+	p.Stop()
+	fmt.Println("Bandersnatch 4D-GLV: ", p.NbConstraints())
 }

--- a/std/algebra/native/twistededwards/curve_test.go
+++ b/std/algebra/native/twistededwards/curve_test.go
@@ -434,13 +434,3 @@ func (circuit *varScalarMul) Define(api frontend.API) error {
 
 	return nil
 }
-
-// bench
-func BenchmarkSM(b *testing.B) {
-	var c varScalarMul
-	c.curveID = twistededwards.BLS12_381_BANDERSNATCH
-	p := profile.Start()
-	_, _ = frontend.Compile(ecc.BLS12_381.ScalarField(), scs.NewBuilder, &c)
-	p.Stop()
-	fmt.Println("Bandersnatch 4D-GLV: ", p.NbConstraints())
-}

--- a/std/algebra/native/twistededwards/hints.go
+++ b/std/algebra/native/twistededwards/hints.go
@@ -16,6 +16,9 @@ import (
 	edbw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761/twistededwards"
 	"github.com/consensys/gnark-crypto/field/zz2"
 	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/std/math/emulated/emparams"
 )
 
 func GetHints() []solver.Hint {
@@ -24,7 +27,9 @@ func GetHints() []solver.Hint {
 		scalarMulHint,
 		decomposeScalar,
 		halfGCDZZ2,
+		halfGCDZZ2Emulated,
 		halfGCDZZ2Signs,
+		decompose,
 	}
 }
 
@@ -93,113 +98,6 @@ func halfGCD(mod *big.Int, inputs, outputs []*big.Int) error {
 		outputs[2].SetUint64(1)
 	}
 
-	return nil
-}
-
-func halfGCDZZ2(mod *big.Int, inputs, outputs []*big.Int) error {
-	if len(inputs) != 2 {
-		return errors.New("expecting two input")
-	}
-	if len(outputs) != 4 {
-		return errors.New("expecting four outputs")
-	}
-	// the efficient endomorphism exists on Bandersnatch only
-	if mod.Cmp(ecc.BLS12_381.ScalarField()) != 0 {
-		return errors.New("no efficient endomorphism is available on this curve")
-	}
-	var glv glvParams
-	var init sync.Once
-	init.Do(func() {
-		glv.lambda.SetString("8913659658109529928382530854484400854125314752504019737736543920008458395397", 10)
-		glv.order.SetString("13108968793781547619861935127046491459309155893440570251786403306729687672801", 10)
-		ecc.PrecomputeLattice(&glv.order, &glv.lambda, &glv.glvBasis)
-	})
-
-	glvBasis := new(ecc.Lattice)
-	ecc.PrecomputeLattice(&glv.order, inputs[1], glvBasis)
-	r := zz2.ComplexNumber{
-		A0: &glvBasis.V1[0],
-		A1: &glvBasis.V1[1],
-	}
-	sp := ecc.SplitScalar(inputs[0], glvBasis)
-	// in-circuit we check that Q - [s]P = 0 or equivalently Q + [-s]P = 0
-	// so here we return -s instead of s.
-	s := zz2.ComplexNumber{
-		A0: &sp[0],
-		A1: &sp[1],
-	}
-	s.Neg(&s)
-	res := zz2.HalfGCD(&r, &s)
-	outputs[0].Set(res[0].A0)
-	outputs[1].Set(res[0].A1)
-	outputs[2].Set(res[1].A0)
-	outputs[3].Set(res[1].A1)
-
-	if outputs[0].Sign() == -1 {
-		outputs[0].Neg(outputs[0])
-	}
-	if outputs[1].Sign() == -1 {
-		outputs[1].Neg(outputs[1])
-	}
-	if outputs[2].Sign() == -1 {
-		outputs[2].Neg(outputs[2])
-	}
-	if outputs[3].Sign() == -1 {
-		outputs[3].Neg(outputs[3])
-	}
-	return nil
-}
-
-func halfGCDZZ2Signs(mod *big.Int, inputs, outputs []*big.Int) error {
-	if len(inputs) != 2 {
-		return errors.New("expecting two input")
-	}
-	if len(outputs) != 4 {
-		return errors.New("expecting four outputs")
-	}
-	// the efficient endomorphism exists on Bandersnatch only
-	if mod.Cmp(ecc.BLS12_381.ScalarField()) != 0 {
-		return errors.New("no efficient endomorphism is available on this curve")
-	}
-	var glv glvParams
-	var init sync.Once
-	init.Do(func() {
-		glv.lambda.SetString("8913659658109529928382530854484400854125314752504019737736543920008458395397", 10)
-		glv.order.SetString("13108968793781547619861935127046491459309155893440570251786403306729687672801", 10)
-		ecc.PrecomputeLattice(&glv.order, &glv.lambda, &glv.glvBasis)
-	})
-
-	glvBasis := new(ecc.Lattice)
-	ecc.PrecomputeLattice(&glv.order, inputs[1], glvBasis)
-	r := zz2.ComplexNumber{
-		A0: &glvBasis.V1[0],
-		A1: &glvBasis.V1[1],
-	}
-	sp := ecc.SplitScalar(inputs[0], glvBasis)
-	s := zz2.ComplexNumber{
-		A0: &sp[0],
-		A1: &sp[1],
-	}
-	s.Neg(&s)
-	res := zz2.HalfGCD(&r, &s)
-
-	outputs[0].SetUint64(0)
-	outputs[1].SetUint64(0)
-	outputs[2].SetUint64(0)
-	outputs[3].SetUint64(0)
-
-	if res[0].A0.Sign() == -1 {
-		outputs[0].SetUint64(1)
-	}
-	if res[0].A1.Sign() == -1 {
-		outputs[1].SetUint64(1)
-	}
-	if res[1].A0.Sign() == -1 {
-		outputs[2].SetUint64(1)
-	}
-	if res[1].A1.Sign() == -1 {
-		outputs[3].SetUint64(1)
-	}
 	return nil
 }
 
@@ -272,6 +170,206 @@ func scalarMulHint(field *big.Int, inputs []*big.Int, outputs []*big.Int) error 
 		P.Y.BigInt(outputs[1])
 	} else {
 		return errors.New("scalarMulHint: unknown curve")
+	}
+	return nil
+}
+
+func halfGCDZZ2(mod *big.Int, inputs, outputs []*big.Int) error {
+	if len(inputs) != 2 {
+		return errors.New("expecting two input")
+	}
+	if len(outputs) != 4 {
+		return errors.New("expecting four outputs")
+	}
+	// the efficient endomorphism exists on Bandersnatch only
+	if mod.Cmp(ecc.BLS12_381.ScalarField()) != 0 {
+		return errors.New("no efficient endomorphism is available on this curve")
+	}
+	var glv glvParams
+	var init sync.Once
+	init.Do(func() {
+		glv.lambda.SetString("8913659658109529928382530854484400854125314752504019737736543920008458395397", 10)
+		glv.order.SetString("13108968793781547619861935127046491459309155893440570251786403306729687672801", 10)
+		ecc.PrecomputeLattice(&glv.order, &glv.lambda, &glv.glvBasis)
+	})
+
+	glvBasis := new(ecc.Lattice)
+	ecc.PrecomputeLattice(&glv.order, inputs[1], glvBasis)
+	r := zz2.ComplexNumber{
+		A0: &glvBasis.V1[0],
+		A1: &glvBasis.V1[1],
+	}
+	sp := ecc.SplitScalar(inputs[0], glvBasis)
+	// in-circuit we check that Q - [s]P = 0 or equivalently Q + [-s]P = 0
+	// so here we return -s instead of s.
+	s := zz2.ComplexNumber{
+		A0: &sp[0],
+		A1: &sp[1],
+	}
+	s.Neg(&s)
+	res := zz2.HalfGCD(&r, &s)
+	outputs[0].Set(res[0].A0)
+	outputs[1].Set(res[0].A1)
+	outputs[2].Set(res[1].A0)
+	outputs[3].Set(res[1].A1)
+
+	if outputs[0].Sign() == -1 {
+		outputs[0].Neg(outputs[0])
+	}
+	if outputs[1].Sign() == -1 {
+		outputs[1].Neg(outputs[1])
+	}
+	if outputs[2].Sign() == -1 {
+		outputs[2].Neg(outputs[2])
+	}
+	if outputs[3].Sign() == -1 {
+		outputs[3].Neg(outputs[3])
+	}
+	return nil
+}
+
+func halfGCDZZ2Emulated(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int) error {
+	return emulated.UnwrapHintWithNativeInput(nativeInputs, nativeOutputs, func(nnMod *big.Int, nninputs, nnOutputs []*big.Int) error {
+		if len(nninputs) != 2 {
+			return errors.New("expecting two input")
+		}
+		if len(nnOutputs) != 4 {
+			return errors.New("expecting four outputs")
+		}
+		// the efficient endomorphism exists on Bandersnatch only
+		if nativeMod.Cmp(ecc.BLS12_381.ScalarField()) != 0 {
+			return errors.New("no efficient endomorphism is available on this curve")
+		}
+		var glv glvParams
+		var init sync.Once
+		init.Do(func() {
+			glv.lambda.SetString("8913659658109529928382530854484400854125314752504019737736543920008458395397", 10)
+			glv.order.SetString("13108968793781547619861935127046491459309155893440570251786403306729687672801", 10)
+			ecc.PrecomputeLattice(&glv.order, &glv.lambda, &glv.glvBasis)
+		})
+
+		glvBasis := new(ecc.Lattice)
+		ecc.PrecomputeLattice(&glv.order, nninputs[1], glvBasis)
+		r := zz2.ComplexNumber{
+			A0: &glvBasis.V1[0],
+			A1: &glvBasis.V1[1],
+		}
+		sp := ecc.SplitScalar(nninputs[0], glvBasis)
+		// in-circuit we check that Q - [s]P = 0 or equivalently Q + [-s]P = 0
+		// so here we return -s instead of s.
+		s := zz2.ComplexNumber{
+			A0: &sp[0],
+			A1: &sp[1],
+		}
+		s.Neg(&s)
+		res := zz2.HalfGCD(&r, &s)
+		nnOutputs[0].Set(res[0].A0)
+		nnOutputs[1].Set(res[0].A1)
+		nnOutputs[2].Set(res[1].A0)
+		nnOutputs[3].Set(res[1].A1)
+
+		return nil
+	})
+}
+
+func halfGCDZZ2Signs(mod *big.Int, inputs, outputs []*big.Int) error {
+	if len(inputs) != 2 {
+		return errors.New("expecting two input")
+	}
+	if len(outputs) != 4 {
+		return errors.New("expecting four outputs")
+	}
+	// the efficient endomorphism exists on Bandersnatch only
+	if mod.Cmp(ecc.BLS12_381.ScalarField()) != 0 {
+		return errors.New("no efficient endomorphism is available on this curve")
+	}
+	var glv glvParams
+	var init sync.Once
+	init.Do(func() {
+		glv.lambda.SetString("8913659658109529928382530854484400854125314752504019737736543920008458395397", 10)
+		glv.order.SetString("13108968793781547619861935127046491459309155893440570251786403306729687672801", 10)
+		ecc.PrecomputeLattice(&glv.order, &glv.lambda, &glv.glvBasis)
+	})
+
+	glvBasis := new(ecc.Lattice)
+	ecc.PrecomputeLattice(&glv.order, inputs[1], glvBasis)
+	r := zz2.ComplexNumber{
+		A0: &glvBasis.V1[0],
+		A1: &glvBasis.V1[1],
+	}
+	sp := ecc.SplitScalar(inputs[0], glvBasis)
+	s := zz2.ComplexNumber{
+		A0: &sp[0],
+		A1: &sp[1],
+	}
+	s.Neg(&s)
+	res := zz2.HalfGCD(&r, &s)
+
+	outputs[0].SetUint64(0)
+	outputs[1].SetUint64(0)
+	outputs[2].SetUint64(0)
+	outputs[3].SetUint64(0)
+
+	if res[0].A0.Sign() == -1 {
+		outputs[0].SetUint64(1)
+	}
+	if res[0].A1.Sign() == -1 {
+		outputs[1].SetUint64(1)
+	}
+	if res[1].A0.Sign() == -1 {
+		outputs[2].SetUint64(1)
+	}
+	if res[1].A1.Sign() == -1 {
+		outputs[3].SetUint64(1)
+	}
+	return nil
+}
+
+func checkHalfGCDZZ2(api frontend.API, s, lambda frontend.Variable) {
+	var fr emparams.BandersnatchFr
+	sapi, err := emulated.NewField[emparams.BandersnatchFr](api)
+	if err != nil {
+		panic(err)
+	}
+
+	// compute the decomposition using a hint. We have to use the emulated
+	// version which takes native input and outputs non-native outputs.
+	//
+	// the hints allow to decompose the scalar s into s1 and s2 such that
+	// 	   u1 + λ * u2 + s * (v1 + λ * v2) == 0 mod r
+	sd, err := sapi.NewHintWithNativeInput(halfGCDZZ2Emulated, 4, s, lambda)
+	if err != nil {
+		panic(err)
+	}
+	// lambda as nonnative element
+	lambdaEmu := sapi.NewElement(lambda)
+	// the scalar as nonnative element. We need to split at 64 bits.
+	limbs, err := api.NewHint(decompose, int(fr.NbLimbs()), s)
+	if err != nil {
+		panic(err)
+	}
+	sEmu := sapi.NewElement(limbs)
+
+	// u1 + λ * u2 + s * (v1 + λ * v2) == 0 mod r
+	lhs := sapi.MulNoReduce(sd[1], lambdaEmu)
+	lhs = sapi.Add(lhs, sd[0])
+	temp := sapi.MulNoReduce(sd[3], lambdaEmu)
+	temp = sapi.Add(temp, sd[2])
+	temp = sapi.MulNoReduce(temp, sEmu)
+	lhs = sapi.Add(lhs, temp)
+
+	sapi.AssertIsEqual(lhs, sapi.Zero())
+}
+
+func decompose(mod *big.Int, inputs, outputs []*big.Int) error {
+	if len(inputs) != 1 && len(outputs) != 4 {
+		return errors.New("input/output length mismatch")
+	}
+	tmp := new(big.Int).Set(inputs[0])
+	mask := new(big.Int).SetUint64(^uint64(0))
+	for i := 0; i < 4; i++ {
+		outputs[i].And(tmp, mask)
+		tmp.Rsh(tmp, 64)
 	}
 	return nil
 }

--- a/std/math/emulated/emparams/emparams.go
+++ b/std/math/emulated/emparams/emparams.go
@@ -16,6 +16,7 @@ import (
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/bandersnatch"
 	"github.com/consensys/gnark-crypto/field/goldilocks"
 )
 
@@ -312,6 +313,37 @@ func (fp STARKCurveFp) Modulus() *big.Int { return ecc.STARK_CURVE.BaseField() }
 type STARKCurveFr struct{ fourLimbPrimeField }
 
 func (fp STARKCurveFr) Modulus() *big.Int { return ecc.STARK_CURVE.ScalarField() }
+
+// BandersnatchFp provides type parametrization for field emulation:
+//   - limbs: 4
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001 (base 16)
+//	52435875175126190479447740508185965837690552500527637822603658699938581184513 (base 10)
+//
+// This is the base field of the Bandersnatch curve, which is equal to the scalar field of the BLS12-381 curve.
+type BandersnatchFp struct{ fourLimbPrimeField }
+
+func (fp BandersnatchFp) Modulus() *big.Int { return ecc.BLS12_381.ScalarField() }
+
+// BandersnatchFr provides type parametrization for field emulation:
+//   - limbs: 4
+//   - limb width: 64 bits
+//
+// The prime modulus for type parametrisation is:
+//
+//	0x1cfb69d4ca675f520cce760202687600ff8f87007419047174fd06b52876e7e1 (base 16)
+//	13108968793781547619861935127046491459309155893440570251786403306729687672801 (base 10)
+//
+// This is the scalar field of the Bandersnatch curve.
+type BandersnatchFr struct{ fourLimbPrimeField }
+
+func (fp BandersnatchFr) Modulus() *big.Int {
+	val := bandersnatch.GetEdwardsCurve().Order
+	return &val
+}
 
 // Mod1e4096 provides type parametrization for emulated arithmetic:
 //   - limbs: 64


### PR DESCRIPTION
# Description

Using a twofold half-GCD, one in ℤ and one in $ℤ[\sqrt{-2}]$, it is possible to turn a $n$-bit scalar multiplication $[s]P$ on Bandersnatch curve into a $(n/4+9)$-bit MSM of size 4. However the total number of constraints is worse than simple GLV or fake GLV ($n/2$-bit MSM of size 2). This is due to 2 reasons:
- A 2-MSM in-circuit needs `Lookup2` while a 4-MSM needs 16-to-1 `Mux`. In native arithmetic point arithmetic (dbl/add) has a similar cost to `Lookup2` while `Mux` is way costlier.
- The 4-dimensional scalar decomposition needs to be verified modulo Bandersnatch order and not the SNARK order. This is done using non-native arithmetic which makes it ever more costly.

This PR is to show the inefficiency of "GLV + fake GLV" in native circuits (e.g. Bandersnatch) compared to the (systematic) "fake GLV" which works for any curve. When the circuit is non-native the "GLV + fake GLV" method is better.

This PR needs https://github.com/Consensys/gnark-crypto/pull/688.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

Tests in `std/algebra/native/twistededwards/curve_test.go`.


# How has this been benchmarked?


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

