### PR TITLE
chore(test): remove unused WithToxicSeed option

### DIFF
--- a/test/unsafekzg/options.go
+++ b/test/unsafekzg/options.go
@@ -1,7 +1,6 @@
 package unsafekzg
 
 import (
-	"crypto/sha256"
 	"errors"
 	"math/big"
 	"os"
@@ -41,22 +40,6 @@ func WithToxicValue(toxicValue *big.Int) Option {
 			return errors.New("toxic value already set")
 		}
 		opt.toxicValue = toxicValue
-		return nil
-	}
-}
-
-// WithToxicSeed sets the toxic value to the sha256 hash of the provided seed.
-//
-// NB! This is a debug option and should not be used in production.
-func WithToxicSeed(seed []byte) Option {
-	return func(opt *config) error {
-		if opt.toxicValue != nil {
-			return errors.New("toxic value already set")
-		}
-		h := sha256.New()
-		h.Write(seed)
-		opt.toxicValue = new(big.Int)
-		opt.toxicValue.SetBytes(h.Sum(nil))
 		return nil
 	}
 }


### PR DESCRIPTION
Removed unused debug-only option WithToxicSeed from unsafe KZG tests

