### PR TITLE
fix: handle OR call for constant inputs

### DIFF
--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -427,7 +427,7 @@ func (builder *builder[E]) Or(_a, _b frontend.Variable) frontend.Variable {
 
 	if bConstant {
 		if builder.cs.IsOne(_bC) {
-			return 1
+			return builder.cstOne()
 		} else {
 			return a
 		}


### PR DESCRIPTION
# Description

Handle `api.Or` in case either of the inputs is a constant without creating a constraint. Already handled this way in SCS.

Thanks to @wuestholz for reporting.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

