### PR TITLE
fix: VerifyProof comment to reflect in-circuit behavior

### DIFF
--- a/std/accumulator/merkle/verify.go
+++ b/std/accumulator/merkle/verify.go
@@ -69,10 +69,12 @@ func nodeSum(api frontend.API, h hash.FieldHasher, a, b frontend.Variable) front
 	return res
 }
 
-// VerifyProof takes a Merkle root, a proofSet, and a proofIndex and returns
-// true if the first element of the proof set is a leaf of data in the Merkle
-// root. False is returned if the proof set or Merkle root is nil, and if
-// 'numLeaves' equals 0.
+// VerifyProof encodes constraints that verify inclusion of a leaf at the given
+// index into the Merkle root stored in mp.RootHash, using the authentication
+// path stored in mp.Path. The argument leaf is the leaf index (little-endian
+// bit order). The actual leaf value must be provided as mp.Path[0]. This
+// method does not return a value; it asserts equality of the recomputed root
+// and mp.RootHash via constraints.
 func (mp *MerkleProof) VerifyProof(api frontend.API, h hash.FieldHasher, leaf frontend.Variable) {
 
 	depth := len(mp.Path) - 1


### PR DESCRIPTION
- Update VerifyProof comment: no boolean return, no numLeaves/nil checks.
- Clarify that leaf is the leaf index (little-endian bits) and actual leaf value is mp.Path[0].
- Explain that verification is encoded via constraints asserting recomputed root equals mp.RootHash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update VerifyProof doc to clarify constraint-based verification, leaf index bit order, leaf value in mp.Path[0], and no return value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10d369e6ce42e0dc3eb70256b713c9de744d9371. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->