### PR TITLE
refactor: remove dead code and redundant checks

### DIFF
--- a/std/gkrapi/testing.go
+++ b/std/gkrapi/testing.go
@@ -62,12 +62,9 @@ func (api *API) SolveInTestEngine(parentApi frontend.API, options ...SolveInTest
 
 	res := make([][]frontend.Variable, len(api.toStore.Circuit))
 	var verifiedGates sync.Map
-	for i, w := range api.toStore.Circuit {
+	for i := range api.toStore.Circuit {
 		res[i] = make([]frontend.Variable, api.nbInstances())
 		copy(res[i], api.assignments[i])
-		if len(w.Inputs) == 0 {
-			continue
-		}
 	}
 	for instanceI := range api.nbInstances() {
 		for wireI, w := range api.toStore.Circuit {
@@ -96,9 +93,6 @@ func (api *API) SolveInTestEngine(parentApi frontend.API, options ...SolveInTest
 					ins[i] = res[in][instanceI]
 				}
 				gate := gkrgates.Get(gkr.GateName(w.Gate))
-				if gate == nil && !w.IsInput() {
-					panic(fmt.Errorf("gate %s not found", w.Gate))
-				}
 				if _, ok := verifiedGates.Load(w.Gate); !ok {
 					verifiedGates.Store(w.Gate, struct{}{})
 
@@ -110,9 +104,7 @@ func (api *API) SolveInTestEngine(parentApi frontend.API, options ...SolveInTest
 						panic(fmt.Errorf("gate %s: %w", w.Gate, err))
 					}
 				}
-				if gate != nil {
-					res[wireI][instanceI] = gate.Evaluate(parentApi, ins...)
-				}
+				res[wireI][instanceI] = gate.Evaluate(parentApi, ins...)
 			}
 		}
 	}


### PR DESCRIPTION
- Delete unreachable gate nil-checks and the if gate != nil wrapper in SolveInTestEngine; gkrgates.Get panics on missing gates, so these branches could never execute.
- Remove the no-op continue in the preparatory loop and drop the unused loop variable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines SolveInTestEngine by removing dead gate nil-checks/conditional evaluation and simplifying the circuit initialization loop.
> 
> - **gkrapi**:
>   - **`std/gkrapi/testing.go` (`SolveInTestEngine`)**:
>     - Remove redundant `gate == nil` checks and the `if gate != nil` wrapper; always evaluate `gate` after retrieval and verification.
>     - Simplify initialization loop over `api.toStore.Circuit`: drop unused loop variable and the no-op `continue`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6b4dcd2d86a1a91afc213d30f265119cb3a08e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->