### PR TITLE
feat: add modular inverse for variable modulus

### DIFF
--- a/std/math/emulated/custommod.go
+++ b/std/math/emulated/custommod.go
@@ -124,7 +124,7 @@ func (f *Field[T]) ModExp(base, exp, modulus *Element[T]) *Element[T] {
 // NB! circuit complexity depends on T rather on the actual length of the modulus.
 func (f *Field[T]) ModInverse(a, modulus *Element[T]) *Element[T] {
 	// fast path when a is zero then result is always zero
-	if len(a.Limbs) == 0 {
+	if a.isStrictZero() {
 		return f.Zero()
 	}
 	k, err := f.computeInverseHint(a.Limbs, modulus)

--- a/std/math/emulated/custommod.go
+++ b/std/math/emulated/custommod.go
@@ -15,7 +15,7 @@ import (
 // NB! circuit complexity depends on T rather on the actual length of the modulus.
 func (f *Field[T]) ModMul(a, b *Element[T], modulus *Element[T]) *Element[T] {
 	// fast path when either of the inputs is zero then result is always zero
-	if len(a.Limbs) == 0 || len(b.Limbs) == 0 {
+	if a.isStrictZero() || b.isStrictZero() {
 		return f.Zero()
 	}
 	res := f.mulMod(a, b, 0, modulus)
@@ -97,8 +97,8 @@ func (f *Field[T]) ModAssertIsEqual(a, b *Element[T], modulus *Element[T]) {
 //
 // NB! circuit complexity depends on T rather on the actual length of the modulus.
 func (f *Field[T]) ModExp(base, exp, modulus *Element[T]) *Element[T] {
-	// fasth path when the base is zero then result is always zero
-	if len(base.Limbs) == 0 {
+	if base.isStrictZero() {
+		// fast path when the base is zero then result is always zero
 		return f.Zero()
 	}
 	expBts := f.ToBits(exp)

--- a/std/math/emulated/custommod_test.go
+++ b/std/math/emulated/custommod_test.go
@@ -192,7 +192,7 @@ func TestVariableInverse(t *testing.T) {
 	a, _ := rand.Int(rand.Reader, modulus)
 	expected := new(big.Int).ModInverse(a, modulus)
 	if expected == nil {
-		t.Skip("no modular inverse")
+		t.Fatal("modular inverse should exists. Check modulus")
 	}
 	circuit := &variableInverse[emparams.Mod1e512]{}
 	assignment := &variableInverse[emparams.Mod1e512]{
@@ -202,4 +202,15 @@ func TestVariableInverse(t *testing.T) {
 	}
 	err := test.IsSolved(circuit, assignment, ecc.BLS12_377.ScalarField())
 	assert.NoError(err)
+
+	modulus2 := new(big.Int).Add(modulus, big.NewInt(1))
+	base2 := big.NewInt(16)
+	expected2 := big.NewInt(0) // no modular inverse
+	assignment2 := &variableInverse[emparams.Mod1e512]{
+		Modulus:  ValueOf[emparams.Mod1e512](modulus2),
+		A:        ValueOf[emparams.Mod1e512](base2),
+		Expected: ValueOf[emparams.Mod1e512](expected2),
+	}
+	err = test.IsSolved(circuit, assignment2, ecc.BLS12_377.ScalarField())
+	assert.Error(err)
 }

--- a/std/math/emulated/field_ops.go
+++ b/std/math/emulated/field_ops.go
@@ -61,7 +61,7 @@ func (f *Field[T]) inverse(a, _ *Element[T], _ uint) *Element[T] {
 	if !f.fParams.IsPrime() {
 		panic("modulus not a prime")
 	}
-	k, err := f.computeInverseHint(a.Limbs)
+	k, err := f.computeInverseHint(a.Limbs, f.Modulus())
 	if err != nil {
 		panic(fmt.Sprintf("compute inverse: %v", err))
 	}

--- a/std/math/emulated/hints.go
+++ b/std/math/emulated/hints.go
@@ -39,7 +39,8 @@ func nbMultiplicationResLimbs(lenLeft, lenRight int) int {
 	return res
 }
 
-// computeInverseHint packs the inputs for the InverseHint hint function.
+// computeInverseHint packs the inputs for the InverseHint hint function. The modulus is passed as an argument,
+// allowing the method to be used both for fixed and variable modulus cases.
 func (f *Field[T]) computeInverseHint(inLimbs []frontend.Variable, modulus *Element[T]) (inverseLimbs []frontend.Variable, err error) {
 	hintInputs := []frontend.Variable{
 		f.fParams.BitsPerLimb(),

--- a/std/math/emulated/hints.go
+++ b/std/math/emulated/hints.go
@@ -40,13 +40,12 @@ func nbMultiplicationResLimbs(lenLeft, lenRight int) int {
 }
 
 // computeInverseHint packs the inputs for the InverseHint hint function.
-func (f *Field[T]) computeInverseHint(inLimbs []frontend.Variable) (inverseLimbs []frontend.Variable, err error) {
+func (f *Field[T]) computeInverseHint(inLimbs []frontend.Variable, modulus *Element[T]) (inverseLimbs []frontend.Variable, err error) {
 	hintInputs := []frontend.Variable{
 		f.fParams.BitsPerLimb(),
 		f.fParams.NbLimbs(),
 	}
-	p := f.Modulus()
-	hintInputs = append(hintInputs, p.Limbs...)
+	hintInputs = append(hintInputs, modulus.Limbs...)
 	hintInputs = append(hintInputs, inLimbs...)
 	return f.api.NewHint(InverseHint, int(f.fParams.NbLimbs()), hintInputs...)
 }


### PR DESCRIPTION
# Description

This PR implements `ModInverse` for testing some ideas for more efficient ModExp. The problem with the approach right now is though that there may not always be an inverse in which case the solver would fail.

@yelhousni - maybe we could work past it by setting the inverse to be something 0 or 1 etc in case it doesn't exist?

Meanwhile - do not merge. I think in most cases we don't want to expose methods which would allow for liveness failure.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestVariableInverse
- [ ] Test B

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

