### PR TITLE
feat: correct curve names in error messages and vector type

### DIFF
--- a/std/recursion/groth16/verifier.go
+++ b/std/recursion/groth16/verifier.go
@@ -129,7 +129,7 @@ func ValueOfProof[G1El algebra.G1ElementT, G2El algebra.G2ElementT](proof groth1
 	case *Proof[sw_bw6761.G1Affine, sw_bw6761.G2Affine]:
 		tProof, ok := proof.(*groth16backend_bw6761.Proof)
 		if !ok {
-			return ret, fmt.Errorf("expected bls24315.Proof, got %T", proof)
+			return ret, fmt.Errorf("expected bw6761.Proof, got %T", proof)
 		}
 		ar.Ar = sw_bw6761.NewG1Affine(tProof.Ar)
 		ar.Krs = sw_bw6761.NewG1Affine(tProof.Krs)
@@ -222,7 +222,7 @@ func ValueOfVerifyingKey[G1El algebra.G1ElementT, G2El algebra.G2ElementT, GtEl 
 	case *VerifyingKey[sw_bls12377.G1Affine, sw_bls12377.G2Affine, sw_bls12377.GT]:
 		tVk, ok := vk.(*groth16backend_bls12377.VerifyingKey)
 		if !ok {
-			return ret, fmt.Errorf("expected bn254.VerifyingKey, got %T", vk)
+			return ret, fmt.Errorf("expected bls12377.VerifyingKey, got %T", vk)
 		}
 		// compute E
 		e, err := bls12377.Pair([]bls12377.G1Affine{tVk.G1.Alpha}, []bls12377.G2Affine{tVk.G2.Beta})
@@ -278,7 +278,7 @@ func ValueOfVerifyingKey[G1El algebra.G1ElementT, G2El algebra.G2ElementT, GtEl 
 	case *VerifyingKey[sw_bls24315.G1Affine, sw_bls24315.G2Affine, sw_bls24315.GT]:
 		tVk, ok := vk.(*groth16backend_bls24315.VerifyingKey)
 		if !ok {
-			return ret, fmt.Errorf("expected bls12381.VerifyingKey, got %T", vk)
+			return ret, fmt.Errorf("expected bls24315.VerifyingKey, got %T", vk)
 		}
 		// compute E
 		e, err := bls24315.Pair([]bls24315.G1Affine{tVk.G1.Alpha}, []bls24315.G2Affine{tVk.G2.Beta})
@@ -374,7 +374,7 @@ func ValueOfVerifyingKeyFixed[G1El algebra.G1ElementT, G2El algebra.G2ElementT, 
 	case *VerifyingKey[sw_bls12377.G1Affine, sw_bls12377.G2Affine, sw_bls12377.GT]:
 		tVk, ok := vk.(*groth16backend_bls12377.VerifyingKey)
 		if !ok {
-			return ret, fmt.Errorf("expected bn254.VerifyingKey, got %T", vk)
+			return ret, fmt.Errorf("expected bls12377.VerifyingKey, got %T", vk)
 		}
 		// compute E
 		e, err := bls12377.Pair([]bls12377.G1Affine{tVk.G1.Alpha}, []bls12377.G2Affine{tVk.G2.Beta})
@@ -430,7 +430,7 @@ func ValueOfVerifyingKeyFixed[G1El algebra.G1ElementT, G2El algebra.G2ElementT, 
 	case *VerifyingKey[sw_bls24315.G1Affine, sw_bls24315.G2Affine, sw_bls24315.GT]:
 		tVk, ok := vk.(*groth16backend_bls24315.VerifyingKey)
 		if !ok {
-			return ret, fmt.Errorf("expected bls12381.VerifyingKey, got %T", vk)
+			return ret, fmt.Errorf("expected bls24315.VerifyingKey, got %T", vk)
 		}
 		// compute E
 		e, err := bls24315.Pair([]bls24315.G1Affine{tVk.G1.Alpha}, []bls24315.G2Affine{tVk.G2.Beta})
@@ -554,7 +554,7 @@ func ValueOfWitness[FR emulated.FieldParams](w witness.Witness) (Witness[FR], er
 	case *Witness[sw_bw6761.ScalarField]:
 		vect, ok := vec.(fr_bw6761.Vector)
 		if !ok {
-			return ret, fmt.Errorf("expected fr_bls24315.Vector, got %T", vec)
+			return ret, fmt.Errorf("expected fr_bw6761.Vector, got %T", vec)
 		}
 		for i := range vect {
 			s.Public = append(s.Public, sw_bw6761.NewScalar(vect[i]))


### PR DESCRIPTION
## Description

This PR fixes several typo-level mismatches in error messages and one vector type in the Groth16 recursion helpers:
- ValueOfProof: bw6-761 branch
  - expected bls24315.Proof → expected bw6761.Proof
- ValueOfVerifyingKey (non-Fixed version):
  - bls12-377 branch: expected bn254.VerifyingKey → expected bls12377.VerifyingKey
  - bls24-315 branch: expected bls12381.VerifyingKey → expected bls24315.VerifyingKey
- ValueOfWitness: bw6-761 branch
  - expected fr_bls24315.Vector → expected fr_bw6761.Vector


## Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

N/A

## How has this been benchmarked?

N/A 

## Checklist
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A for typo fixes)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [ ] golangci-lint does not output errors locally
- [x] New and existing unit tests pass locally with my changes (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
