### PR TITLE
feat: bump gnark version

### DIFF
--- a/backend/plonk/bls12-377/prove.go
+++ b/backend/plonk/bls12-377/prove.go
@@ -206,6 +206,12 @@ func newInstance(ctx context.Context, spr *cs.SparseR1CS, pk *ProvingKey, fullWi
 	if opts.HashToFieldFn == nil {
 		opts.HashToFieldFn = hash_to_field.New([]byte("BSB22-Plonk"))
 	}
+	fs := fiatshamir.NewTranscript(opts.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return nil, err
+		}
+	}
 	s := instance{
 		ctx:                    ctx,
 		pk:                     pk,
@@ -214,7 +220,7 @@ func newInstance(ctx context.Context, spr *cs.SparseR1CS, pk *ProvingKey, fullWi
 		opt:                    opts,
 		fullWitness:            fullWitness,
 		bp:                     make([]*iop.Polynomial, nb_blinding_polynomials),
-		fs:                     fiatshamir.NewTranscript(opts.ChallengeHash, "gamma", "beta", "alpha", "zeta"),
+		fs:                     fs,
 		kzgFoldingHash:         opts.KZGFoldingHash,
 		htfFunc:                opts.HashToFieldFn,
 		chLRO:                  make(chan struct{}, 1),

--- a/backend/plonk/bls12-377/verify.go
+++ b/backend/plonk/bls12-377/verify.go
@@ -75,7 +75,12 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 	}
 
 	// transcript to derive the challenge
-	fs := fiatshamir.NewTranscript(cfg.ChallengeHash, "gamma", "beta", "alpha", "zeta")
+	fs := fiatshamir.NewTranscript(cfg.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return err
+		}
+	}
 
 	// The first challenge is derived using the public data: the commitments to the permutation,
 	// the coefficients of the circuit, and the public inputs.

--- a/backend/plonk/bls12-381/prove.go
+++ b/backend/plonk/bls12-381/prove.go
@@ -206,6 +206,12 @@ func newInstance(ctx context.Context, spr *cs.SparseR1CS, pk *ProvingKey, fullWi
 	if opts.HashToFieldFn == nil {
 		opts.HashToFieldFn = hash_to_field.New([]byte("BSB22-Plonk"))
 	}
+	fs := fiatshamir.NewTranscript(opts.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return nil, err
+		}
+	}
 	s := instance{
 		ctx:                    ctx,
 		pk:                     pk,
@@ -214,7 +220,7 @@ func newInstance(ctx context.Context, spr *cs.SparseR1CS, pk *ProvingKey, fullWi
 		opt:                    opts,
 		fullWitness:            fullWitness,
 		bp:                     make([]*iop.Polynomial, nb_blinding_polynomials),
-		fs:                     fiatshamir.NewTranscript(opts.ChallengeHash, "gamma", "beta", "alpha", "zeta"),
+		fs:                     fs,
 		kzgFoldingHash:         opts.KZGFoldingHash,
 		htfFunc:                opts.HashToFieldFn,
 		chLRO:                  make(chan struct{}, 1),

--- a/backend/plonk/bls12-381/verify.go
+++ b/backend/plonk/bls12-381/verify.go
@@ -75,7 +75,12 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 	}
 
 	// transcript to derive the challenge
-	fs := fiatshamir.NewTranscript(cfg.ChallengeHash, "gamma", "beta", "alpha", "zeta")
+	fs := fiatshamir.NewTranscript(cfg.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return err
+		}
+	}
 
 	// The first challenge is derived using the public data: the commitments to the permutation,
 	// the coefficients of the circuit, and the public inputs.

--- a/backend/plonk/bn254/prove.go
+++ b/backend/plonk/bn254/prove.go
@@ -206,6 +206,12 @@ func newInstance(ctx context.Context, spr *cs.SparseR1CS, pk *ProvingKey, fullWi
 	if opts.HashToFieldFn == nil {
 		opts.HashToFieldFn = hash_to_field.New([]byte("BSB22-Plonk"))
 	}
+	fs := fiatshamir.NewTranscript(opts.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return nil, err
+		}
+	}
 	s := instance{
 		ctx:                    ctx,
 		pk:                     pk,
@@ -214,7 +220,7 @@ func newInstance(ctx context.Context, spr *cs.SparseR1CS, pk *ProvingKey, fullWi
 		opt:                    opts,
 		fullWitness:            fullWitness,
 		bp:                     make([]*iop.Polynomial, nb_blinding_polynomials),
-		fs:                     fiatshamir.NewTranscript(opts.ChallengeHash, "gamma", "beta", "alpha", "zeta"),
+		fs:                     fs,
 		kzgFoldingHash:         opts.KZGFoldingHash,
 		htfFunc:                opts.HashToFieldFn,
 		chLRO:                  make(chan struct{}, 1),

--- a/backend/plonk/bn254/verify.go
+++ b/backend/plonk/bn254/verify.go
@@ -75,7 +75,12 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 	}
 
 	// transcript to derive the challenge
-	fs := fiatshamir.NewTranscript(cfg.ChallengeHash, "gamma", "beta", "alpha", "zeta")
+	fs := fiatshamir.NewTranscript(cfg.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return err
+		}
+	}
 
 	// The first challenge is derived using the public data: the commitments to the permutation,
 	// the coefficients of the circuit, and the public inputs.

--- a/backend/plonk/bw6-761/prove.go
+++ b/backend/plonk/bw6-761/prove.go
@@ -206,6 +206,12 @@ func newInstance(ctx context.Context, spr *cs.SparseR1CS, pk *ProvingKey, fullWi
 	if opts.HashToFieldFn == nil {
 		opts.HashToFieldFn = hash_to_field.New([]byte("BSB22-Plonk"))
 	}
+	fs := fiatshamir.NewTranscript(opts.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return nil, err
+		}
+	}
 	s := instance{
 		ctx:                    ctx,
 		pk:                     pk,
@@ -214,7 +220,7 @@ func newInstance(ctx context.Context, spr *cs.SparseR1CS, pk *ProvingKey, fullWi
 		opt:                    opts,
 		fullWitness:            fullWitness,
 		bp:                     make([]*iop.Polynomial, nb_blinding_polynomials),
-		fs:                     fiatshamir.NewTranscript(opts.ChallengeHash, "gamma", "beta", "alpha", "zeta"),
+		fs:                     fs,
 		kzgFoldingHash:         opts.KZGFoldingHash,
 		htfFunc:                opts.HashToFieldFn,
 		chLRO:                  make(chan struct{}, 1),

--- a/backend/plonk/bw6-761/verify.go
+++ b/backend/plonk/bw6-761/verify.go
@@ -75,7 +75,12 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 	}
 
 	// transcript to derive the challenge
-	fs := fiatshamir.NewTranscript(cfg.ChallengeHash, "gamma", "beta", "alpha", "zeta")
+	fs := fiatshamir.NewTranscript(cfg.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return err
+		}
+	}
 
 	// The first challenge is derived using the public data: the commitments to the permutation,
 	// the coefficients of the circuit, and the public inputs.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/bavard v0.2.2-0.20260118153501-cba9f5475432
 	github.com/consensys/compress v0.3.0
-	github.com/consensys/gnark-crypto v0.19.3-0.20260210233638-4abc1c162a65
+	github.com/consensys/gnark-crypto v0.19.3-0.20260224184411-30b4255fd898
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/consensys/compress v0.3.0 h1:HRIcHvWkW9C9req0ZWg7mhYHzBarohXhcszIwHON
 github.com/consensys/compress v0.3.0/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
 github.com/consensys/gnark-crypto v0.19.3-0.20260210233638-4abc1c162a65 h1:uqG0l8Ou1qcqu2S+vRNn1ye7tw92x3R1UFzYiJemHI0=
 github.com/consensys/gnark-crypto v0.19.3-0.20260210233638-4abc1c162a65/go.mod h1:LlrRbe6b7BIune9Un5L6sRTUUWrAIIqGK+L0duYwpoM=
+github.com/consensys/gnark-crypto v0.19.3-0.20260224184411-30b4255fd898 h1:m1OulZPukY0eUB+rJEW4xDW5f0+E3Jr41X5b0XBZ7ec=
+github.com/consensys/gnark-crypto v0.19.3-0.20260224184411-30b4255fd898/go.mod h1:LlrRbe6b7BIune9Un5L6sRTUUWrAIIqGK+L0duYwpoM=
 github.com/consensys/gnark-solidity-checker v0.2.0 h1:i5iUEzNOkUvpaKm23UEe0wajBMwj7NzyT4EI0T2N8WQ=
 github.com/consensys/gnark-solidity-checker v0.2.0/go.mod h1:cEvl4g5AH+L4qGQLDOVZjqvn5IKZIAZdhSi8zAM6BiY=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/internal/generator/backend/template/gkr/gkr.go.tmpl
+++ b/internal/generator/backend/template/gkr/gkr.go.tmpl
@@ -473,7 +473,12 @@ func setup(c Circuit, assignment WireAssignment, transcriptSettings fiatshamir.S
 
 	if transcriptSettings.Transcript == nil {
 		challengeNames := ChallengeNames(o.sorted, o.nbVars, transcriptSettings.Prefix)
-		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash, challengeNames...)
+		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash)
+		for _, name := range challengeNames {
+			if err = o.transcript.NewChallenge(name); err != nil {
+				return o, err
+			}
+		}
 		for i := range transcriptSettings.BaseChallenges {
 			if err = o.transcript.Bind(challengeNames[0], transcriptSettings.BaseChallenges[i]); err != nil {
 				return o, err

--- a/internal/generator/backend/template/gkr/sumcheck.go.tmpl
+++ b/internal/generator/backend/template/gkr/sumcheck.go.tmpl
@@ -48,7 +48,12 @@ func setupTranscript(claimsNum int, varsNum int, settings *fiatshamir.Settings) 
 		challengeNames[i+numChallenges-varsNum] = prefix + strconv.Itoa(i)
 	}
 	if settings.Transcript == nil {
-		transcript := fiatshamir.NewTranscript(settings.Hash, challengeNames...)
+		transcript := fiatshamir.NewTranscript(settings.Hash)
+		for _, name := range challengeNames {
+			if err = transcript.NewChallenge(name); err != nil {
+				return
+			}
+		}
 		settings.Transcript = transcript
 	}
 

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.prove.go.tmpl
@@ -194,6 +194,12 @@ func newInstance(ctx context.Context, spr *cs.SparseR1CS, pk *ProvingKey, fullWi
 	if opts.HashToFieldFn == nil {
 		opts.HashToFieldFn = hash_to_field.New([]byte("BSB22-Plonk"))
 	}
+	fs := fiatshamir.NewTranscript(opts.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return nil, err
+		}
+	}
 	s := instance{
 		ctx:                    ctx,
 		pk:                     pk,
@@ -202,7 +208,7 @@ func newInstance(ctx context.Context, spr *cs.SparseR1CS, pk *ProvingKey, fullWi
 		opt:                    opts,
 		fullWitness:            fullWitness,
 		bp:                     make([]*iop.Polynomial, nb_blinding_polynomials),
-		fs:                     fiatshamir.NewTranscript(opts.ChallengeHash, "gamma", "beta", "alpha", "zeta"),
+		fs:                     fs,
 		kzgFoldingHash:         opts.KZGFoldingHash,
 		htfFunc:                opts.HashToFieldFn,
 		chLRO:                  make(chan struct{}, 1),

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.verify.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.verify.go.tmpl
@@ -72,7 +72,12 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 	}
 
 	// transcript to derive the challenge
-	fs := fiatshamir.NewTranscript(cfg.ChallengeHash, "gamma", "beta", "alpha", "zeta")
+	fs := fiatshamir.NewTranscript(cfg.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return err
+		}
+	}
 
 	// The first challenge is derived using the public data: the commitments to the permutation,
 	// the coefficients of the circuit, and the public inputs.

--- a/internal/generator/backend/template/zkpschemes/plonkfri/plonk.prove.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonkfri/plonk.prove.go.tmpl
@@ -55,7 +55,12 @@ func Prove(spr *cs.SparseR1CS, pk *ProvingKey, fullWitness witness.Witness, opts
 	var proof Proof
 
 	// 0 - Fiat Shamir
-	fs := fiatshamir.NewTranscript(opt.ChallengeHash, "gamma", "beta", "alpha", "zeta")
+	fs := fiatshamir.NewTranscript(opt.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return nil, err
+		}
+	}
 
 	// 1 - solve the system
 	_solution, err := spr.Solve(fullWitness, opt.SolverOpts...)

--- a/internal/generator/backend/template/zkpschemes/plonkfri/plonk.verify.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonkfri/plonk.verify.go.tmpl
@@ -18,7 +18,12 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 	}
 
 	// 0 - derive the challenges with Fiat Shamir
-	fs := fiatshamir.NewTranscript(cfg.ChallengeHash, "gamma", "beta", "alpha", "zeta")
+	fs := fiatshamir.NewTranscript(cfg.ChallengeHash)
+	for _, challenge := range []string{"gamma", "beta", "alpha", "zeta"} {
+		if err := fs.NewChallenge(challenge); err != nil {
+			return err
+		}
+	}
 
 	dataFiatShamir := make([][fr.Bytes]byte, len(publicWitness)+3)
 	for i := 0; i < len(publicWitness); i++ {

--- a/internal/gkr/bls12-377/gkr.go
+++ b/internal/gkr/bls12-377/gkr.go
@@ -478,7 +478,12 @@ func setup(c Circuit, assignment WireAssignment, transcriptSettings fiatshamir.S
 
 	if transcriptSettings.Transcript == nil {
 		challengeNames := ChallengeNames(o.sorted, o.nbVars, transcriptSettings.Prefix)
-		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash, challengeNames...)
+		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash)
+		for _, name := range challengeNames {
+			if err = o.transcript.NewChallenge(name); err != nil {
+				return o, err
+			}
+		}
 		for i := range transcriptSettings.BaseChallenges {
 			if err = o.transcript.Bind(challengeNames[0], transcriptSettings.BaseChallenges[i]); err != nil {
 				return o, err

--- a/internal/gkr/bls12-377/sumcheck.go
+++ b/internal/gkr/bls12-377/sumcheck.go
@@ -56,7 +56,12 @@ func setupTranscript(claimsNum int, varsNum int, settings *fiatshamir.Settings) 
 		challengeNames[i+numChallenges-varsNum] = prefix + strconv.Itoa(i)
 	}
 	if settings.Transcript == nil {
-		transcript := fiatshamir.NewTranscript(settings.Hash, challengeNames...)
+		transcript := fiatshamir.NewTranscript(settings.Hash)
+		for _, name := range challengeNames {
+			if err = transcript.NewChallenge(name); err != nil {
+				return
+			}
+		}
 		settings.Transcript = transcript
 	}
 

--- a/internal/gkr/bls12-381/gkr.go
+++ b/internal/gkr/bls12-381/gkr.go
@@ -478,7 +478,12 @@ func setup(c Circuit, assignment WireAssignment, transcriptSettings fiatshamir.S
 
 	if transcriptSettings.Transcript == nil {
 		challengeNames := ChallengeNames(o.sorted, o.nbVars, transcriptSettings.Prefix)
-		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash, challengeNames...)
+		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash)
+		for _, name := range challengeNames {
+			if err = o.transcript.NewChallenge(name); err != nil {
+				return o, err
+			}
+		}
 		for i := range transcriptSettings.BaseChallenges {
 			if err = o.transcript.Bind(challengeNames[0], transcriptSettings.BaseChallenges[i]); err != nil {
 				return o, err

--- a/internal/gkr/bls12-381/sumcheck.go
+++ b/internal/gkr/bls12-381/sumcheck.go
@@ -56,7 +56,12 @@ func setupTranscript(claimsNum int, varsNum int, settings *fiatshamir.Settings) 
 		challengeNames[i+numChallenges-varsNum] = prefix + strconv.Itoa(i)
 	}
 	if settings.Transcript == nil {
-		transcript := fiatshamir.NewTranscript(settings.Hash, challengeNames...)
+		transcript := fiatshamir.NewTranscript(settings.Hash)
+		for _, name := range challengeNames {
+			if err = transcript.NewChallenge(name); err != nil {
+				return
+			}
+		}
 		settings.Transcript = transcript
 	}
 

--- a/internal/gkr/bn254/gkr.go
+++ b/internal/gkr/bn254/gkr.go
@@ -478,7 +478,12 @@ func setup(c Circuit, assignment WireAssignment, transcriptSettings fiatshamir.S
 
 	if transcriptSettings.Transcript == nil {
 		challengeNames := ChallengeNames(o.sorted, o.nbVars, transcriptSettings.Prefix)
-		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash, challengeNames...)
+		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash)
+		for _, name := range challengeNames {
+			if err = o.transcript.NewChallenge(name); err != nil {
+				return o, err
+			}
+		}
 		for i := range transcriptSettings.BaseChallenges {
 			if err = o.transcript.Bind(challengeNames[0], transcriptSettings.BaseChallenges[i]); err != nil {
 				return o, err

--- a/internal/gkr/bn254/sumcheck.go
+++ b/internal/gkr/bn254/sumcheck.go
@@ -56,7 +56,12 @@ func setupTranscript(claimsNum int, varsNum int, settings *fiatshamir.Settings) 
 		challengeNames[i+numChallenges-varsNum] = prefix + strconv.Itoa(i)
 	}
 	if settings.Transcript == nil {
-		transcript := fiatshamir.NewTranscript(settings.Hash, challengeNames...)
+		transcript := fiatshamir.NewTranscript(settings.Hash)
+		for _, name := range challengeNames {
+			if err = transcript.NewChallenge(name); err != nil {
+				return
+			}
+		}
 		settings.Transcript = transcript
 	}
 

--- a/internal/gkr/bw6-761/gkr.go
+++ b/internal/gkr/bw6-761/gkr.go
@@ -478,7 +478,12 @@ func setup(c Circuit, assignment WireAssignment, transcriptSettings fiatshamir.S
 
 	if transcriptSettings.Transcript == nil {
 		challengeNames := ChallengeNames(o.sorted, o.nbVars, transcriptSettings.Prefix)
-		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash, challengeNames...)
+		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash)
+		for _, name := range challengeNames {
+			if err = o.transcript.NewChallenge(name); err != nil {
+				return o, err
+			}
+		}
 		for i := range transcriptSettings.BaseChallenges {
 			if err = o.transcript.Bind(challengeNames[0], transcriptSettings.BaseChallenges[i]); err != nil {
 				return o, err

--- a/internal/gkr/bw6-761/sumcheck.go
+++ b/internal/gkr/bw6-761/sumcheck.go
@@ -56,7 +56,12 @@ func setupTranscript(claimsNum int, varsNum int, settings *fiatshamir.Settings) 
 		challengeNames[i+numChallenges-varsNum] = prefix + strconv.Itoa(i)
 	}
 	if settings.Transcript == nil {
-		transcript := fiatshamir.NewTranscript(settings.Hash, challengeNames...)
+		transcript := fiatshamir.NewTranscript(settings.Hash)
+		for _, name := range challengeNames {
+			if err = transcript.NewChallenge(name); err != nil {
+				return
+			}
+		}
 		settings.Transcript = transcript
 	}
 

--- a/internal/gkr/small_rational/gkr.go
+++ b/internal/gkr/small_rational/gkr.go
@@ -478,7 +478,12 @@ func setup(c Circuit, assignment WireAssignment, transcriptSettings fiatshamir.S
 
 	if transcriptSettings.Transcript == nil {
 		challengeNames := ChallengeNames(o.sorted, o.nbVars, transcriptSettings.Prefix)
-		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash, challengeNames...)
+		o.transcript = fiatshamir.NewTranscript(transcriptSettings.Hash)
+		for _, name := range challengeNames {
+			if err = o.transcript.NewChallenge(name); err != nil {
+				return o, err
+			}
+		}
 		for i := range transcriptSettings.BaseChallenges {
 			if err = o.transcript.Bind(challengeNames[0], transcriptSettings.BaseChallenges[i]); err != nil {
 				return o, err

--- a/internal/gkr/small_rational/sumcheck.go
+++ b/internal/gkr/small_rational/sumcheck.go
@@ -56,7 +56,12 @@ func setupTranscript(claimsNum int, varsNum int, settings *fiatshamir.Settings) 
 		challengeNames[i+numChallenges-varsNum] = prefix + strconv.Itoa(i)
 	}
 	if settings.Transcript == nil {
-		transcript := fiatshamir.NewTranscript(settings.Hash, challengeNames...)
+		transcript := fiatshamir.NewTranscript(settings.Hash)
+		for _, name := range challengeNames {
+			if err = transcript.NewChallenge(name); err != nil {
+				return
+			}
+		}
 		settings.Transcript = transcript
 	}
 


### PR DESCRIPTION
update to gnark-crypto [PR#811](https://github.com/Consensys/gnark-crypto/pull/811)
wait for PR#811 to be merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Fiat-Shamir transcript setup used by provers/verifiers across multiple curves; any mismatch in challenge registration/order could change derived challenges and break proof compatibility.
> 
> **Overview**
> Updates PLONK prover/verifier code (BLS12-377/381, BN254, BW6-761) and related codegen templates to stop passing challenge names into `fiatshamir.NewTranscript`, and instead create the transcript first and then register `gamma`, `beta`, `alpha`, and `zeta` via `NewChallenge` with error handling.
> 
> Bumps the `github.com/consensys/gnark-crypto` dependency to a newer commit and updates `go.sum` accordingly, propagating the transcript API change across GKR and PLONK/PLONKFRI generated code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e002a37bb76c4ffa8206d6043c3341ee52ec1bac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->