### PR TITLE
fix: propagate ReadFrom errors in generated r1cs tests

### DIFF
--- a/constraint/babybear/r1cs_test.go
+++ b/constraint/babybear/r1cs_test.go
@@ -108,14 +108,14 @@ func TestSerialization(t *testing.T) {
 				var r, r2 cs.R1CS
 				n, err = r.ReadFrom(&buffer)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 				if n == 0 {
 					t.Fatal("No bytes are read")
 				}
 				_, err = r2.ReadFrom(&buffer2)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 
 				if !reflect.DeepEqual(r, r2) {

--- a/constraint/bls12-377/r1cs_test.go
+++ b/constraint/bls12-377/r1cs_test.go
@@ -103,14 +103,14 @@ func TestSerialization(t *testing.T) {
 				var r, r2 cs.R1CS
 				n, err = r.ReadFrom(&buffer)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 				if n == 0 {
 					t.Fatal("No bytes are read")
 				}
 				_, err = r2.ReadFrom(&buffer2)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 
 				if !reflect.DeepEqual(r, r2) {

--- a/constraint/bls12-381/r1cs_test.go
+++ b/constraint/bls12-381/r1cs_test.go
@@ -103,14 +103,14 @@ func TestSerialization(t *testing.T) {
 				var r, r2 cs.R1CS
 				n, err = r.ReadFrom(&buffer)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 				if n == 0 {
 					t.Fatal("No bytes are read")
 				}
 				_, err = r2.ReadFrom(&buffer2)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 
 				if !reflect.DeepEqual(r, r2) {

--- a/constraint/bls24-315/r1cs_test.go
+++ b/constraint/bls24-315/r1cs_test.go
@@ -103,14 +103,14 @@ func TestSerialization(t *testing.T) {
 				var r, r2 cs.R1CS
 				n, err = r.ReadFrom(&buffer)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 				if n == 0 {
 					t.Fatal("No bytes are read")
 				}
 				_, err = r2.ReadFrom(&buffer2)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 
 				if !reflect.DeepEqual(r, r2) {

--- a/constraint/bls24-317/r1cs_test.go
+++ b/constraint/bls24-317/r1cs_test.go
@@ -103,14 +103,14 @@ func TestSerialization(t *testing.T) {
 				var r, r2 cs.R1CS
 				n, err = r.ReadFrom(&buffer)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 				if n == 0 {
 					t.Fatal("No bytes are read")
 				}
 				_, err = r2.ReadFrom(&buffer2)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 
 				if !reflect.DeepEqual(r, r2) {

--- a/constraint/bn254/r1cs_test.go
+++ b/constraint/bn254/r1cs_test.go
@@ -103,14 +103,14 @@ func TestSerialization(t *testing.T) {
 				var r, r2 cs.R1CS
 				n, err = r.ReadFrom(&buffer)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 				if n == 0 {
 					t.Fatal("No bytes are read")
 				}
 				_, err = r2.ReadFrom(&buffer2)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 
 				if !reflect.DeepEqual(r, r2) {

--- a/constraint/bw6-633/r1cs_test.go
+++ b/constraint/bw6-633/r1cs_test.go
@@ -103,14 +103,14 @@ func TestSerialization(t *testing.T) {
 				var r, r2 cs.R1CS
 				n, err = r.ReadFrom(&buffer)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 				if n == 0 {
 					t.Fatal("No bytes are read")
 				}
 				_, err = r2.ReadFrom(&buffer2)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 
 				if !reflect.DeepEqual(r, r2) {

--- a/constraint/bw6-761/r1cs_test.go
+++ b/constraint/bw6-761/r1cs_test.go
@@ -106,14 +106,14 @@ func TestSerialization(t *testing.T) {
 				var r, r2 cs.R1CS
 				n, err = r.ReadFrom(&buffer)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 				if n == 0 {
 					t.Fatal("No bytes are read")
 				}
 				_, err = r2.ReadFrom(&buffer2)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 
 				if !reflect.DeepEqual(r, r2) {

--- a/constraint/koalabear/r1cs_test.go
+++ b/constraint/koalabear/r1cs_test.go
@@ -108,14 +108,14 @@ func TestSerialization(t *testing.T) {
 				var r, r2 cs.R1CS
 				n, err = r.ReadFrom(&buffer)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 				if n == 0 {
 					t.Fatal("No bytes are read")
 				}
 				_, err = r2.ReadFrom(&buffer2)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 
 				if !reflect.DeepEqual(r, r2) {

--- a/constraint/tinyfield/r1cs_test.go
+++ b/constraint/tinyfield/r1cs_test.go
@@ -111,14 +111,14 @@ func TestSerialization(t *testing.T) {
 				var r, r2 cs.R1CS
 				n, err = r.ReadFrom(&buffer)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 				if n == 0 {
 					t.Fatal("No bytes are read")
 				}
 				_, err = r2.ReadFrom(&buffer2)
 				if err != nil {
-					t.Fatal(nil)
+					t.Fatal(err)
 				}
 
 				if !reflect.DeepEqual(r, r2) {

--- a/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/tests/r1cs.go.tmpl
@@ -113,14 +113,14 @@ func TestSerialization(t *testing.T) {
 			var r, r2 cs.R1CS
 			n, err = r.ReadFrom(&buffer)
 			if err != nil {
-				t.Fatal(nil)
+				t.Fatal(err)
 			}
 			if n == 0 {
 				t.Fatal("No bytes are read")
 			}
 			_, err = r2.ReadFrom(&buffer2)
 			if err != nil {
-				t.Fatal(nil)
+				t.Fatal(err)
 			}
 
 			if !reflect.DeepEqual(r, r2) {


### PR DESCRIPTION
## Problem
Generated R1CS serialization tests were using `t.Fatal(nil)` instead of `t.Fatal(err)` 
when handling ReadFrom errors, causing tests to fail without proper error context.
     
## Solution
 ixed the generator template `internal/generator/backend/template/representations/tests/r1cs.go.tmpl` 
 to use `t.Fatal(err)` and regenerated all affected test files.
     
## Files Changed
- Template: `internal/generator/backend/template/representations/tests/r1cs.go.tmpl`
- Generated tests: All `constraint/*/r1cs_test.go` files
     
## Testing
- [x] Code generation completed successfully
- [x] All affected test files updated consistently