### PR TITLE
Improve Registry Locking with Read Locks

### DIFF
--- a/constraint/solver/hint_registry.go
+++ b/constraint/solver/hint_registry.go
@@ -36,8 +36,8 @@ func RegisterHint(hintFns ...Hint) {
 }
 
 func GetRegisteredHint(key HintID) Hint {
-	registryM.Lock()
-	defer registryM.Unlock()
+	registryM.RLock()
+	defer registryM.RUnlock()
 	return registry[key]
 }
 
@@ -62,8 +62,8 @@ func GetRegisteredHints() []Hint {
 }
 
 func cloneHintRegistry() map[HintID]Hint {
-	registryM.Lock()
-	defer registryM.Unlock()
+	registryM.RLock()
+	defer registryM.RUnlock()
 	return maps.Clone(registry)
 }
 


### PR DESCRIPTION
# Hint Registry Lock Optimization

## Summary

This update improves the performance and concurrency of the **hint registry** by making the following changes:

- **Replaced write lock with read lock** in `GetRegisteredHint`, allowing multiple goroutines to safely access the registry simultaneously.
- **Switched `cloneHintRegistry` to use a read lock**, ensuring the registry can be copied without blocking other concurrent readers.
-  Maintained strict write locking in `RegisterNamedHint` to prevent duplicate key registration and preserve thread safety.

These changes reduce lock contention and improve overall registry responsiveness, **especially in read-heavy** workloads.

---

## Testing
```bash
go test ./constraint/solver
```
## Key Improvement Suggestions (Future Work)

### Add Concurrency-Focused Tests
Introduce tests to simulate high-concurrency access to the registry and detect race conditions or locking regressions. These tests will help ensure thread safety during future updates or refactoring.

---

### Standardize Read/Write Lock Usage
Review other shared-state access patterns across the codebase to ensure consistent and appropriate use of `RLock` vs `Lock`. Prefer `RLock` in read-heavy scenarios to improve concurrency.

---

### Integrate Automated Linting Rules
Implement static analysis tools or CI checks to flag potential misuse of `sync.Mutex` and `sync.RWMutex` during development and code review. This will help maintain thread safety and code quality over time.
