### PR TITLE
refactor: remove unused integrated gate name helper

### DIFF
--- a/std/permutation/poseidon2/gkr-poseidon2/gkr.go
+++ b/std/permutation/poseidon2/gkr-poseidon2/gkr.go
@@ -429,8 +429,3 @@ func newRoundGateNamer(p fmt.Stringer) roundGateNamer {
 func (n roundGateNamer) linear(varIndex, round int) gkr.GateName {
 	return gkr.GateName(fmt.Sprintf("x%d-l-op-round=%d;%s", varIndex, round, n))
 }
-
-// integrated is the name of a gate where a polynomial of total degree 1 is applied to the input, followed by an S-box
-func (n roundGateNamer) integrated(varIndex, round int) gkr.GateName {
-	return gkr.GateName(fmt.Sprintf("x%d-i-op-round=%d;%s", varIndex, round, n))
-}


### PR DESCRIPTION
The integrated gate name helper on roundGateNamer was never used anywhere in the Poseidon2 GKR circuit or in gate registration. Removed the method and its comment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the unused `roundGateNamer.integrated` gate name helper from `std/permutation/poseidon2/gkr-poseidon2/gkr.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87a7522ff84bcde13abede76b9daac753d6e6720. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->