### PR TITLE
fix: panic on zero-length inputs in Mux

### DIFF
--- a/std/selector/multiplexer.go
+++ b/std/selector/multiplexer.go
@@ -56,6 +56,9 @@ func Map(api frontend.API, queryKey frontend.Variable,
 // inputs, otherwise the proof will fail.
 func Mux(api frontend.API, sel frontend.Variable, inputs ...frontend.Variable) frontend.Variable {
 	n := uint(len(inputs))
+	if n == 0 {
+		panic("invalid input length for Mux (0)")
+	}
 	if n == 1 {
 		api.AssertIsEqual(sel, 0)
 		return inputs[0]


### PR DESCRIPTION
# Description

Add explicit check in Mux to panic when inputs length is zero.
Prevents undefined behavior: previously n==0 led to bits.Len(n-1) on MaxUint and slicing inputs[:leftCount], causing non-obvious runtime panics and potential big.Int overflow in comparator bound construction.
Aligns with package style where invalid shape/size inputs trigger panic, while out-of-range selectors cause proof failure.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

go test -v ./std/selector
go test -v -run "Mux" ./std/selector
go test -v ./...


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

