### PR TITLE
plonk(recursion): fix incorrect error messages for bw6-761 and bn254 branches

### DIFF
--- a/std/recursion/plonk/verifier.go
+++ b/std/recursion/plonk/verifier.go
@@ -177,7 +177,7 @@ func ValueOfProof[FR emulated.FieldParams, G1El algebra.G1ElementT, G2El algebra
 	case *Proof[sw_bw6761.ScalarField, sw_bw6761.G1Affine, sw_bw6761.G2Affine]:
 		tProof, ok := proof.(*plonkbackend_bw6761.Proof)
 		if !ok {
-			return ret, fmt.Errorf("expected sw_bls12377.Proof, got %T", proof)
+			return ret, fmt.Errorf("expected sw_bw6761.Proof, got %T", proof)
 		}
 		for i := range r.LRO {
 			r.LRO[i], err = kzg.ValueOfCommitment[sw_bw6761.G1Affine](tProof.LRO[i])
@@ -214,7 +214,7 @@ func ValueOfProof[FR emulated.FieldParams, G1El algebra.G1ElementT, G2El algebra
 	case *Proof[sw_bn254.ScalarField, sw_bn254.G1Affine, sw_bn254.G2Affine]:
 		tProof, ok := proof.(*plonkbackend_bn254.Proof)
 		if !ok {
-			return ret, fmt.Errorf("expected sw_bls12377.Proof, got %T", proof)
+			return ret, fmt.Errorf("expected sw_bn254.Proof, got %T", proof)
 		}
 		for i := range r.LRO {
 			r.LRO[i], err = kzg.ValueOfCommitment[sw_bn254.G1Affine](tProof.LRO[i])
@@ -353,7 +353,7 @@ func ValueOfBaseVerifyingKey[FR emulated.FieldParams, G1El algebra.G1ElementT, G
 	case *BaseVerifyingKey[sw_bw6761.ScalarField, sw_bw6761.G1Affine, sw_bw6761.G2Affine]:
 		tVk, ok := vk.(*plonkbackend_bw6761.VerifyingKey)
 		if !ok {
-			return ret, fmt.Errorf("expected bls12377.VerifyingKey, got %T", vk)
+			return ret, fmt.Errorf("expected bw6761.VerifyingKey, got %T", vk)
 		}
 		r.NbPublicVariables = tVk.NbPublicVariables
 		r.Kzg, err = kzg.ValueOfVerifyingKeyFixed[sw_bw6761.G1Affine, sw_bw6761.G2Affine](tVk.Kzg)
@@ -523,7 +523,7 @@ func ValueOfCircuitVerifyingKey[FR emulated.FieldParams, G1El algebra.G1ElementT
 	case *CircuitVerifyingKey[sw_bw6761.ScalarField, sw_bw6761.G1Affine]:
 		tVk, ok := vk.(*plonkbackend_bw6761.VerifyingKey)
 		if !ok {
-			return ret, fmt.Errorf("expected bls12377.VerifyingKey, got %T", vk)
+			return ret, fmt.Errorf("expected bw6761.VerifyingKey, got %T", vk)
 		}
 		r.Size = tVk.Size
 		r.SizeInv = sw_bw6761.NewScalar(tVk.SizeInv)


### PR DESCRIPTION
# Description

Correct the expected type strings in error messages within ValueOfProof, ValueOfBaseVerifyingKey, and ValueOfCircuitVerifyingKey for bw6-761 and bn254. Previously, these branches incorrectly referenced bls12377 types. Fixing these messages ensures accurate diagnostics when type mismatches occur, aligning with the actual backend types used (plonkbackend_bw6761.*, plonkbackend_bn254.*) and matching the conventions used for other curves.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

