### PR TITLE
fix: completeness issue for scalarmulFakeGLVAndGLV

### DIFF
--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -210,8 +210,8 @@ func (c *Curve[B, S]) AssertIsOnCurve(p *AffinePoint[B]) {
 	// (X,Y) ∈ {Y² == X³ + aX + b} U (0,0)
 
 	// if p=(0,0) we assign b=0 and continue
-	selector := c.api.And(c.baseApi.IsZero(&p.X), c.baseApi.IsZero(&p.Y))
-	b := c.baseApi.Select(selector, c.baseApi.Zero(), &c.b)
+	isInfinity := c.api.And(c.baseApi.IsZero(&p.X), c.baseApi.IsZero(&p.Y))
+	b := c.baseApi.Select(isInfinity, c.baseApi.Zero(), &c.b)
 
 	var check *emulated.Element[B]
 	if !c.addA {
@@ -234,10 +234,10 @@ func (c *Curve[B, S]) AssertIsOnCurve(p *AffinePoint[B]) {
 // [EVM]: https://ethereum.github.io/yellowpaper/paper.pdf
 func (c *Curve[B, S]) AddUnified(p, q *AffinePoint[B]) *AffinePoint[B] {
 
-	// selector1 = 1 when p is (0,0) and 0 otherwise
-	selector1 := c.api.And(c.baseApi.IsZero(&p.X), c.baseApi.IsZero(&p.Y))
-	// selector2 = 1 when q is (0,0) and 0 otherwise
-	selector2 := c.api.And(c.baseApi.IsZero(&q.X), c.baseApi.IsZero(&q.Y))
+	// isPInfinity = 1 when p is (0,0) and 0 otherwise
+	isPInfinity := c.api.And(c.baseApi.IsZero(&p.X), c.baseApi.IsZero(&p.Y))
+	// isQInfinity = 1 when q is (0,0) and 0 otherwise
+	isQInfinity := c.api.And(c.baseApi.IsZero(&q.X), c.baseApi.IsZero(&q.Y))
 
 	zero := c.baseApi.Zero()
 	infinity := AffinePoint[B]{X: *zero, Y: *zero}
@@ -286,9 +286,9 @@ func (c *Curve[B, S]) AddUnified(p, q *AffinePoint[B]) *AffinePoint[B] {
 		}
 
 		// if p=(0,0) return q
-		result = *c.Select(selector1, q, &result)
+		result = *c.Select(isPInfinity, q, &result)
 		// if q=(0,0) return p
-		result = *c.Select(selector2, p, &result)
+		result = *c.Select(isQInfinity, p, &result)
 		// if p = −q (same X, different Y) return O.
 		// When xEqual=1 and y2IsZero=1, both points are (0,0) — already
 		// handled above. Otherwise xEqual=1 ∧ ¬yEqual means p.Y = −q.Y.
@@ -311,8 +311,8 @@ func (c *Curve[B, S]) AddUnified(p, q *AffinePoint[B]) *AffinePoint[B] {
 		num = c.baseApi.Add(num, &c.a)
 		denum := c.baseApi.Add(&p.Y, &q.Y)
 		// if p.y + q.y = 0, assign dummy 1 to denum and continue
-		selector3 := c.baseApi.IsZero(denum)
-		denum = c.baseApi.Select(selector3, c.baseApi.One(), denum)
+		isYSumZero := c.baseApi.IsZero(denum)
+		denum = c.baseApi.Select(isYSumZero, c.baseApi.One(), denum)
 		λ := c.baseApi.Div(num, denum)
 
 		// x = λ^2 - p.x - q.x
@@ -329,11 +329,11 @@ func (c *Curve[B, S]) AddUnified(p, q *AffinePoint[B]) *AffinePoint[B] {
 		}
 
 		// if p=(0,0) return q
-		result = *c.Select(selector1, q, &result)
+		result = *c.Select(isPInfinity, q, &result)
 		// if q=(0,0) return p
-		result = *c.Select(selector2, p, &result)
+		result = *c.Select(isQInfinity, p, &result)
 		// if p.y + q.y = 0, return (0, 0)
-		result = *c.Select(selector3, &infinity, &result)
+		result = *c.Select(isYSumZero, &infinity, &result)
 	}
 
 	return &result
@@ -362,15 +362,15 @@ func (c *Curve[B, S]) doubleGeneric(p *AffinePoint[B], unified bool) *AffinePoin
 		xx3a = c.baseApi.Add(xx3a, &c.a)
 	}
 	y2 := c.baseApi.MulConst(&p.Y, big.NewInt(2))
-	var selector frontend.Variable = 0
+	var isDoubleYZero frontend.Variable = 0
 	if unified {
 		// if 2*p.y = 0, assign dummy 1 to y2 and continue
-		selector = c.baseApi.IsZero(y2)
-		y2 = c.baseApi.Select(selector, c.baseApi.One(), y2)
+		isDoubleYZero = c.baseApi.IsZero(y2)
+		y2 = c.baseApi.Select(isDoubleYZero, c.baseApi.One(), y2)
 	}
 	λ := c.baseApi.Div(xx3a, y2)
 	if unified {
-		λ = c.baseApi.Select(selector, c.baseApi.Zero(), λ)
+		λ = c.baseApi.Select(isDoubleYZero, c.baseApi.Zero(), λ)
 	}
 
 	// xr = λ²-2p.x
@@ -409,15 +409,15 @@ func (c *Curve[B, S]) tripleGeneric(p *AffinePoint[B], unified bool) *AffinePoin
 		xx = c.baseApi.Add(xx, &c.a)
 	}
 	y2 := c.baseApi.MulConst(&p.Y, big.NewInt(2))
-	var selector frontend.Variable = 0
+	var isDoubleYZero frontend.Variable = 0
 	if unified {
 		// if 2p.y = 0, assign dummy 1 to y2 and continue
-		selector = c.baseApi.IsZero(y2)
-		y2 = c.baseApi.Select(selector, c.baseApi.One(), y2)
+		isDoubleYZero = c.baseApi.IsZero(y2)
+		y2 = c.baseApi.Select(isDoubleYZero, c.baseApi.One(), y2)
 	}
 	λ1 := c.baseApi.Div(xx, y2)
 	if unified {
-		λ1 = c.baseApi.Select(selector, c.baseApi.Zero(), λ1)
+		λ1 = c.baseApi.Select(isDoubleYZero, c.baseApi.Zero(), λ1)
 	}
 
 	// xr = λ1²-2p.x
@@ -426,14 +426,14 @@ func (c *Curve[B, S]) tripleGeneric(p *AffinePoint[B], unified bool) *AffinePoin
 	// omit y2 computation, and
 	// compute λ2 = 2p.y/(x2 − p.x) − λ1.
 	x1x2 := c.baseApi.Sub(&p.X, x2)
-	selector = 0
+	var isSecondSlopeDenominatorZero frontend.Variable = 0
 	if unified {
-		selector = c.baseApi.IsZero(x1x2)
-		x1x2 = c.baseApi.Select(selector, c.baseApi.One(), x1x2)
+		isSecondSlopeDenominatorZero = c.baseApi.IsZero(x1x2)
+		x1x2 = c.baseApi.Select(isSecondSlopeDenominatorZero, c.baseApi.One(), x1x2)
 	}
 	λ2 := c.baseApi.Div(y2, x1x2)
 	if unified {
-		λ2 = c.baseApi.Select(selector, c.baseApi.Zero(), λ2)
+		λ2 = c.baseApi.Select(isSecondSlopeDenominatorZero, c.baseApi.Zero(), λ2)
 	}
 	λ2 = c.baseApi.Sub(λ2, λ1)
 
@@ -470,14 +470,14 @@ func (c *Curve[B, S]) doubleAndAddGeneric(p, q *AffinePoint[B], unified bool) *A
 	yqyp := c.baseApi.Sub(&q.Y, &p.Y)
 	xpn := c.baseApi.Neg(&p.X)
 	xqxp := c.baseApi.Add(&q.X, xpn)
-	var selector frontend.Variable = 0
+	var isChordDenominatorZero frontend.Variable = 0
 	if unified {
-		selector = c.baseApi.IsZero(xqxp)
-		xqxp = c.baseApi.Select(selector, c.baseApi.One(), xqxp)
+		isChordDenominatorZero = c.baseApi.IsZero(xqxp)
+		xqxp = c.baseApi.Select(isChordDenominatorZero, c.baseApi.One(), xqxp)
 	}
 	λ1 := c.baseApi.Div(yqyp, xqxp)
 	if unified {
-		λ1 = c.baseApi.Select(selector, c.baseApi.Zero(), λ1)
+		λ1 = c.baseApi.Select(isChordDenominatorZero, c.baseApi.Zero(), λ1)
 	}
 
 	// compute x2 = λ1²-p.x-q.x
@@ -488,14 +488,14 @@ func (c *Curve[B, S]) doubleAndAddGeneric(p, q *AffinePoint[B], unified bool) *A
 	// compute -λ2 = λ1+2*p.y/(x2-p.x)
 	ypyp := c.baseApi.MulConst(&p.Y, big.NewInt(2))
 	x2xp := c.baseApi.Add(x2, xpn)
-	selector = 0
+	var isSecondSlopeDenominatorZero frontend.Variable = 0
 	if unified {
-		selector = c.baseApi.IsZero(x2xp)
-		x2xp = c.baseApi.Select(selector, c.baseApi.One(), x2xp)
+		isSecondSlopeDenominatorZero = c.baseApi.IsZero(x2xp)
+		x2xp = c.baseApi.Select(isSecondSlopeDenominatorZero, c.baseApi.One(), x2xp)
 	}
 	λ2 := c.baseApi.Div(ypyp, x2xp)
 	if unified {
-		λ2 = c.baseApi.Select(selector, c.baseApi.Zero(), λ2)
+		λ2 = c.baseApi.Select(isSecondSlopeDenominatorZero, c.baseApi.Zero(), λ2)
 	}
 	λ2 = c.baseApi.Add(λ1, λ2)
 
@@ -639,13 +639,13 @@ func (c *Curve[B, S]) scalarMulGLV(Q *AffinePoint[B], s *emulated.Element[S], op
 		panic(err)
 	}
 	addFn := c.Add
-	var selector frontend.Variable
+	var isPointAtInfinity frontend.Variable
 	if cfg.CompleteArithmetic {
 		addFn = c.AddUnified
 		// if Q=(0,0) we assign a dummy (1,1) to Q and continue
-		selector = c.api.And(c.baseApi.IsZero(&Q.X), c.baseApi.IsZero(&Q.Y))
+		isPointAtInfinity = c.api.And(c.baseApi.IsZero(&Q.X), c.baseApi.IsZero(&Q.Y))
 		one := c.baseApi.One()
-		Q = c.Select(selector, &AffinePoint[B]{X: *one, Y: *one}, Q)
+		Q = c.Select(isPointAtInfinity, &AffinePoint[B]{X: *one, Y: *one}, Q)
 	}
 
 	// We use the endomorphism à la GLV to compute [s]Q as
@@ -662,9 +662,9 @@ func (c *Curve[B, S]) scalarMulGLV(Q *AffinePoint[B], s *emulated.Element[S], op
 		panic(fmt.Sprintf("compute GLV decomposition: %v", err))
 	}
 	s1, s2 := sd[0], sd[1]
-	selector1, selector2 := sdBits[0], sdBits[1]
-	s3 := c.scalarApi.Select(selector1, c.scalarApi.Neg(s1), s1)
-	s4 := c.scalarApi.Select(selector2, c.scalarApi.Neg(s2), s2)
+	isS1Negative, isS2Negative := sdBits[0], sdBits[1]
+	s3 := c.scalarApi.Select(isS1Negative, c.scalarApi.Neg(s1), s1)
+	s4 := c.scalarApi.Select(isS2Negative, c.scalarApi.Neg(s2), s2)
 	// s == s3 + [λ]s4
 	c.scalarApi.AssertIsEqual(
 		c.scalarApi.Add(s3, c.scalarApi.Mul(s4, c.eigenvalue)),
@@ -681,18 +681,18 @@ func (c *Curve[B, S]) scalarMulGLV(Q *AffinePoint[B], s *emulated.Element[S], op
 	negQY := c.baseApi.Neg(&Q.Y)
 	tableQ[1] = &AffinePoint[B]{
 		X: Q.X,
-		Y: *c.baseApi.Select(selector1, negQY, &Q.Y),
+		Y: *c.baseApi.Select(isS1Negative, negQY, &Q.Y),
 	}
 	tableQ[0] = c.Neg(tableQ[1])
 	tablePhiQ[1] = &AffinePoint[B]{
 		X: *c.baseApi.Mul(&Q.X, c.thirdRootOne),
-		Y: *c.baseApi.Select(selector2, negQY, &Q.Y),
+		Y: *c.baseApi.Select(isS2Negative, negQY, &Q.Y),
 	}
 	tablePhiQ[0] = c.Neg(tablePhiQ[1])
 	tableQ[2] = c.triple(tableQ[1])
 	tablePhiQ[2] = &AffinePoint[B]{
 		X: *c.baseApi.Mul(&tableQ[2].X, c.thirdRootOne),
-		Y: *c.baseApi.Select(selector2, c.baseApi.Neg(&tableQ[2].Y), &tableQ[2].Y),
+		Y: *c.baseApi.Select(isS2Negative, c.baseApi.Neg(&tableQ[2].Y), &tableQ[2].Y),
 	}
 
 	// we suppose that the first bits of the sub-scalars are 1 and set:
@@ -812,7 +812,7 @@ func (c *Curve[B, S]) scalarMulGLV(Q *AffinePoint[B], s *emulated.Element[S], op
 
 	if cfg.CompleteArithmetic {
 		zero := c.baseApi.Zero()
-		Acc = c.Select(selector, &AffinePoint[B]{X: *zero, Y: *zero}, Acc)
+		Acc = c.Select(isPointAtInfinity, &AffinePoint[B]{X: *zero, Y: *zero}, Acc)
 	}
 
 	return Acc
@@ -845,12 +845,12 @@ func (c *Curve[B, S]) scalarMulJoye(p *AffinePoint[B], s *emulated.Element[S], o
 	if err != nil {
 		panic(fmt.Sprintf("parse opts: %v", err))
 	}
-	var selector frontend.Variable
+	var isPointAtInfinity frontend.Variable
 	if cfg.CompleteArithmetic {
 		// if p=(0,0) we assign a dummy (0,1) to p and continue
-		selector = c.api.And(c.baseApi.IsZero(&p.X), c.baseApi.IsZero(&p.Y))
+		isPointAtInfinity = c.api.And(c.baseApi.IsZero(&p.X), c.baseApi.IsZero(&p.Y))
 		one := c.baseApi.One()
-		p = c.Select(selector, &AffinePoint[B]{X: *one, Y: *one}, p)
+		p = c.Select(isPointAtInfinity, &AffinePoint[B]{X: *one, Y: *one}, p)
 	}
 
 	var st S
@@ -885,7 +885,7 @@ func (c *Curve[B, S]) scalarMulJoye(p *AffinePoint[B], s *emulated.Element[S], o
 	if cfg.CompleteArithmetic {
 		// if p=(0,0), return (0,0)
 		zero := c.baseApi.Zero()
-		R0 = c.Select(selector, &AffinePoint[B]{X: *zero, Y: *zero}, R0)
+		R0 = c.Select(isPointAtInfinity, &AffinePoint[B]{X: *zero, Y: *zero}, R0)
 	}
 
 	return R0
@@ -989,9 +989,9 @@ func (c *Curve[B, S]) jointScalarMulGLVUnsafe(Q, R *AffinePoint[B], s, t *emulat
 		panic(fmt.Sprintf("compute GLV decomposition s: %v", err))
 	}
 	s1, s2 := sd[0], sd[1]
-	selector1, selector2 := sdBits[0], sdBits[1]
-	s3 := c.scalarApi.Select(selector1, c.scalarApi.Neg(s1), s1)
-	s4 := c.scalarApi.Select(selector2, c.scalarApi.Neg(s2), s2)
+	isS1Negative, isS2Negative := sdBits[0], sdBits[1]
+	s3 := c.scalarApi.Select(isS1Negative, c.scalarApi.Neg(s1), s1)
+	s4 := c.scalarApi.Select(isS2Negative, c.scalarApi.Neg(s2), s2)
 	// s == s3 + [λ]s4
 	c.scalarApi.AssertIsEqual(
 		c.scalarApi.Add(s3, c.scalarApi.Mul(s4, c.eigenvalue)),
@@ -1004,9 +1004,9 @@ func (c *Curve[B, S]) jointScalarMulGLVUnsafe(Q, R *AffinePoint[B], s, t *emulat
 		panic(fmt.Sprintf("compute GLV decomposition t: %v", err))
 	}
 	t1, t2 := td[0], td[1]
-	selector3, selector4 := tdBits[0], tdBits[1]
-	t3 := c.scalarApi.Select(selector3, c.scalarApi.Neg(t1), t1)
-	t4 := c.scalarApi.Select(selector4, c.scalarApi.Neg(t2), t2)
+	isT1Negative, isT2Negative := tdBits[0], tdBits[1]
+	t3 := c.scalarApi.Select(isT1Negative, c.scalarApi.Neg(t1), t1)
+	t4 := c.scalarApi.Select(isT2Negative, c.scalarApi.Neg(t2), t2)
 	// t == t3 + [λ]t4
 	c.scalarApi.AssertIsEqual(
 		c.scalarApi.Add(t3, c.scalarApi.Mul(t4, c.eigenvalue)),
@@ -1018,12 +1018,12 @@ func (c *Curve[B, S]) jointScalarMulGLVUnsafe(Q, R *AffinePoint[B], s, t *emulat
 	negQY := c.baseApi.Neg(&Q.Y)
 	tableQ[1] = &AffinePoint[B]{
 		X: Q.X,
-		Y: *c.baseApi.Select(selector1, negQY, &Q.Y),
+		Y: *c.baseApi.Select(isS1Negative, negQY, &Q.Y),
 	}
 	tableQ[0] = c.Neg(tableQ[1])
 	tablePhiQ[1] = &AffinePoint[B]{
 		X: *c.baseApi.Mul(&Q.X, c.thirdRootOne),
-		Y: *c.baseApi.Select(selector2, negQY, &Q.Y),
+		Y: *c.baseApi.Select(isS2Negative, negQY, &Q.Y),
 	}
 	tablePhiQ[0] = c.Neg(tablePhiQ[1])
 
@@ -1032,12 +1032,12 @@ func (c *Curve[B, S]) jointScalarMulGLVUnsafe(Q, R *AffinePoint[B], s, t *emulat
 	negRY := c.baseApi.Neg(&R.Y)
 	tableR[1] = &AffinePoint[B]{
 		X: R.X,
-		Y: *c.baseApi.Select(selector3, negRY, &R.Y),
+		Y: *c.baseApi.Select(isT1Negative, negRY, &R.Y),
 	}
 	tableR[0] = c.Neg(tableR[1])
 	tablePhiR[1] = &AffinePoint[B]{
 		X: *c.baseApi.Mul(&R.X, c.thirdRootOne),
-		Y: *c.baseApi.Select(selector4, negRY, &R.Y),
+		Y: *c.baseApi.Select(isT2Negative, negRY, &R.Y),
 	}
 	tablePhiR[0] = c.Neg(tablePhiR[1])
 
@@ -1051,15 +1051,15 @@ func (c *Curve[B, S]) jointScalarMulGLVUnsafe(Q, R *AffinePoint[B], s, t *emulat
 	tableS[3] = c.Neg(tableS[2])
 	f0 := c.baseApi.Mul(&tableS[0].X, c.thirdRootOne)
 	f2 := c.baseApi.Mul(&tableS[2].X, c.thirdRootOne)
-	xor := c.api.Xor(selector2, selector4)
+	isPhiXTwisted := c.api.Xor(isS2Negative, isT2Negative)
 	tablePhiS[0] = &AffinePoint[B]{
-		X: *c.baseApi.Select(xor, f2, f0),
-		Y: *c.baseApi.Lookup2(selector2, selector4, &tableS[0].Y, &tableS[2].Y, &tableS[3].Y, &tableS[1].Y),
+		X: *c.baseApi.Select(isPhiXTwisted, f2, f0),
+		Y: *c.baseApi.Lookup2(isS2Negative, isT2Negative, &tableS[0].Y, &tableS[2].Y, &tableS[3].Y, &tableS[1].Y),
 	}
 	tablePhiS[1] = c.Neg(tablePhiS[0])
 	tablePhiS[2] = &AffinePoint[B]{
-		X: *c.baseApi.Select(xor, f0, f2),
-		Y: *c.baseApi.Lookup2(selector2, selector4, &tableS[2].Y, &tableS[0].Y, &tableS[1].Y, &tableS[3].Y),
+		X: *c.baseApi.Select(isPhiXTwisted, f0, f2),
+		Y: *c.baseApi.Lookup2(isS2Negative, isT2Negative, &tableS[2].Y, &tableS[0].Y, &tableS[1].Y, &tableS[3].Y),
 	}
 	tablePhiS[3] = c.Neg(tablePhiS[2])
 
@@ -1082,10 +1082,10 @@ func (c *Curve[B, S]) jointScalarMulGLVUnsafe(Q, R *AffinePoint[B], s, t *emulat
 			c.baseApi.Mul(&g0.X, c.thirdRootOne), c.thirdRootOne),
 		Y: g0.Y,
 	}
-	selector0 := c.baseApi.IsZero(
+	isAccNegGenerator := c.baseApi.IsZero(
 		c.baseApi.Add(&Acc.Y, &g0.Y),
 	)
-	g := c.Select(selector0, g1, g0)
+	g := c.Select(isAccNegGenerator, g1, g0)
 	// Acc = Q + R + Φ(Q) + Φ(R) + G or
 	// Q + R + Φ(Q) + Φ(R) + Φ²(G) ( = -G+Φ²(G) = -2G-Φ(G) )
 	Acc = c.Add(Acc, g)
@@ -1168,7 +1168,7 @@ func (c *Curve[B, S]) jointScalarMulGLVUnsafe(Q, R *AffinePoint[B], s, t *emulat
 	// subtract [2^nbits]G or conditionally [2^nbits]Φ²(G)
 	gm := c.GeneratorMultiples()[nbits-1]
 	g = c.Select(
-		selector0,
+		isAccNegGenerator,
 		// [2^nbits]Φ²(G)
 		&AffinePoint[B]{
 			X: *c.baseApi.Mul(
@@ -1290,11 +1290,11 @@ func (c *Curve[B, S]) scalarMulFakeGLV(Q *AffinePoint[B], s *emulated.Element[S]
 		panic(err)
 	}
 
-	var selector1 frontend.Variable
+	var isScalarZero frontend.Variable
 	_s := s
 	if cfg.CompleteArithmetic {
-		selector1 = c.scalarApi.IsZero(s)
-		_s = c.scalarApi.Select(selector1, c.scalarApi.One(), s)
+		isScalarZero = c.scalarApi.IsZero(s)
+		_s = c.scalarApi.Select(isScalarZero, c.scalarApi.One(), s)
 	}
 
 	// First we find the sub-salars s1, s2 s.t. s1 + s2*s = 0 mod r and s1, s2 < sqrt(r).
@@ -1323,17 +1323,17 @@ func (c *Curve[B, S]) scalarMulFakeGLV(Q *AffinePoint[B], s *emulated.Element[S]
 	}
 	r0, r1 := R[0], R[1]
 
-	var selector2 frontend.Variable
+	var isInputPointAtInfinity frontend.Variable
 	one := c.baseApi.One()
 	dummy := &AffinePoint[B]{X: *one, Y: *one}
 	addFn := c.Add
 	if cfg.CompleteArithmetic {
 		addFn = c.AddUnified
 		// if Q=(0,0) we assign a dummy (1,1) to Q and R and continue
-		selector2 = c.api.And(c.baseApi.IsZero(&Q.X), c.baseApi.IsZero(&Q.Y))
-		Q = c.Select(selector2, dummy, Q)
-		r0 = c.baseApi.Select(selector2, c.baseApi.Zero(), r0)
-		r1 = c.baseApi.Select(selector2, &dummy.Y, r1)
+		isInputPointAtInfinity = c.api.And(c.baseApi.IsZero(&Q.X), c.baseApi.IsZero(&Q.Y))
+		Q = c.Select(isInputPointAtInfinity, dummy, Q)
+		r0 = c.baseApi.Select(isInputPointAtInfinity, c.baseApi.Zero(), r0)
+		r1 = c.baseApi.Select(isInputPointAtInfinity, &dummy.Y, r1)
 	}
 
 	var st S
@@ -1516,7 +1516,7 @@ func (c *Curve[B, S]) scalarMulFakeGLV(Q *AffinePoint[B], s *emulated.Element[S]
 	Acc = c.Select(s2bits[0], Acc, tableR[0])
 
 	if cfg.CompleteArithmetic {
-		Acc = c.Select(c.api.Or(selector1, selector2), tableR[2], Acc)
+		Acc = c.Select(c.api.Or(isScalarZero, isInputPointAtInfinity), tableR[2], Acc)
 	}
 	// we added [3]R at the last iteration so the result should be
 	// 		Acc = [s1]Q + [s2]R + [3]R
@@ -1535,7 +1535,7 @@ func (c *Curve[B, S]) scalarMulFakeGLV(Q *AffinePoint[B], s *emulated.Element[S]
 		// On the complete-arithmetic edge branches (s=0 or Q=(0,0)) the
 		// accumulator check is rerouted through a dummy path, so we must also
 		// return the canonical infinity point instead of the unverified hint output.
-		res = c.Select(c.api.Or(selector1, selector2), &AffinePoint[B]{X: *zero, Y: *zero}, res)
+		res = c.Select(c.api.Or(isScalarZero, isInputPointAtInfinity), &AffinePoint[B]{X: *zero, Y: *zero}, res)
 	}
 	return res
 }
@@ -1561,17 +1561,16 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 	}
 
 	// handle 0-scalar and (-1)-scalar cases
-	var selector0, selector1 frontend.Variable
+	var isScalarZeroOrMinusOne, isScalarOne frontend.Variable
+	isScalarZero := c.scalarApi.IsZero(s)
+	isScalarMinusOne := frontend.Variable(0)
 	_s := s
 	if cfg.CompleteArithmetic {
 		one := c.scalarApi.One()
-		selector1 = c.scalarApi.IsZero(c.scalarApi.Sub(s, one))
-		selector0 = c.api.Or(
-			c.scalarApi.IsZero(s),
-			c.scalarApi.IsZero(
-				c.scalarApi.Add(s, one)),
-		)
-		_s = c.scalarApi.Select(selector0, one, s)
+		isScalarOne = c.scalarApi.IsZero(c.scalarApi.Sub(s, one))
+		isScalarMinusOne = c.scalarApi.IsZero(c.scalarApi.Add(s, one))
+		isScalarZeroOrMinusOne = c.api.Or(isScalarZero, isScalarMinusOne)
+		_s = c.scalarApi.Select(isScalarZeroOrMinusOne, one, s)
 	}
 
 	// Instead of computing [s]P=Q, we check that Q-[s]P == 0.
@@ -1647,16 +1646,16 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 	Q := &AffinePoint[B]{X: *point[0], Y: *point[1]}
 
 	// handle (0,0)-point
-	var _selector0 frontend.Variable
+	var isInputPointAtInfinity frontend.Variable
 	_P := P
 	if cfg.CompleteArithmetic {
 		// if Q=(0,0) we assign a dummy point to Q and continue
-		Q = c.Select(selector0, &c.GeneratorMultiples()[3], Q)
+		Q = c.Select(isScalarZeroOrMinusOne, &c.GeneratorMultiples()[3], Q)
 		// if P=(0,0) we assign a dummy point to P and continue
-		_selector0 = c.api.And(c.baseApi.IsZero(&P.X), c.baseApi.IsZero(&P.Y))
-		_P = c.Select(_selector0, &c.GeneratorMultiples()[4], P)
+		isInputPointAtInfinity = c.api.And(c.baseApi.IsZero(&P.X), c.baseApi.IsZero(&P.Y))
+		_P = c.Select(isInputPointAtInfinity, &c.GeneratorMultiples()[4], P)
 		// if s=1 we assign a dummy point to Q and continue
-		Q = c.Select(selector1, &c.GeneratorMultiples()[3], Q)
+		Q = c.Select(isScalarOne, &c.GeneratorMultiples()[3], Q)
 	}
 
 	addFn := c.Add
@@ -1802,7 +1801,7 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 	// Acc should be now equal to [2^nbits]G
 	gm := c.GeneratorMultiples()[nbits-1]
 	if cfg.CompleteArithmetic {
-		Acc = c.Select(c.api.Or(c.api.Or(selector0, _selector0), selector1), &gm, Acc)
+		Acc = c.Select(c.api.Or(c.api.Or(isScalarZeroOrMinusOne, isInputPointAtInfinity), isScalarOne), &gm, Acc)
 	}
 	c.AssertIsEqual(Acc, &gm)
 
@@ -1815,10 +1814,10 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 		// The complete-arithmetic edge branches (s=0, s=-1, s=1, or P=(0,0))
 		// reroute the accumulator check through dummy points, so we must also
 		// return the canonical in-circuit result instead of the unverified hint output.
-		res = c.Select(selector1, _P, res)
-		res = c.Select(selector0, c.Neg(_P), res)
-		res = c.Select(c.scalarApi.IsZero(s), &AffinePoint[B]{X: *zero, Y: *zero}, res)
-		res = c.Select(_selector0, &AffinePoint[B]{X: *zero, Y: *zero}, res)
+		res = c.Select(isScalarOne, _P, res)
+		res = c.Select(isScalarZeroOrMinusOne, c.Neg(_P), res)
+		res = c.Select(isScalarZero, &AffinePoint[B]{X: *zero, Y: *zero}, res)
+		res = c.Select(isInputPointAtInfinity, &AffinePoint[B]{X: *zero, Y: *zero}, res)
 	}
 	return res
 }

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -1526,10 +1526,18 @@ func (c *Curve[B, S]) scalarMulFakeGLV(Q *AffinePoint[B], s *emulated.Element[S]
 	// 		    = [3]R
 	c.AssertIsEqual(Acc, tableR[2])
 
-	return &AffinePoint[B]{
+	res := &AffinePoint[B]{
 		X: *R[0],
 		Y: *R[1],
 	}
+	if cfg.CompleteArithmetic {
+		zero := c.baseApi.Zero()
+		// On the complete-arithmetic edge branches (s=0 or Q=(0,0)) the
+		// accumulator check is rerouted through a dummy path, so we must also
+		// return the canonical infinity point instead of the unverified hint output.
+		res = c.Select(c.api.Or(selector1, selector2), &AffinePoint[B]{X: *zero, Y: *zero}, res)
+	}
+	return res
 }
 
 // scalarMulGLVAndFakeGLV computes [s]P and returns it. It doesn't modify P nor s.

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -1562,9 +1562,8 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 	}
 
 	// handle 0-scalar and (-1)-scalar cases
-	var isScalarZeroOrMinusOne, isScalarOne frontend.Variable
+	var isScalarZeroOrMinusOne, isScalarOne, isScalarMinusOne frontend.Variable
 	isScalarZero := c.scalarApi.IsZero(s)
-	isScalarMinusOne := frontend.Variable(0)
 	_s := s
 	if cfg.CompleteArithmetic {
 		one := c.scalarApi.One()

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -1651,6 +1651,11 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 		Q = c.Select(_selector1, &c.GeneratorMultiples()[3], Q)
 	}
 
+	addFn := c.Add
+	if cfg.CompleteArithmetic {
+		addFn = c.AddUnified
+	}
+
 	// precompute -P, -Φ(P), Φ(P)
 	var tableP, tablePhiP [2]*AffinePoint[B]
 	negPY := c.baseApi.Neg(&_P.Y)
@@ -1681,18 +1686,18 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 
 	// precompute -P-Q, P+Q, P-Q, -P+Q, -Φ(P)-Φ(Q), Φ(P)+Φ(Q), Φ(P)-Φ(Q), -Φ(P)+Φ(Q)
 	var tableS, tablePhiS [4]*AffinePoint[B]
-	tableS[0] = c.Add(tableP[0], tableQ[0])
+	tableS[0] = addFn(tableP[0], tableQ[0])
 	tableS[1] = c.Neg(tableS[0])
-	tableS[2] = c.Add(tableP[1], tableQ[0])
+	tableS[2] = addFn(tableP[1], tableQ[0])
 	tableS[3] = c.Neg(tableS[2])
-	tablePhiS[0] = c.Add(tablePhiP[0], tablePhiQ[0])
+	tablePhiS[0] = addFn(tablePhiP[0], tablePhiQ[0])
 	tablePhiS[1] = c.Neg(tablePhiS[0])
-	tablePhiS[2] = c.Add(tablePhiP[1], tablePhiQ[0])
+	tablePhiS[2] = addFn(tablePhiP[1], tablePhiQ[0])
 	tablePhiS[3] = c.Neg(tablePhiS[2])
 
 	// we suppose that the first bits of the sub-scalars are 1 and set:
 	// 		Acc = P + Q + Φ(P) + Φ(Q)
-	Acc := c.Add(tableS[1], tablePhiS[1])
+	Acc := addFn(tableS[1], tablePhiS[1])
 	b1 := Acc
 	// then we add G (the base point) to Acc to avoid incomplete additions in
 	// the loop, because when doing doubleAndAdd(Acc, Bi) as (Acc+Bi)+Acc it
@@ -1702,7 +1707,7 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 	//
 	// N.B.: Acc cannot be equal to G, otherwise this means G = -Φ²([s+1]P)
 	g := c.Generator()
-	Acc = c.Add(Acc, g)
+	Acc = addFn(Acc, g)
 
 	// u1, u2, v1, v2 < r^{1/4} (up to a constant factor).
 	// We prove that the factor is log_(3/sqrt(3)))(r).
@@ -1716,19 +1721,19 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 	// At each iteration we look up the point Bi from:
 	// 		B1  = +P + Q + Φ(P) + Φ(Q)
 	// 		B2  = +P + Q + Φ(P) - Φ(Q)
-	B2 := c.Add(tableS[1], tablePhiS[2])
+	B2 := addFn(tableS[1], tablePhiS[2])
 	// 		b3  = +P + Q - Φ(P) + Φ(Q)
-	b3 := c.Add(tableS[1], tablePhiS[3])
+	b3 := addFn(tableS[1], tablePhiS[3])
 	// 		B4  = +P + Q - Φ(P) - Φ(Q)
-	B4 := c.Add(tableS[1], tablePhiS[0])
+	B4 := addFn(tableS[1], tablePhiS[0])
 	// 		b5  = +P - Q + Φ(P) + Φ(Q)
-	b5 := c.Add(tableS[2], tablePhiS[1])
+	b5 := addFn(tableS[2], tablePhiS[1])
 	// 		B6  = +P - Q + Φ(P) - Φ(Q)
-	B6 := c.Add(tableS[2], tablePhiS[2])
+	B6 := addFn(tableS[2], tablePhiS[2])
 	// 		b7  = +P - Q - Φ(P) + Φ(Q)
-	b7 := c.Add(tableS[2], tablePhiS[3])
+	b7 := addFn(tableS[2], tablePhiS[3])
 	// 		B8  = +P - Q - Φ(P) - Φ(Q)
-	B8 := c.Add(tableS[2], tablePhiS[0])
+	B8 := addFn(tableS[2], tablePhiS[0])
 	// 		B10 = -P + Q + Φ(P) - Φ(Q)
 	B10 := c.Neg(b7)
 	// 		B12 = -P + Q - Φ(P) - Φ(Q)
@@ -1767,18 +1772,23 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 			),
 		}
 		// Acc = [2]Acc + Bi
-		Acc = c.doubleAndAdd(Acc, Bi)
+		if cfg.CompleteArithmetic {
+			Acc = c.doubleGeneric(Acc, true)
+			Acc = addFn(Acc, Bi)
+		} else {
+			Acc = c.doubleAndAdd(Acc, Bi)
+		}
 	}
 
 	// i = 0
 	// subtract the P, Q, Φ(P), Φ(Q) if the first bits are 0
-	tableP[0] = c.Add(tableP[0], Acc)
+	tableP[0] = addFn(tableP[0], Acc)
 	Acc = c.Select(u1bits[0], Acc, tableP[0])
-	tablePhiP[0] = c.Add(tablePhiP[0], Acc)
+	tablePhiP[0] = addFn(tablePhiP[0], Acc)
 	Acc = c.Select(u2bits[0], Acc, tablePhiP[0])
-	tableQ[0] = c.Add(tableQ[0], Acc)
+	tableQ[0] = addFn(tableQ[0], Acc)
 	Acc = c.Select(v1bits[0], Acc, tableQ[0])
-	tablePhiQ[0] = c.Add(tablePhiQ[0], Acc)
+	tablePhiQ[0] = addFn(tablePhiQ[0], Acc)
 	Acc = c.Select(v2bits[0], Acc, tablePhiQ[0])
 
 	// Acc should be now equal to [2^nbits]G

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -293,7 +293,8 @@ func (c *Curve[B, S]) AddUnified(p, q *AffinePoint[B]) *AffinePoint[B] {
 		// When xEqual=1 and y2IsZero=1, both points are (0,0) — already
 		// handled above. Otherwise xEqual=1 ∧ ¬yEqual means p.Y = −q.Y.
 		yEqual := c.baseApi.IsZero(c.baseApi.Sub(&p.Y, &q.Y))
-		isInverse := c.api.And(xEqual, c.api.Sub(1, yEqual))
+		areFinite := c.api.And(c.api.Sub(1, isPInfinity), c.api.Sub(1, isQInfinity))
+		isInverse := c.api.And(c.api.And(xEqual, c.api.Sub(1, yEqual)), areFinite)
 		result = *c.Select(isInverse, &infinity, &result)
 	} else {
 		// ---------------------------------------------------------------

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -239,41 +239,102 @@ func (c *Curve[B, S]) AddUnified(p, q *AffinePoint[B]) *AffinePoint[B] {
 	// selector2 = 1 when q is (0,0) and 0 otherwise
 	selector2 := c.api.And(c.baseApi.IsZero(&q.X), c.baseApi.IsZero(&q.Y))
 
-	// λ = ((p.x+q.x)² - p.x*q.x + a)/(p.y + q.y)
-	pxqx := c.baseApi.MulMod(&p.X, &q.X)
-	pxplusqx := c.baseApi.Add(&p.X, &q.X)
-	num := c.baseApi.MulMod(pxplusqx, pxplusqx)
-	num = c.baseApi.Sub(num, pxqx)
-	if c.addA {
-		num = c.baseApi.Add(num, &c.a)
-	}
-	denum := c.baseApi.Add(&p.Y, &q.Y)
-	// if p.y + q.y = 0, assign dummy 1 to denum and continue
-	selector3 := c.baseApi.IsZero(denum)
-	denum = c.baseApi.Select(selector3, c.baseApi.One(), denum)
-	λ := c.baseApi.Div(num, denum)
-
-	// x = λ^2 - p.x - q.x
-	xr := c.baseApi.MulMod(λ, λ)
-	xr = c.baseApi.Sub(xr, pxplusqx)
-
-	// y = λ(p.x - xr) - p.y
-	yr := c.baseApi.Sub(&p.X, xr)
-	yr = c.baseApi.MulMod(yr, λ)
-	yr = c.baseApi.Sub(yr, &p.Y)
-	result := AffinePoint[B]{
-		X: *c.baseApi.Reduce(xr),
-		Y: *c.baseApi.Reduce(yr),
-	}
-
 	zero := c.baseApi.Zero()
 	infinity := AffinePoint[B]{X: *zero, Y: *zero}
-	// if p=(0,0) return q
-	result = *c.Select(selector1, q, &result)
-	// if q=(0,0) return p
-	result = *c.Select(selector2, p, &result)
-	// if p.y + q.y = 0, return (0, 0)
-	result = *c.Select(selector3, &infinity, &result)
+
+	var result AffinePoint[B]
+	if !c.addA {
+		// ---------------------------------------------------------------
+		// j-invariant 0 (a == 0).
+		//
+		// The Brier–Joye unified formula λ = (x₁²+x₁x₂+x₂²)/(y₁+y₂) is
+		// NOT complete on these curves: Fp contains nontrivial cube roots
+		// of unity ω, so two distinct non-inverse points can satisfy
+		// y₁ + y₂ = 0 (e.g. q = −Φ(p) where Φ: (x,y) ↦ (ωx,y)).
+		//
+		// Instead we compute two slopes and select:
+		//   • chord   λ = (q.Y − p.Y) / (q.X − p.X)   when p.X ≠ q.X
+		//   • tangent λ = 3p.X² / (2p.Y)               when p.X = q.X (doubling)
+		// and handle p = −q  (return O) and p/q = O via selectors.
+		// ---------------------------------------------------------------
+
+		xDiff := c.baseApi.Sub(&q.X, &p.X)
+		xEqual := c.baseApi.IsZero(xDiff)
+
+		// -- chord slope (used when p.X ≠ q.X) --
+		xDiff = c.baseApi.Select(xEqual, c.baseApi.One(), xDiff)
+		λchord := c.baseApi.Div(c.baseApi.Sub(&q.Y, &p.Y), xDiff)
+
+		// -- tangent slope (used when p.X = q.X, i.e. p = ±q) --
+		xx := c.baseApi.MulMod(&p.X, &p.X)
+		xx3 := c.baseApi.MulConst(xx, big.NewInt(3))
+		y2 := c.baseApi.MulConst(&p.Y, big.NewInt(2))
+		y2IsZero := c.baseApi.IsZero(y2)
+		y2 = c.baseApi.Select(y2IsZero, c.baseApi.One(), y2)
+		λtangent := c.baseApi.Div(xx3, y2)
+		λtangent = c.baseApi.Select(y2IsZero, c.baseApi.Zero(), λtangent)
+
+		// select the appropriate slope
+		λ := c.baseApi.Select(xEqual, λtangent, λchord)
+
+		// compute the result point from λ
+		xr := c.baseApi.Eval([][]*emulated.Element[B]{{λ, λ}, {&p.X}, {&q.X}}, []int{1, -1, -1})
+		yr := c.baseApi.Eval([][]*emulated.Element[B]{{λ, c.baseApi.Sub(&p.X, xr)}, {&p.Y}}, []int{1, -1})
+		result = AffinePoint[B]{
+			X: *xr,
+			Y: *yr,
+		}
+
+		// if p=(0,0) return q
+		result = *c.Select(selector1, q, &result)
+		// if q=(0,0) return p
+		result = *c.Select(selector2, p, &result)
+		// if p = −q (same X, different Y) return O.
+		// When xEqual=1 and y2IsZero=1, both points are (0,0) — already
+		// handled above. Otherwise xEqual=1 ∧ ¬yEqual means p.Y = −q.Y.
+		yEqual := c.baseApi.IsZero(c.baseApi.Sub(&p.Y, &q.Y))
+		isInverse := c.api.And(xEqual, c.api.Sub(1, yEqual))
+		result = *c.Select(isInverse, &infinity, &result)
+	} else {
+		// ---------------------------------------------------------------
+		// j-invariant ≠ 0 (a ≠ 0).
+		//
+		// On these curves p.Y + q.Y = 0 implies p = −q, so the Brier–Joye
+		// unified formula is complete.
+		// ---------------------------------------------------------------
+
+		// λ = ((p.x+q.x)² - p.x*q.x + a)/(p.y + q.y)
+		pxqx := c.baseApi.MulMod(&p.X, &q.X)
+		pxplusqx := c.baseApi.Add(&p.X, &q.X)
+		num := c.baseApi.MulMod(pxplusqx, pxplusqx)
+		num = c.baseApi.Sub(num, pxqx)
+		num = c.baseApi.Add(num, &c.a)
+		denum := c.baseApi.Add(&p.Y, &q.Y)
+		// if p.y + q.y = 0, assign dummy 1 to denum and continue
+		selector3 := c.baseApi.IsZero(denum)
+		denum = c.baseApi.Select(selector3, c.baseApi.One(), denum)
+		λ := c.baseApi.Div(num, denum)
+
+		// x = λ^2 - p.x - q.x
+		xr := c.baseApi.MulMod(λ, λ)
+		xr = c.baseApi.Sub(xr, pxplusqx)
+
+		// y = λ(p.x - xr) - p.y
+		yr := c.baseApi.Sub(&p.X, xr)
+		yr = c.baseApi.MulMod(yr, λ)
+		yr = c.baseApi.Sub(yr, &p.Y)
+		result = AffinePoint[B]{
+			X: *xr,
+			Y: *yr,
+		}
+
+		// if p=(0,0) return q
+		result = *c.Select(selector1, q, &result)
+		// if q=(0,0) return p
+		result = *c.Select(selector2, p, &result)
+		// if p.y + q.y = 0, return (0, 0)
+		result = *c.Select(selector3, &infinity, &result)
+	}
 
 	return &result
 }

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -1561,10 +1561,11 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 	}
 
 	// handle 0-scalar and (-1)-scalar cases
-	var selector0 frontend.Variable
+	var selector0, selector1 frontend.Variable
 	_s := s
 	if cfg.CompleteArithmetic {
 		one := c.scalarApi.One()
+		selector1 = c.scalarApi.IsZero(c.scalarApi.Sub(s, one))
 		selector0 = c.api.Or(
 			c.scalarApi.IsZero(s),
 			c.scalarApi.IsZero(
@@ -1646,7 +1647,7 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 	Q := &AffinePoint[B]{X: *point[0], Y: *point[1]}
 
 	// handle (0,0)-point
-	var _selector0, _selector1 frontend.Variable
+	var _selector0 frontend.Variable
 	_P := P
 	if cfg.CompleteArithmetic {
 		// if Q=(0,0) we assign a dummy point to Q and continue
@@ -1654,9 +1655,8 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 		// if P=(0,0) we assign a dummy point to P and continue
 		_selector0 = c.api.And(c.baseApi.IsZero(&P.X), c.baseApi.IsZero(&P.Y))
 		_P = c.Select(_selector0, &c.GeneratorMultiples()[4], P)
-		// if s=±1 we assign a dummy point to Q and continue
-		_selector1 = c.baseApi.IsZero(c.baseApi.Sub(&P.X, &Q.X))
-		Q = c.Select(_selector1, &c.GeneratorMultiples()[3], Q)
+		// if s=1 we assign a dummy point to Q and continue
+		Q = c.Select(selector1, &c.GeneratorMultiples()[3], Q)
 	}
 
 	addFn := c.Add
@@ -1802,12 +1802,23 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 	// Acc should be now equal to [2^nbits]G
 	gm := c.GeneratorMultiples()[nbits-1]
 	if cfg.CompleteArithmetic {
-		Acc = c.Select(c.api.Or(c.api.Or(selector0, _selector0), _selector1), &gm, Acc)
+		Acc = c.Select(c.api.Or(c.api.Or(selector0, _selector0), selector1), &gm, Acc)
 	}
 	c.AssertIsEqual(Acc, &gm)
 
-	return &AffinePoint[B]{
+	res := &AffinePoint[B]{
 		X: *point[0],
 		Y: *point[1],
 	}
+	if cfg.CompleteArithmetic {
+		zero := c.baseApi.Zero()
+		// The complete-arithmetic edge branches (s=0, s=-1, s=1, or P=(0,0))
+		// reroute the accumulator check through dummy points, so we must also
+		// return the canonical in-circuit result instead of the unverified hint output.
+		res = c.Select(selector1, _P, res)
+		res = c.Select(selector0, c.Neg(_P), res)
+		res = c.Select(c.scalarApi.IsZero(s), &AffinePoint[B]{X: *zero, Y: *zero}, res)
+		res = c.Select(_selector0, &AffinePoint[B]{X: *zero, Y: *zero}, res)
+	}
+	return res
 }

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -380,8 +380,8 @@ func (c *Curve[B, S]) doubleGeneric(p *AffinePoint[B], unified bool) *AffinePoin
 	yr := c.baseApi.Eval([][]*emulated.Element[B]{{λ, c.baseApi.Sub(&p.X, xr)}, {&p.Y}}, []int{1, -1})
 
 	return &AffinePoint[B]{
-		X: *c.baseApi.Reduce(xr),
-		Y: *c.baseApi.Reduce(yr),
+		X: *xr,
+		Y: *yr,
 	}
 }
 
@@ -444,8 +444,8 @@ func (c *Curve[B, S]) tripleGeneric(p *AffinePoint[B], unified bool) *AffinePoin
 	yr := c.baseApi.Eval([][]*emulated.Element[B]{{λ2, c.baseApi.Sub(&p.X, xr)}, {&p.Y}}, []int{1, -1})
 
 	return &AffinePoint[B]{
-		X: *c.baseApi.Reduce(xr),
-		Y: *c.baseApi.Reduce(yr),
+		X: *xr,
+		Y: *yr,
 	}
 }
 
@@ -506,8 +506,8 @@ func (c *Curve[B, S]) doubleAndAddGeneric(p, q *AffinePoint[B], unified bool) *A
 	y3 := c.baseApi.Eval([][]*emulated.Element[B]{{λ2, c.baseApi.Add(x3, xpn)}, {&p.Y}}, []int{1, -1})
 
 	return &AffinePoint[B]{
-		X: *c.baseApi.Reduce(x3),
-		Y: *c.baseApi.Reduce(y3),
+		X: *x3,
+		Y: *y3,
 	}
 
 }

--- a/std/algebra/emulated/sw_emulated/point_test.go
+++ b/std/algebra/emulated/sw_emulated/point_test.go
@@ -2512,6 +2512,70 @@ func TestScalarMulGLVAndFakeGLVEdgeCasesEdgeCases(t *testing.T) {
 	assert.NoError(err)
 }
 
+// This is a regression for the missing complete-formula handling in
+// scalarMulGLVAndFakeGLV. For secp256k1 and s=2, the halfGCDEisenstein
+// decomposition yields signs corresponding to
+//
+//	b1 = -P + Q + Phi(P) + Phi(Q).
+//
+// Choosing P = [k]G with k = -(-1+s+lambda)^(-1) mod r forces b1 = -G, so the
+// subsequent biased addition Add(b1, G) hits the incomplete p = -q case even
+// though WithCompleteArithmetic() is set.
+func TestScalarMulGLVAndFakeGLVCompleteBiasCollisionFails(t *testing.T) {
+	assert := test.NewAssert(t)
+
+	s := big.NewInt(2)
+	px, _ := new(big.Int).SetString("94965683177328971411667606145825844139344978940117793175623205041120367451491", 10)
+	py, _ := new(big.Int).SetString("38527804351792152920115251132777683131500237568498526614282003522453447585331", 10)
+	rx, _ := new(big.Int).SetString("77384702278326987461233747693816699041502972512620163658749372669210393534086", 10)
+	ry, _ := new(big.Int).SetString("5133619745831577372541345842802261169510513692806955885865310987294091530663", 10)
+
+	circuit := ScalarMulGLVAndFakeGLVEdgeCasesTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{}
+	witness := ScalarMulGLVAndFakeGLVEdgeCasesTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
+		S: emulated.ValueOf[emulated.Secp256k1Fr](s),
+		P: AffinePoint[emulated.Secp256k1Fp]{
+			X: emulated.ValueOf[emulated.Secp256k1Fp](px),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](py),
+		},
+		R: AffinePoint[emulated.Secp256k1Fp]{
+			X: emulated.ValueOf[emulated.Secp256k1Fp](rx),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](ry),
+		},
+	}
+
+	err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())
+	assert.NoError(err)
+}
+
+// This is a regression for a remaining incomplete-addition hole in the
+// scalarMulGLVAndFakeGLV table construction on the master code path. For
+// secp256k1, P=G and this specific scalar, one of the Bi precomputations still
+// hits an unsafe c.Add even with WithCompleteArithmetic() set.
+func TestScalarMulGLVAndFakeGLVCompletePrecomputeCollisionFails(t *testing.T) {
+	assert := test.NewAssert(t)
+	_, g := secp256k1.Generators()
+
+	s, _ := new(big.Int).SetString("75436160726311993805852442966950040901855315110965173977233241085775995960037", 10)
+	var expected secp256k1.G1Affine
+	expected.ScalarMultiplication(&g, s)
+
+	circuit := ScalarMulGLVAndFakeGLVEdgeCasesTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{}
+	witness := ScalarMulGLVAndFakeGLVEdgeCasesTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
+		S: emulated.ValueOf[emulated.Secp256k1Fr](s),
+		P: AffinePoint[emulated.Secp256k1Fp]{
+			X: emulated.ValueOf[emulated.Secp256k1Fp](g.X),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](g.Y),
+		},
+		R: AffinePoint[emulated.Secp256k1Fp]{
+			X: emulated.ValueOf[emulated.Secp256k1Fp](expected.X),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](expected.Y),
+		},
+	}
+
+	err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())
+	assert.NoError(err)
+}
+
 func TestScalarMulGLVAndFakeGLVEdgeCasesEdgeCases2(t *testing.T) {
 	assert := test.NewAssert(t)
 	_, _, g, _ := bn254.Generators()

--- a/std/algebra/emulated/sw_emulated/point_test.go
+++ b/std/algebra/emulated/sw_emulated/point_test.go
@@ -2424,6 +2424,8 @@ func TestScalarMulGLVAndFakeGLVEdgeCasesEdgeCases(t *testing.T) {
 	assert.NoError(err)
 
 	// -1 * P == -P
+	var expected secp256k1.G1Affine
+	expected.Neg(&g)
 	witness5 := ScalarMulGLVAndFakeGLVEdgeCasesTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
 		S: emulated.ValueOf[emulated.Secp256k1Fr](big.NewInt(-1)),
 		P: AffinePoint[emulated.Secp256k1Fp]{
@@ -2431,8 +2433,8 @@ func TestScalarMulGLVAndFakeGLVEdgeCasesEdgeCases(t *testing.T) {
 			Y: emulated.ValueOf[emulated.Secp256k1Fp](g.Y),
 		},
 		R: AffinePoint[emulated.Secp256k1Fp]{
-			X: emulated.ValueOf[emulated.Secp256k1Fp](g.X),
-			Y: emulated.ValueOf[emulated.Secp256k1Fp](g.Y.Neg(&g.Y)),
+			X: emulated.ValueOf[emulated.Secp256k1Fp](expected.X),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](expected.Y),
 		},
 	}
 	err = test.IsSolved(&circuit, &witness5, testCurve.ScalarField())
@@ -2440,7 +2442,6 @@ func TestScalarMulGLVAndFakeGLVEdgeCasesEdgeCases(t *testing.T) {
 
 	// -2 * P == -2P
 	minusTwo := big.NewInt(-2)
-	var expected secp256k1.G1Affine
 	expected.ScalarMultiplication(&g, minusTwo)
 	witness6 := ScalarMulGLVAndFakeGLVEdgeCasesTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
 		S: emulated.ValueOf[emulated.Secp256k1Fr](minusTwo),

--- a/std/algebra/emulated/sw_emulated/point_test.go
+++ b/std/algebra/emulated/sw_emulated/point_test.go
@@ -480,6 +480,59 @@ func TestAddUnifiedEdgeCases(t *testing.T) {
 	assert.NoError(err)
 }
 
+// TestAddUnifiedCubeRootEdgeCase tests AddUnified on j-invariant 0 curves
+// (e.g. secp256k1, BN254) with two points where p.Y + q.Y = 0 but p.X ≠ q.X.
+// This happens because Fp contains nontrivial cube roots of unity ω: for a
+// curve point P = (x, y), the point (ω·x, -y) is also on the curve and has
+// the same |Y| but different X. The Brier–Joye unified formula divides by
+// (p.Y + q.Y) which is zero in this case, giving the wrong result O instead
+// of the correct sum.
+func TestAddUnifiedCubeRootEdgeCase(t *testing.T) {
+	assert := test.NewAssert(t)
+
+	// secp256k1 generator
+	_, g := secp256k1.Generators()
+
+	// Phi(G) = (ω·G.x, G.y), -Phi(G) = (ω·G.x, -G.y)
+	omega, _ := new(big.Int).SetString("55594575648329892869085402983802832744385952214688224221778511981742606582254", 10)
+	var phiGx fp_secp.Element
+	phiGx.SetBigInt(omega)
+	var gx fp_secp.Element
+	gx.Set(&g.X)
+	phiGx.Mul(&phiGx, &gx)
+	negPhiG := secp256k1.G1Affine{X: phiGx, Y: g.Y}
+	negPhiG.Y.Neg(&negPhiG.Y) // (ω·G.x, -G.y)
+
+	// Compute R = G + (-Phi(G)) natively using Jacobian (correct result)
+	var Rjac secp256k1.G1Jac
+	Rjac.FromAffine(&g)
+	var tmp secp256k1.G1Jac
+	tmp.FromAffine(&negPhiG)
+	Rjac.AddAssign(&tmp)
+	var R secp256k1.G1Affine
+	R.FromJacobian(&Rjac)
+
+	circuit := AddUnifiedEdgeCasesTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{}
+
+	// G + (-Phi(G)): p.Y + q.Y = G.y + (-G.y) = 0, but p.X ≠ q.X
+	witness := AddUnifiedEdgeCasesTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
+		P: AffinePoint[emulated.Secp256k1Fp]{
+			X: emulated.ValueOf[emulated.Secp256k1Fp](g.X),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](g.Y),
+		},
+		Q: AffinePoint[emulated.Secp256k1Fp]{
+			X: emulated.ValueOf[emulated.Secp256k1Fp](negPhiG.X),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](negPhiG.Y),
+		},
+		R: AffinePoint[emulated.Secp256k1Fp]{
+			X: emulated.ValueOf[emulated.Secp256k1Fp](R.X),
+			Y: emulated.ValueOf[emulated.Secp256k1Fp](R.Y),
+		},
+	}
+	err := test.IsSolved(&circuit, &witness, testCurve.ScalarField())
+	assert.NoError(err)
+}
+
 type ScalarMulBaseTest[T, S emulated.FieldParams] struct {
 	Q AffinePoint[T]
 	S emulated.Element[S]

--- a/std/algebra/native/sw_bls12377/g1.go
+++ b/std/algebra/native/sw_bls12377/g1.go
@@ -859,8 +859,16 @@ func (p *G1Affine) scalarMulGLVAndFakeGLV(api frontend.API, P G1Affine, s fronte
 	}
 	Acc.AssertIsEqual(api, H)
 
-	p.X = point[0]
-	p.Y = point[1]
+	hintedQ := G1Affine{X: point[0], Y: point[1]}
+	if cfg.CompleteArithmetic {
+		// On the zero-scalar and infinity-input branches we replace Q and P with
+		// dummy points to keep the incomplete formulas safe, so the raw hinted
+		// output is no longer constrained there. Select back to the canonical
+		// infinity result instead of returning the unchecked hint.
+		p.Select(api, api.Or(selector0, _selector0), G1Affine{X: 0, Y: 0}, hintedQ)
+	} else {
+		*p = hintedQ
+	}
 
 	return p
 }


### PR DESCRIPTION
# Description

The current implementation didn't handle all edge cases even when we had WithCompleteArithmetic set (contrary to scalarmulGLV and scalarmulFakeGLV).

Additionally, when implementing, I found a bug in unified addition formula which was incomplete when j=0.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Added regression tests for all fixes.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches elliptic-curve group law and scalar-multiplication logic (including complete-arithmetic edge paths and hint verification), where subtle mistakes can break correctness or soundness for proofs.
> 
> **Overview**
> Fixes **completeness bugs in emulated elliptic-curve arithmetic** when `WithCompleteArithmetic()` is enabled, ensuring edge cases like `s=0`, `s=±1`, and `(0,0)` inputs return the canonical infinity/expected point instead of unconstrained hint outputs.
> 
> Updates `AddUnified` to be *actually complete* on **j-invariant 0 curves** by avoiding the Brier–Joye denominator-zero failure when `p.Y+q.Y=0` but `p.X≠q.X` (cube-root-of-unity twist), and adjusts scalar-mul routines (notably `scalarMulGLVAndFakeGLV`/`scalarMulFakeGLV`) to consistently use unified ops and avoid remaining incomplete-addition collisions.
> 
> Adds targeted regression tests for the cube-root edge case and multiple `scalarMulGLVAndFakeGLV` complete-arithmetic collision scenarios, and applies the same “don’t return unchecked hint output on dummy branches” fix to native `sw_bls12377` GLV+fake-GLV.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baa146b4d8f6f6d1bd167fc1db5f5927ecaf3c52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->