### PR TITLE
fix: don't use assignment to compile

### DIFF
--- a/std/math/emulated/element_test.go
+++ b/std/math/emulated/element_test.go
@@ -1589,6 +1589,6 @@ func testLookup2AndMuxOnAllLimbs[T FieldParams](t *testing.T) {
 	assert := test.NewAssert(t)
 	var fp T
 	a, _ := rand.Int(rand.Reader, fp.Modulus())
-	circuit := &TestLookup2AndMuxOnAllLimbsCircuit[T]{A: ValueOf[T](a)}
-	assert.CheckCircuit(circuit, test.WithValidAssignment(circuit))
+	assignment := &TestLookup2AndMuxOnAllLimbsCircuit[T]{A: ValueOf[T](a)}
+	assert.CheckCircuit(&TestLookup2AndMuxOnAllLimbsCircuit[T]{}, test.WithValidAssignment(assignment))
 }


### PR DESCRIPTION
# Description

Fixes test introduced in #1505. I didn't catch it before as PR CI doesn't run prover checks.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
