### PR TITLE
fix: up eisenstein path per last gnark-crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.24.9
 require (
 	github.com/bits-and-blooms/bitset v1.24.4
 	github.com/blang/semver/v4 v4.0.0
-	github.com/consensys/bavard v0.2.2-0.20260105201452-c69d26cc6346
+	github.com/consensys/bavard v0.2.2-0.20260118153501-cba9f5475432
 	github.com/consensys/compress v0.3.0
-	github.com/consensys/gnark-crypto v0.19.3-0.20260105204507-a918ce1daf68
+	github.com/consensys/gnark-crypto v0.19.3-0.20260210161253-243aa4749a4a
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f

--- a/go.sum
+++ b/go.sum
@@ -57,12 +57,12 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/consensys/bavard v0.2.2-0.20260105201452-c69d26cc6346 h1:KaN+W79qr3H/qNEcv3QyPUoZzuL3SLn4Wz1+6fFWtBU=
-github.com/consensys/bavard v0.2.2-0.20260105201452-c69d26cc6346/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
+github.com/consensys/bavard v0.2.2-0.20260118153501-cba9f5475432 h1:4ACburMEVC+uaqG54jGgAwYTQmKHixtNej9j1Xs0H0o=
+github.com/consensys/bavard v0.2.2-0.20260118153501-cba9f5475432/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
 github.com/consensys/compress v0.3.0 h1:HRIcHvWkW9C9req0ZWg7mhYHzBarohXhcszIwHONVkM=
 github.com/consensys/compress v0.3.0/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
-github.com/consensys/gnark-crypto v0.19.3-0.20260105204507-a918ce1daf68 h1:zbj6/MPF/DJq/SufzCdNka7typgXAC3iRyODeDhFT6A=
-github.com/consensys/gnark-crypto v0.19.3-0.20260105204507-a918ce1daf68/go.mod h1:b5W02CwD3DvO1S5u98zUx/8oySyQZdSZW62o+pYm49M=
+github.com/consensys/gnark-crypto v0.19.3-0.20260210161253-243aa4749a4a h1:ffO/ONCvDL2YXvYi2uGulGnaHmUFXTpJuCvvI8SJaXc=
+github.com/consensys/gnark-crypto v0.19.3-0.20260210161253-243aa4749a4a/go.mod h1:wCDVWxJD3czvDwVK2UcQZAPiWQSv37hx0YfQjteHNUM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/std/algebra/emulated/sw_emulated/hints.go
+++ b/std/algebra/emulated/sw_emulated/hints.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/consensys/gnark-crypto/algebra/eisenstein"
 	"github.com/consensys/gnark-crypto/ecc"
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	bls12381_fp "github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
@@ -17,7 +18,6 @@ import (
 	secp_fp "github.com/consensys/gnark-crypto/ecc/secp256k1/fp"
 	stark_curve "github.com/consensys/gnark-crypto/ecc/stark-curve"
 	stark_fp "github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
-	"github.com/consensys/gnark-crypto/field/eisenstein"
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/std/math/emulated"
 )

--- a/std/algebra/native/sw_bls12377/hints.go
+++ b/std/algebra/native/sw_bls12377/hints.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/consensys/gnark-crypto/algebra/eisenstein"
 	"github.com/consensys/gnark-crypto/ecc"
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
-	"github.com/consensys/gnark-crypto/field/eisenstein"
 	"github.com/consensys/gnark/constraint/solver"
 )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily a dependency bump and import-path update; behavior should be unchanged aside from whatever is introduced by the newer `gnark-crypto` version.
> 
> **Overview**
> Updates dependencies to newer `github.com/consensys/gnark-crypto` (and `bavard`) versions.
> 
> Adjusts the scalar-decomposition hint implementations in `std/algebra/emulated/sw_emulated/hints.go` and `std/algebra/native/sw_bls12377/hints.go` to import Eisenstein arithmetic from `gnark-crypto/algebra/eisenstein` instead of the previous `gnark-crypto/field/eisenstein`, aligning with the upstream package move.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 658b82a434ac769b30ade2209e1a7a622c5ec338. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->