### PR TITLE
fix: prevent division by zero in dotgraph node color calculation

### DIFF
--- a/profile/internal/graph/dotgraph.go
+++ b/profile/internal/graph/dotgraph.go
@@ -186,10 +186,14 @@ func (b *builder) addNode(node *Node, nodeID int, maxFlat float64) {
 	}
 
 	// Create DOT attribute for node.
+	var cumRatio float64
+	if b.config.Total != 0 {
+		cumRatio = float64(node.CumValue()) / float64(abs64(b.config.Total))
+	}
 	attr := fmt.Sprintf(`label="%s" id="node%d" fontsize=%d shape=%s tooltip="%s (%s)" color="%s" fillcolor="%s"`,
 		label, nodeID, fontSize, shape, escapeForDot(node.Info.PrintableName()), cumValue,
-		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), false),
-		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), true))
+		dotColor(cumRatio, false),
+		dotColor(cumRatio, true))
 
 	// Add on extra attributes if provided.
 	if attrs != nil {


### PR DESCRIPTION
Fix potential division by zero panic in dotgraph.go when b.config.Total is zero

The issue occurred in the addNode function where node.CumValue() was divided by abs64(b.config.Total) without checking if Total is zero first. 
This couldcause a runtime panic when processing profiles with zero total values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard node color/fillcolor ratio calculation in `profile/internal/graph/dotgraph.go` by using a precomputed `cumRatio` only when `b.config.Total` is non-zero.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c48acbb96f9807726885ebdc831a95d57e054b65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->