### PR TITLE
fix: update broken Ethereum precompile contract links

### DIFF
--- a/std/evmprecompiles/01-ecrecover.go
+++ b/std/evmprecompiles/01-ecrecover.go
@@ -22,7 +22,7 @@ import (
 //  1. The public key is zero.
 //  2. The value r^3 + 7 is not a quadratic residue.
 //
-// [ECRECOVER]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/ecrecover/index.html
+// [ECRECOVER]: https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/vm/precompiled_contracts/ecrecover.py
 func ECRecover(api frontend.API, msg emulated.Element[emulated.Secp256k1Fr],
 	v frontend.Variable, r, s emulated.Element[emulated.Secp256k1Fr],
 	strictRange frontend.Variable, isFailure frontend.Variable) *sw_emulated.AffinePoint[emulated.Secp256k1Fp] {

--- a/std/evmprecompiles/05-expmod.go
+++ b/std/evmprecompiles/05-expmod.go
@@ -13,7 +13,7 @@ import (
 // upper bounding the sizes of the inputs. The runtime is constant regardless of
 // the actual length of the inputs.
 //
-// [MODEXP]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/expmod/index.html
+// [MODEXP]: https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/vm/precompiled_contracts/modexp.py
 func Expmod[P emulated.FieldParams](api frontend.API, base, exp, modulus *emulated.Element[P]) *emulated.Element[P] {
 	// x^0 = 1 (unless mod 0 or mod 1)
 	// x mod 0 = 0

--- a/std/evmprecompiles/06-bnadd.go
+++ b/std/evmprecompiles/06-bnadd.go
@@ -8,7 +8,7 @@ import (
 
 // ECAdd implements [ALT_BN128_ADD] precompile contract at address 0x06.
 //
-// [ALT_BN128_ADD]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/alt_bn128/index.html#alt-bn128-add
+// [ALT_BN128_ADD]: https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/vm/precompiled_contracts/alt_bn128.py
 func ECAdd(api frontend.API, P, Q *sw_emulated.AffinePoint[emulated.BN254Fp]) *sw_emulated.AffinePoint[emulated.BN254Fp] {
 	curve, err := sw_emulated.New[emulated.BN254Fp, emulated.BN254Fr](api, sw_emulated.GetBN254Params())
 	if err != nil {

--- a/std/evmprecompiles/07-bnmul.go
+++ b/std/evmprecompiles/07-bnmul.go
@@ -9,7 +9,7 @@ import (
 
 // ECMul implements [ALT_BN128_MUL] precompile contract at address 0x07.
 //
-// [ALT_BN128_MUL]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/alt_bn128/index.html#alt-bn128-mul
+// [ALT_BN128_MUL]: https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/vm/precompiled_contracts/alt_bn128.py
 func ECMul(api frontend.API, P *sw_emulated.AffinePoint[emulated.BN254Fp], u *emulated.Element[emulated.BN254Fr]) *sw_emulated.AffinePoint[emulated.BN254Fp] {
 	curve, err := sw_emulated.New[emulated.BN254Fp, emulated.BN254Fr](api, sw_emulated.GetBN254Params())
 	if err != nil {

--- a/std/evmprecompiles/08-bnpairing.go
+++ b/std/evmprecompiles/08-bnpairing.go
@@ -26,7 +26,7 @@ import (
 // See the methods [ECPairMillerLoopAndMul] and [ECPairMillerLoopAndFinalExpCheck] for the fixed circuits.
 // See the method [ECPairIsOnG2] for the check that Qᵢ are on G2.
 //
-// [ALT_BN128_PAIRING_CHECK]: https://ethereum.github.io/execution-specs/autoapi/ethereum/paris/vm/precompiled_contracts/alt_bn128/index.html#alt-bn128-pairing-check
+// [ALT_BN128_PAIRING_CHECK]: https://github.com/ethereum/execution-specs/blob/master/src/ethereum/cancun/vm/precompiled_contracts/alt_bn128.py
 // [On Proving Pairings]: https://eprint.iacr.org/2024/640.pdf
 func ECPair(api frontend.API, P []*sw_bn254.G1Affine, Q []*sw_bn254.G2Affine) {
 	if len(P) != len(Q) {


### PR DESCRIPTION
# Description

Update links to Ethereum precompiled contract documentation from outdated Paris execution-specs autoapi URLs to current Cancun implementation files in the GitHub repository. This ensures correct reference to implementation details for MODEXP, ALT_BN128_ADD, ECRECOVER, ALT_BN128_PAIRING_CHECK, and ALT_BN128_MUL.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes