### PR TITLE
docs: clarify hash-to-field comment in commit test circuits

### DIFF
--- a/internal/backend/circuits/commit.go
+++ b/internal/backend/circuits/commit.go
@@ -55,7 +55,10 @@ func (circuit *noCommitCircuit) Define(api frontend.API) error {
 }
 
 func init() {
-	// need to have separate test cases as the hash-to-field for PLONK and Groth16 verifiers are different
+	// We need separate test cases because hash-to-field implementations differ between PLONK and Groth16 verifiers.
+	// commitCircuit tests circuits with commitments, where hash-to-field differences between backends are critical.
+	// noCommitCircuit tests circuits without commitments, where these differences don't affect verification.
+	// We test only on bn254 as the hash-to-field behavior is consistent across curves for this test scenario.
 	addEntry(
 		"commit",
 		&commitCircuit{}, &commitCircuit{Public: 16, X: 3}, &commitCircuit{Public: 0, X: 4},


### PR DESCRIPTION
Expand the comment in commit.go init() to explain why separate test cases are needed for commitCircuit and noCommitCircuit. The comment now clarifies that hash-to-field implementations differ between PLONK and Groth16 verifiers, and explains why we test only on bn254 for this scenario.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves test documentation in `internal/backend/circuits/commit.go`.
> 
> - Expands `init()` comments to explain that differing hash-to-field implementations between PLONK and Groth16 matter for `commitCircuit` (with commitments) but not for `noCommitCircuit` (without commitments)
> - Clarifies that tests run only on `bn254` for this scenario, where behavior is consistent across curves
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcfb55f414a7f118327585461fb6e7274e46c0d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->