### PR TITLE
fix: KZG proof verification for edge cases

### DIFF
--- a/std/commitments/kzg/verifier.go
+++ b/std/commitments/kzg/verifier.go
@@ -426,14 +426,14 @@ func (v *Verifier[FR, G1El, G2El, GTEl]) CheckOpeningProof(commitment Commitment
 
 	// [f(a)]G1 + [-a]([H(α)]G₁) = [f(a) - a*H(α)]G₁
 	pointNeg := v.scalarApi.Neg(&point)
-	totalG1, err := v.curve.MultiScalarMul([]*G1El{&vk.G1, &proof.Quotient}, []*emulated.Element[FR]{&proof.ClaimedValue, pointNeg})
+	totalG1, err := v.curve.MultiScalarMul([]*G1El{&vk.G1, &proof.Quotient}, []*emulated.Element[FR]{&proof.ClaimedValue, pointNeg}, algopts.WithCompleteArithmetic())
 	if err != nil {
 		return fmt.Errorf("check opening proof: %w", err)
 	}
 
 	// [f(a) - a*H(α)]G₁ + [-f(α)]G₁  = [f(a) - f(α) - a*H(α)]G₁
 	commitmentNeg := v.curve.Neg(&commitment.G1El)
-	totalG1 = v.curve.Add(totalG1, commitmentNeg)
+	totalG1 = v.curve.AddUnified(totalG1, commitmentNeg)
 
 	// e([f(a)-f(α)-a*H(α)]G₁], G₂).e([H(α)]G₁, [α]G₂) == 1
 	if err := v.pairing.PairingCheck(

--- a/std/commitments/kzg/verifier.go
+++ b/std/commitments/kzg/verifier.go
@@ -426,6 +426,7 @@ func (v *Verifier[FR, G1El, G2El, GTEl]) CheckOpeningProof(commitment Commitment
 
 	// [f(a)]G1 + [-a]([H(α)]G₁) = [f(a) - a*H(α)]G₁
 	pointNeg := v.scalarApi.Neg(&point)
+	// we use complete arithmetic to allow verifying commitment to 0 polynomial.
 	totalG1, err := v.curve.MultiScalarMul([]*G1El{&vk.G1, &proof.Quotient}, []*emulated.Element[FR]{&proof.ClaimedValue, pointNeg}, algopts.WithCompleteArithmetic())
 	if err != nil {
 		return fmt.Errorf("check opening proof: %w", err)


### PR DESCRIPTION
# Description

This PR implements complete formulas for KZG proof verification to allow checking proofs for zero polynomials and constructed polynomials.

Maybe there is a more efficient way than using complete formulas for MSM which adds quite a lot of overhead. But it seems that we don't use this method directly, for PLONK recursive verifier we manually prepare the inputs and use batch verification where we already have an option to use complete formulas.

Maybe here we could also add an option for using complete formulas? Although for me it seems that it is a valid case to commit to a zero polynomial and I'd rather have a default behaviour which allows it, rather than not.

For PLONK previously 2701912, now 2772838. Diff 70926
For Groth16 previously 713893, now 734527. Diff 20634

It doesn't seem to change PLONK recursion cost as there we don't use the method directly, but rather fold multiple and then do the pairing check.

This PR is required for Linea to support PointEval precompile for all inputs allowed in specification.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- Added tests to handle edge cases

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

