### PR TITLE
fix: use the little-endian representation for serialized values in KZG Pointeval precompile

### DIFF
--- a/std/evmprecompiles/10-kzg_point_evaluation.go
+++ b/std/evmprecompiles/10-kzg_point_evaluation.go
@@ -123,7 +123,7 @@ func KzgPointEvaluation(
 	// versioned hash
 	var versionedHashBytes [sha256.Size]uints.U8
 	for i := range versionedHash {
-		res, err := conversion.NativeToBytes(api, versionedHash[len(versionedHash)-1-i])
+		res, err := conversion.NativeToBytes(api, versionedHash[i])
 		if err != nil {
 			return fmt.Errorf("convert versioned hash element %d to bytes: %w", i, err)
 		}
@@ -133,7 +133,7 @@ func KzgPointEvaluation(
 	// commitment
 	var comSerializedBytes [bls12381.SizeOfG1AffineCompressed]uints.U8
 	for i := range commitmentCompressed {
-		res, err := conversion.NativeToBytes(api, commitmentCompressed[len(commitmentCompressed)-1-i])
+		res, err := conversion.NativeToBytes(api, commitmentCompressed[i])
 		if err != nil {
 			return fmt.Errorf("convert commitment element %d to bytes: %w", i, err)
 		}
@@ -142,7 +142,7 @@ func KzgPointEvaluation(
 	// proof
 	var proofSerialisedBytes [bls12381.SizeOfG1AffineCompressed]uints.U8
 	for i := range proofCompressed {
-		res, err := conversion.NativeToBytes(api, proofCompressed[len(proofCompressed)-1-i])
+		res, err := conversion.NativeToBytes(api, proofCompressed[i])
 		if err != nil {
 			return fmt.Errorf("convert proof element %d to bytes: %w", i, err)
 		}
@@ -289,8 +289,8 @@ func KzgPointEvaluationFailure(
 		Y: *fp.NewElement(0),
 	}
 	dummyVersionedHash := []frontend.Variable{
-		"0xdef7ab966d7b770905398eba3c444014",
 		"0x010657f37554c781402a22917dee2f75",
+		"0xdef7ab966d7b770905398eba3c444014",
 	}
 	// -- check that the masks of compressed commitment and proof are correct
 	// (infinity, small y, large y). If either of them is not correct, then we
@@ -300,7 +300,7 @@ func KzgPointEvaluationFailure(
 	// - first we unpack the packed commitment and proof into bytes
 	var comSerializedBytes [bls12381.SizeOfG1AffineCompressed]uints.U8
 	for i := range commitmentCompressed {
-		res, err := conversion.NativeToBytes(api, commitmentCompressed[len(commitmentCompressed)-1-i])
+		res, err := conversion.NativeToBytes(api, commitmentCompressed[i])
 		if err != nil {
 			return fmt.Errorf("convert commitment element %d to bytes: %w", i, err)
 		}
@@ -308,7 +308,7 @@ func KzgPointEvaluationFailure(
 	}
 	var proofSerialisedBytes [bls12381.SizeOfG1AffineCompressed]uints.U8
 	for i := range proofCompressed {
-		res, err := conversion.NativeToBytes(api, proofCompressed[len(proofCompressed)-1-i])
+		res, err := conversion.NativeToBytes(api, proofCompressed[i])
 		if err != nil {
 			return fmt.Errorf("convert proof element %d to bytes: %w", i, err)
 		}
@@ -458,7 +458,7 @@ func KzgPointEvaluationFailure(
 	// - first map the versioned hash to bytes
 	var versionedHashBytes [sha256.Size]uints.U8
 	for i := range versionedHash {
-		res, err := conversion.NativeToBytes(api, versionedHash[len(versionedHash)-1-i])
+		res, err := conversion.NativeToBytes(api, versionedHash[i])
 		if err != nil {
 			return fmt.Errorf("convert versioned hash element %d to bytes: %w", i, err)
 		}

--- a/std/evmprecompiles/10-kzg_point_evaluation_test.go
+++ b/std/evmprecompiles/10-kzg_point_evaluation_test.go
@@ -80,21 +80,21 @@ func TestKzgPointEvaluationPrecompile(t *testing.T) {
 	h[0] = blobCommitmentVersionKZG
 
 	witnessHash := [2]frontend.Variable{
-		encode(h[16:32]),
 		encode(h[0:16]),
+		encode(h[16:32]),
 	}
 	// - commitment into 3 limbs
 	witnessCommitment := [3]frontend.Variable{
-		encode(commitmentBytes[32:48]),
-		encode(commitmentBytes[16:32]),
 		encode(commitmentBytes[0:16]),
+		encode(commitmentBytes[16:32]),
+		encode(commitmentBytes[32:48]),
 	}
 	// - proof into 3 limbs
 	proofUncompressed := kzgProof.H.Bytes()
 	witnessProof := [3]frontend.Variable{
-		encode(proofUncompressed[32:48]),
-		encode(proofUncompressed[16:32]),
 		encode(proofUncompressed[0:16]),
+		encode(proofUncompressed[16:32]),
+		encode(proofUncompressed[32:48]),
 	}
 
 	// prepare the constant return values
@@ -141,20 +141,20 @@ func (c *kzgPointEvalFailureCircuit) Define(api frontend.API) error {
 
 func runFailureCircuit(_ *test.Assert, evaluationPoint fr.Element, claimedValue fr.Element, hashBytes []byte, commitmentBytes [48]byte, proofBytes [48]byte, blobSize []int, blsModulus []string) error {
 	witnessHash := [2]frontend.Variable{
-		encode(hashBytes[16:32]),
 		encode(hashBytes[0:16]),
+		encode(hashBytes[16:32]),
 	}
 	// - commitment into 3 limbs
 	witnessCommitment := [3]frontend.Variable{
-		encode(commitmentBytes[32:48]),
-		encode(commitmentBytes[16:32]),
 		encode(commitmentBytes[0:16]),
+		encode(commitmentBytes[16:32]),
+		encode(commitmentBytes[32:48]),
 	}
 	// - proof into 3 limbs
 	witnessProof := [3]frontend.Variable{
-		encode(proofBytes[32:48]),
-		encode(proofBytes[16:32]),
 		encode(proofBytes[0:16]),
+		encode(proofBytes[16:32]),
+		encode(proofBytes[32:48]),
 	}
 
 	// prepare the constant return values


### PR DESCRIPTION
# Description

Changes the ordering of serialized values (hash, compressed points) to little-endian to match with the ordering the arithmetization encodes.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


# How has this been tested?

- [x] local tests updates
- [x] tests on linea-monorepo side working (both generated and with arithmetization traces)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

