### PR TITLE
chore: use self hosted runners

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
   
   test:
     needs: staticcheck
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     permissions: 
       pull-requests: write
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.23.x]
-        os: [gha-runner-scale-set-ubuntu-22.04-amd64-xxl, windows-latest, macos-latest]
+        os: [gha-runner-scale-set-ubuntu-24-amd64-xxl, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     needs:
       - staticcheck


### PR DESCRIPTION
This repo has been identified as a higher cost repo in our Org.

Move runners to self hosted runners to mitigate cost and increase performance.

Thanks!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move PR and push workflows to a self-hosted Ubuntu runner, update OS condition checks, and add 30m timeouts to tagged tests.
> 
> - **CI (GitHub Actions)**
>   - **PR workflow (`.github/workflows/pr.yml`)**:
>     - Switch test job runner to `gha-runner-scale-set-ubuntu-24-amd64-xxl`.
>     - Add `-timeout=30m` to tagged `go test` commands.
>   - **Push workflow (`.github/workflows/push.yml`)**:
>     - Replace matrix OS `ubuntu-latest-128` with `gha-runner-scale-set-ubuntu-24-amd64-xxl`.
>     - Update Ubuntu checks to `startsWith(matrix.os, 'gha-runner-scale-set-ubuntu')`.
>     - Gate solc deps install and Ubuntu-specific tests behind the new runner check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9901895af96c6bc8ce43ad10c8c1f26b05c4d3fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->