### PR TITLE
feat: add separate Bytes API in `std/math/uints` package for handling bytes (U8) directly

### DIFF
--- a/internal/kvstore/kvstore_test.go
+++ b/internal/kvstore/kvstore_test.go
@@ -1,0 +1,73 @@
+package kvstore_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/frontend/cs/scs"
+	"github.com/consensys/gnark/internal/kvstore"
+	"github.com/consensys/gnark/test"
+)
+
+type ctxKey[T comparable] struct{}
+type toStore[T comparable] struct {
+	Value T
+}
+
+type Circuit[T comparable] struct {
+	A frontend.Variable
+}
+
+func (c *Circuit[T]) Define(api frontend.API) error {
+	kv, ok := api.(kvstore.Store)
+	if !ok {
+		panic("builder should implement key-value store")
+	}
+	stored1 := kv.GetKeyValue(ctxKey[T]{})
+	if stored1 != nil {
+		// should be nil
+		return fmt.Errorf("expected nil, got %v", stored1)
+	}
+	if tStored1, ok := stored1.(*toStore[T]); ok {
+		// should be nil interface
+		return fmt.Errorf("expected nil, got %v", tStored1)
+	}
+	// store something
+	var t T
+	stored2 := &toStore[T]{Value: t}
+	kv.SetKeyValue(ctxKey[T]{}, stored2)
+	stored3 := kv.GetKeyValue(ctxKey[T]{})
+	if stored3 == nil {
+		return fmt.Errorf("expected non nil, got nil")
+	}
+	tStored3, ok := stored3.(*toStore[T])
+	if !ok {
+		return fmt.Errorf("expected toStore[T], got %T", stored3)
+	}
+	if tStored3.Value != t {
+		return fmt.Errorf("expected %v, got %v", t, tStored3.Value)
+	}
+	return nil
+}
+
+func TestKeyValue(t *testing.T) {
+	assert := test.NewAssert(t)
+	// test with int
+	err := test.IsSolved(&Circuit[int]{}, &Circuit[int]{A: 1}, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	// test with uint
+	err = test.IsSolved(&Circuit[uint]{}, &Circuit[uint]{A: 1}, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	// test with string
+	err = test.IsSolved(&Circuit[string]{}, &Circuit[string]{A: "1234"}, ecc.BN254.ScalarField())
+	assert.NoError(err)
+
+	// test during compilation
+	_, err = frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &Circuit[int]{})
+	assert.NoError(err)
+	_, err = frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &Circuit[int]{})
+	assert.NoError(err)
+}

--- a/std/hash/ripemd160/ripemd160_test.go
+++ b/std/hash/ripemd160/ripemd160_test.go
@@ -21,7 +21,7 @@ func (c *ripemd160Circuit) Define(api frontend.API) error {
 	if err != nil {
 		return err
 	}
-	uapi, err := uints.New[uints.U32](api)
+	uapi, err := uints.NewBytes(api)
 	if err != nil {
 		return err
 	}
@@ -31,7 +31,7 @@ func (c *ripemd160Circuit) Define(api frontend.API) error {
 		return fmt.Errorf("not 20 bytes")
 	}
 	for i := range c.Expected {
-		uapi.ByteAssertEq(c.Expected[i], res[i])
+		uapi.AssertIsEqual(c.Expected[i], res[i])
 	}
 	return nil
 }

--- a/std/hash/sha2/sha2_test.go
+++ b/std/hash/sha2/sha2_test.go
@@ -23,7 +23,7 @@ func (c *sha2Circuit) Define(api frontend.API) error {
 	if err != nil {
 		return err
 	}
-	uapi, err := uints.New[uints.U32](api)
+	uapi, err := uints.NewBytes(api)
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func (c *sha2Circuit) Define(api frontend.API) error {
 		return fmt.Errorf("not 32 bytes")
 	}
 	for i := range c.Expected {
-		uapi.ByteAssertEq(c.Expected[i], res[i])
+		uapi.AssertIsEqual(c.Expected[i], res[i])
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func (c *sha2FixedLengthCircuit) Define(api frontend.API) error {
 	if err != nil {
 		return err
 	}
-	uapi, err := uints.New[uints.U32](api)
+	uapi, err := uints.NewBytes(api)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (c *sha2FixedLengthCircuit) Define(api frontend.API) error {
 		return fmt.Errorf("not 32 bytes")
 	}
 	for i := range c.Expected {
-		uapi.ByteAssertEq(c.Expected[i], res[i])
+		uapi.AssertIsEqual(c.Expected[i], res[i])
 	}
 	return nil
 }

--- a/std/hash/sha3/sha3_test.go
+++ b/std/hash/sha3/sha3_test.go
@@ -44,7 +44,7 @@ func (c *sha3Circuit) Define(api frontend.API) error {
 	if err != nil {
 		return err
 	}
-	uapi, err := uints.New[uints.U64](api)
+	uapi, err := uints.NewBytes(api)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (c *sha3Circuit) Define(api frontend.API) error {
 	res := h.Sum()
 
 	for i := range c.Expected {
-		uapi.ByteAssertEq(c.Expected[i], res[i])
+		uapi.AssertIsEqual(c.Expected[i], res[i])
 	}
 	return nil
 }
@@ -109,7 +109,7 @@ func (c *sha3FixedLengthSumCircuit) Define(api frontend.API) error {
 	if err != nil {
 		return err
 	}
-	uapi, err := uints.New[uints.U64](api)
+	uapi, err := uints.NewBytes(api)
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (c *sha3FixedLengthSumCircuit) Define(api frontend.API) error {
 	res := h.FixedLengthSum(c.Length)
 
 	for i := range c.Expected {
-		uapi.ByteAssertEq(c.Expected[i], res[i])
+		uapi.AssertIsEqual(c.Expected[i], res[i])
 	}
 	return nil
 }

--- a/std/hints.go
+++ b/std/hints.go
@@ -7,11 +7,13 @@ import (
 	"github.com/consensys/gnark/std/algebra/emulated/fields_bls12381"
 	"github.com/consensys/gnark/std/algebra/emulated/fields_bn254"
 	"github.com/consensys/gnark/std/algebra/emulated/fields_bw6761"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_bw6761"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
 	"github.com/consensys/gnark/std/algebra/native/fields_bls12377"
 	"github.com/consensys/gnark/std/algebra/native/fields_bls24315"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls12377"
 	"github.com/consensys/gnark/std/algebra/native/sw_bls24315"
+	"github.com/consensys/gnark/std/algebra/native/twistededwards"
 	"github.com/consensys/gnark/std/evmprecompiles"
 	"github.com/consensys/gnark/std/hash/sha3"
 	"github.com/consensys/gnark/std/internal/logderivarg"
@@ -19,6 +21,7 @@ import (
 	"github.com/consensys/gnark/std/math/bitslice"
 	"github.com/consensys/gnark/std/math/cmp"
 	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/std/math/uints"
 	"github.com/consensys/gnark/std/rangecheck"
 	"github.com/consensys/gnark/std/selector"
 )
@@ -44,6 +47,7 @@ func registerHints() {
 	solver.RegisterHint(logderivarg.GetHints()...)
 	solver.RegisterHint(bitslice.GetHints()...)
 	solver.RegisterHint(sha3.GetHints()...)
+	solver.RegisterHint(uints.GetHints()...)
 	// emulated fields
 	solver.RegisterHint(fields_bls12381.GetHints()...)
 	solver.RegisterHint(fields_bn254.GetHints()...)
@@ -51,8 +55,10 @@ func registerHints() {
 	// native fields
 	solver.RegisterHint(fields_bls12377.GetHints()...)
 	solver.RegisterHint(fields_bls24315.GetHints()...)
+	solver.RegisterHint(twistededwards.GetHints()...)
 	// emulated curves
 	solver.RegisterHint(sw_emulated.GetHints()...)
+	solver.RegisterHint(sw_bw6761.GetHints()...)
 	// native curves
 	solver.RegisterHint(sw_bls12377.GetHints()...)
 	solver.RegisterHint(sw_bls24315.GetHints()...)

--- a/std/math/uints/bytes.go
+++ b/std/math/uints/bytes.go
@@ -1,0 +1,102 @@
+package uints
+
+import (
+	"fmt"
+
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/internal/kvstore"
+	"github.com/consensys/gnark/std/internal/logderivprecomp"
+	"github.com/consensys/gnark/std/rangecheck"
+)
+
+// ctxKey is used to store the API in the key-value store. In case we
+// re-initialize using [NewBytes] method, then we can reuse the existing API. This
+// ensures we don't rebuild any of the tables.
+type ctxKey struct{}
+
+// Bytes implements methods for manipulating bytes in circuit. Use [NewBytes] to
+// create a new instance.
+type Bytes struct {
+	api             frontend.API
+	xorT, andT, orT *logderivprecomp.Precomputed
+	rchecker        frontend.Rangechecker
+	allOne          U8
+}
+
+// NewBytes creates a new [Bytes] instance which can manipulate bytes and byte
+// arrays. For manipulating long integers, use [BinaryField] instead.
+//
+// This is a caching constructor, meaning that it will return the same instance
+// if called multiple times. This is useful as internally it uses lookup tables
+// for bitwise operations and it amortizes the cost of creating these lookup
+// tables.
+func NewBytes(api frontend.API) (*Bytes, error) {
+	if kv, ok := api.Compiler().(kvstore.Store); ok {
+		uapi := kv.GetKeyValue(ctxKey{})
+		if tuapi, ok := uapi.(*Bytes); ok {
+			return tuapi, nil
+		}
+	}
+	xorT, err := logderivprecomp.New(api, xorHint, []uint{8})
+	if err != nil {
+		return nil, fmt.Errorf("new xor table: %w", err)
+	}
+	andT, err := logderivprecomp.New(api, andHint, []uint{8})
+	if err != nil {
+		return nil, fmt.Errorf("new and table: %w", err)
+	}
+	orT, err := logderivprecomp.New(api, orHint, []uint{8})
+	if err != nil {
+		return nil, fmt.Errorf("new or table: %w", err)
+	}
+	rchecker := rangecheck.New(api)
+	bf := &Bytes{
+		api:      api,
+		xorT:     xorT,
+		andT:     andT,
+		orT:      orT,
+		rchecker: rchecker,
+	}
+	// TODO: this is const. add way to init constants
+	bf.allOne = bf.ValueOf(0xff)
+
+	// store the API in the key-value store so that can be easily reused
+	if kv, ok := api.(kvstore.Store); ok {
+		kv.SetKeyValue(ctxKey{}, bf)
+	}
+	return bf, nil
+}
+
+// ValueOf returns a constrainted [U8] variable. For a constant value, use
+// [NewU8] instead.
+func (bf *Bytes) ValueOf(a frontend.Variable) U8 {
+	bf.rchecker.Check(a, 8)
+	return U8{Val: a, internal: true}
+}
+
+func (bf *Bytes) twoArgFn(tbl *logderivprecomp.Precomputed, a ...U8) U8 {
+	if len(a) == 0 {
+		return NewU8(0)
+	}
+	if len(a) == 1 {
+		return a[0]
+	}
+	ret := tbl.Query(a[0].Val, a[1].Val)[0]
+	for i := 2; i < len(a); i++ {
+		ret = tbl.Query(ret, a[i].Val)[0]
+	}
+	return U8{Val: ret}
+}
+
+func (bf *Bytes) Not(a U8) U8 {
+	ret := bf.xorT.Query(a.Val, bf.allOne.Val)
+	return U8{Val: ret[0]}
+}
+
+func (bf *Bytes) And(a ...U8) U8 { return bf.twoArgFn(bf.andT, a...) }
+func (bf *Bytes) Or(a ...U8) U8  { return bf.twoArgFn(bf.orT, a...) }
+func (bf *Bytes) Xor(a ...U8) U8 { return bf.twoArgFn(bf.xorT, a...) }
+
+func (bf *Bytes) AssertIsEqual(a, b U8) {
+	bf.api.AssertIsEqual(a.Val, b.Val)
+}

--- a/std/math/uints/uint8.go
+++ b/std/math/uints/uint8.go
@@ -30,41 +30,18 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/internal/logderivprecomp"
 	"github.com/consensys/gnark/std/math/bitslice"
-	"github.com/consensys/gnark/std/rangecheck"
 )
-
-// TODO: if internal then enforce range check!
 
 // TODO: all operations can take rand linear combinations instead. Then instead
 // of one check can perform multiple at the same time.
 
-// TODO: implement versions which take multiple inputs. Maybe can combine multiple together
-
-// TODO: instantiate tables only when we first query. Maybe do not need to build!
-
 // TODO: maybe can store everything in a single table? Later! Or if we have a
 // lot of queries then makes sense to extract into separate table?
-
-// TODO: in ValueOf ensure consistency
-
-// TODO: distinguish between when we set constant in-circuit or witness
-// assignment. For constant we don't have to range check but for witness
-// assignment we have to.
-
-// TODO: add something which allows to store array in native element
-
-// TODO: add methods for checking if U8/Long is constant.
-
-// TODO: should something for byte-only ops. Implement a type and then embed it in BinaryField
 
 // TODO: add helper method to call hints which allows to pass in uint8s (bytes)
 // and returns bytes. Then can to byte array manipulation nicely. It is useful
 // for X509. For the implementation we want to pack as much bytes into a field
 // element as possible.
-
-// TODO: methods for converting uint array into emulated element and native
-// element. Most probably should add the implementation for non-native in its
-// package, but for native we should add it here.
 
 type U8 struct {
 	Val      frontend.Variable
@@ -84,45 +61,47 @@ type U32 [4]U8
 
 type Long interface{ U32 | U64 }
 
-type BinaryField[T U32 | U64] struct {
-	api             frontend.API
-	xorT, andT, orT *logderivprecomp.Precomputed
-	rchecker        frontend.Rangechecker
-	allOne          U8
+type BinaryField[T Long] struct {
+	*Bytes
 }
 
+// NewBinaryField creates a new [BinaryField] for the given integer type T
+// specified by parameter [Long]. It allows to manipulate long integers in
+// circuit.
+func NewBinaryField[T Long](api frontend.API) (*BinaryField[T], error) {
+	bts, err := NewBytes(api)
+	if err != nil {
+		return nil, fmt.Errorf("new bytes: %w", err)
+	}
+	return &BinaryField[T]{Bytes: bts}, nil
+}
+
+// New is an alias to [NewBinaryField]. It is retained for backwards
+// compatibility. New uses should use [NewBinaryField] instead.
 func New[T Long](api frontend.API) (*BinaryField[T], error) {
-	xorT, err := logderivprecomp.New(api, xorHint, []uint{8})
-	if err != nil {
-		return nil, fmt.Errorf("new xor table: %w", err)
-	}
-	andT, err := logderivprecomp.New(api, andHint, []uint{8})
-	if err != nil {
-		return nil, fmt.Errorf("new and table: %w", err)
-	}
-	orT, err := logderivprecomp.New(api, orHint, []uint{8})
-	if err != nil {
-		return nil, fmt.Errorf("new or table: %w", err)
-	}
-	rchecker := rangecheck.New(api)
-	bf := &BinaryField[T]{
-		api:      api,
-		xorT:     xorT,
-		andT:     andT,
-		orT:      orT,
-		rchecker: rchecker,
-	}
-	// TODO: this is const. add way to init constants
-	allOne := bf.ByteValueOf(0xff)
-	bf.allOne = allOne
-	return bf, nil
+	return NewBinaryField[T](api)
 }
 
+// NewU8 creates a new [U8] value. It represents a single byte. It can both be
+// used in-circuit to initialize a constant or as a witness assignment. For
+// in-circuit initialization use [Bytes.ValueOf] method instead which ensures
+// that the value is range checked.
 func NewU8(v uint8) U8 {
-	// TODO: don't have to check constants
+	// if NewU8 is used inside the circuit, then this means that the input is a
+	// constant and this ensures that the value is already range checked by
+	// default (as the argument is uint8). If it is used as a witness
+	// assignment, then the flag `internal` is not set for the actual witness
+	// value inside the circuit, as witness parser only copies
+	// [frontend.Variable] part of U8. And the `internal=false` is set in the
+	// [U8.Initialize] method.
 	return U8{Val: v, internal: true}
 }
 
+// NewU32 creates a new [U32] value. It represents a 32-bit unsigned integer
+// which is split into 4 bytes. It can both be used in-circuit to initialize a
+// constant or as a witness assignment. For in-circuit initialization use
+// [BinaryField.ValueOf] method instead which ensures that the value is range
+// checked.
 func NewU32(v uint32) U32 {
 	return [4]U8{
 		NewU8(uint8((v >> (0 * 8)) & 0xff)),
@@ -132,6 +111,11 @@ func NewU32(v uint32) U32 {
 	}
 }
 
+// NewU64 creates a new [U64] value. It represents a 64-bit unsigned integer
+// which is split into 4 bytes. It can both be used in-circuit to initialize a
+// constant or as a witness assignment. For in-circuit initialization use
+// [BinaryField.ValueOf] method instead which ensures that the value is range
+// checked.
 func NewU64(v uint64) U64 {
 	return [8]U8{
 		NewU8(uint8((v >> (0 * 8)) & 0xff)),
@@ -145,6 +129,8 @@ func NewU64(v uint64) U64 {
 	}
 }
 
+// NewU8Array is a utility method to create a slice of [U8] from a slice of
+// uint8.
 func NewU8Array(v []uint8) []U8 {
 	ret := make([]U8, len(v))
 	for i := range v {
@@ -153,6 +139,8 @@ func NewU8Array(v []uint8) []U8 {
 	return ret
 }
 
+// NewU32Array is a utility method to create a slice of [U32] from a slice of
+// uint32.
 func NewU32Array(v []uint32) []U32 {
 	ret := make([]U32, len(v))
 	for i := range v {
@@ -161,6 +149,8 @@ func NewU32Array(v []uint32) []U32 {
 	return ret
 }
 
+// NewU64Array is a utility method to create a slice of [U64] from a slice of
+// uint64.
 func NewU64Array(v []uint64) []U64 {
 	ret := make([]U64, len(v))
 	for i := range v {
@@ -170,19 +160,18 @@ func NewU64Array(v []uint64) []U64 {
 }
 
 func (bf *BinaryField[T]) ByteValueOf(a frontend.Variable) U8 {
-	bf.rchecker.Check(a, 8)
-	return U8{Val: a, internal: true}
+	return bf.Bytes.ValueOf(a)
 }
 
 func (bf *BinaryField[T]) ValueOf(a frontend.Variable) T {
 	var r T
-	bts, err := bf.api.Compiler().NewHint(toBytes, len(r), len(r), a)
+	bts, err := bf.api.Compiler().NewHint(toBytes, bf.lenBts(), bf.lenBts(), a)
 	if err != nil {
 		panic(err)
 	}
 
 	for i := range bts {
-		r[i] = bf.ByteValueOf(bts[i])
+		r[i] = bf.Bytes.ValueOf(bts[i])
 	}
 	expectedValue := bf.ToValue(r)
 	bf.api.AssertIsEqual(a, expectedValue)
@@ -217,8 +206,8 @@ func (bf *BinaryField[T]) PackLSB(a ...U8) T {
 
 func (bf *BinaryField[T]) UnpackMSB(a T) []U8 {
 	ret := make([]U8, bf.lenBts())
-	for i := 0; i < len(ret); i++ {
-		ret[len(a)-i-1] = a[i]
+	for i := range ret {
+		ret[bf.lenBts()-i-1] = a[i]
 	}
 	return ret
 }
@@ -226,23 +215,15 @@ func (bf *BinaryField[T]) UnpackMSB(a T) []U8 {
 func (bf *BinaryField[T]) UnpackLSB(a T) []U8 {
 	// cannot deduce that a can be cast to []U8
 	ret := make([]U8, bf.lenBts())
-	for i := 0; i < len(ret); i++ {
+	for i := range ret {
 		ret[i] = a[i]
 	}
 	return ret
 }
 
-func (bf *BinaryField[T]) twoArgFn(tbl *logderivprecomp.Precomputed, a ...U8) U8 {
-	ret := tbl.Query(a[0].Val, a[1].Val)[0]
-	for i := 2; i < len(a); i++ {
-		ret = tbl.Query(ret, a[i].Val)[0]
-	}
-	return U8{Val: ret}
-}
-
 func (bf *BinaryField[T]) twoArgWideFn(tbl *logderivprecomp.Precomputed, a ...T) T {
 	var r T
-	for i, v := range reslice(a) {
+	for i, v := range bf.reslice(a) {
 		r[i] = bf.twoArgFn(tbl, v...)
 	}
 	return r
@@ -252,15 +233,10 @@ func (bf *BinaryField[T]) And(a ...T) T { return bf.twoArgWideFn(bf.andT, a...) 
 func (bf *BinaryField[T]) Xor(a ...T) T { return bf.twoArgWideFn(bf.xorT, a...) }
 func (bf *BinaryField[T]) Or(a ...T) T  { return bf.twoArgWideFn(bf.orT, a...) }
 
-func (bf *BinaryField[T]) not(a U8) U8 {
-	ret := bf.xorT.Query(a.Val, bf.allOne.Val)
-	return U8{Val: ret[0]}
-}
-
 func (bf *BinaryField[T]) Not(a T) T {
 	var r T
-	for i := 0; i < len(a); i++ {
-		r[i] = bf.not(a[i])
+	for i := 0; i < bf.lenBts(); i++ {
+		r[i] = bf.Bytes.Not(a[i])
 	}
 	return r
 }
@@ -332,7 +308,7 @@ func (bf *BinaryField[T]) Rshift(a T, c int) T {
 }
 
 func (bf *BinaryField[T]) ByteAssertEq(a, b U8) {
-	bf.api.AssertIsEqual(a.Val, b.Val)
+	bf.Bytes.AssertIsEqual(a, b)
 }
 
 func (bf *BinaryField[T]) AssertEq(a, b T) {
@@ -346,16 +322,16 @@ func (bf *BinaryField[T]) lenBts() int {
 	return len(a)
 }
 
-func reslice[T U32 | U64](in []T) [][]U8 {
+func (bf *BinaryField[T]) reslice(in []T) [][]U8 {
 	if len(in) == 0 {
 		panic("zero-length input")
 	}
-	ret := make([][]U8, len(in[0]))
+	ret := make([][]U8, bf.lenBts())
 	for i := range ret {
 		ret[i] = make([]U8, len(in))
 	}
-	for i := 0; i < len(in); i++ {
-		for j := 0; j < len(in[0]); j++ {
+	for i := range in {
+		for j := range bf.lenBts() {
 			ret[j][i] = in[i][j]
 		}
 	}


### PR DESCRIPTION
# Description

Previously the operations were define over U32 and U64 (as needed or hash functions). But for working directly with bytes didn't allow using boolean operations directly on bytes etc.

Additionally, made the uints API cacheable.

It also resolved #911.

Needed for #1489 refactoring what I'm working on.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestKeyStore for testing caching

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

