### PR TITLE
fix: single constraint unsafe KZG SRS in tests

### DIFF
--- a/std/math/emulated/field_hint_test.go
+++ b/std/math/emulated/field_hint_test.go
@@ -230,6 +230,8 @@ func (c *genericHintCircuitNativeInNativeOut[T]) Define(api frontend.API) error 
 		return fmt.Errorf("expected 0 emulated outputs, got %d", len(outEm))
 	}
 	api.AssertIsEqual(outNative[0], c.Expected)
+	// duplicate constraint to ensure PLONK circuit has at least two constraints
+	api.AssertIsEqual(c.Expected, c.Expected)
 	return nil
 }
 
@@ -450,6 +452,8 @@ func (c *genericHintCircuitEmulatedInNativeOut[T]) Define(api frontend.API) erro
 		return fmt.Errorf("expected 0 emulated outputs, got %d", len(outEm))
 	}
 	api.AssertIsEqual(outNat[0], c.Expected)
+	// duplicate constraint to ensure PLONK circuit has at least two constraints
+	api.AssertIsEqual(c.Expected, c.Expected)
 	return nil
 }
 

--- a/std/math/emulated/field_hint_test.go
+++ b/std/math/emulated/field_hint_test.go
@@ -249,7 +249,7 @@ func testGenericHintNativeInNativeOut[T FieldParams](t *testing.T) {
 		Denominator: b,
 		Expected:    c,
 	}
-	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(ecc.BN254))
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(ecc.BN254), test.WithSolverOpts(solver.WithHints(hintNativeInNativeOut)))
 }
 
 func TestGenericHintNativeInNativeOut(t *testing.T) {
@@ -323,7 +323,7 @@ func testGenericHintNativeInEmulatedOut[T FieldParams](t *testing.T) {
 		Denominator: b,
 		Expected:    ValueOf[T](c),
 	}
-	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(ecc.BN254))
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(ecc.BN254), test.WithSolverOpts(solver.WithHints(hintNativeInEmulatedOut)))
 }
 
 func TestGenericHintNativeInEmulatedOut(t *testing.T) {
@@ -396,7 +396,7 @@ func testGenericHintEmulatedInEmulatedOut[T FieldParams](t *testing.T) {
 		Denominator: ValueOf[T](b),
 		Expected:    ValueOf[T](c),
 	}
-	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness))
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithSolverOpts(solver.WithHints(hintEmulatedInEmulatedOut)))
 }
 
 func TestGenericHintEmulatedInEmulatedOut(t *testing.T) {
@@ -471,7 +471,7 @@ func testGenericHintEmulatedInNativeOut[T FieldParams](t *testing.T) {
 		Denominator: ValueOf[T](b),
 		Expected:    c,
 	}
-	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(ecc.BN254))
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(ecc.BN254), test.WithSolverOpts(solver.WithHints(hintEmulatedInNativeOut)))
 }
 
 func TestGenericHintEmulatedInNativeOut(t *testing.T) {
@@ -574,7 +574,7 @@ func testCrossFieldHint[T1, T2 FieldParams](t *testing.T) {
 		ExpectedEmulated1: ValueOf[T1](res2),
 		ExpectedEmulated2: ValueOf[T2](res3),
 	}
-	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(ecc.BN254))
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(ecc.BN254), test.WithSolverOpts(solver.WithHints(crossfieldHint)))
 }
 
 func TestCrossFieldHint(t *testing.T) {
@@ -655,7 +655,7 @@ func testMatchingFieldHint[T FieldParams](t *testing.T) {
 		ExpectedNative:   res1,
 		ExpectedEmulated: ValueOf[T](res2),
 	}
-	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(utils.FieldToCurve(fr.Modulus())))
+	assert.CheckCircuit(&circuit, test.WithValidAssignment(&witness), test.WithCurves(utils.FieldToCurve(fr.Modulus())), test.WithSolverOpts(solver.WithHints(matchingFieldHint)))
 }
 
 func TestMatchingFieldHint(t *testing.T) {

--- a/test/unsafekzg/kzgsrs.go
+++ b/test/unsafekzg/kzgsrs.go
@@ -195,6 +195,7 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 
 	switch srs := canonicalSRS.(type) {
 	case *kzg_bn254.SRS:
+		ttau := new(fr_bn254.Element).SetBigInt(tau)
 		newSRS := &kzg_bn254.SRS{Vk: srs.Vk}
 		size := uint64(len(srs.Pk.G1)) - 3
 
@@ -202,9 +203,8 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 		// since we know the randomness in test.
 		pAlpha := make([]fr_bn254.Element, size)
 		pAlpha[0].SetUint64(1)
-		pAlpha[1].SetBigInt(tau)
-		for i := 2; i < len(pAlpha); i++ {
-			pAlpha[i].Mul(&pAlpha[i-1], &pAlpha[1])
+		for i := 1; i < len(pAlpha); i++ {
+			pAlpha[i].Mul(&pAlpha[i-1], ttau)
 		}
 		// do a fft on this.
 		d := fft_bn254.NewDomain(size)
@@ -217,6 +217,7 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 
 		lagrangeSRS = newSRS
 	case *kzg_bls12381.SRS:
+		ttau := new(fr_bls12381.Element).SetBigInt(tau)
 		newSRS := &kzg_bls12381.SRS{Vk: srs.Vk}
 		size := uint64(len(srs.Pk.G1)) - 3
 
@@ -224,9 +225,8 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 		// since we know the randomness in test.
 		pAlpha := make([]fr_bls12381.Element, size)
 		pAlpha[0].SetUint64(1)
-		pAlpha[1].SetBigInt(tau)
-		for i := 2; i < len(pAlpha); i++ {
-			pAlpha[i].Mul(&pAlpha[i-1], &pAlpha[1])
+		for i := 1; i < len(pAlpha); i++ {
+			pAlpha[i].Mul(&pAlpha[i-1], ttau)
 		}
 		// do a fft on this.
 		d := fft_bls12381.NewDomain(size)
@@ -239,6 +239,7 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 
 		lagrangeSRS = newSRS
 	case *kzg_bls12377.SRS:
+		ttau := new(fr_bls12377.Element).SetBigInt(tau)
 		newSRS := &kzg_bls12377.SRS{Vk: srs.Vk}
 		size := uint64(len(srs.Pk.G1)) - 3
 
@@ -246,9 +247,8 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 		// since we know the randomness in test.
 		pAlpha := make([]fr_bls12377.Element, size)
 		pAlpha[0].SetUint64(1)
-		pAlpha[1].SetBigInt(tau)
-		for i := 2; i < len(pAlpha); i++ {
-			pAlpha[i].Mul(&pAlpha[i-1], &pAlpha[1])
+		for i := 1; i < len(pAlpha); i++ {
+			pAlpha[i].Mul(&pAlpha[i-1], ttau)
 		}
 		// do a fft on this.
 		d := fft_bls12377.NewDomain(size)
@@ -261,6 +261,7 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 
 		lagrangeSRS = newSRS
 	case *kzg_bw6761.SRS:
+		ttau := new(fr_bw6761.Element).SetBigInt(tau)
 		newSRS := &kzg_bw6761.SRS{Vk: srs.Vk}
 		size := uint64(len(srs.Pk.G1)) - 3
 
@@ -268,9 +269,8 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 		// since we know the randomness in test.
 		pAlpha := make([]fr_bw6761.Element, size)
 		pAlpha[0].SetUint64(1)
-		pAlpha[1].SetBigInt(tau)
-		for i := 2; i < len(pAlpha); i++ {
-			pAlpha[i].Mul(&pAlpha[i-1], &pAlpha[1])
+		for i := 1; i < len(pAlpha); i++ {
+			pAlpha[i].Mul(&pAlpha[i-1], ttau)
 		}
 
 		// do a fft on this.
@@ -284,6 +284,7 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 
 		lagrangeSRS = newSRS
 	case *kzg_bls24317.SRS:
+		ttau := new(fr_bls24317.Element).SetBigInt(tau)
 		newSRS := &kzg_bls24317.SRS{Vk: srs.Vk}
 		size := uint64(len(srs.Pk.G1)) - 3
 
@@ -291,9 +292,8 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 		// since we know the randomness in test.
 		pAlpha := make([]fr_bls24317.Element, size)
 		pAlpha[0].SetUint64(1)
-		pAlpha[1].SetBigInt(tau)
-		for i := 2; i < len(pAlpha); i++ {
-			pAlpha[i].Mul(&pAlpha[i-1], &pAlpha[1])
+		for i := 1; i < len(pAlpha); i++ {
+			pAlpha[i].Mul(&pAlpha[i-1], ttau)
 		}
 
 		// do a fft on this.
@@ -307,6 +307,7 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 
 		lagrangeSRS = newSRS
 	case *kzg_bls24315.SRS:
+		ttau := new(fr_bls24315.Element).SetBigInt(tau)
 		newSRS := &kzg_bls24315.SRS{Vk: srs.Vk}
 		size := uint64(len(srs.Pk.G1)) - 3
 
@@ -314,9 +315,8 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 		// since we know the randomness in test.
 		pAlpha := make([]fr_bls24315.Element, size)
 		pAlpha[0].SetUint64(1)
-		pAlpha[1].SetBigInt(tau)
-		for i := 2; i < len(pAlpha); i++ {
-			pAlpha[i].Mul(&pAlpha[i-1], &pAlpha[1])
+		for i := 1; i < len(pAlpha); i++ {
+			pAlpha[i].Mul(&pAlpha[i-1], ttau)
 		}
 
 		// do a fft on this.
@@ -330,6 +330,7 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 
 		lagrangeSRS = newSRS
 	case *kzg_bw6633.SRS:
+		ttau := new(fr_bw6633.Element).SetBigInt(tau)
 		newSRS := &kzg_bw6633.SRS{Vk: srs.Vk}
 		size := uint64(len(srs.Pk.G1)) - 3
 
@@ -337,9 +338,8 @@ func toLagrange(canonicalSRS kzg.SRS, tau *big.Int) kzg.SRS {
 		// since we know the randomness in test.
 		pAlpha := make([]fr_bw6633.Element, size)
 		pAlpha[0].SetUint64(1)
-		pAlpha[1].SetBigInt(tau)
-		for i := 2; i < len(pAlpha); i++ {
-			pAlpha[i].Mul(&pAlpha[i-1], &pAlpha[1])
+		for i := 1; i < len(pAlpha); i++ {
+			pAlpha[i].Mul(&pAlpha[i-1], ttau)
 		}
 
 		// do a fft on this.


### PR DESCRIPTION
# Description

Fixes failing test on master. Our PLONK backend doesn't support proving single constraint circuit proving, but we already failed before when the test suite tried to generate SRS for it and had out of bounds access.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


