### PR TITLE
fix: bls12-381 edge cases

### DIFF
--- a/std/algebra/emulated/sw_bls12381/g1.go
+++ b/std/algebra/emulated/sw_bls12381/g1.go
@@ -147,6 +147,17 @@ func (g1 G1) doubleAndAdd(p, q *G1Affine) *G1Affine {
 }
 
 func (g1 *G1) scalarMulBySeedSquare(q *G1Affine) *G1Affine {
+	// It computes the scalar multiplication by the seed square. It is used to
+	// verify if a point is in the subgroup of G1. However, it uses incomplete
+	// formulas and as such doesn't work for point at infinity as we get a
+	// division by zero. But as we represent the point at infinity as (0,0),
+	// then in this case we can run the computations using a dummy point (1,1)
+	// and then later replace it again with the point at infinity.
+	isInfinity := g1.api.And(g1.curveF.IsZero(&q.X), g1.curveF.IsZero(&q.Y))
+	q = &G1Affine{
+		X: *g1.curveF.Select(isInfinity, g1.curveF.One(), &q.X),
+		Y: *g1.curveF.Select(isInfinity, g1.curveF.One(), &q.Y),
+	}
 	z := g1.double(q)
 	z = g1.add(q, z)
 	z = g1.double(z)
@@ -168,6 +179,11 @@ func (g1 *G1) scalarMulBySeedSquare(q *G1Affine) *G1Affine {
 	z = g1.doubleN(z, 32)
 	z = g1.doubleAndAdd(z, q)
 	z = g1.doubleN(z, 32)
+
+	z = &G1Affine{
+		X: *g1.curveF.Select(isInfinity, g1.curveF.Zero(), &z.X),
+		Y: *g1.curveF.Select(isInfinity, g1.curveF.Zero(), &z.Y),
+	}
 
 	return z
 }

--- a/std/algebra/emulated/sw_bls12381/pairing.go
+++ b/std/algebra/emulated/sw_bls12381/pairing.go
@@ -315,13 +315,15 @@ func (pr Pairing) AssertIsOnG1(P *G1Affine) {
 // IsOnG1 returns a boolean indicating if the G1 point is on the curve and in
 // the prime subgroup.
 func (pr Pairing) IsOnG1(P *G1Affine) frontend.Variable {
-	// 1 - is Q on curve
+	// 1 - is P on curve
 	isOnCurve := pr.IsOnCurve(P)
-	// 2 - is Q in the subgroup
+	// 2- Check P has the right subgroup order
+	// [x²]ϕ(P)
 	phiP := pr.g1.phi(P)
 	_P := pr.g1.scalarMulBySeedSquare(phiP)
 	_P = pr.curve.Neg(_P)
-	isInSubgroup := pr.g1.IsEqual(_P, phiP)
+	// [r]Q == 0 <==>  P = -[x²]ϕ(P)
+	isInSubgroup := pr.g1.IsEqual(_P, P)
 	return pr.api.And(isOnCurve, isInSubgroup)
 }
 

--- a/std/algebra/emulated/sw_bls12381/pairing.go
+++ b/std/algebra/emulated/sw_bls12381/pairing.go
@@ -399,10 +399,13 @@ func (pr Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init *
 	xNegOverY := make([]*baseEl, n)
 
 	for k := 0; k < n; k++ {
-		// P are supposed to be on G1 respectively of prime order r.
-		// The point (x,0) is of order 2. But this function does not check
-		// subgroup membership.
-		yInv[k] = pr.curveF.Inverse(&P[k].Y)
+		// P are supposed to be on G1 respectively of prime order r. The point
+		// (x,0) is of order 2. But this function does not check subgroup
+		// membership. So, we instead check if y is zero (for which there isn't
+		// an inverse) and selectively set the y inverse result.
+		isYZero := pr.curveF.IsZero(&P[k].Y)
+		y := pr.curveF.Select(isYZero, pr.curveF.One(), &P[k].Y)
+		yInv[k] = pr.curveF.Select(isYZero, pr.curveF.Zero(), pr.curveF.Inverse(y))
 		xNegOverY[k] = pr.curveF.MulMod(&P[k].X, yInv[k])
 		xNegOverY[k] = pr.curveF.Neg(xNegOverY[k])
 	}


### PR DESCRIPTION
# Description

This PR fixes the following edge cases:
- Miller loop computation when G1 point is 0
- Subgroup membership check for G1 is point is 0

Additionally, it fixes IsOnG1 method which had a typo.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Added corresponding regression tests.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

