### PR TITLE
Update Go version to 1.24. in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     - name: install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
 
     - name: install deps
       run: go install golang.org/x/tools/cmd/goimports@latest && go install github.com/klauspost/asmfmt/cmd/asmfmt@latest
@@ -42,7 +42,7 @@ jobs:
     - name: install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
 
     - name: install deps
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
     - name: install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
 
     - name: install deps
       run: go install golang.org/x/tools/cmd/goimports@latest && go install github.com/klauspost/asmfmt/cmd/asmfmt@latest


### PR DESCRIPTION
Replaced go-version: 1.23.x with 1.24.x across all CI jobs to use the latest stable release.

Reference: Go 1.24.4 release notes(https://go.dev/doc/devel/release#go1.24.minor)
(Released July 2025 includes security fixes and performance improvements)

CI passes with the new version. No other changes made.

