### PR TITLE
fix: optimize zero constant detection and assignment

### DIFF
--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -234,6 +234,10 @@ func (builder *builder[E]) mulConstant(v1 expr.LinearExpression[E], lambda E, in
 	} else {
 		res = v1.Clone()
 	}
+	if lambda.IsZero() {
+		res = builder.cstZero()
+		return res
+	}
 
 	for i := 0; i < len(res); i++ {
 		res[i].Coeff = builder.cs.Mul(res[i].Coeff, lambda)

--- a/frontend/cs/r1cs/builder.go
+++ b/frontend/cs/r1cs/builder.go
@@ -311,19 +311,29 @@ func (builder *builder[E]) constantValue(v frontend.Variable) (E, bool) {
 	var zero E
 	if _v, ok := v.(expr.LinearExpression[E]); ok {
 		assertIsSet(_v)
-
-		if len(_v) != 1 {
-			// TODO @gbotrel this assumes linear expressions of coeff are not possible
-			// and are always reduced to one element. may not always be true?
-			return zero, false
-		}
-		if _v[0].Coeff == zero { // fast path for zero comparison to avoid overhead of calling IsZero
+		switch len(_v) {
+		case 0:
+			// empty linear expression, this is a constant zero
+			return zero, true
+		case 1:
+			// linear expression with one term, check if it is a constant
+			if _v[0].Coeff == zero { // fast path for zero comparison to avoid overhead of calling IsZero
+				return zero, true
+			}
+			if !(_v[0].WireID() == 0) { // public ONE WIRE
+				return zero, false
+			}
+			return _v[0].Coeff, true
+		default:
+			// linear expression with more than one term. Here it is only constant in case all coefficients are zero.
+			for _, t := range _v {
+				if !t.Coeff.IsZero() {
+					return zero, false
+				}
+			}
+			// all coefficients are zero, this is a constant zero
 			return zero, true
 		}
-		if !(_v[0].WireID() == 0) { // public ONE WIRE
-			return zero, false
-		}
-		return _v[0].Coeff, true
 	}
 	return builder.cs.FromInterface(v), true
 }


### PR DESCRIPTION
# Description

Found in fuzzing test:
```go
type C1_6314_8435483601975321392 struct {
	X0V frontend.Variable
	Y0V frontend.Variable `gnark:",public"`
}

func (circuit *C1_6314_8435483601975321392) Define(api frontend.API) error {
	x1 := api.IsZero(circuit.X0V) // depends on X0V
	x2 := api.And(0, x1)          // always 0
	x3 := api.Cmp(x2, 1)          // always -1
	api.AssertIsEqual(1, x3)      // always false
	return nil
}

type C2_6314_8435483601975321392 struct {
	X0V frontend.Variable
	Y0V frontend.Variable `gnark:",public"`
}

func (circuit *C2_6314_8435483601975321392) Define(api frontend.API) error {
	x1 := api.Cmp(circuit.X0V, circuit.X0V) // always 0
	x2 := api.Cmp(x1, -1)                   // always -1
	x3 := api.IsZero(x2)                    // always 0
	x4 := api.IsZero(circuit.X0V)           // depends on X0V
	x5 := api.IsZero(circuit.X0V)           // depends on X0v
	x6 := api.Select(x3, x4, x5)            // always returns x5
	x7 := api.And(0, x6)                    // always 0
	api.AssertIsLessOrEqual(1, x7)          // always fails
	return nil
}
```
Where previously R1CS compiler didn't fail for second circuit but did for SCS.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been benchmarked?

Ran BW6 in BN254 Groth16 verifier circuit to benchmark compile time (as we now do big loop for constant value checking).
```
              │  old.txt   │           new.txt           │
              │   sec/op   │   sec/op    vs base         │
BW6InBN254-16   9.434 ± 2%   9.501 ± 1%  ~ (p=0.589 n=6)

              │   old.txt    │            new.txt            │
              │     B/op     │     B/op      vs base         │
BW6InBN254-16   21.28Gi ± 0%   21.28Gi ± 0%  ~ (p=1.000 n=6)

              │   old.txt   │           new.txt            │
              │  allocs/op  │  allocs/op   vs base         │
BW6InBN254-16   91.48M ± 0%   91.48M ± 0%  ~ (p=0.937 n=6)
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

