### PR TITLE
fix: range over all limbs in normalized form for lookup

### DIFF
--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -275,7 +275,7 @@ func (f *Field[T]) Lookup2(b0, b1 frontend.Variable, a, b, c, d *Element[T]) *El
 	bNormLimbs := normalize(b.Limbs)
 	cNormLimbs := normalize(c.Limbs)
 	dNormLimbs := normalize(d.Limbs)
-	for i := range a.Limbs {
+	for i := range nbLimbs {
 		e.Limbs[i] = f.api.Lookup2(b0, b1, aNormLimbs[i], bNormLimbs[i], cNormLimbs[i], dNormLimbs[i])
 	}
 	return e
@@ -324,7 +324,7 @@ func (f *Field[T]) Mux(sel frontend.Variable, inputs ...*Element[T]) *Element[T]
 		}
 	}
 	e := f.newInternalElement(make([]frontend.Variable, nbLimbs), overflow)
-	for i := range inputs[0].Limbs {
+	for i := range nbLimbs {
 		e.Limbs[i] = selector.Mux(f.api, sel, normLimbsTransposed[i]...)
 	}
 	return e


### PR DESCRIPTION
# Description

For non-native arithmetic Lookup2 and Mux we used Lookup2 and Mux on individual limbs. We normalized the inputs so that we would always have the same number of limbs, but when we did the final Lookup2/Mux, we only range over the number of limbs the first input had.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- [x] TestLookup2AndMuxOnAllLimbs

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

