### PR TITLE
sha2: fix invalid slice-to-array conversion in test

### DIFF
--- a/std/hash/sha2/sha2_test.go
+++ b/std/hash/sha2/sha2_test.go
@@ -92,10 +92,12 @@ func TestSHA2FixedLengthSum(t *testing.T) {
 		for _, length := range []int{0, 1, 63, 64, 65, len(bts)} {
 			assert.Run(func(assert *test.Assert) {
 				dgst := sha256.Sum256(bts[:length])
+				var exp [32]uints.U8
+				copy(exp[:], uints.NewU8Array(dgst[:]))
 				witness := &sha2FixedLengthCircuit{
 					In:       uints.NewU8Array(bts),
 					Length:   length,
-					Expected: [32]uints.U8(uints.NewU8Array(dgst[:])),
+					Expected: exp,
 				}
 
 				err = test.IsSolved(circuit, witness, ecc.BN254.ScalarField())


### PR DESCRIPTION
# Description

Replace direct conversion [32]uints.U8(uints.NewU8Array(...)) with copying into a predeclared array. Go does not allow converting a slice []T to an array [N]T; copying is required. This aligns with the pattern already used in TestSHA2 and fixes a compile-time error in TestSHA2FixedLengthSum.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

go test ./std/hash/sha2 -run TestSHA2FixedLengthSum -v
and
go test ./std/hash/sha2 -v

