### PR TITLE
fix(emulated): MulConst negative constant handling and correct mul-check formula comment

### DIFF
--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -85,7 +85,7 @@ type deferredChecker interface {
 //
 // Given these values, the following holds:
 //
-//	a * b = r * k*p
+//	a * b = r + k*p
 //
 // But for asserting that the previous equation holds, we instead use the
 // polynomial representation of the elements. If a non-native element a is given
@@ -623,7 +623,7 @@ func (f *Field[T]) MulConst(a *Element[T], c *big.Int) *Element[T] {
 	}
 	switch c.Sign() {
 	case -1:
-		f.MulConst(f.Neg(a), new(big.Int).Neg(c))
+		return f.MulConst(f.Neg(a), new(big.Int).Neg(c))
 	case 0:
 		return f.Zero()
 	}


### PR DESCRIPTION
- Correct the modular multiplication formula comment from “ab = rkp” to “ab = r + kp”, aligning with the documented identity used across the package.

- Add a missing return in MulConst when c < 0 to avoid a dead recursive call that adds unnecessary constraints and then discards the result. This keeps behavior unchanged but removes redundant work and improves efficiency.