### PR TITLE
fix: scalarmul by 0 on twisted edwards curves

### DIFF
--- a/std/algebra/native/twistededwards/curve_test.go
+++ b/std/algebra/native/twistededwards/curve_test.go
@@ -416,26 +416,3 @@ func (p *CurveParams) randomScalar() *big.Int {
 	r, _ := rand.Int(rand.Reader, p.Order)
 	return r
 }
-
-type varScalarMul struct {
-	curveID twistededwards.ID
-	P       Point
-	R       Point
-	S       frontend.Variable
-}
-
-func (circuit *varScalarMul) Define(api frontend.API) error {
-
-	// get edwards curve curve
-	curve, err := NewEdCurve(api, circuit.curveID)
-	if err != nil {
-		return err
-	}
-
-	// scalar mul
-	res := curve.ScalarMul(circuit.P, circuit.S)
-	api.AssertIsEqual(res.X, circuit.R.X)
-	api.AssertIsEqual(res.Y, circuit.R.Y)
-
-	return nil
-}

--- a/std/algebra/native/twistededwards/hints.go
+++ b/std/algebra/native/twistededwards/hints.go
@@ -73,6 +73,16 @@ func halfGCD(mod *big.Int, inputs, outputs []*big.Int) error {
 	if len(outputs) != 4 {
 		return errors.New("expecting four outputs")
 	}
+	// using PrecomputeLattice for scalar decomposition is a hack and it doesn't
+	// work in case the scalar is zero. override it for now to avoid division by
+	// zero until a long-term solution is found.
+	if inputs[0].Sign() == 0 {
+		outputs[0].SetUint64(0)
+		outputs[1].SetUint64(0)
+		outputs[2].SetUint64(0)
+		outputs[3].SetUint64(0)
+		return nil
+	}
 	glvBasis := new(ecc.Lattice)
 	ecc.PrecomputeLattice(inputs[1], inputs[0], glvBasis)
 	outputs[0].Set(&glvBasis.V1[0])


### PR DESCRIPTION
# Description

When requesting for decomposition of zero scalar, then add hot path which avoids calling ecc.PrecomputeLattice directly as it panics due to division by zero. Checked that this unsafe way of calling `ecc.PrecomputeLattice` was only done here, everywhere else the parameters are either constants (through curve parameters) or we explicitly set the scalar to be 1 if it is 0 and later switch between actual and dummy result.

Fixes #1547 

Thanks for @lucasmenendez and @p4u for reporting!

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Expanded current tests to include zero inputs.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

