### PR TITLE
feat: allow taking benchmarking instance in NewAssert

### DIFF
--- a/test/assert.go
+++ b/test/assert.go
@@ -36,12 +36,13 @@ type Assert struct {
 	*require.Assertions
 }
 
-// NewAssert returns an Assert helper embedding a testify/require object for convenience
+// NewAssert returns an Assert helper embedding a testify/require object for convenience.
+// It accepts either a *testing.T or *testing.B object.
 //
-// The Assert object caches the compiled circuit:
-//
-// the first call to assert.ProverSucceeded/Failed will compile the circuit for n curves, m backends
-// and subsequent calls will re-use the result of the compilation, if available.
+// The Assert object caches the compiled circuit. This means that the first call
+// to [Assert.CheckCircuit] will compile the circuit for n curves, m
+// backends and subsequent calls will re-use the result of the compilation, if
+// available. Be careful when benchmarking!
 func NewAssert(tb testing.TB) *Assert {
 	switch t := (tb).(type) {
 	case *testing.T:

--- a/test/assert_checkcircuit.go
+++ b/test/assert_checkcircuit.go
@@ -101,7 +101,9 @@ func (assert *Assert) CheckCircuit(circuit frontend.Circuit, opts ...TestingOpti
 					}
 
 					// we need to run the setup, prove and verify and check serialization
-					assert.t.Parallel()
+					if assert.t != nil {
+						assert.t.Parallel()
+					}
 
 					var concreteBackend tBackend
 

--- a/test/assert_solidity.go
+++ b/test/assert_solidity.go
@@ -24,7 +24,11 @@ func (assert *Assert) solidityVerification(b backend.ID, vk solidity.VerifyingKe
 	if !SolcCheck || len(validPublicWitness.Vector().(fr_bn254.Vector)) == 0 {
 		return // nothing to check, will make solc fail.
 	}
-	assert.t.Helper()
+	if assert.b != nil {
+		assert.b.Helper()
+	} else {
+		assert.t.Helper()
+	}
 
 	// make temp dir
 	tmpDir, err := os.MkdirTemp("", "gnark-solidity-check*")
@@ -44,7 +48,7 @@ func (assert *Assert) solidityVerification(b backend.ID, vk solidity.VerifyingKe
 	// generate assets
 	// gnark-solidity-checker generate --dir tmpdir --solidity contract_g16.sol
 	cmd := exec.Command("gnark-solidity-checker", "generate", "--dir", tmpDir, "--solidity", "gnark_verifier.sol")
-	assert.t.Log("running ", cmd.String())
+	assert.Log("running ", cmd.String())
 	out, err := cmd.CombinedOutput()
 	assert.NoError(err, string(out))
 
@@ -90,7 +94,7 @@ func (assert *Assert) solidityVerification(b backend.ID, vk solidity.VerifyingKe
 	// verify proof
 	// gnark-solidity-checker verify --dir tmdir --groth16 --nb-public-inputs 1 --proof 1234 --public-inputs dead
 	cmd = exec.Command("gnark-solidity-checker", checkerOpts...)
-	assert.t.Log("running ", cmd.String())
+	assert.Log("running ", cmd.String())
 	out, err = cmd.CombinedOutput()
 	assert.NoError(err, string(out))
 }


### PR DESCRIPTION
# Description

Sometimes when trying to benchmark some existing tests (i.e. compile time, proving time etc), I'd want to copy-paste current test and then run it. But as `test.Assert` does not support taking `*testing.B` as input then I had to rewrite a lot.

This PR makes it take either and then switch the implementation. Benchmarking with `Assert.CheckCircuit` doesn't make much sense as it reuses compiled circuits, but I added a comment to indicate that. And we usually benchmark only a very specific part.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

