### PR TITLE
fix: update Zcash protocol specification link

### DIFF
--- a/frontend/cs/r1cs/api_assertions.go
+++ b/frontend/cs/r1cs/api_assertions.go
@@ -88,7 +88,7 @@ func (builder *builder[E]) AssertIsCrumb(i1 frontend.Variable) {
 // bound can be a constant or a Variable
 //
 // derived from:
-// https://github.com/zcash/zips/blob/main/protocol/protocol.pdf
+// https://zips.z.cash/protocol/protocol.pdf
 func (builder *builder[E]) AssertIsLessOrEqual(v frontend.Variable, bound frontend.Variable) {
 	cv, vConst := builder.constantValue(v)
 	cb, bConst := builder.constantValue(bound)


### PR DESCRIPTION
# Description

Update the Zcash protocol specification link in api_assertions.go from the GitHub repository path to the official Zcash documentation site. This ensures access to the most up-to-date version of the specification.

## Type of change

- [x]  Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- [x]  Verified the new link is accessible and points to the correct documentation

# Checklist:

- [x]  I have performed a self-review of my code
- [x]  I have made corresponding changes to the documentation
- [x]  `golangci-lint` does not output errors locally
- [x]  New and existing unit tests pass locally with my changes


