### PR TITLE
fix: add G1 membership for ML and FE in bls precompile

### DIFF
--- a/std/evmprecompiles/15-blspairing.go
+++ b/std/evmprecompiles/15-blspairing.go
@@ -94,6 +94,9 @@ func ECPairBLSMillerLoopAndMul(api frontend.API, accumulator *sw_bls12381.GTEl, 
 	if err != nil {
 		return fmt.Errorf("new pairing: %w", err)
 	}
+	// Miller loop below already checks that Q is in G2, but doesn't check that
+	// P is. So we do it manually.
+	pairing.AssertIsOnG1(P)
 	ml, err := pairing.MillerLoopAndMul(P, Q, accumulator)
 	if err != nil {
 		return fmt.Errorf("miller loop and mul: %w", err)
@@ -111,7 +114,9 @@ func ECPairBLSMillerLoopAndFinalExpCheck(api frontend.API, accumulator *sw_bls12
 	if err != nil {
 		return fmt.Errorf("new pairing: %w", err)
 	}
-
+	// Miller loop below already checks that Q is in G2, but doesn't check that
+	// P is. So we do it manually.
+	pairing.AssertIsOnG1(P)
 	isSuccess := pairing.IsMillerLoopAndFinalExpOne(P, Q, accumulator)
 	api.AssertIsEqual(expectedIsSuccess, isSuccess)
 	return nil


### PR DESCRIPTION
# Description

The Miller loop line computation already checks that second input is in G2, but we don't check it for first argument. Add explicit check.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

