### PR TITLE
perf(bls12-381/map-to-g1): use triple in mul by seed

### DIFF
--- a/std/algebra/emulated/sw_bls12381/g1.go
+++ b/std/algebra/emulated/sw_bls12381/g1.go
@@ -159,15 +159,15 @@ func (g1 G1) triple(p *G1Affine) *G1Affine {
 	x2 := g1.curveF.Eval([][]*baseEl{{λ1, λ1}, {mone, &p.X}}, []int{1, 2})
 
 	// omit y2 computation, and
-	// compute λ2 = 2p.y/(x2 − p.x) − λ1.
+	// compute λ2 = 2p.y/(p.x-x2) − λ1.
 	x1x2 := g1.curveF.Sub(&p.X, x2)
 	λ2 := g1.curveF.Div(y2, x1x2)
 	λ2 = g1.curveF.Sub(λ2, λ1)
 
-	// xr = λ²-p.x-x2
+	// xr = λ2²-p.x-x2
 	xr := g1.curveF.Eval([][]*baseEl{{λ2, λ2}, {mone, &p.X}, {mone, x2}}, []int{1, 1, 1})
 
-	// yr = λ(p.x-xr) - p.y
+	// yr = λ2(p.x-xr) - p.y
 	yr := g1.curveF.Eval([][]*baseEl{{λ2, g1.curveF.Sub(&p.X, xr)}, {mone, &p.Y}}, []int{1, 1})
 
 	return &G1Affine{

--- a/std/algebra/emulated/sw_bls12381/g1_test.go
+++ b/std/algebra/emulated/sw_bls12381/g1_test.go
@@ -1,0 +1,60 @@
+package sw_bls12381
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+)
+
+type tripleCircuit struct {
+	In, Res G1Affine
+}
+
+func (c *tripleCircuit) Define(api frontend.API) error {
+	g1, err := NewG1(api)
+	if err != nil {
+		return fmt.Errorf("new G1 struct: %w", err)
+	}
+	res := g1.triple(&c.In)
+	g1.AssertIsEqual(res, &c.Res)
+	return nil
+}
+
+type tripleCircuitConsistency struct {
+	In G1Affine
+}
+
+func (c *tripleCircuitConsistency) Define(api frontend.API) error {
+	g1, err := NewG1(api)
+	if err != nil {
+		return fmt.Errorf("new G1 struct: %w", err)
+	}
+	res1 := g1.triple(&c.In)
+	res2 := g1.double(&c.In)
+	res2 = g1.add(res2, &c.In)
+	g1.AssertIsEqual(res1, res2)
+	return nil
+}
+
+func TestTripleG1(t *testing.T) {
+	assert := test.NewAssert(t)
+	in, _ := randomG1G2Affines()
+	var res bls12381.G1Affine
+	res.Double(&in).Add(&res, &in)
+	witness := tripleCircuit{
+		In:  NewG1Affine(in),
+		Res: NewG1Affine(res),
+	}
+	err := test.IsSolved(&tripleCircuit{}, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+
+	witness2 := tripleCircuitConsistency{
+		In: NewG1Affine(in),
+	}
+	err = test.IsSolved(&tripleCircuitConsistency{}, &witness2, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}

--- a/std/algebra/emulated/sw_bls12381/map_to_g1.go
+++ b/std/algebra/emulated/sw_bls12381/map_to_g1.go
@@ -53,8 +53,7 @@ func (g1 *G1) ClearCofactor(q *G1Affine) *G1Affine {
 	// cf https://eprint.iacr.org/2019/403.pdf, 5
 
 	// mulBySeed
-	z := g1.double(q)
-	z = g1.add(z, q)
+	z := g1.triple(q)
 	z = g1.double(z)
 	z = g1.doubleAndAdd(z, q)
 	z = g1.doubleN(z, 2)


### PR DESCRIPTION
# Description

Tiny PR to use affine point tripling in G1 mul by seed for BLS12-381 curve.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

MapToG1 and ClearCofactor tests pass.

# How has this been benchmarked?

Saves 450 scs.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

