### PR TITLE
fix(std/compress): NumReader.SetNumNbBits window expansion logic

### DIFF
--- a/std/compress/io.go
+++ b/std/compress/io.go
@@ -188,10 +188,14 @@ func (nr *NumReader) SetNumNbBits(numNbBits int) {
 	}
 
 	if nr.last != nil { // nothing to compensate for if no values have yet been read
-		nbToRead := min(len(nr.toRead), wordsPerNum-nr.wordsPerNum)
-		delta := ReadNum(nr.api, nr.toRead[:nbToRead], nr.radix)
-		nr.toRead = nr.toRead[:nbToRead]
-		nr.last = nr.api.Add(nr.api.Mul(nr.last, twoPow(wordsPerNum-nr.wordsPerNum)), delta)
+		k := wordsPerNum - nr.wordsPerNum
+		available := 0
+		if len(nr.toRead) > nr.wordsPerNum {
+			available = len(nr.toRead) - nr.wordsPerNum
+		}
+		nbToRead := min(available, k)
+		delta := ReadNum(nr.api, nr.toRead[nr.wordsPerNum:nr.wordsPerNum+nbToRead], nr.radix)
+		nr.last = nr.api.Add(nr.api.Mul(nr.last, twoPow(k*wordNbBits)), delta)
 	}
 
 	nr.wordsPerNum, nr.numBound = wordsPerNum, twoPow(numNbBits)


### PR DESCRIPTION
- Use radix^(Δwords) = 2^((wordsPerNum-nr.wordsPerNum)wordNbBits) instead of 2^(Δwords)
- Compute delta from the slice after the previous right edge: nr.toRead[oldWordsPerNum:oldWordsPerNum+Δwords]
- Do not mutate nr.toRead in SetNumNbBits (Next relies on stable indexing)
- These fixes are necessary because the previous code only worked when wordNbBits=1 and/or Δwords<=1. For wordNbBits>1, the scaling factor was too small, and slicing from the head plus truncation corrupted the window indices used by Next(), leading to incorrect numbers.