### PR TITLE
perf: save 1 inverse in P256Verify circuit

### DIFF
--- a/std/evmprecompiles/256-p256verify.go
+++ b/std/evmprecompiles/256-p256verify.go
@@ -43,9 +43,8 @@ func P256Verify(api frontend.API,
 		panic(err)
 	}
 	// we don't perform range checks on r and s as they are done by the arithmetization
-	sinv := scalarApi.Inverse(s)
-	msInv := scalarApi.Mul(msgHash, sinv)
-	rsInv := scalarApi.Mul(r, sinv)
+	msInv := scalarApi.Div(msgHash, s)
+	rsInv := scalarApi.Div(r, s)
 	PK := sw_emulated.AffinePoint[emulated.P256Fp]{X: *qx, Y: *qy}
 	Rprime := curve.JointScalarMulBase(&PK, rsInv, msInv, algopts.WithCompleteArithmetic())
 


### PR DESCRIPTION
# Description

tiny PR for compatibility with ECRECOVER + saves 144 SCS

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

same tests.

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

- old: 705923 scs
- new: 705779 scs

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces inverse-and-multiply with direct divisions to compute `msInv` and `rsInv` in `P256Verify`.
> 
> - **P256Verify (`std/evmprecompiles/256-p256verify.go`)**:
>   - Compute `msInv` and `rsInv` via `scalarApi.Div(..., s)` instead of computing `sinv` and multiplying.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 800ce75b5a45221f2d6a30a64e1cc3c1b3b3ed56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->