### PR TITLE
feat:N3 contract export

### DIFF
--- a/backend/groth16/bls12-377/verify.go
+++ b/backend/groth16/bls12-377/verify.go
@@ -133,3 +133,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -43,6 +43,283 @@ func (proof *Proof) isValid() bool {
 	return proof.Ar.IsInSubGroup() && proof.Krs.IsInSubGroup() && proof.Bs.IsInSubGroup()
 }
 
+type SolveResult struct {
+	solution               *cs.R1CSSolution
+	proof                  *Proof // commitment
+	privateCommittedValues [][]fr.Element
+	commitmentInfo         constraint.Groth16Commitments
+	nbPublic               int
+}
+
+// Solve since this processing has a very-low cpu-usage in most circuits, we take it out of the backend.Prove so we can have a pipeline
+// i.e. Only Witness Generation
+func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...backend.ProverOption) (*SolveResult, error) {
+	opt, err := backend.NewProverConfig(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("new prover config: %w", err)
+	}
+	if opt.HashToFieldFn == nil {
+		opt.HashToFieldFn = hash_to_field.New([]byte(constraint.CommitmentDst))
+	}
+
+	commitmentInfo := r1cs.CommitmentInfo.(constraint.Groth16Commitments)
+
+	proof := &Proof{Commitments: make([]curve.G1Affine, len(commitmentInfo))}
+
+	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
+
+	privateCommittedValues := make([][]fr.Element, len(commitmentInfo))
+
+	// override hints
+	bsb22ID := solver.GetHintID(fcs.Bsb22CommitmentComputePlaceholder)
+	solverOpts = append(solverOpts, solver.OverrideHint(bsb22ID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+		i := int(in[0].Int64())
+		in = in[1:]
+		privateCommittedValues[i] = make([]fr.Element, len(commitmentInfo[i].PrivateCommitted))
+		hashed := in[:len(commitmentInfo[i].PublicAndCommitmentCommitted)]
+		committed := in[+len(hashed):]
+		for j, inJ := range committed {
+			privateCommittedValues[i][j].SetBigInt(inJ)
+		}
+
+		var err error
+		if proof.Commitments[i], err = pk.CommitmentKeys[i].Commit(privateCommittedValues[i]); err != nil {
+			return err
+		}
+
+		opt.HashToFieldFn.Write(constraint.SerializeCommitment(proof.Commitments[i].Marshal(), hashed, (fr.Bits-1)/8+1))
+		hashBts := opt.HashToFieldFn.Sum(nil)
+		opt.HashToFieldFn.Reset()
+		nbBuf := fr.Bytes
+		if opt.HashToFieldFn.Size() < fr.Bytes {
+			nbBuf = opt.HashToFieldFn.Size()
+		}
+		var res fr.Element
+		res.SetBytes(hashBts[:nbBuf])
+		res.BigInt(out[0])
+		return nil
+	}))
+
+	_solution, err := r1cs.Solve(fullWitness, solverOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return &SolveResult{
+		solution:               _solution.(*cs.R1CSSolution),
+		proof:                  proof,
+		privateCommittedValues: privateCommittedValues,
+		commitmentInfo:         commitmentInfo,
+		nbPublic:               r1cs.GetNbPublicVariables(),
+	}, nil
+}
+
+// ProofComputing another pipeline processing, it has a high-usage of cpu and is fast
+// fft and msm
+func ProofComputing(solve *SolveResult, pk *ProvingKey) (*Proof, error) {
+	wireValues := []fr.Element(solve.solution.W)
+	proof := solve.proof
+	poks := make([]curve.G1Affine, len(pk.CommitmentKeys))
+	for i := range pk.CommitmentKeys {
+		var err error
+		if poks[i], err = pk.CommitmentKeys[i].ProveKnowledge(solve.privateCommittedValues[i]); err != nil {
+			return nil, err
+		}
+	}
+	// compute challenge for folding the PoKs from the commitments
+	commitmentsSerialized := make([]byte, fr.Bytes*len(solve.commitmentInfo))
+	for i := range solve.commitmentInfo {
+		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[solve.commitmentInfo[i].CommitmentIndex].Marshal())
+	}
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = proof.CommitmentPok.Fold(poks, challenge[0], ecc.MultiExpConfig{NbTasks: 1}); err != nil {
+		return nil, err
+	}
+	// H (witness reduction / FFT part)
+	var h []fr.Element
+	chHDone := make(chan struct{}, 1)
+	go func() {
+		h = computeH(solve.solution.A, solve.solution.B, solve.solution.C, &pk.Domain)
+		solve.solution.A = nil
+		solve.solution.B = nil
+		solve.solution.C = nil
+		chHDone <- struct{}{}
+	}()
+
+	// we need to copy and filter the wireValues for each multi exp
+	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
+	var wireValuesA, wireValuesB []fr.Element
+	chWireValuesA, chWireValuesB := make(chan struct{}, 1), make(chan struct{}, 1)
+
+	go func() {
+		wireValuesA = make([]fr.Element, len(wireValues)-int(pk.NbInfinityA))
+		for i, j := 0, 0; j < len(wireValuesA); i++ {
+			if pk.InfinityA[i] {
+				continue
+			}
+			wireValuesA[j] = wireValues[i]
+			j++
+		}
+		close(chWireValuesA)
+	}()
+	go func() {
+		wireValuesB = make([]fr.Element, len(wireValues)-int(pk.NbInfinityB))
+		for i, j := 0, 0; j < len(wireValuesB); i++ {
+			if pk.InfinityB[i] {
+				continue
+			}
+			wireValuesB[j] = wireValues[i]
+			j++
+		}
+		close(chWireValuesB)
+	}()
+
+	// sample random r and s
+	var r, s big.Int
+	var _r, _s, _kr fr.Element
+	if _, err := _r.SetRandom(); err != nil {
+		return nil, err
+	}
+	if _, err := _s.SetRandom(); err != nil {
+		return nil, err
+	}
+	_kr.Mul(&_r, &_s).Neg(&_kr)
+
+	_r.BigInt(&r)
+	_s.BigInt(&s)
+
+	// computes r[δ], s[δ], kr[δ]
+	deltas := curve.BatchScalarMultiplicationG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
+
+	var bs1, ar curve.G1Jac
+
+	n := runtime.NumCPU()
+
+	chBs1Done := make(chan error, 1)
+	computeBS1 := func() {
+		<-chWireValuesB
+		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+			chBs1Done <- err
+			close(chBs1Done)
+			return
+		}
+		bs1.AddMixed(&pk.G1.Beta)
+		bs1.AddMixed(&deltas[1])
+		chBs1Done <- nil
+	}
+
+	chArDone := make(chan error, 1)
+	computeAR1 := func() {
+		<-chWireValuesA
+		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+			chArDone <- err
+			close(chArDone)
+			return
+		}
+		ar.AddMixed(&pk.G1.Alpha)
+		ar.AddMixed(&deltas[0])
+		proof.Ar.FromJacobian(&ar)
+		chArDone <- nil
+	}
+
+	chKrsDone := make(chan error, 1)
+	computeKRS := func() {
+		// we could NOT split the Krs multiExp in 2, and just append pk.G1.K and pk.G1.Z
+		// however, having similar lengths for our tasks helps with parallelism
+
+		var krs, krs2, p1 curve.G1Jac
+		chKrs2Done := make(chan error, 1)
+		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
+		go func() {
+			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			chKrs2Done <- err
+		}()
+
+		// filter the wire values if needed
+		// TODO Perf @Tabaie worst memory allocation offender
+		toRemove := solve.commitmentInfo.GetPrivateCommitted()
+		toRemove = append(toRemove, solve.commitmentInfo.CommitmentIndexes())
+		_wireValues := filterHeap(wireValues[solve.nbPublic:], solve.nbPublic, internal.ConcatAll(toRemove...))
+
+		if _, err := krs.MultiExp(pk.G1.K, _wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+			chKrsDone <- err
+			return
+		}
+		krs.AddMixed(&deltas[2])
+		n := 3
+		for n != 0 {
+			select {
+			case err := <-chKrs2Done:
+				if err != nil {
+					chKrsDone <- err
+					return
+				}
+				krs.AddAssign(&krs2)
+			case err := <-chArDone:
+				if err != nil {
+					chKrsDone <- err
+					return
+				}
+				p1.ScalarMultiplication(&ar, &s)
+				krs.AddAssign(&p1)
+			case err := <-chBs1Done:
+				if err != nil {
+					chKrsDone <- err
+					return
+				}
+				p1.ScalarMultiplication(&bs1, &r)
+				krs.AddAssign(&p1)
+			}
+			n--
+		}
+
+		proof.Krs.FromJacobian(&krs)
+		chKrsDone <- nil
+	}
+
+	computeBS2 := func() error {
+		// Bs2 (1 multi exp G2 - size = len(wires))
+		var Bs, deltaS curve.G2Jac
+
+		nbTasks := n
+		if nbTasks <= 16 {
+			// if we don't have a lot of CPUs, this may artificially split the MSM
+			nbTasks *= 2
+		}
+		<-chWireValuesB
+		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
+			return err
+		}
+
+		deltaS.FromAffine(&pk.G2.Delta)
+		deltaS.ScalarMultiplication(&deltaS, &s)
+		Bs.AddAssign(&deltaS)
+		Bs.AddMixed(&pk.G2.Beta)
+
+		proof.Bs.FromJacobian(&Bs)
+		return nil
+	}
+
+	// wait for FFT to end, as it uses all our CPUs
+	<-chHDone
+
+	// schedule our proof part computations
+	go computeKRS()
+	go computeAR1()
+	go computeBS1()
+	if err := computeBS2(); err != nil {
+		return nil, err
+	}
+
+	// wait for all parts of the proof to be computed.
+	if err := <-chKrsDone; err != nil {
+		return nil, err
+	}
+	return proof, nil
+}
+
 // CurveID returns the curveID
 func (proof *Proof) CurveID() ecc.ID {
 	return curve.ID

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -55,6 +55,7 @@ type SolveResult struct {
 // i.e. Only Witness Generation
 func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...backend.ProverOption) (*SolveResult, error) {
 	opt, err := backend.NewProverConfig(opts...)
+	log := logger.Logger().With().Str("curve", r1cs.CurveID().String()).Str("acceleration", "none").Int("nbConstraints", r1cs.GetNbConstraints()).Str("backend", "groth16").Logger()
 	if err != nil {
 		return nil, fmt.Errorf("new prover config: %w", err)
 	}
@@ -99,8 +100,10 @@ func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		res.BigInt(out[0])
 		return nil
 	}))
-
+	start := time.Now()
 	_solution, err := r1cs.Solve(fullWitness, solverOpts...)
+	log.Debug().Dur("took", time.Since(start)).Msg("solver done")
+
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +119,8 @@ func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 // ProofComputing another pipeline processing, it has a high-usage of cpu and is fast
 // fft and msm
 func ProofComputing(solve *SolveResult, pk *ProvingKey) (*Proof, error) {
+	log := logger.Logger().With().Str("curve", pk.CurveID().String()).Str("acceleration", "none").Int("nbCommitmentInfo", len(solve.commitmentInfo)).Int("nbPublic", solve.nbPublic).Int("nbPrivateCommittedValues", len(solve.privateCommittedValues)).Str("backend", "groth16").Logger()
+	start := time.Now()
 	wireValues := []fr.Element(solve.solution.W)
 	proof := solve.proof
 	poks := make([]curve.G1Affine, len(pk.CommitmentKeys))
@@ -317,6 +322,8 @@ func ProofComputing(solve *SolveResult, pk *ProvingKey) (*Proof, error) {
 	if err := <-chKrsDone; err != nil {
 		return nil, err
 	}
+	log.Debug().Dur("took", time.Since(start)).Msg("prover done")
+
 	return proof, nil
 }
 

--- a/backend/groth16/bls12-381/verify.go
+++ b/backend/groth16/bls12-381/verify.go
@@ -133,3 +133,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/bls24-315/verify.go
+++ b/backend/groth16/bls24-315/verify.go
@@ -133,3 +133,6 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/bls24-317/verify.go
+++ b/backend/groth16/bls24-317/verify.go
@@ -133,3 +133,6 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/bn254/n3_contract.go
+++ b/backend/groth16/bn254/n3_contract.go
@@ -1,0 +1,412 @@
+package groth16
+
+import (
+	"bytes"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+)
+
+const n3ContractTemplate = `
+{{- $numPublic := sub (len .Vk.G1.K) 1 }}
+{{- $numCommitments := len .Vk.PublicAndCommitmentCommitted }}
+{{- $numWitness := sub $numPublic $numCommitments }}
+{{- $PublicAndCommitmentCommitted := .Vk.PublicAndCommitmentCommitted }}
+using Neo.SmartContract.Framework.Attributes;
+using System;
+using System.ComponentModel;
+using System.Numerics;
+using Neo.SmartContract.Framework;
+
+namespace Neo.Compiler.CSharp.TestContracts	
+{
+    [DisplayName("ZkpVerifyContract")]
+    public class ZkpVerifyContract : SmartContract.Framework.SmartContract
+    {
+        static readonly string PublicInputNotInField = "PublicInputNotInField";
+        static readonly string ProofInvalid = "ProofInvalid";
+        static readonly string CommitmentInvalid = "CommitmentInvalid";
+
+        static readonly BigInteger PRECOMPILE_MODEXP = 0x05;
+        static readonly BigInteger PRECOMPILE_ADD = 0x06;
+        static readonly BigInteger PRECOMPILE_MUL = 0x07;
+        static readonly BigInteger PRECOMPILE_VERIFY = 0x08;
+
+ 		// Base field Fp order P and scalar field Fr order R.
+        // For BN254 these are computed as follows:
+        //     t = 4965661367192848881
+        //     P = 36⋅t⁴ + 36⋅t³ + 24⋅t² + 6⋅t + 1
+        //     R = 36⋅t⁴ + 36⋅t³ + 18⋅t² + 6⋅t + 1
+        static readonly BigInteger P =  BigInteger.Parse("21888242871839275222246405745257275088696311157297823662689037894645226208583");//0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47
+        static readonly BigInteger R = BigInteger.Parse("21888242871839275222246405745257275088548364400416034343698204186575808495617");//0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
+
+		// Extension field Fp2 = Fp[i] / (i² + 1)
+        // Note: This is the complex extension field of Fp with i² = -1.
+        //       Values in Fp2 are represented as a pair of Fp elements (a₀, a₁) as a₀ + a₁⋅i.
+        // Note: The order of Fp2 elements is *opposite* that of the pairing contract, which
+        //       expects Fp2 elements in order (a₁, a₀). This is also the order in which
+        //       Fp2 elements are encoded in the public interface as this became convention.
+
+        // Constants in Fp
+        static readonly BigInteger FRACTION_1_2_FP = BigInteger.Parse("10944121435919637611123202872628637544348155578648911831344518947322613104292");//0x183227397098d014dc2822db40c0ac2ecbc0b548b438e5469e10460b6c3e7ea4
+        static readonly BigInteger FRACTION_27_82_FP = BigInteger.Parse("19485874751759354771024239261021720505790618469301721065564631296452457478373");//0x2b149d40ceb8aaae81be18991be06ac3b5b4c5e559dbefa33267e6dc24a138e5
+        static readonly BigInteger FRACTION_3_82_FP = BigInteger.Parse("21621313080719284060999498358119991246151234191964923374119659383734918571893");//0x2fcd3ac2a640a154eb23960892a85a68f031ca0c8344b23a577dcf1052b9e775
+
+        // Exponents for inversions and square roots mod P
+        static readonly BigInteger EXP_INVERSE_FP = BigInteger.Parse("21888242871839275222246405745257275088696311157297823662689037894645226208581"); // P - 2//0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD45
+        static readonly BigInteger EXP_SQRT_FP = BigInteger.Parse("5472060717959818805561601436314318772174077789324455915672259473661306552146"); // (P + 1) / 4;//0xC19139CB84C680A6E14116DA060561765E05AA45A1C72A34F082305B61F3F52
+
+      	// Automatically filled and generated
+		
+		// Groth16 alpha point in G1
+        static readonly BigInteger ALPHA_X = BigInteger.Parse("{{ (fpstr .Vk.G1.Alpha.X) }}");
+        static readonly BigInteger ALPHA_Y = BigInteger.Parse("{{ (fpstr .Vk.G1.Alpha.Y) }} ");
+
+		// Groth16 alpha point in G2 in powers of i 
+        static readonly BigInteger BETA_NEG_X_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Beta.X.A0) }}");
+        static readonly BigInteger BETA_NEG_X_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Beta.X.A1) }}");
+        static readonly BigInteger BETA_NEG_Y_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Beta.Y.A0) }}");
+        static readonly BigInteger BETA_NEG_Y_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Beta.Y.A1) }}");
+
+    	// Groth16 gamma point in G2 in powers of i
+        static readonly BigInteger GAMMA_NEG_X_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Gamma.X.A0) }}");
+        static readonly BigInteger GAMMA_NEG_X_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Gamma.X.A1) }}");
+        static readonly BigInteger GAMMA_NEG_Y_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Gamma.Y.A0) }}");
+        static readonly BigInteger GAMMA_NEG_Y_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Gamma.Y.A1) }}");
+
+    	// Groth16 delta point in G2 in powers of i
+        static readonly BigInteger DELTA_NEG_X_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Delta.X.A0) }}");
+        static readonly BigInteger DELTA_NEG_X_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Delta.X.A1) }}");
+        static readonly BigInteger DELTA_NEG_Y_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Delta.Y.A0) }}");
+        static readonly BigInteger DELTA_NEG_Y_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Delta.Y.A1) }}");
+
+        {{- if gt $numCommitments 0 }}
+    	// Pedersen G point in G2 in powers of i
+    	{{- $cmtVk0 := index .Vk.CommitmentKeys 0 }}
+        static readonly BigInteger PEDERSEN_G_X_0 = BigInteger.Parse("{{ (fpstr $cmtVk0.G.X.A0) }}");
+        static readonly BigInteger PEDERSEN_G_X_1 = BigInteger.Parse("{{ (fpstr $cmtVk0.G.X.A1) }}");
+        static readonly BigInteger PEDERSEN_G_Y_0 = BigInteger.Parse("{{ (fpstr $cmtVk0.G.Y.A0) }}");
+        static readonly BigInteger PEDERSEN_G_Y_1 = BigInteger.Parse("{{ (fpstr $cmtVk0.G.Y.A1) }}");
+
+    	// Pedersen GSigmaNeg point in G2 in powers of i
+        static readonly BigInteger PEDERSEN_GSIGMANEG_X_0 = BigInteger.Parse("{{ (fpstr $cmtVk0.GSigmaNeg.X.A0) }}");
+        static readonly BigInteger PEDERSEN_GSIGMANEG_X_1 = BigInteger.Parse("{{ (fpstr $cmtVk0.GSigmaNeg.X.A1) }}");
+        static readonly BigInteger PEDERSEN_GSIGMANEG_Y_0 = BigInteger.Parse("{{ (fpstr $cmtVk0.GSigmaNeg.Y.A0) }}");
+        static readonly BigInteger PEDERSEN_GSIGMANEG_Y_1 = BigInteger.Parse("{{ (fpstr $cmtVk0.GSigmaNeg.Y.A1) }}");
+        {{ end }}
+
+        // Constant and public input points
+    	{{- $k0 := index .Vk.G1.K 0}}
+        static readonly BigInteger CONSTANT_X = BigInteger.Parse("{{ (fpstr $k0.X) }}");
+        static readonly BigInteger CONSTANT_Y = BigInteger.Parse("{{ (fpstr $k0.Y) }}");
+
+        {{- range $i, $ki := .Vk.G1.K }}
+        	{{- if gt $i 0 }}
+        static readonly BigInteger PUB_{{sub $i 1}}_X = BigInteger.Parse("{{ (fpstr $ki.X) }}");
+        static readonly BigInteger PUB_{{sub $i 1}}_Y = BigInteger.Parse("{{ (fpstr $ki.Y) }}");
+            {{- end }}
+    	{{- end }}
+
+        /// Negation in Fp.
+        /// @notice Returns a number x such that a + x = 0 in Fp.
+        /// @notice The input does not need to be reduced.
+        /// @param a the base
+        /// @return x the result
+        [Safe]
+        public static BigInteger Negate(BigInteger a)
+        {
+            unchecked
+            {
+                return (P - (a % P)) % P;
+            }
+        }
+
+        /// Exponentiation in Fp.
+        /// @notice Returns a number x such that a ^ e = x in Fp.
+        /// @notice The input does not need to be reduced.
+        /// @param a the base
+        /// @param e the exponent
+        /// @return x the result
+        [Safe]
+        public static BigInteger Exp(BigInteger a, BigInteger e)
+        {
+            return BigInteger.ModPow(a, e, P);
+        }
+
+        /// Exponentiation in Fp.
+        /// @notice Returns a number x such that a*b = x in Fp.
+        /// @notice The input does not need to be reduced.
+        /// @param a the mul number 1
+        /// @param b the mul number 2
+        /// @return x the result
+        [Safe]
+        public static BigInteger MulMod(BigInteger a, BigInteger b, BigInteger p)
+        {
+            return a.ModMultiply(b, p);
+        }
+
+        /// Exponentiation in Fp.
+        /// @notice Returns a number x such that a*b = x in Fp.
+        /// @notice The input does not need to be reduced.
+        /// @param a the add number 1
+        /// @param b the add number 2
+        /// @return x the result
+        [Safe]
+        public static BigInteger AddMod(BigInteger a, BigInteger b, BigInteger p)
+        {
+            return (a + b) % p;
+        }
+
+        /// Invertsion in Fp.
+        /// @notice Returns a number x such that a * x = 1 in Fp.
+        /// @notice The input does not need to be reduced.
+        /// @notice Reverts with ProofInvalid() if the inverse does not exist
+        /// @param a the input
+        /// @return x the solution
+        [Safe]
+        public static BigInteger Invert_Fp(BigInteger a)
+        {
+            BigInteger x = Exp(a, EXP_INVERSE_FP);
+            if (!MulMod(a, x, P).Equals(1))
+            {
+                throw new Exception(ProofInvalid);
+            }
+            return x;
+        }
+
+        /// Square root in Fp.
+        /// @notice Returns a number x such that x * x = a in Fp.
+        /// @notice Will revert with InvalidProof() if the input is not a square
+        /// or not reduced.
+        /// @param a the square
+        /// @return x the solution
+        [Safe]
+        public static BigInteger Sqrt_Fp(BigInteger a)
+        {
+            BigInteger x = Exp(a, EXP_SQRT_FP);
+            if (MulMod(x, x, P) != a)
+            {
+                throw new Exception(ProofInvalid);
+            }
+            return x;
+        }
+
+        /// Square test in Fp.
+        /// @notice Returns whether a number x exists such that x * x = a in Fp.
+        /// @notice Will revert with InvalidProof() if the input is not a square
+        /// or not reduced.
+        /// @param a the square
+        /// @return x the solution
+        [Safe]
+        public static bool IsSquare_Fp(BigInteger a)
+        {
+            BigInteger x = Exp(a, EXP_SQRT_FP);
+            return MulMod(x, x, P) == a;
+        }
+
+        /// Square root in Fp2.
+        /// @notice Fp2 is the complex extension Fp[i]/(i^2 + 1). The input is
+        /// a0 + a1 ⋅ i and the result is x0 + x1 ⋅ i.
+        /// @notice Will revert with InvalidProof() if
+        ///   * the input is not a square,
+        ///   * the hint is incorrect, or
+        ///   * the input coefficients are not reduced.
+        /// @param a0 The real part of the input.
+        /// @param a1 The imaginary part of the input.
+        /// @param hint A hint which of two possible signs to pick in the equation.
+        /// @return x0 The real part of the square root.
+        /// @return x1 The imaginary part of the square root.
+        [Safe]
+        public static (BigInteger x0, BigInteger x1) Sqrt_Fp2(BigInteger a0, BigInteger a1, bool hint)
+        {
+            BigInteger d = Sqrt_Fp(AddMod(MulMod(a0, a0, P), MulMod(a1, a1, P), P));
+            if (hint) d = Negate(d);
+
+            BigInteger x0 = Sqrt_Fp(MulMod(AddMod(a0, d, P), FRACTION_1_2_FP, P));
+            BigInteger x1 = MulMod(a1, Invert_Fp(MulMod(x0, 2, P)), P);
+
+            // 结果校验
+            if (a0 != AddMod(MulMod(x0, x0, P), Negate(MulMod(x1, x1, P)), P)
+                || a1 != MulMod(2, MulMod(x0, x1, P), P))
+            {
+                throw new Exception(ProofInvalid);
+            }
+            return (x0, x1);
+        }
+
+        /// Compress a G1 point.
+        /// @notice Reverts with InvalidProof if the coordinates are not reduced
+        /// or if the point is not on the curve.
+        /// @notice The point at infinity is encoded as (0,0) and compressed to 0.
+        /// @param x The X coordinate in Fp.
+        /// @param y The Y coordinate in Fp.
+        /// @return c The compresed point (x with one signal bit).
+        [Safe]
+        public static BigInteger Compress_g1(BigInteger x, BigInteger y)
+        {
+            if (x >= P || y >= P) throw new Exception(ProofInvalid);
+            if (x == 0 && y == 0) return 0;
+
+            BigInteger y_pos = Sqrt_Fp(AddMod(MulMod(MulMod(x, x, P), x, P), 3, P));
+            if (y == y_pos) return (x << 1) | 0;
+            if (y == Negate(y_pos)) return (x << 1) | 1;
+
+            throw new Exception(ProofInvalid);
+        }
+
+        /// Decompress a G1 point.
+        /// @notice Reverts with InvalidProof if the input does not represent a valid point.
+        /// @notice The point at infinity is encoded as (0,0) and compressed to 0.
+        /// @param c The compresed point (x with one signal bit).
+        /// @return x The X coordinate in Fp.
+        /// @return y The Y coordinate in Fp.
+        [Safe]
+        public static (BigInteger x, BigInteger y) Decompress_g1(BigInteger c)
+        {
+            if (c == 0) return (0, 0);
+
+            bool negatePoint = (c & 1) == 1;
+            BigInteger x = c >> 1;
+            if (x >= P) throw new Exception(ProofInvalid);
+
+            BigInteger y = Sqrt_Fp(AddMod(MulMod(MulMod(x, x, P), x, P), 3, P));
+            if (negatePoint) y = Negate(y);
+
+            return (x, y);
+        }
+
+       /// Compress a G2 point.
+        /// @notice Reverts with InvalidProof if the coefficients are not reduced
+        /// or if the point is not on the curve.
+        /// @notice The G2 curve is defined over the complex extension Fp[i]/(i^2 + 1)
+        /// with coordinates (x0 + x1 ⋅ i, y0 + y1 ⋅ i).
+        /// @notice The point at infinity is encoded as (0,0,0,0) and compressed to (0,0).
+        /// @param x0 The real part of the X coordinate.
+        /// @param x1 The imaginary poart of the X coordinate.
+        /// @param y0 The real part of the Y coordinate.
+        /// @param y1 The imaginary part of the Y coordinate.
+        /// @return c0 The first half of the compresed point (x0 with two signal bits).
+        /// @return c1 The second half of the compressed point (x1 unmodified).
+		[Safe]
+        public static (BigInteger c0,BigInteger c1) Compress_g2(BigInteger x0, BigInteger x1, BigInteger y0, BigInteger y1)
+        {
+            if (x0 >= P || x1 >= P || y0 >= P || y1 >= P)
+            {
+                // G2 point not in field.
+                throw new Exception(ProofInvalid);
+            }
+            if ((x0 | x1 | y0 | y1) == 0)
+            {
+                // Point at infinity
+                return (0, 0);
+            }
+
+            // Compute y^2
+            // Note: shadowing variables and scoping to avoid stack-to-deep.
+            BigInteger y0_pos;
+            BigInteger y1_pos;
+            {
+                BigInteger n3ab = MulMod(MulMod(x0, x1, P), P - 3, P);
+                BigInteger a_3 = MulMod(MulMod(x0, x0, P), x0, P);
+                BigInteger b_3 = MulMod(MulMod(x1, x1, P), x1, P);
+                y0_pos = AddMod(FRACTION_27_82_FP, AddMod(a_3, MulMod(n3ab, x1, P), P), P);
+                y1_pos = Negate(AddMod(FRACTION_3_82_FP, AddMod(b_3, MulMod(n3ab, x0, P), P), P));
+            }
+
+            // Determine hint bit
+            // If this sqrt fails the x coordinate is not on the curve.
+            bool hint;
+            {
+                BigInteger d = Sqrt_Fp(AddMod(MulMod(y0_pos, y0_pos, P), MulMod(y1_pos, y1_pos, P), P));
+                hint = !IsSquare_Fp(MulMod(AddMod(y0_pos, d, P), FRACTION_1_2_FP, P));
+            }
+            BigInteger c0 = 0;
+            BigInteger c1 = 0;
+            // Recover y
+            (y0_pos,y1_pos)= Sqrt_Fp2(y0_pos, y1_pos, hint);
+            if (y0 == y0_pos && y1 == y1_pos)
+            {
+                c0 = (x0 << 2) | (hint ? 2 : 0) | 0;
+                c1 = x1;
+                return (c0, c1);
+            }
+            else if (y0 == Negate(y0_pos) && y1 == Negate(y1_pos))
+            {
+                c0 = (x0 << 2) | (hint ? 2 : 0) | 1;
+                c1 = x1;
+                return (c0, c1);
+            }
+            else
+            {
+                // G1 point not on curve.
+                throw new Exception(ProofInvalid);
+            }
+        }
+
+        /// Decompress a G2 point.
+        /// @notice Reverts with InvalidProof if the input does not represent a valid point.
+        /// @notice The G2 curve is defined over the complex extension Fp[i]/(i^2 + 1)
+        /// with coordinates (x0 + x1 ⋅ i, y0 + y1 ⋅ i).
+        /// @notice The point at infinity is encoded as (0,0,0,0) and compressed to (0,0).
+        /// @param c0 The first half of the compresed point (x0 with two signal bits).
+        /// @param c1 The second half of the compressed point (x1 unmodified).
+        /// @return x0 The real part of the X coordinate.
+        /// @return x1 The imaginary poart of the X coordinate.
+        /// @return y0 The real part of the Y coordinate.
+        /// @return y1 The imaginary part of the Y coordinate.
+        [Safe]
+        public static (BigInteger x0, BigInteger x1, BigInteger y0, BigInteger y1)  Decompress_g2(BigInteger c0, BigInteger c1)
+        {
+            // Note that X = (0, 0) is not on the curve since 0³ + 3/(9 + i) is not a square.
+            // so we can use it to represent the point at infinity.
+            if (c0 == 0 && c1 == 0)
+            {
+                // Point at infinity as encoded in EIP197.
+                return (0, 0, 0, 0);
+            }
+            bool negate_point = (c0 & 1) == 1;
+            bool hint = (c0 & 2) == 2;
+            BigInteger x0 = c0 >> 2;
+            BigInteger x1 = c1;
+            if (x0 >= P || x1 >= P)
+            {
+                // G2 x0 or x1 coefficient not in field.
+                throw new Exception(ProofInvalid);
+            }
+
+            BigInteger n3ab = MulMod(MulMod(x0, x1, P), P - 3, P);
+            BigInteger a_3 = MulMod(MulMod(x0, x0, P), x0, P);
+            BigInteger b_3 = MulMod(MulMod(x1, x1, P), x1, P);
+
+            BigInteger y0 = AddMod(FRACTION_27_82_FP, AddMod(a_3, MulMod(n3ab, x1, P), P), P);
+            BigInteger y1 = Negate(AddMod(FRACTION_3_82_FP, AddMod(b_3, MulMod(n3ab, x0, P), P), P));
+
+            // Note: sqrt_Fp2 reverts if there is no solution, i.e. the point is not on the curve.
+            // Note: (X³ + 3/(9 + i)) is irreducible in Fp2, so y can not be zero.
+            //       But y0 or y1 may still independently be zero.
+            (y0,y1)= Sqrt_Fp2(y0, y1, hint);
+            if (negate_point)
+            {
+                y0 = Negate(y0);
+                y1 = Negate(y1);
+            }
+            return (x0,  x1, y0, y1);
+        }
+    }
+}
+`
+
+// MarshalN3Contract converts a proof to a byte array that can be used in a
+// n3 contract.
+func (proof *Proof) MarshalN3Contract() []byte {
+	var buf bytes.Buffer
+	_, err := proof.WriteRawTo(&buf)
+	if err != nil {
+		panic(err)
+	}
+
+	// If there are no commitments, we can return only Ar | Bs | Krs
+	if len(proof.Commitments) > 0 {
+		return buf.Bytes()
+	} else {
+		return buf.Bytes()[:8*fr.Bytes]
+	}
+}

--- a/backend/groth16/bn254/verify.go
+++ b/backend/groth16/bn254/verify.go
@@ -229,3 +229,95 @@ func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.Expor
 
 	return err
 }
+
+// ExportN3Contract writes a n3 Verifier contract on provided writer.
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	cfg, err := solidity.NewExportConfig(exportOpts...)
+	log := logger.Logger()
+	if err != nil {
+		return err
+	}
+	if cfg.HashToFieldFn == nil {
+		// set the target hash function to legacy keccak256 as it is the default for `solidity.WithTargetSolidityVerifier``
+		cfg.HashToFieldFn = sha3.NewLegacyKeccak256()
+		log.Debug().Msg("hash to field function not set, using keccak256 as default")
+	}
+	// a bit hacky way to understand what hash function is provided. We already
+	// receive instance of hash function but it is difficult to compare it with
+	// sha256.New() or sha3.NewLegacyKeccak256() directly.
+	//
+	// So, we hash an empty input and compare the outputs.
+	cfg.HashToFieldFn.Reset()
+	hashBts := cfg.HashToFieldFn.Sum(nil)
+	var hashFnName string
+	if bytes.Equal(hashBts, sha256.New().Sum(nil)) {
+		hashFnName = "sha256"
+	} else if bytes.Equal(hashBts, sha3.NewLegacyKeccak256().Sum(nil)) {
+		hashFnName = "keccak256"
+	} else {
+		return fmt.Errorf("unsupported hash function used, only supported sha256 and legacy keccak256")
+	}
+	cfg.HashToFieldFn.Reset()
+	helpers := template.FuncMap{
+		"sum": func(a, b int) int {
+			return a + b
+		},
+		"sub": func(a, b int) int {
+			return a - b
+		},
+		"mul": func(a, b int) int {
+			return a * b
+		},
+		"intRange": func(max int) []int {
+			out := make([]int, max)
+			for i := 0; i < max; i++ {
+				out[i] = i
+			}
+			return out
+		},
+		"fpstr": func(x fp.Element) string {
+			bv := new(big.Int)
+			x.BigInt(bv)
+			return bv.String()
+		},
+		"hashFnName": func() string {
+			return hashFnName
+		}, // may be used in future (verifyCompressedProof, verifyProof)
+	}
+
+	if len(vk.PublicAndCommitmentCommitted) > 1 {
+		log.Warn().Msg("exporting solidity verifier with more than one commitment is not supported")
+	} else if len(vk.PublicAndCommitmentCommitted) == 1 {
+		log.Warn().Msg("exporting solidity verifier only supports `sha256` as `HashToField`. The generated contract may not work for proofs generated with other hash functions.")
+	}
+
+	tmpl, err := template.New("").Funcs(helpers).Parse(n3ContractTemplate)
+	if err != nil {
+		return err
+	}
+
+	// negate Beta, Gamma and Delta, to avoid negating proof elements in the verifier
+	var betaNeg curve.G2Affine
+	betaNeg.Neg(&vk.G2.Beta)
+	beta := vk.G2.Beta
+	vk.G2.Beta = betaNeg
+	vk.G2.Gamma, vk.G2.gammaNeg = vk.G2.gammaNeg, vk.G2.Gamma
+	vk.G2.Delta, vk.G2.deltaNeg = vk.G2.deltaNeg, vk.G2.Delta
+
+	// execute template
+	err = tmpl.Execute(w, struct {
+		Cfg solidity.ExportConfig
+		Vk  VerifyingKey
+	}{
+		Cfg: cfg,
+		Vk:  *vk,
+	})
+
+	// restore Beta, Gamma and Delta
+	vk.G2.Beta = beta
+	vk.G2.Gamma, vk.G2.gammaNeg = vk.G2.gammaNeg, vk.G2.Gamma
+	vk.G2.Delta, vk.G2.deltaNeg = vk.G2.deltaNeg, vk.G2.Delta
+
+	return err
+
+}

--- a/backend/groth16/bw6-633/verify.go
+++ b/backend/groth16/bw6-633/verify.go
@@ -133,3 +133,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/bw6-761/verify.go
+++ b/backend/groth16/bw6-761/verify.go
@@ -133,3 +133,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -9,6 +9,7 @@
 package groth16
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -166,6 +167,54 @@ func Verify(proof Proof, vk VerifyingKey, publicWitness witness.Witness, opts ..
 			return witness.ErrInvalidWitness
 		}
 		return groth16_bw6633.Verify(_proof, vk.(*groth16_bw6633.VerifyingKey), w, opts...)
+	default:
+		panic("unrecognized R1CS curve type")
+	}
+}
+
+func Solve(r1cs constraint.ConstraintSystem, pk ProvingKey, fullWitness witness.Witness, opts ...backend.ProverOption) (any, error) {
+	switch _r1cs := r1cs.(type) {
+	case *cs_bls12377.R1CS:
+		return groth16_bls12377.Solve(_r1cs, pk.(*groth16_bls12377.ProvingKey), fullWitness, opts...)
+	case *cs_bls12381.R1CS:
+		return groth16_bls12381.Solve(_r1cs, pk.(*groth16_bls12381.ProvingKey), fullWitness, opts...)
+	case *cs_bn254.R1CS:
+		if icicle_bn254.HasIcicle {
+			return nil, fmt.Errorf("bn254 icicle has not impl solve")
+		}
+		return groth16_bn254.Solve(_r1cs, pk.(*groth16_bn254.ProvingKey), fullWitness, opts...)
+	case *cs_bw6761.R1CS:
+		return groth16_bw6761.Solve(_r1cs, pk.(*groth16_bw6761.ProvingKey), fullWitness, opts...)
+	case *cs_bls24317.R1CS:
+		return groth16_bls24317.Solve(_r1cs, pk.(*groth16_bls24317.ProvingKey), fullWitness, opts...)
+	case *cs_bls24315.R1CS:
+		return groth16_bls24315.Solve(_r1cs, pk.(*groth16_bls24315.ProvingKey), fullWitness, opts...)
+	case *cs_bw6633.R1CS:
+		return groth16_bw6633.Solve(_r1cs, pk.(*groth16_bw6633.ProvingKey), fullWitness, opts...)
+	default:
+		panic("unrecognized R1CS curve type")
+	}
+}
+
+func ProofComputing(solveResult any, pk ProvingKey) (Proof, error) {
+	switch solveResult.(type) {
+	case *groth16_bls12377.SolveResult:
+		return groth16_bls12377.ProofComputing(solveResult.(*groth16_bls12377.SolveResult), pk.(*groth16_bls12377.ProvingKey))
+	case *groth16_bls12381.SolveResult:
+		return groth16_bls12381.ProofComputing(solveResult.(*groth16_bls12381.SolveResult), pk.(*groth16_bls12381.ProvingKey))
+	case *groth16_bn254.SolveResult:
+		if icicle_bn254.HasIcicle {
+			return nil, fmt.Errorf("bn254 icicle has not impl solve")
+		}
+		return groth16_bn254.ProofComputing(solveResult.(*groth16_bn254.SolveResult), pk.(*groth16_bn254.ProvingKey))
+	case *groth16_bw6761.SolveResult:
+		return groth16_bw6761.ProofComputing(solveResult.(*groth16_bw6761.SolveResult), pk.(*groth16_bw6761.ProvingKey))
+	case *groth16_bls24317.SolveResult:
+		return groth16_bls24317.ProofComputing(solveResult.(*groth16_bls24317.SolveResult), pk.(*groth16_bls24317.ProvingKey))
+	case *groth16_bls24315.SolveResult:
+		return groth16_bls24315.ProofComputing(solveResult.(*groth16_bls24315.SolveResult), pk.(*groth16_bls24315.ProvingKey))
+	case *groth16_bw6633.SolveResult:
+		return groth16_bw6633.ProofComputing(solveResult.(*groth16_bw6633.SolveResult), pk.(*groth16_bw6633.ProvingKey))
 	default:
 		panic("unrecognized R1CS curve type")
 	}

--- a/backend/plonk/bls12-377/verify.go
+++ b/backend/plonk/bls12-377/verify.go
@@ -386,3 +386,7 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/plonk/bls12-381/verify.go
+++ b/backend/plonk/bls12-381/verify.go
@@ -386,3 +386,6 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/plonk/bls24-315/verify.go
+++ b/backend/plonk/bls24-315/verify.go
@@ -386,3 +386,7 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/plonk/bls24-317/verify.go
+++ b/backend/plonk/bls24-317/verify.go
@@ -386,3 +386,6 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/plonk/bn254/n3_contract.go
+++ b/backend/plonk/bn254/n3_contract.go
@@ -1,0 +1,11 @@
+package plonk
+
+import (
+	"errors"
+	"github.com/consensys/gnark/backend/solidity"
+	"io"
+)
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/plonk/bw6-633/verify.go
+++ b/backend/plonk/bw6-633/verify.go
@@ -121,11 +121,11 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 	one := fr.One()
 	bExpo.SetUint64(vk.Size)
 	zetaPowerM.Exp(zeta, &bExpo)
-	zhZeta.Sub(&zetaPowerM, &one)  // ζⁿ-1
+	zhZeta.Sub(&zetaPowerM, &one) // ζⁿ-1
 	lagrangeZero.Sub(&zeta, &one). // ζ-1
-					Inverse(&lagrangeZero).         // 1/(ζ-1)
-					Mul(&lagrangeZero, &zhZeta).    // (ζ^n-1)/(ζ-1)
-					Mul(&lagrangeZero, &vk.SizeInv) // 1/n * (ζ^n-1)/(ζ-1)
+		Inverse(&lagrangeZero). // 1/(ζ-1)
+		Mul(&lagrangeZero, &zhZeta). // (ζ^n-1)/(ζ-1)
+		Mul(&lagrangeZero, &vk.SizeInv) // 1/n * (ζ^n-1)/(ζ-1)
 
 	// compute PI = ∑_{i<n} Lᵢ*wᵢ
 	var pi fr.Element
@@ -173,9 +173,9 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 			den.Sub(&zeta, &wPowI) // ζ-wⁱ
 			lagrange.SetOne().
 				Sub(&zetaPowerM, &lagrange). // ζⁿ-1
-				Mul(&lagrange, &wPowI).      // wⁱ(ζⁿ-1)
-				Div(&lagrange, &den).        // wⁱ(ζⁿ-1)/(ζ-wⁱ)
-				Mul(&lagrange, &vk.SizeInv)  // wⁱ/n (ζⁿ-1)/(ζ-wⁱ)
+				Mul(&lagrange, &wPowI). // wⁱ(ζⁿ-1)
+				Div(&lagrange, &den). // wⁱ(ζⁿ-1)/(ζ-wⁱ)
+				Mul(&lagrange, &vk.SizeInv) // wⁱ/n (ζⁿ-1)/(ζ-wⁱ)
 
 			xiLi.Mul(&lagrange, &hashedCmt)
 			pi.Add(&pi, &xiLi)
@@ -384,5 +384,9 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 
 // ExportSolidity not implemented for BW6-633
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }

--- a/backend/plonk/bw6-761/verify.go
+++ b/backend/plonk/bw6-761/verify.go
@@ -386,3 +386,7 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/solidity/verifyingkey.go
+++ b/backend/solidity/verifyingkey.go
@@ -6,4 +6,5 @@ import "io"
 type VerifyingKey interface {
 	NbPublicWitness() int
 	ExportSolidity(io.Writer, ...ExportOption) error
+	ExportN3Contract(io.Writer, ...ExportOption) error // export n3 contract
 }

--- a/std/algebra/emulated/sw_bls12381/g1_test.go
+++ b/std/algebra/emulated/sw_bls12381/g1_test.go
@@ -14,6 +14,72 @@ import (
 	"github.com/consensys/gnark/test"
 )
 
+type ToBytesG1Test struct {
+	P               G1Affine
+	CompressedPoint []uints.U8
+}
+
+func (c *ToBytesG1Test) Define(api frontend.API) error {
+	g, err := NewG1(api)
+	if err != nil {
+		return err
+	}
+	bytes, err := g.ToCompressedBytes(c.P)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < len(c.CompressedPoint); i++ {
+		api.AssertIsEqual(c.CompressedPoint[i].Val, bytes[i].Val)
+	}
+	return nil
+}
+
+func TestToBytesG1(t *testing.T) {
+	assert := test.NewAssert(t)
+	{
+		_, _, p, _ := bls12381.Generators()
+		var r fr_bls12381.Element
+		r.SetRandom()
+		p.ScalarMultiplication(&p, r.BigInt(new(big.Int)))
+		pMarshalled := p.Bytes()
+		var witness, circuit ToBytesG1Test
+		nbBytes := fp_bls12381.Bytes
+		witness.CompressedPoint = make([]uints.U8, nbBytes)
+		circuit.CompressedPoint = make([]uints.U8, nbBytes)
+		for i := 0; i < nbBytes; i++ {
+			witness.CompressedPoint[i] = uints.NewU8(pMarshalled[i])
+		}
+		witness.P = G1Affine{
+			X: emulated.ValueOf[emulated.BLS12381Fp](p.X),
+			Y: emulated.ValueOf[emulated.BLS12381Fp](p.Y),
+		}
+
+		err := test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+		assert.NoError(err)
+	}
+	// infinity
+	{
+		var witness, circuit ToBytesG1Test
+		nbBytes := fp_bls12381.Bytes
+		witness.CompressedPoint = make([]uints.U8, nbBytes)
+		circuit.CompressedPoint = make([]uints.U8, nbBytes)
+		var p bls12381.G1Affine
+		p.X.SetZero()
+		p.Y.SetZero()
+		pMarshalled := p.Bytes()
+		for i := 0; i < nbBytes; i++ {
+			witness.CompressedPoint[i] = uints.NewU8(pMarshalled[i])
+		}
+		witness.P = G1Affine{
+			X: emulated.ValueOf[emulated.BLS12381Fp](0),
+			Y: emulated.ValueOf[emulated.BLS12381Fp](0),
+		}
+
+		err := test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+		assert.NoError(err)
+	}
+}
+
 type FromBytesG1Test struct {
 	CompressedPoint []uints.U8
 	X               emulated.Element[BaseField]

--- a/std/algebra/emulated/sw_bls12381/g1_test.go
+++ b/std/algebra/emulated/sw_bls12381/g1_test.go
@@ -1,0 +1,77 @@
+package sw_bls12381
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	fp_bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
+	fr_bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/std/math/uints"
+	"github.com/consensys/gnark/test"
+)
+
+type FromBytesG1Test struct {
+	CompressedPoint []uints.U8
+	X               emulated.Element[BaseField]
+	Y               emulated.Element[BaseField]
+}
+
+func (c *FromBytesG1Test) Define(api frontend.API) error {
+	g, err := NewG1(api)
+	if err != nil {
+		return err
+	}
+	point, err := g.FromCompressedBytes(c.CompressedPoint)
+	if err != nil {
+		return err
+	}
+	g.curveF.AssertIsEqual(&point.X, &c.X)
+	g.curveF.AssertIsEqual(&point.Y, &c.Y)
+	return nil
+}
+
+func TestFromBytesG1(t *testing.T) {
+	assert := test.NewAssert(t)
+	{
+		_, _, p, _ := bls12381.Generators()
+		var r fr_bls12381.Element
+		r.SetRandom()
+		p.ScalarMultiplication(&p, r.BigInt(new(big.Int)))
+		pMarshalled := p.Bytes()
+		var witness, circuit FromBytesG1Test
+		nbBytes := fp_bls12381.Bytes
+		witness.CompressedPoint = make([]uints.U8, nbBytes)
+		circuit.CompressedPoint = make([]uints.U8, nbBytes)
+		for i := 0; i < nbBytes; i++ {
+			witness.CompressedPoint[i] = uints.NewU8(pMarshalled[i])
+		}
+		witness.X = emulated.ValueOf[BaseField](p.X)
+		witness.Y = emulated.ValueOf[BaseField](p.Y)
+
+		err := test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+		assert.NoError(err)
+	}
+	// infinity
+	{
+		var witness, circuit FromBytesG1Test
+		nbBytes := fp_bls12381.Bytes
+		witness.CompressedPoint = make([]uints.U8, nbBytes)
+		circuit.CompressedPoint = make([]uints.U8, nbBytes)
+		var p bls12381.G1Affine
+		p.X.SetZero()
+		p.Y.SetZero()
+		pMarshalled := p.Bytes()
+		for i := 0; i < nbBytes; i++ {
+			witness.CompressedPoint[i] = uints.NewU8(pMarshalled[i])
+		}
+		witness.X = emulated.ValueOf[BaseField](0)
+		witness.Y = emulated.ValueOf[BaseField](0)
+
+		err := test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+		assert.NoError(err)
+	}
+}

--- a/std/algebra/emulated/sw_bls12381/g2.go
+++ b/std/algebra/emulated/sw_bls12381/g2.go
@@ -335,6 +335,20 @@ func (g2 G2) add(p, q *G2Affine) *G2Affine {
 	}
 }
 
+func (g2 G2) Neg(p G2Affine) G2Affine {
+	xr := &p.P.X
+	yr := g2.Ext2.Neg(&p.P.Y)
+	return G2Affine{
+		P: g2AffP{
+			X: *xr,
+			Y: fields_bls12381.E2{
+				A0: *g2.fp.Reduce(&yr.A0),
+				A1: *g2.fp.Reduce(&yr.A1),
+			},
+		},
+	}
+}
+
 func (g2 G2) neg(p *G2Affine) *G2Affine {
 	xr := &p.P.X
 	yr := g2.Ext2.Neg(&p.P.Y)

--- a/std/algebra/emulated/sw_bls12381/hash_to_g2.go
+++ b/std/algebra/emulated/sw_bls12381/hash_to_g2.go
@@ -1,0 +1,187 @@
+package sw_bls12381
+
+import (
+	"math/big"
+	"slices"
+
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/fields_bls12381"
+	"github.com/consensys/gnark/std/hash/tofield"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/std/math/emulated/emparams"
+	"github.com/consensys/gnark/std/math/uints"
+)
+
+const (
+	security_level       = 128
+	len_per_base_element = 64
+)
+
+func (g2 *G2) HashToG2(api frontend.API, msg []uints.U8, dst []byte) (*G2Affine, error) {
+	fp, e := emulated.NewField[emulated.BLS12381Fp](api)
+	if e != nil {
+		return &G2Affine{}, e
+	}
+
+	// Steps:
+	// 1. u = hash_to_field(msg, 2)
+	// 2. Q0 = map_to_curve(u[0])
+	// 3. Q1 = map_to_curve(u[1])
+	// 4. R = Q0 + Q1              # Point addition
+	// 5. P = clear_cofactor(R)
+	// 6. return P
+	lenPerBaseElement := len_per_base_element
+	lenInBytes := lenPerBaseElement * 4
+	uniformBytes, e := tofield.ExpandMsgXmd(api, msg, dst, lenInBytes)
+	if e != nil {
+		return &G2Affine{}, e
+	}
+
+	ele1 := bytesToElement(api, fp, uniformBytes[:lenPerBaseElement])
+	ele2 := bytesToElement(api, fp, uniformBytes[lenPerBaseElement:lenPerBaseElement*2])
+	ele3 := bytesToElement(api, fp, uniformBytes[lenPerBaseElement*2:lenPerBaseElement*3])
+	ele4 := bytesToElement(api, fp, uniformBytes[lenPerBaseElement*3:])
+
+	// we will still do iso_map before point addition, as we do not have point addition in E' (yet)
+	Q0, e := g2.MapToCurve2(&fields_bls12381.E2{A0: *ele1, A1: *ele2})
+	if e != nil {
+		return &G2Affine{}, e
+	}
+	Q1, e := g2.MapToCurve2(&fields_bls12381.E2{A0: *ele3, A1: *ele4})
+	if e != nil {
+		return &G2Affine{}, e
+	}
+	Q0 = g2.isogeny(Q0)
+	Q1 = g2.isogeny(Q1)
+
+	R := g2.AddUnified(Q0, Q1)
+
+	return clearCofactor(g2, fp, R), nil
+}
+
+func bytesToElement(api frontend.API, fp *emulated.Field[emulated.BLS12381Fp], data []uints.U8) *emulated.Element[emulated.BLS12381Fp] {
+	// data in BE, need to convert to LE
+	slices.Reverse(data)
+
+	bits := make([]frontend.Variable, len(data)*8)
+	for i := 0; i < len(data); i++ {
+		u8 := data[i]
+		u8Bits := api.ToBinary(u8.Val, 8)
+		for j := 0; j < 8; j++ {
+			bits[i*8+j] = u8Bits[j]
+		}
+	}
+
+	cutoff := 17
+	tailBits, headBits := bits[:cutoff*8], bits[cutoff*8:]
+	tail := fp.FromBits(tailBits...)
+	head := fp.FromBits(headBits...)
+
+	byteMultiplier := big.NewInt(256)
+	headMultiplier := byteMultiplier.Exp(byteMultiplier, big.NewInt(int64(cutoff)), big.NewInt(0))
+	head = fp.MulConst(head, headMultiplier)
+
+	return fp.Add(head, tail)
+}
+
+type g2Polynomial []fields_bls12381.E2
+
+type isogeny struct {
+	x_numerator, x_denominator, y_numerator, y_denominator g2Polynomial
+}
+
+func newIsogeny() *isogeny {
+	return &isogeny{
+		x_numerator: g2Polynomial([]fields_bls12381.E2{
+			*e2FromStrings(
+				"889424345604814976315064405719089812568196182208668418962679585805340366775741747653930584250892369786198727235542",
+				"889424345604814976315064405719089812568196182208668418962679585805340366775741747653930584250892369786198727235542"),
+			*e2FromStrings(
+				"0",
+				"2668273036814444928945193217157269437704588546626005256888038757416021100327225242961791752752677109358596181706522"),
+			*e2FromStrings(
+				"2668273036814444928945193217157269437704588546626005256888038757416021100327225242961791752752677109358596181706526",
+				"1334136518407222464472596608578634718852294273313002628444019378708010550163612621480895876376338554679298090853261"),
+			*e2FromStrings(
+				"3557697382419259905260257622876359250272784728834673675850718343221361467102966990615722337003569479144794908942033",
+				"0"),
+		}),
+		x_denominator: g2Polynomial([]fields_bls12381.E2{
+			*e2FromStrings(
+				"0",
+				"4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559715"),
+			*e2FromStrings(
+				"12",
+				"4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559775"),
+			*e2FromStrings(
+				"1",
+				"0"),
+		}),
+		y_numerator: g2Polynomial([]fields_bls12381.E2{
+			*e2FromStrings(
+				"3261222600550988246488569487636662646083386001431784202863158481286248011511053074731078808919938689216061999863558",
+				"3261222600550988246488569487636662646083386001431784202863158481286248011511053074731078808919938689216061999863558"),
+			*e2FromStrings(
+				"0",
+				"889424345604814976315064405719089812568196182208668418962679585805340366775741747653930584250892369786198727235518"),
+			*e2FromStrings(
+				"2668273036814444928945193217157269437704588546626005256888038757416021100327225242961791752752677109358596181706524",
+				"1334136518407222464472596608578634718852294273313002628444019378708010550163612621480895876376338554679298090853263"),
+			*e2FromStrings(
+				"2816510427748580758331037284777117739799287910327449993381818688383577828123182200904113516794492504322962636245776",
+				"0"),
+		}),
+		y_denominator: g2Polynomial([]fields_bls12381.E2{
+			*e2FromStrings(
+				"4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559355",
+				"4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559355"),
+			*e2FromStrings(
+				"0",
+				"4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559571"),
+			*e2FromStrings(
+				"18",
+				"4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559769"),
+			*e2FromStrings(
+				"1",
+				"0"),
+		}),
+	}
+}
+
+func e2FromStrings(x, y string) *fields_bls12381.E2 {
+	A0, _ := new(big.Int).SetString(x, 10)
+	A1, _ := new(big.Int).SetString(y, 10)
+
+	a0 := emulated.ValueOf[emulated.BLS12381Fp](A0)
+	a1 := emulated.ValueOf[emulated.BLS12381Fp](A1)
+
+	return &fields_bls12381.E2{A0: a0, A1: a1}
+}
+
+// Follow RFC 9380 Apendix G.3 to compute efficiently.
+func clearCofactor(g2 *G2, fp *emulated.Field[emparams.BLS12381Fp], p *G2Affine) *G2Affine {
+	// Steps:
+	// 1.  t1 = c1 * P
+	// c1 = -15132376222941642752
+	t1 := g2.scalarMulBySeed(p)
+	// 2.  t2 = psi(P)
+	t2 := g2.psi(p)
+	// 3.  t3 = 2 * P
+	t3 := g2.double(p)
+	// 4.  t3 = psi2(t3)
+	t3 = g2.psi2(t3)
+	// 5.  t3 = t3 - t2
+	t3 = g2.sub(t3, t2)
+	// 6.  t2 = t1 + t2
+	t2 = g2.AddUnified(t1, t2)
+	// 7.  t2 = c1 * t2
+	t2 = g2.scalarMulBySeed(t2)
+	// 8.  t3 = t3 + t2
+	t3 = g2.AddUnified(t3, t2)
+	// 9.  t3 = t3 - t1
+	t3 = g2.sub(t3, t1)
+	// 10.  Q = t3 - P
+	Q := g2.sub(t3, p)
+	// 11. return Q
+	return Q
+}

--- a/std/algebra/emulated/sw_bls12381/hash_to_g2_test.go
+++ b/std/algebra/emulated/sw_bls12381/hash_to_g2_test.go
@@ -1,0 +1,244 @@
+package sw_bls12381
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	bls12381fp "github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
+	"github.com/consensys/gnark/constraint"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/frontend/cs/scs"
+	"github.com/consensys/gnark/std/algebra/emulated/fields_bls12381"
+	"github.com/consensys/gnark/std/hash/tofield"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/std/math/uints"
+	"github.com/consensys/gnark/test"
+)
+
+func getMsgs() []string {
+	return []string{"", "a", "ab", "abc", "abcd", "abcde", "abcdef", "abcdefg", "1", "2", "3", "4", "5", "5656565656565656565656565656565656565656565656565656565656565656"}
+}
+
+func getDst() []byte {
+	dstHex := "412717974da474d0f8c420f320ff81e8432adb7c927d9bd082b4fb4d16c0a236"
+	dst := make([]byte, len(dstHex)/2)
+	hex.Decode(dst, []byte(dstHex))
+	return dst
+}
+
+type hashToFieldCircuit struct {
+	Msg []byte
+	Dst []byte
+	Res bls12381fp.Element
+}
+
+func (c *hashToFieldCircuit) Define(api frontend.API) error {
+	msg := uints.NewU8Array(c.Msg)
+	uniformBytes, _ := tofield.ExpandMsgXmd(api, msg, c.Dst, 64)
+	fp, _ := emulated.NewField[emulated.BLS12381Fp](api)
+
+	ele := bytesToElement(api, fp, uniformBytes)
+
+	fp.AssertIsEqual(ele, fp.NewElement(c.Res))
+
+	return nil
+}
+
+func TestHashToFieldTestSolve(t *testing.T) {
+	assert := test.NewAssert(t)
+	dst := getDst()
+
+	for _, msg := range getMsgs() {
+
+		rawEles, _ := bls12381fp.Hash([]byte(msg), dst, 1)
+
+		circuit := hashToFieldCircuit{
+			Msg: []byte(msg),
+			Dst: dst,
+			Res: rawEles[0],
+		}
+		witness := hashToFieldCircuit{
+			Msg: []byte(msg),
+			Dst: dst,
+			Res: rawEles[0],
+		}
+		err := test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+		assert.NoError(err)
+	}
+}
+
+type mapToCurveCircuit struct {
+	Msg []byte
+	Dst []byte
+	Res G2Affine
+}
+
+func (c *mapToCurveCircuit) Define(api frontend.API) error {
+	msg := uints.NewU8Array(c.Msg)
+	fp, _ := emulated.NewField[emulated.BLS12381Fp](api)
+
+	uniformBytes, _ := tofield.ExpandMsgXmd(api, msg, c.Dst, 128)
+	ele1 := bytesToElement(api, fp, uniformBytes[:64])
+	ele2 := bytesToElement(api, fp, uniformBytes[64:])
+	e := fields_bls12381.E2{A0: *ele1, A1: *ele2}
+
+	g2, err := NewG2(api)
+	if err != nil {
+		return err
+	}
+	affine, err := g2.MapToCurve2(&e)
+	if err != nil {
+		return err
+	}
+	g2.AssertIsEqual(affine, &c.Res)
+
+	return nil
+}
+
+func TestMapToCurveTestSolve(t *testing.T) {
+	assert := test.NewAssert(t)
+	dst := getDst()
+
+	for _, msg := range getMsgs() {
+
+		rawEles, _ := bls12381fp.Hash([]byte(msg), dst, 2)
+		rawAffine := bls12381.MapToCurve2(&bls12381.E2{A0: rawEles[0], A1: rawEles[1]})
+		wrappedRawAffine := NewG2Affine(rawAffine)
+
+		circuit := mapToCurveCircuit{
+			Msg: []byte(msg),
+			Dst: dst,
+			Res: wrappedRawAffine,
+		}
+		witness := mapToCurveCircuit{
+			Msg: []byte(msg),
+			Dst: dst,
+			Res: wrappedRawAffine,
+		}
+		err := test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+		assert.NoError(err)
+	}
+}
+
+type hashToG2Circuit struct {
+	Msg []byte
+	Dst []byte
+	Res G2Affine
+}
+
+func (c *hashToG2Circuit) Define(api frontend.API) error {
+	g2, err := NewG2(api)
+	if err != nil {
+		return err
+	}
+	res, e := g2.HashToG2(api, uints.NewU8Array(c.Msg), c.Dst)
+	if e != nil {
+		return e
+	}
+	g2.AssertIsEqual(res, &c.Res)
+	return nil
+}
+
+func TestHashToG2TestSolve(t *testing.T) {
+	assert := test.NewAssert(t)
+	dst := getDst()
+
+	for _, msg := range getMsgs() {
+
+		expected, _ := bls12381.HashToG2([]uint8(msg), dst)
+		wrappedRes := NewG2Affine(expected)
+
+		circuit := hashToG2Circuit{
+			Msg: []uint8(msg),
+			Dst: dst,
+			Res: wrappedRes,
+		}
+		witness := hashToG2Circuit{
+			Msg: []uint8(msg),
+			Dst: dst,
+			Res: wrappedRes,
+		}
+		err := test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+		assert.NoError(err)
+	}
+}
+
+type hashToG2BenchCircuit struct {
+	Msg []byte
+	Dst []byte
+}
+
+func (c *hashToG2BenchCircuit) Define(api frontend.API) error {
+	g2, err := NewG2(api)
+	if err != nil {
+		return err
+	}
+	_, e := g2.HashToG2(api, uints.NewU8Array(c.Msg), c.Dst)
+	return e
+}
+
+func BenchmarkHashToG2(b *testing.B) {
+
+	dst := getDst()
+
+	msg := "abcd"
+	witness := hashToG2BenchCircuit{
+		Msg: []uint8(msg),
+		Dst: dst,
+	}
+	w, err := frontend.NewWitness(&witness, ecc.BN254.ScalarField())
+	if err != nil {
+		b.Fatal(err)
+	}
+	var ccs constraint.ConstraintSystem
+	b.Run("compile scs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if ccs, err = frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &hashToG2BenchCircuit{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	var buf bytes.Buffer
+	_, err = ccs.WriteTo(&buf)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Logf("scs size: %d (bytes), nb constraints %d, nbInstructions: %d", buf.Len(), ccs.GetNbConstraints(), ccs.GetNbInstructions())
+	b.Run("solve scs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := ccs.Solve(w); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("compile r1cs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if ccs, err = frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &hashToG2BenchCircuit{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	buf.Reset()
+	_, err = ccs.WriteTo(&buf)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Logf("r1cs size: %d (bytes), nb constraints %d, nbInstructions: %d", buf.Len(), ccs.GetNbConstraints(), ccs.GetNbInstructions())
+
+	b.Run("solve r1cs", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := ccs.Solve(w); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+}

--- a/std/algebra/emulated/sw_bls12381/hints.go
+++ b/std/algebra/emulated/sw_bls12381/hints.go
@@ -27,7 +27,9 @@ func GetHints() []solver.Hint {
 		decomposeScalarG1Signs,
 		g1SqrtRatioHint,
 		g2SqrtRatioHint,
+		g1MarshalMaskHint,
 		g1UnmarshalHint,
+		g2MarshalMaskHint,
 		g2UnmarshalHint,
 	}
 }
@@ -388,6 +390,35 @@ func g2SqrtRatioHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
 	})
 }
 
+func g1MarshalMaskHint(field *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	nbBytes := 2 * fp.Bytes
+	rawBytes := make([]byte, nbBytes)
+	if len(inputs) != nbBytes {
+		return ErrInvalidSizeEncodedX
+	}
+	for i := 0; i < nbBytes; i++ {
+		tmp := inputs[i].Bytes()
+		if len(tmp) == 0 {
+			rawBytes[i] = 0
+		} else {
+			rawBytes[i] = tmp[0]
+		}
+	}
+
+	var point bls12381.G1Affine
+	_, err := point.SetBytes(rawBytes)
+	if err != nil {
+		return err
+	}
+
+	compressedBytes := point.Bytes()
+	for i := 0; i < 4; i++ {
+		outputs[i].SetBytes([]byte{compressedBytes[i]})
+	}
+
+	return nil
+}
+
 func g1UnmarshalHint(field *big.Int, inputs []*big.Int, outputs []*big.Int) error {
 	nbBytes := fp.Bytes
 	xCoord := make([]byte, nbBytes)
@@ -414,6 +445,35 @@ func g1UnmarshalHint(field *big.Int, inputs []*big.Int, outputs []*big.Int) erro
 	yMarshalled := point.Y.Marshal()
 	for i := 0; i < len(yMarshalled); i++ {
 		outputs[i].SetBytes([]byte{yMarshalled[i]})
+	}
+
+	return nil
+}
+
+func g2MarshalMaskHint(field *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	nbBytes := 4 * fp.Bytes
+	rawBytes := make([]byte, nbBytes)
+	if len(inputs) != nbBytes {
+		return ErrInvalidSizeEncodedX
+	}
+	for i := 0; i < nbBytes; i++ {
+		tmp := inputs[i].Bytes()
+		if len(tmp) == 0 {
+			rawBytes[i] = 0
+		} else {
+			rawBytes[i] = tmp[0]
+		}
+	}
+
+	var point bls12381.G2Affine
+	_, err := point.SetBytes(rawBytes)
+	if err != nil {
+		return err
+	}
+
+	compressedBytes := point.Bytes()
+	for i := 0; i < 4; i++ {
+		outputs[i].SetBytes([]byte{compressedBytes[i]})
 	}
 
 	return nil

--- a/std/algebra/emulated/sw_bls12381/marshal.go
+++ b/std/algebra/emulated/sw_bls12381/marshal.go
@@ -1,0 +1,56 @@
+package sw_bls12381
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/std/math/uints"
+)
+
+func bitsFromU8(api frontend.API, b []uints.U8) []frontend.Variable {
+	nbBits := 8 * len(b)
+	res := make([]frontend.Variable, nbBits)
+
+	lb := len(b)
+	for i := 0; i < len(b); i++ {
+		buf := api.ToBinary(b[i].Val, 8)
+		copy(res[8*(lb-1-i):8*(lb-i)], buf) // <- bit reverse op is done here
+	}
+
+	return res
+}
+
+func bitsToU8(api frontend.API, b []frontend.Variable) []uints.U8 {
+	nbBits := len(b)
+	nbBytes := (nbBits + 7) / 8
+	res := make([]uints.U8, nbBytes)
+
+	for i := 0; i < nbBytes; i++ {
+		buf := make([]frontend.Variable, 8)
+		for j := 0; j < 8 && 8*i+j < nbBits; j++ {
+			buf[j] = b[8*i+j]
+		}
+		res[i].Val = api.FromBinary(buf)
+	}
+
+	return res
+}
+
+func Unmarshal[F emulated.FieldParams](api frontend.API, b []uints.U8) (*emulated.Element[F], error) {
+	emApi, err := emulated.NewField[F](api)
+	if err != nil {
+		return nil, err
+	}
+	bs := bitsFromU8(api, b)
+	res := emApi.FromBits(bs...)
+	return res, nil
+}
+
+func Marshal[F emulated.FieldParams](api frontend.API, e *emulated.Element[F]) ([]uints.U8, error) {
+	emApi, err := emulated.NewField[F](api)
+	if err != nil {
+		return nil, err
+	}
+	bs := emApi.ToBits(e)
+	res := bitsToU8(api, bs)
+	return res, nil
+}

--- a/std/algebra/emulated/sw_bls12381/marshal.go
+++ b/std/algebra/emulated/sw_bls12381/marshal.go
@@ -2,6 +2,7 @@ package sw_bls12381
 
 import (
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/bits"
 	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/std/math/uints"
 )
@@ -29,7 +30,7 @@ func bitsToU8(api frontend.API, b []frontend.Variable) []uints.U8 {
 		for j := 0; j < 8 && 8*i+j < nbBits; j++ {
 			buf[j] = b[8*i+j]
 		}
-		res[i].Val = api.FromBinary(buf)
+		res[i].Val = bits.FromBinary(api, buf)
 	}
 
 	return res

--- a/std/algebra/emulated/sw_bls12381/marshal.go
+++ b/std/algebra/emulated/sw_bls12381/marshal.go
@@ -27,8 +27,12 @@ func bitsToU8(api frontend.API, b []frontend.Variable) []uints.U8 {
 
 	for i := 0; i < nbBytes; i++ {
 		buf := make([]frontend.Variable, 8)
-		for j := 0; j < 8 && 8*i+j < nbBits; j++ {
-			buf[j] = b[8*i+j]
+		for j := 0; j < 8; j++ {
+			if 8*i+j < nbBits {
+				buf[j] = b[8*i+j]
+			} else {
+				buf[j] = 0
+			}
 		}
 		res[i].Val = bits.FromBinary(api, buf)
 	}

--- a/std/algebra/emulated/sw_bls12381/marshal_test.go
+++ b/std/algebra/emulated/sw_bls12381/marshal_test.go
@@ -1,0 +1,84 @@
+package sw_bls12381
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/emulated"
+	"github.com/consensys/gnark/std/math/uints"
+	"github.com/consensys/gnark/test"
+)
+
+type unmarshalCircuit struct {
+	InBaseField []uints.U8
+	RBaseField  emulated.Element[BaseField]
+
+	InScalarField []uints.U8
+	RScalarField  emulated.Element[ScalarField]
+}
+
+func (c *unmarshalCircuit) Define(api frontend.API) error {
+	g, err := NewG1(api)
+	if err != nil {
+		return err
+	}
+
+	{
+		r, err := Unmarshal[BaseField](api, c.InBaseField)
+		if err != nil {
+			return err
+		}
+		g.curveF.AssertIsEqual(&c.RBaseField, r)
+	}
+	{
+		r, err := Unmarshal[ScalarField](api, c.InScalarField)
+		if err != nil {
+			return err
+		}
+		sApi, err := emulated.NewField[ScalarField](api)
+		if err != nil {
+			return err
+		}
+		sApi.AssertIsEqual(&c.RScalarField, r)
+	}
+
+	return nil
+}
+
+func TestUnmarshal(t *testing.T) {
+	assert := test.NewAssert(t)
+	nbBytesFp := fp.Bytes
+	nbBytesFr := fr.Bytes
+
+	var witness, circuit unmarshalCircuit
+	{
+		var a fp.Element
+		a.SetRandom()
+		aMarshalled := a.Marshal()
+
+		witness.InBaseField = make([]uints.U8, nbBytesFp)
+		circuit.InBaseField = make([]uints.U8, nbBytesFp)
+		for i := 0; i < nbBytesFp; i++ {
+			witness.InBaseField[i] = uints.NewU8(aMarshalled[i])
+		}
+		witness.RBaseField = emulated.ValueOf[BaseField](a)
+	}
+	{
+		var a fr.Element
+		a.SetRandom()
+		aMarshalled := a.Marshal()
+
+		witness.InScalarField = make([]uints.U8, nbBytesFr)
+		circuit.InScalarField = make([]uints.U8, nbBytesFr)
+		for i := 0; i < nbBytesFr; i++ {
+			witness.InScalarField[i] = uints.NewU8(aMarshalled[i])
+		}
+		witness.RScalarField = emulated.ValueOf[ScalarField](a)
+	}
+
+	err := test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}

--- a/std/hash/tofield/doc.go
+++ b/std/hash/tofield/doc.go
@@ -1,0 +1,3 @@
+// Package tofield provides ZKP circuits for expanding messages to field elements, according to
+// RFC9380 (section 5.3.1).
+package tofield

--- a/std/hash/tofield/expand.go
+++ b/std/hash/tofield/expand.go
@@ -1,0 +1,102 @@
+package tofield
+
+import (
+	"errors"
+
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/hash/sha2"
+	"github.com/consensys/gnark/std/math/uints"
+)
+
+const (
+	block_size = 64
+)
+
+// ExpandMsgXmd expands msg to a slice of lenInBytes bytes according to RFC9380 (section 5.3.1)
+// Spec: https://datatracker.ietf.org/doc/html/rfc9380#name-expand_message_xmd (hashutils.go)
+// Implementation was adapted from gnark-crypto/field/hash.ExpandMsgXmd.
+func ExpandMsgXmd(api frontend.API, msg []uints.U8, dst []byte, lenInBytes int) ([]uints.U8, error) {
+	h, e := sha2.New(api)
+	if e != nil {
+		return nil, e
+	}
+
+	ell := (lenInBytes + h.Size() - 1) / h.Size() // ceil(len_in_bytes / b_in_bytes)
+	if ell > 255 {
+		return nil, errors.New("invalid lenInBytes")
+	}
+	if len(dst) > 255 {
+		return nil, errors.New("invalid domain size (>255 bytes)")
+	}
+	sizeDomain := uint8(len(dst))
+
+	dst_prime := make([]uints.U8, len(dst)+1)
+	copy(dst_prime, uints.NewU8Array(dst))
+	dst_prime[len(dst)] = uints.NewU8(uint8(sizeDomain))
+
+	Z_pad_raw := make([]uint8, block_size)
+	Z_pad := uints.NewU8Array(Z_pad_raw)
+	h.Write(Z_pad)
+	h.Write(msg)
+	h.Write([]uints.U8{uints.NewU8(uint8(lenInBytes >> 8)), uints.NewU8(uint8(lenInBytes)), uints.NewU8(0)})
+	h.Write(dst_prime)
+	b0 := h.Sum()
+
+	h, e = sha2.New(api)
+	if e != nil {
+		return nil, e
+	}
+	h.Write(b0)
+	h.Write([]uints.U8{uints.NewU8(1)})
+	h.Write(dst_prime)
+	b1 := h.Sum()
+
+	res := make([]uints.U8, lenInBytes)
+	copy(res[:h.Size()], b1)
+
+	for i := 2; i <= ell; i++ {
+		h, e = sha2.New(api)
+		if e != nil {
+			return nil, e
+		}
+
+		// b_i = H(strxor(b₀, b_(i - 1)) ∥ I2OSP(i, 1) ∥ DST_prime)
+		strxor := make([]uints.U8, h.Size())
+		for j := 0; j < h.Size(); j++ {
+			strxor[j], e = xor(api, b0[j], b1[j])
+			if e != nil {
+				return res, e
+			}
+		}
+		h.Write(strxor)
+		h.Write([]uints.U8{uints.NewU8(uint8(i))})
+		h.Write(dst_prime)
+		b1 = h.Sum()
+		copy(res[h.Size()*(i-1):min(h.Size()*i, len(res))], b1)
+	}
+
+	return res, nil
+}
+
+func xor(api frontend.API, a, b uints.U8) (uints.U8, error) {
+	aBits := api.ToBinary(a.Val, 8)
+	bBits := api.ToBinary(b.Val, 8)
+	cBits := make([]frontend.Variable, 8)
+
+	for i := 0; i < 8; i++ {
+		cBits[i] = api.Xor(aBits[i], bBits[i])
+	}
+
+	uapi, err := uints.New[uints.U32](api)
+	if err != nil {
+		return uints.NewU8(255), err
+	}
+	return uapi.ByteValueOf(api.FromBinary(cBits...)), nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/std/hash/tofield/expand_test.go
+++ b/std/hash/tofield/expand_test.go
@@ -1,0 +1,158 @@
+package tofield
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/uints"
+	"github.com/consensys/gnark/test"
+)
+
+type expandMsgXmdCircuit struct {
+	Msg      []uints.U8
+	Dst      []uint8
+	Len      int
+	Expected []uints.U8
+}
+
+type expandMsgXmdTestCase struct {
+	msg             string
+	lenInBytes      int
+	uniformBytesHex string
+}
+
+func (c *expandMsgXmdCircuit) Define(api frontend.API) error {
+	uapi, err := uints.New[uints.U32](api)
+	if err != nil {
+		return err
+	}
+	expanded, err := ExpandMsgXmd(api, c.Msg, c.Dst, c.Len)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < c.Len; i++ {
+		uapi.ByteAssertEq(expanded[i], c.Expected[i])
+	}
+
+	return nil
+}
+
+// adapted from gnark-crypto/field/hash/hashutils_test.go
+func TestExpandMsgXmd(t *testing.T) {
+	//name := "expand_message_xmd"
+	dst := "QUUX-V01-CS02-with-expander-SHA256-128"
+	//hash := "SHA256"
+	//k := 128
+
+	testCases := []expandMsgXmdTestCase{
+		{
+			"",
+			0x20,
+			"68a985b87eb6b46952128911f2a4412bbc302a9d759667f87f7a21d803f07235",
+		},
+
+		{
+			"abc",
+			0x20,
+			"d8ccab23b5985ccea865c6c97b6e5b8350e794e603b4b97902f53a8a0d605615",
+		},
+
+		{
+			"abcdef0123456789",
+			0x20,
+			"eff31487c770a893cfb36f912fbfcbff40d5661771ca4b2cb4eafe524333f5c1",
+		},
+
+		{
+			"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+			0x20,
+			"b23a1d2b4d97b2ef7785562a7e8bac7eed54ed6e97e29aa51bfe3f12ddad1ff9",
+		},
+
+		{
+			"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			0x20,
+			"4623227bcc01293b8c130bf771da8c298dede7383243dc0993d2d94823958c4c",
+		},
+		{
+			"",
+			0x80,
+			"af84c27ccfd45d41914fdff5df25293e221afc53d8ad2ac06d5e3e29485dadbee0d121587713a3e0dd4d5e69e93eb7cd4f5df4cd103e188cf60cb02edc3edf18eda8576c412b18ffb658e3dd6ec849469b979d444cf7b26911a08e63cf31f9dcc541708d3491184472c2c29bb749d4286b004ceb5ee6b9a7fa5b646c993f0ced",
+		},
+		{
+			"",
+			0x20,
+			"68a985b87eb6b46952128911f2a4412bbc302a9d759667f87f7a21d803f07235",
+		},
+		{
+			"abc",
+			0x80,
+			"abba86a6129e366fc877aab32fc4ffc70120d8996c88aee2fe4b32d6c7b6437a647e6c3163d40b76a73cf6a5674ef1d890f95b664ee0afa5359a5c4e07985635bbecbac65d747d3d2da7ec2b8221b17b0ca9dc8a1ac1c07ea6a1e60583e2cb00058e77b7b72a298425cd1b941ad4ec65e8afc50303a22c0f99b0509b4c895f40",
+		},
+		{
+			"abcdef0123456789",
+			0x80,
+			"ef904a29bffc4cf9ee82832451c946ac3c8f8058ae97d8d629831a74c6572bd9ebd0df635cd1f208e2038e760c4994984ce73f0d55ea9f22af83ba4734569d4bc95e18350f740c07eef653cbb9f87910d833751825f0ebefa1abe5420bb52be14cf489b37fe1a72f7de2d10be453b2c9d9eb20c7e3f6edc5a60629178d9478df",
+		},
+		{
+			"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+			0x80,
+			"80be107d0884f0d881bb460322f0443d38bd222db8bd0b0a5312a6fedb49c1bbd88fd75d8b9a09486c60123dfa1d73c1cc3169761b17476d3c6b7cbbd727acd0e2c942f4dd96ae3da5de368d26b32286e32de7e5a8cb2949f866a0b80c58116b29fa7fabb3ea7d520ee603e0c25bcaf0b9a5e92ec6a1fe4e0391d1cdbce8c68a",
+		},
+		{
+			"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			0x80,
+			"546aff5444b5b79aa6148bd81728704c32decb73a3ba76e9e75885cad9def1d06d6792f8a7d12794e90efed817d96920d728896a4510864370c207f99bd4a608ea121700ef01ed879745ee3e4ceef777eda6d9e5e38b90c86ea6fb0b36504ba4a45d22e86f6db5dd43d98a294bebb9125d5b794e9d2a81181066eb954966a487",
+		},
+		//test cases not in the standard
+		{
+			"",
+			0x30,
+			"3808e9bb0ade2df3aa6f1b459eb5058a78142f439213ddac0c97dcab92ae5a8408d86b32bbcc87de686182cbdf65901f",
+		},
+		{
+			"abc",
+			0x30,
+			"2b877f5f0dfd881405426c6b87b39205ef53a548b0e4d567fc007cb37c6fa1f3b19f42871efefca518ac950c27ac4e28",
+		},
+		{
+			"abcdef0123456789",
+			0x30,
+			"226da1780b06e59723714f80da9a63648aebcfc1f08e0db87b5b4d16b108da118214c1450b0e86f9cefeb44903fd3aba",
+		},
+		{
+			"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+			0x30,
+			"12b23ae2e888f442fd6d0d85d90a0d7ed5337d38113e89cdc7c22db91bd0abaec1023e9a8f0ef583a111104e2f8a0637",
+		},
+		{
+			"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			0x30,
+			"1aaee90016547a85ab4dc55e4f78a364c2e239c0e58b05753453c63e6e818334005e90d9ce8f047bddab9fbb315f8722",
+		},
+	}
+
+	for _, testCase := range testCases {
+		uniformBytes := make([]uint8, len(testCase.uniformBytesHex)>>1)
+		hex.Decode(uniformBytes, []uint8(testCase.uniformBytesHex))
+		witness := expandMsgXmdCircuit{
+			Msg:      uints.NewU8Array([]uint8(testCase.msg)),
+			Dst:      []uint8(dst),
+			Len:      testCase.lenInBytes,
+			Expected: uints.NewU8Array(uniformBytes),
+		}
+		circuit := expandMsgXmdCircuit{
+			Msg:      uints.NewU8Array(make([]uint8, len(testCase.msg))),
+			Dst:      []uint8(dst),
+			Len:      testCase.lenInBytes,
+			Expected: uints.NewU8Array(uniformBytes),
+		}
+		err := test.IsSolved(&circuit, &witness, ecc.BN254.ScalarField())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
In order to automatically export N3 contracts from VerifiingKey, the ExportN3Contract() function was added to the interface of VerifiingKey. Currently, only the bn254 curve of groth16 has been implemented. Among them, the other curves of groth16 have not been officially implemented with corresponding ExportSolidity() by gnark, and the same is true for other curves of plonk. The N3 template for plonk's bn254 curve has not been implemented yet, so it also returns 'not implemented'.