### PR TITLE
refactor: support dynamic emulation parameters for ecrec

### DIFF
--- a/std/evmprecompiles/01-ecrecover_test.go
+++ b/std/evmprecompiles/01-ecrecover_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/secp256k1/ecdsa"
 	"github.com/consensys/gnark-crypto/ecc/secp256k1/fr"
+	"github.com/consensys/gnark-crypto/field/koalabear"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
 	"github.com/consensys/gnark/std/math/emulated"
@@ -301,4 +302,11 @@ func TestLargeV(t *testing.T) {
 		err := test.IsSolved(&circuit, &witness, ecc.BLS12_377.ScalarField())
 		assert.Error(err)
 	}
+}
+
+func TestOverKoalabear(t *testing.T) {
+	assert := test.NewAssert(t)
+	circuit, witness := testRoutineECRecover(t, false)
+	err := test.IsSolved(circuit, witness, koalabear.Modulus())
+	assert.NoError(err)
 }


### PR DESCRIPTION
# Description

Adds support for dynamic limb parameters for ECRECOVER precompile for using in Linea with small fields. Does not change limb composition for large fields.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestOverKoalabear


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch ECRECOVER and its hint to dynamic limb sizing based on the native modulus and add a test over `koalabear`.
> 
> - **ECRecover (`std/evmprecompiles/01-ecrecover.go`)**:
>   - Use `GetEffectiveFieldParams[Secp256k1Fp]` to derive `nbFpLimbs` from the native field.
>   - Update hint output sizing and limb slicing to use `nbFpLimbs`.
> - **Hints (`std/evmprecompiles/hints.go`)**:
>   - Change `recoverPublicKeyHint` signature to accept `nativeMod` and compute dynamic params via `GetEffectiveFieldParams` for both `Fr` and `Fp`.
>   - Adjust input/output length checks and (re)composition using dynamic limb counts/bits; update zero-flag index to `2*nbFpLimbs`.
> - **Tests (`std/evmprecompiles/01-ecrecover_test.go`)**:
>   - Add `TestOverKoalabear` to solve the circuit over `koalabear.Modulus()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e539d0229998973c28cd6d7871074d1974d5ade. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->