### PR TITLE
ci: bump golangci-lint version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-          version: v2.1.6
+          version: v1.57.2
           args: -v --timeout=5m
   
   test:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.1.6
+        version: v1.57.2
         args: -v --timeout=5m
   
   test:


### PR DESCRIPTION
Update golangci-lint binary to latest stable 1.x in CI workflows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CI to use `golangci-lint` `v1.57.2` in both workflows.
> 
> - Bumps `version` input for `golangci/golangci-lint-action@v8` in `pr.yml` and `push.yml` from `v2.1.6` to `v1.57.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f8edd7f5da6180250d0f728f4eb1f4225ed8bcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->