### PR TITLE
feat(emulated): checkZero mulcheck in hint

### DIFF
--- a/std/math/emulated/field_mul.go
+++ b/std/math/emulated/field_mul.go
@@ -534,8 +534,12 @@ func (f *Field[T]) callMulHint(a, b *Element[T], isMulMod bool, customMod *Eleme
 	if customMod != nil {
 		modulusLimbs = customMod.Limbs
 	}
-	hintInputs := make([]frontend.Variable, 0, 4+len(modulusLimbs)+len(a.Limbs)+len(b.Limbs))
-	hintInputs = append(hintInputs, nbBits, nbLimbs, len(a.Limbs), nbQuoLimbs)
+	isCheckZero := 0
+	if !isMulMod {
+		isCheckZero = 1
+	}
+	hintInputs := make([]frontend.Variable, 0, 5+len(modulusLimbs)+len(a.Limbs)+len(b.Limbs))
+	hintInputs = append(hintInputs, nbBits, nbLimbs, len(a.Limbs), nbQuoLimbs, isCheckZero)
 	hintInputs = append(hintInputs, modulusLimbs...)
 	hintInputs = append(hintInputs, a.Limbs...)
 	hintInputs = append(hintInputs, b.Limbs...)
@@ -566,8 +570,9 @@ func mulHint(field *big.Int, inputs, outputs []*big.Int) error {
 	nbLimbs := int(inputs[1].Int64())
 	nbALen := int(inputs[2].Int64())
 	nbQuoLen := int(inputs[3].Int64())
-	nbBLen := len(inputs) - 4 - nbLimbs - nbALen
-	ptr := 4
+	isCheckZero := inputs[4].Int64() == 1
+	nbBLen := len(inputs) - 5 - nbLimbs - nbALen
+	ptr := 5
 	plimbs := inputs[ptr : ptr+nbLimbs]
 	ptr += nbLimbs
 	alimbs := inputs[ptr : ptr+nbALen]
@@ -610,6 +615,10 @@ func mulHint(field *big.Int, inputs, outputs []*big.Int) error {
 	ab.Mul(a, b)
 	if p.Sign() != 0 {
 		quo.QuoRem(ab, p, rem)
+	}
+	if isCheckZero && rem.Sign() != 0 {
+		// we expect the remainder to be zero
+		return fmt.Errorf("unexpected non-zero remainder for checkZero")
 	}
 	if err := limbs.Decompose(quo, uint(nbBits), quoLimbs); err != nil {
 		return fmt.Errorf("decompose quo: %w", err)


### PR DESCRIPTION
closes consensys/gnark#1748

# Description

**Is your feature request related to a problem? Please describe.**
When an emulated element assert fails, it's hard to track the point of failure.

This is because when mulcheck is returned by the hint, the remainder is swapped out with zero, which is very constraint efficient.
However, a failing assert only triggers much later in deferred check call, making it hard to track the bug.

**Describe the solution you'd like**

Instead of adding a failing mulcheck in assert, assert call can tell the hint if a particular mulcheck should have zero remainder (forward existing `isMulMod` var) to the hint, and then hint can fail on computation itself allowing for easy error tracking.

This will make sure only valid `mulcheck`s are added to deferred checks. And have better devX for writing emulated circuits.

**Describe alternatives you've considered**
Tried script for debugging (thanks @ivokub). Which helped with the debugging :)
But I believe this should be cleaner.

**Additional context**
Almost ended up thinking `mulcheck`s weren't working properly for my large unruly overflowing emulated elements. Validated the added mulcheck in some python playground. It was failing. Found out about assert calls setting mulcheck rem to `0`.

With this, we'll have no extra constraints, and error call stacks will provide easier path to follow for finding issues.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] All emulated tests for BN254 fields

# How has this been benchmarked?

- na -

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the `mulHint` input contract and adds an early error path in a core emulated-field hint; could change when/where failing circuits error and may break any callers that assume the old hint input layout.
> 
> **Overview**
> Propagates a `checkZero` flag into the multiplication hint inputs (via `callMulHint`), extending the hint’s input header by one value.
> 
> Updates `mulHint` to parse the new flag and, when invoked for `checkZero`/mulcheck cases, **fail immediately** if `a*b mod p` produces a non-zero remainder, instead of letting an invalid mulcheck surface later during deferred verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434bd2dcc6bc3d1ce5489dd5643ed70d47430efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->