### PR TITLE
perf(debug): pre-allocate memory in Stack() function

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -9,6 +9,7 @@ import (
 
 func Stack() string {
 	var sbb strings.Builder
+	sbb.Grow(1024) // Pre-allocate memory to reduce reallocations
 	writeStack(&sbb)
 	return sbb.String()
 }


### PR DESCRIPTION
# Description

Pre-allocate memory for strings.Builder in the Stack() function to reduce memory reallocations when building stack traces. This improves performance when generating stack traces, especially for deep call stacks during debugging.




