### PR TITLE
gkrgates: fix VerifyDegree error wrapping and degree search bound

### DIFF
--- a/constraint/solver/gkrgates/registry.go
+++ b/constraint/solver/gkrgates/registry.go
@@ -230,11 +230,12 @@ func (v *gateVerifier) isVarSolvable(f gkr.GateFunction, claimedSolvableVar, nbI
 
 func (v *gateVerifier) VerifyDegree(g *gkrtypes.Gate) error {
 	if err := v.verifyDegree(g.Evaluate, g.Degree(), g.NbIn()); err != nil {
-		deg, errFind := v.findDegree(g.Evaluate, g.Degree(), g.NbIn())
+		const maxAutoDegreeBound = 32
+		deg, errFind := v.findDegree(g.Evaluate, maxAutoDegreeBound, g.NbIn())
 		if errFind != nil {
-			return fmt.Errorf("could not find gate degree: %w\n\tdegree verification error: %w", errFind, errFind)
+			return fmt.Errorf("could not find gate degree: %w\n\tdegree verification error: %w", errFind, err)
 		}
-		return fmt.Errorf("detected degree %d\n\tdegree verification error: %w", deg, errFind)
+		return fmt.Errorf("detected degree %d\n\tdegree verification error: %w", deg, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Wrap the original verification error instead of the finder error to preserve context in diagnostics.
Use a sensible max bound (32) when inferring degree for diagnostics, aligned with Register.
Improves error messages (“detected degree X …”) and avoids false negatives when the claimed degree is too low.