### PR TITLE
fix: add missing error checks (errcheck linter fixes)

### DIFF
--- a/frontend/schema/internal/reflectwalk/reflectwalk.go
+++ b/frontend/schema/internal/reflectwalk/reflectwalk.go
@@ -179,7 +179,9 @@ func walk(v reflect.Value, w interface{}) (err error) {
 func walkSlice(v reflect.Value, w interface{}) (err error) {
 	ew, ok := w.(EnterExitWalker)
 	if ok {
-		ew.Enter(Slice)
+		if err := ew.Enter(Slice); err != nil {
+			return err
+		}
 	}
 
 	if sw, ok := w.(SliceWalker); ok {
@@ -199,7 +201,9 @@ func walkSlice(v reflect.Value, w interface{}) (err error) {
 
 		ew, ok := w.(EnterExitWalker)
 		if ok {
-			ew.Enter(SliceElem)
+			if err := ew.Enter(SliceElem); err != nil {
+				return err
+			}
 		}
 
 		if err := walk(elem, w); err != nil && err != ErrSkipEntry {
@@ -207,13 +211,17 @@ func walkSlice(v reflect.Value, w interface{}) (err error) {
 		}
 
 		if ok {
-			ew.Exit(SliceElem)
+			if err := ew.Exit(SliceElem); err != nil {
+				return err
+			}
 		}
 	}
 
 	ew, ok = w.(EnterExitWalker)
 	if ok {
-		ew.Exit(Slice)
+		if err := ew.Exit(Slice); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -222,7 +230,9 @@ func walkSlice(v reflect.Value, w interface{}) (err error) {
 func walkArray(v reflect.Value, w interface{}) (err error) {
 	ew, ok := w.(EnterExitWalker)
 	if ok {
-		ew.Enter(Array)
+		if err := ew.Enter(Array); err != nil {
+			return err
+		}
 	}
 
 	if aw, ok := w.(ArrayWalker); ok {
@@ -250,7 +260,9 @@ func walkArray(v reflect.Value, w interface{}) (err error) {
 		}
 
 		if ok {
-			ew.Exit(ArrayElem)
+			if err := ew.Exit(ArrayElem); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/profile/internal/graph/dotgraph.go
+++ b/profile/internal/graph/dotgraph.go
@@ -110,13 +110,13 @@ func (b *builder) start() {
 	if b.config.Title != "" {
 		graphname = b.config.Title
 	}
-	fmt.Fprintln(b, `digraph "`+graphname+`" {`)
-	fmt.Fprintln(b, `node [style=filled fillcolor="#f8f8f8"]`)
+	_, _ = fmt.Fprintln(b, `digraph "`+graphname+`" {`)
+	_, _ = fmt.Fprintln(b, `node [style=filled fillcolor="#f8f8f8"]`)
 }
 
 // finish closes the opening curly bracket in the constructed DOT buffer.
 func (b *builder) finish() {
-	fmt.Fprintln(b, "}")
+	_, _ = fmt.Fprintln(b, "}")
 }
 
 // addLegend generates a legend in DOT format.
@@ -126,7 +126,7 @@ func (b *builder) addLegend() {
 		return
 	}
 	title := labels[0]
-	fmt.Fprintf(b, `subgraph cluster_L { "%s" [shape=box fontsize=16`, escapeForDot(title))
+	_, _ = fmt.Fprintf(b, `subgraph cluster_L { "%s" [shape=box fontsize=16`, escapeForDot(title))
 	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(escapeAllForDot(labels), `\l`))
 	if b.config.LegendURL != "" {
 		fmt.Fprintf(b, ` URL="%s" target="_blank"`, b.config.LegendURL)


### PR DESCRIPTION
Add proper error handling for:
- EnterExitWalker.Enter/Exit methods in reflectwalk
- fmt.Fprintln/Fprintf calls in dotgraph (explicit ignore with _ assignment)

Fixes 5 errcheck linter violations.