### PR TITLE
Enforce Stable Hint IDs: Disallow Anonymous Hint Functions in GetHintID

### DIFF
--- a/constraint/solver/hint.go
+++ b/constraint/solver/hint.go
@@ -102,6 +102,11 @@ func GetHintID(fn Hint) HintID {
 
 	// TODO relying on name to derive UUID is risky; if fn is an anonymous func, will be package.glob..funcN
 	// and if new anonymous functions are added in the package, N may change, so will UUID.
+	// Enforce that hint functions are named to ensure stability of the derived ID.
+	if oldStyleAnonRe.MatchString(name) || newStyleAnonRe.MatchString(name) {
+		panic("anonymous hint function is not allowed: " + name + "; use a named function or solver.RegisterNamedHint with a stable HintID")
+	}
+	
 	hf.Write([]byte(name)) // #nosec G104 -- does not err
 
 	return HintID(hf.Sum32())
@@ -122,3 +127,6 @@ func newToOldStyle(name string) string {
 }
 
 var newStyleAnonRe = regexp.MustCompile(`^(?P<pkgname>.*\.)init(?P<funcname>\.func\d+)$`)
+
+// oldStyleAnonRe matches fully-qualified names translated to the legacy style: "...glob.funcN"
+var oldStyleAnonRe = regexp.MustCompile(`\.glob\.func\d+$`)


### PR DESCRIPTION

```markdown
## Summary
Enforces stability of hint identifiers by rejecting anonymous hint functions in `GetHintID`. This prevents brittle, build-dependent IDs and reduces the risk of collisions.

## Motivation
`GetHintID` previously hashed the function name (including patterns like `...glob.funcN`). These names can change between builds or compiler versions, making IDs unstable and potentially causing collisions or incorrect hint dispatch.

## Changes
- Disallow anonymous hint functions in `GetHintID` (panic with clear guidance).
- Add `oldStyleAnonRe` to detect legacy-style anonymous function names.
- Keep existing hashing approach but ensure only named functions are allowed.

```