### PR TITLE
fix: use dynamic expected/actual counts in toBytes error

### DIFF
--- a/std/math/uints/hints.go
+++ b/std/math/uints/hints.go
@@ -2,6 +2,7 @@ package uints
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/consensys/gnark/constraint/solver"
@@ -44,7 +45,7 @@ func toBytes(m *big.Int, inputs []*big.Int, outputs []*big.Int) error {
 	}
 	nbLimbs := int(inputs[0].Uint64())
 	if len(outputs) != nbLimbs {
-		return errors.New("output must be 8 elements")
+		return fmt.Errorf("expecting %d outputs, got %d", nbLimbs, len(outputs))
 	}
 	if !inputs[1].IsUint64() {
 		return errors.New("input must be 64 bits")


### PR DESCRIPTION
Replace hardcoded "output must be 8 elements" with a dynamic error that reports the expected number of outputs (nbLimbs) and the actual length. This aligns with conventions across other hints, prevents misleading errors for U32 (4 outputs), and improves diagnostics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace hardcoded output count error in `toBytes` with a dynamic message reporting expected and actual counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45d26a8e1a459c800c8b655ca3fd76ffe0adaf5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->