### PR TITLE
fix(constraint): Correct field access for Term in CompressHint

### DIFF
--- a/constraint/blueprint_hint.go
+++ b/constraint/blueprint_hint.go
@@ -53,7 +53,7 @@ func (b *BlueprintGenericHint) CompressHint(h HintMapping, to *[]uint32) {
 	for _, l := range h.Inputs {
 		(*to) = append((*to), uint32(len(l)))
 		for _, t := range l {
-			(*to) = append((*to), uint32(t.CoeffID()), uint32(t.WireID()))
+			(*to) = append((*to), t.CID, t.VID)
 		}
 	}
 


### PR DESCRIPTION
## Describe your changes

This PR fixes a bug in the `CompressHint` method of `BlueprintGenericHint` that prevented it from compiling.

The method was attempting to serialize a `constraint.Term` object by calling non-existent methods (`.CoeffID()` and `.WireID()`). The `constraint.Term` struct exposes its coefficient and wire IDs through public fields `CID` and `VID`, respectively.

This change aligns the implementation with the `Term ` struct's public API and fixes the compilation error, allowing the `CompressHint ` functionality to work as intended.

While working on this fix, I also noticed two other small areas for potential improvement that could be addressed in a follow-up PR:
Misleading Variable Name: In `CompressHint`, the variable `nbInputs ` is used to count the total size of the calldata, not the number of inputs. Renaming it to `calldataSize ` would improve clarity.
