### PR TITLE
fix: add error handling for file close in profile package

### DIFF
--- a/profile/profile.go
+++ b/profile/profile.go
@@ -128,7 +128,9 @@ func (p *Profile) Stop() {
 		if err := p.pprof.Write(f); err != nil {
 			log.Error().Err(err).Msg("writing profile")
 		}
-		f.Close()
+		if err := f.Close(); err != nil {
+			log.Error().Err(err).Msg("closing profile file")
+		}
 		log.Info().Str("path", p.filePath).Msg("gnark profiling disabled")
 	} else {
 		log.Warn().Msg("gnark profiling disabled [not writing to disk]")


### PR DESCRIPTION
Add proper error handling when closing profile file in profile.Stop() method.

Previously, f.Close() was called without checking for errors, which could
lead to silent failures when closing the profile file. This change ensures
that any errors during file closure are properly logged using the logger.

This follows the same error handling pattern used elsewhere in the codebase
and improves the robustness of the profiling functionality.