### PR TITLE
fix: prevent early return in RegisterHint causing missing registrations

### DIFF
--- a/constraint/solver/hint_registry.go
+++ b/constraint/solver/hint_registry.go
@@ -29,7 +29,7 @@ func RegisterHint(hintFns ...Hint) {
 		if _, ok := registry[key]; ok {
 			log := logger.Logger()
 			log.Debug().Str("name", name).Msg("function registered multiple times")
-			return
+			continue
 		}
 		registry[key] = hintFn
 	}


### PR DESCRIPTION
Fix bug where RegisterHint would stop registering subsequent hint functions if one function was already registered. 

Changed `return` to `continue` to ensure all functions in the slice are processed.

This bug could cause missing hint function registrations leading to solver errors.