### PR TITLE
chore: fix typo in WithNbScalarBits error string

### DIFF
--- a/std/algebra/algopts/algopts.go
+++ b/std/algebra/algopts/algopts.go
@@ -27,7 +27,7 @@ type AlgebraOption func(*algebraCfg) error
 func WithNbScalarBits(bits int) AlgebraOption {
 	return func(ac *algebraCfg) error {
 		if ac.NbScalarBits != 0 {
-			return errors.New("WithNbBits already set")
+			return errors.New("WithNbScalarBits already set")
 		}
 		ac.NbScalarBits = bits
 		return nil


### PR DESCRIPTION
The error returned by WithNbScalarBits used the shortened label "WithNbBits already set", which is inconsistent with the naming convention used by other options in the same file such as WithCompleteArithmetic, WithCanonicalBitRepresentation, and 
WithNoSubgroupMembershipCheck. There are no in-repo consumers asserting the previous string, and a repository-wide search shows the old text was not reused elsewhere, so updating it is safe. This change improves diagnostic clarity by matching the error string with the public function name WithNbScalarBits, making error messages precise and consistent with the rest of the API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix typo in the WithNbScalarBits error string to match the function name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7557860e2a73abfc87e861d9275da76dfc65daf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->