### PR TITLE
feat(emulated/polyring): Polynomial ring arithmetic for deferred pairing checks in BN254

### DIFF
--- a/std/algebra/emulated/fields_bn254/e12.go
+++ b/std/algebra/emulated/fields_bn254/e12.go
@@ -11,6 +11,7 @@ import (
 
 type E12 struct {
 	A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11 baseEl
+	poly                                             *basePoly
 }
 
 type Ext12 struct {
@@ -42,12 +43,15 @@ func NewExt12(api frontend.API) *Ext12 {
 
 // PolyConv implementation for E12
 func (a *E12) ToPoly() *basePoly {
-	return &basePoly{
-		Coeffs: []*baseEl{
-			&a.A0, &a.A1, &a.A2, &a.A3, &a.A4, &a.A5,
-			&a.A6, &a.A7, &a.A8, &a.A9, &a.A10, &a.A11,
-		},
+	if a.poly == nil {
+		a.poly = &basePoly{
+			Coeffs: []*baseEl{
+				&a.A0, &a.A1, &a.A2, &a.A3, &a.A4, &a.A5,
+				&a.A6, &a.A7, &a.A8, &a.A9, &a.A10, &a.A11,
+			},
+		}
 	}
+	return a.poly
 }
 
 func (e Ext12) ToPoly(a *E12) *basePoly {
@@ -59,19 +63,24 @@ func (e Ext12) PolyToE12(p *basePoly) *E12 {
 		panic("invalid number of coefficients for E12")
 	}
 	return &E12{
-		A0:  *p.Coeffs[0],
-		A1:  *p.Coeffs[1],
-		A2:  *p.Coeffs[2],
-		A3:  *p.Coeffs[3],
-		A4:  *p.Coeffs[4],
-		A5:  *p.Coeffs[5],
-		A6:  *p.Coeffs[6],
-		A7:  *p.Coeffs[7],
-		A8:  *p.Coeffs[8],
-		A9:  *p.Coeffs[9],
-		A10: *p.Coeffs[10],
-		A11: *p.Coeffs[11],
+		A0:   *p.Coeffs[0],
+		A1:   *p.Coeffs[1],
+		A2:   *p.Coeffs[2],
+		A3:   *p.Coeffs[3],
+		A4:   *p.Coeffs[4],
+		A5:   *p.Coeffs[5],
+		A6:   *p.Coeffs[6],
+		A7:   *p.Coeffs[7],
+		A8:   *p.Coeffs[8],
+		A9:   *p.Coeffs[9],
+		A10:  *p.Coeffs[10],
+		A11:  *p.Coeffs[11],
+		poly: p,
 	}
+}
+
+func (e Ext12) NewPolyRingAccumulator(targetDeg int) *emulated.PolyRingAccumulator[emulated.BN254Fp] {
+	return e.fp.NewPolyRingAccumulator(e.ring, targetDeg)
 }
 
 func (e Ext12) MulPoly(inputs ...*basePoly) *basePoly {
@@ -258,7 +267,8 @@ func (e Ext12) Conjugate(x *E12) *E12 {
 }
 
 func (e Ext12) Mul(x, y *E12) *E12 {
-	return e.mulDirect(x, y)
+	return e.PolyToE12(e.MulPoly(x.ToPoly(), y.ToPoly()))
+	// return e.mulDirect(x, y)
 }
 
 func (e Ext12) mulDirect(a, b *E12) *E12 {
@@ -471,6 +481,30 @@ func (e Ext12) Inverse(x *E12) *E12 {
 	e.AssertIsEqual(one, _one)
 
 	return &inv
+
+}
+
+func (e Ext12) InversePoly(xPoly *basePoly) *basePoly {
+	x := xPoly.Coeffs
+	res, err := e.fp.NewHint(inverseE12Hint, 12, x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10], x[11])
+	if err != nil {
+		// err is non-nil only for invalid number of inputs
+		panic(err)
+	}
+
+	inv := &basePoly{
+		Coeffs: []*baseEl{
+			res[0], res[1], res[2], res[3], res[4], res[5],
+			res[6], res[7], res[8], res[9], res[10], res[11]},
+	}
+	one := e.One()
+
+	// 1 == inv * x
+	_one := e.MulPoly(xPoly, inv)
+	// _one := e.Mul(&inv, x)
+	e.AssertIsEqual(one, e.PolyToE12(_one))
+
+	return inv
 
 }
 

--- a/std/algebra/emulated/fields_bn254/e12.go
+++ b/std/algebra/emulated/fields_bn254/e12.go
@@ -27,7 +27,6 @@ func NewExt12(api frontend.API) *Ext12 {
 	}
 	modPoly := fp.MakePoly(82, 0, 0, 0, 0, 0, -18, 0, 0, 0, 0, 0, 1)
 	modEval := func(xPowers []*baseEl) *baseEl {
-		// return fp.Eval([][]*baseEl{{xPowers[0]}, {xPowers[6]}, {xPowers[12]}}, []int{82, -18, 1})
 		a0 := fp.MulConst(xPowers[0], big.NewInt(82))
 		a6 := fp.MulConst(xPowers[6], big.NewInt(-18))
 		a12 := xPowers[12]
@@ -41,7 +40,7 @@ func NewExt12(api frontend.API) *Ext12 {
 	}
 }
 
-// PolyLike implementation for E12
+// PolyConv implementation for E12
 func (a *E12) ToPoly() *basePoly {
 	return &basePoly{
 		Coeffs: []*baseEl{
@@ -49,6 +48,10 @@ func (a *E12) ToPoly() *basePoly {
 			&a.A6, &a.A7, &a.A8, &a.A9, &a.A10, &a.A11,
 		},
 	}
+}
+
+func (e Ext12) ToPoly(a *E12) *basePoly {
+	return a.ToPoly()
 }
 
 func (e Ext12) PolyToE12(p *basePoly) *E12 {
@@ -369,15 +372,6 @@ func (e Ext12) mulDirect(a, b *E12) *E12 {
 		A9:  *d9,
 		A10: *d10,
 		A11: *d11,
-	}
-}
-
-func (e Ext12) ToPoly(a *E12) *basePoly {
-	return &basePoly{
-		Coeffs: []*baseEl{
-			&a.A0, &a.A1, &a.A2, &a.A3, &a.A4, &a.A5,
-			&a.A6, &a.A7, &a.A8, &a.A9, &a.A10, &a.A11,
-		},
 	}
 }
 

--- a/std/algebra/emulated/fields_bn254/e12.go
+++ b/std/algebra/emulated/fields_bn254/e12.go
@@ -26,11 +26,18 @@ func NewExt12(api frontend.API) *Ext12 {
 		panic(err)
 	}
 	modPoly := fp.MakePoly([]any{82, 0, 0, 0, 0, 0, -18, 0, 0, 0, 0, 0, 1})
+	modEval := func(xPowers []*baseEl) *baseEl {
+		// return fp.Eval([][]*baseEl{{xPowers[0]}, {xPowers[6]}, {xPowers[12]}}, []int{82, -18, 1})
+		a0 := fp.MulConst(xPowers[0], big.NewInt(82))
+		a6 := fp.MulConst(xPowers[6], big.NewInt(-18))
+		a12 := xPowers[12]
+		return fp.Add(a0, fp.Add(a6, a12))
+	}
 	return &Ext12{
 		Ext2: NewExt2(api),
 		api:  api,
 		fp:   fp,
-		ring: fp.NewPolyRingCheck(modPoly),
+		ring: fp.NewPolyRingCheck(modPoly, modEval),
 	}
 }
 

--- a/std/algebra/emulated/fields_bn254/e12.go
+++ b/std/algebra/emulated/fields_bn254/e12.go
@@ -324,27 +324,29 @@ func (e Ext12) mulDirect(a, b *E12) *E12 {
 	}
 }
 
-func (e Ext12) ToPoly(a *E12) emulated.Poly[emulated.BN254Fp] {
-	return emulated.Poly[emulated.BN254Fp]{
-		&a.A0, &a.A1, &a.A2, &a.A3, &a.A4, &a.A5,
-		&a.A6, &a.A7, &a.A8, &a.A9, &a.A10, &a.A11,
+func (e Ext12) ToPoly(a *E12) *emulated.Poly[emulated.BN254Fp] {
+	return &emulated.Poly[emulated.BN254Fp]{
+		Coeffs: []*baseEl{
+			&a.A0, &a.A1, &a.A2, &a.A3, &a.A4, &a.A5,
+			&a.A6, &a.A7, &a.A8, &a.A9, &a.A10, &a.A11,
+		},
 	}
 }
 
-func (e Ext12) FromPoly(p emulated.Poly[emulated.BN254Fp]) *E12 {
+func (e Ext12) FromPoly(p *emulated.Poly[emulated.BN254Fp]) *E12 {
 	return &E12{
-		A0:  *p[0],
-		A1:  *p[1],
-		A2:  *p[2],
-		A3:  *p[3],
-		A4:  *p[4],
-		A5:  *p[5],
-		A6:  *p[6],
-		A7:  *p[7],
-		A8:  *p[8],
-		A9:  *p[9],
-		A10: *p[10],
-		A11: *p[11],
+		A0:  *p.Coeffs[0],
+		A1:  *p.Coeffs[1],
+		A2:  *p.Coeffs[2],
+		A3:  *p.Coeffs[3],
+		A4:  *p.Coeffs[4],
+		A5:  *p.Coeffs[5],
+		A6:  *p.Coeffs[6],
+		A7:  *p.Coeffs[7],
+		A8:  *p.Coeffs[8],
+		A9:  *p.Coeffs[9],
+		A10: *p.Coeffs[10],
+		A11: *p.Coeffs[11],
 	}
 }
 

--- a/std/algebra/emulated/fields_bn254/e12.go
+++ b/std/algebra/emulated/fields_bn254/e12.go
@@ -15,8 +15,9 @@ type E12 struct {
 
 type Ext12 struct {
 	*Ext2
-	api frontend.API
-	fp  *curveF
+	api  frontend.API
+	fp   *curveF
+	ring *emulated.PolyRingGroupChecks[emulated.BN254Fp]
 }
 
 func NewExt12(api frontend.API) *Ext12 {
@@ -24,11 +25,48 @@ func NewExt12(api frontend.API) *Ext12 {
 	if err != nil {
 		panic(err)
 	}
+	modPoly := fp.MakePoly([]any{82, 0, 0, 0, 0, 0, -18, 0, 0, 0, 0, 0, 1})
 	return &Ext12{
 		Ext2: NewExt2(api),
 		api:  api,
 		fp:   fp,
+		ring: fp.NewPolyRingCheck(modPoly),
 	}
+}
+
+// PolyLike implementation for E12
+func (a *E12) ToPoly() *basePoly {
+	return &basePoly{
+		Coeffs: []*baseEl{
+			&a.A0, &a.A1, &a.A2, &a.A3, &a.A4, &a.A5,
+			&a.A6, &a.A7, &a.A8, &a.A9, &a.A10, &a.A11,
+		},
+	}
+}
+
+func (e Ext12) FromPoly(p *basePoly) *E12 {
+	return &E12{
+		A0:  *p.Coeffs[0],
+		A1:  *p.Coeffs[1],
+		A2:  *p.Coeffs[2],
+		A3:  *p.Coeffs[3],
+		A4:  *p.Coeffs[4],
+		A5:  *p.Coeffs[5],
+		A6:  *p.Coeffs[6],
+		A7:  *p.Coeffs[7],
+		A8:  *p.Coeffs[8],
+		A9:  *p.Coeffs[9],
+		A10: *p.Coeffs[10],
+		A11: *p.Coeffs[11],
+	}
+}
+
+func (e Ext12) MulPoly(inputs ...*basePoly) *basePoly {
+	rem, err := e.fp.MulPolyRings(e.ring, inputs...)
+	if err != nil {
+		panic(err)
+	}
+	return rem
 }
 
 func (e Ext12) Zero() *E12 {
@@ -324,29 +362,12 @@ func (e Ext12) mulDirect(a, b *E12) *E12 {
 	}
 }
 
-func (e Ext12) ToPoly(a *E12) *emulated.Poly[emulated.BN254Fp] {
-	return &emulated.Poly[emulated.BN254Fp]{
+func (e Ext12) ToPoly(a *E12) *basePoly {
+	return &basePoly{
 		Coeffs: []*baseEl{
 			&a.A0, &a.A1, &a.A2, &a.A3, &a.A4, &a.A5,
 			&a.A6, &a.A7, &a.A8, &a.A9, &a.A10, &a.A11,
 		},
-	}
-}
-
-func (e Ext12) FromPoly(p *emulated.Poly[emulated.BN254Fp]) *E12 {
-	return &E12{
-		A0:  *p.Coeffs[0],
-		A1:  *p.Coeffs[1],
-		A2:  *p.Coeffs[2],
-		A3:  *p.Coeffs[3],
-		A4:  *p.Coeffs[4],
-		A5:  *p.Coeffs[5],
-		A6:  *p.Coeffs[6],
-		A7:  *p.Coeffs[7],
-		A8:  *p.Coeffs[8],
-		A9:  *p.Coeffs[9],
-		A10: *p.Coeffs[10],
-		A11: *p.Coeffs[11],
 	}
 }
 

--- a/std/algebra/emulated/fields_bn254/e12.go
+++ b/std/algebra/emulated/fields_bn254/e12.go
@@ -324,6 +324,30 @@ func (e Ext12) mulDirect(a, b *E12) *E12 {
 	}
 }
 
+func (e Ext12) ToPoly(a *E12) emulated.Poly[emulated.BN254Fp] {
+	return emulated.Poly[emulated.BN254Fp]{
+		&a.A0, &a.A1, &a.A2, &a.A3, &a.A4, &a.A5,
+		&a.A6, &a.A7, &a.A8, &a.A9, &a.A10, &a.A11,
+	}
+}
+
+func (e Ext12) FromPoly(p emulated.Poly[emulated.BN254Fp]) *E12 {
+	return &E12{
+		A0:  *p[0],
+		A1:  *p[1],
+		A2:  *p[2],
+		A3:  *p[3],
+		A4:  *p[4],
+		A5:  *p[5],
+		A6:  *p[6],
+		A7:  *p[7],
+		A8:  *p[8],
+		A9:  *p[9],
+		A10: *p[10],
+		A11: *p[11],
+	}
+}
+
 func (e Ext12) Square(x *E12) *E12 {
 	return e.squareDirect(x)
 }

--- a/std/algebra/emulated/fields_bn254/e12.go
+++ b/std/algebra/emulated/fields_bn254/e12.go
@@ -25,7 +25,7 @@ func NewExt12(api frontend.API) *Ext12 {
 	if err != nil {
 		panic(err)
 	}
-	modPoly := fp.MakePoly([]any{82, 0, 0, 0, 0, 0, -18, 0, 0, 0, 0, 0, 1})
+	modPoly := fp.MakePoly(82, 0, 0, 0, 0, 0, -18, 0, 0, 0, 0, 0, 1)
 	modEval := func(xPowers []*baseEl) *baseEl {
 		// return fp.Eval([][]*baseEl{{xPowers[0]}, {xPowers[6]}, {xPowers[12]}}, []int{82, -18, 1})
 		a0 := fp.MulConst(xPowers[0], big.NewInt(82))
@@ -51,7 +51,10 @@ func (a *E12) ToPoly() *basePoly {
 	}
 }
 
-func (e Ext12) FromPoly(p *basePoly) *E12 {
+func (e Ext12) PolyToE12(p *basePoly) *E12 {
+	if len(p.Coeffs) != 12 {
+		panic("invalid number of coefficients for E12")
+	}
 	return &E12{
 		A0:  *p.Coeffs[0],
 		A1:  *p.Coeffs[1],

--- a/std/algebra/emulated/fields_bn254/e12_pairing.go
+++ b/std/algebra/emulated/fields_bn254/e12_pairing.go
@@ -269,6 +269,34 @@ func (e *Ext12) Mul01379By01379(e3, e4, c3, c4 *E2) [10]*baseEl {
 	return [10]*baseEl{d0, d1, d2, d3, d4, d6, d7, d8, d9, d10}
 }
 
+// ToPoly01379 converts to polynomial of degree 9 an E12 sparse
+// element b of the form:
+//
+//	b.A0  =  1
+//	b.A1  =  c3.A0 - 9 * c3.A1
+//	b.A2  =  0
+//	b.A3  =  c4.A0 - 9 * c4.A1
+//	b.A4  =  0
+//	b.A5  =  0
+//	b.A6  =  0
+//	b.A7  =  c3.A1
+//	b.A8  =  0
+//	b.A9  =  c4.A1
+//	b.A10 =  0
+//	b.A11 =  0
+func (e Ext12) ToPoly01379(c3, c4 *E2) *basePoly {
+	nine := big.NewInt(9)
+	b1 := e.fp.Sub(&c3.A0, e.fp.MulConst(&c3.A1, nine))
+	b3 := e.fp.Sub(&c4.A0, e.fp.MulConst(&c4.A1, nine))
+	b7 := &c3.A1
+	b9 := &c4.A1
+
+	return &basePoly{
+		Coeffs: []*baseEl{
+			e.fp.One(), b1, nil, b3, nil, nil, nil, b7, nil, b9},
+	}
+}
+
 // MulBy012346789 multiplies a by an E12 sparse element b of the form
 //
 //	b.A0  =  b[0]
@@ -333,5 +361,29 @@ func (e *Ext12) MulBy012346789(a *E12, b [10]*baseEl) *E12 {
 		A9:  *d9,
 		A10: *d10,
 		A11: *d11,
+	}
+}
+
+// ToPoly012346789 converts to polynomial of degree 10 an E12 sparse
+// element b of the form:
+//
+//	b.A0  =  b[0]
+//	b.A1  =  b[1]
+//	b.A2  =  b[2]
+//	b.A3  =  b[3]
+//	b.A4  =  b[4]
+//	b.A5  =  0
+//	b.A6  =  b[5]
+//	b.A7  =  b[6]
+//	b.A8  =  b[7]
+//	b.A9  =  b[8]
+//	b.A10 =  b[9]
+//	b.A11 =  0
+
+func (e Ext12) ToPoly012346789(b [10]*baseEl) *basePoly {
+	return &basePoly{
+		Coeffs: []*baseEl{
+			b[0], b[1], b[2], b[3], b[4], nil,
+			b[5], b[6], b[7], b[8], b[9]},
 	}
 }

--- a/std/algebra/emulated/fields_bn254/e12_test.go
+++ b/std/algebra/emulated/fields_bn254/e12_test.go
@@ -136,18 +136,9 @@ type e12MulPolyRing struct {
 }
 
 func (circuit *e12MulPolyRing) Define(api frontend.API) error {
-	fp, err := emulated.NewField[emulated.BN254Fp](api)
-	if err != nil {
-		return err
-	}
-	modPoly := fp.MakePoly([]interface{}{82, 0, 0, 0, 0, 0, -18, 0, 0, 0, 0, 0, 1})
-	ringGroup := fp.NewPolyRingCheck(modPoly)
 	e := NewExt12(api)
-	expected, err := fp.MulPolyRings(
-		[]*emulated.Poly[emulated.BN254Fp]{e.ToPoly(&circuit.A), e.ToPoly(&circuit.B)},
-		ringGroup,
-	)
-	e.AssertIsEqual(e.FromPoly(r), &circuit.C)
+	expected := e.MulPoly(e.ToPoly(&circuit.A), e.ToPoly(&circuit.B))
+	e.AssertIsEqual(e.FromPoly(expected), &circuit.C)
 	return nil
 }
 
@@ -168,10 +159,6 @@ func TestMulFp12PolyRing(t *testing.T) {
 
 	err := test.IsSolved(&e12MulPolyRing{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
-
-	scs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &witness)
-	assert.NoError(err)
-	println("Fp12 mul poly ring scs constraints:", scs.GetNbConstraints())
 }
 
 type e12Div struct {

--- a/std/algebra/emulated/fields_bn254/e12_test.go
+++ b/std/algebra/emulated/fields_bn254/e12_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/test"
 )
 
@@ -126,6 +127,44 @@ func TestMulFp12(t *testing.T) {
 	}
 
 	err := test.IsSolved(&e12Mul{}, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+
+}
+
+type e12MulPolyRing struct {
+	A, B, C E12
+}
+
+func (circuit *e12MulPolyRing) Define(api frontend.API) error {
+	fp, err := emulated.NewField[emulated.BN254Fp](api)
+	if err != nil {
+		return err
+	}
+	e := NewExt12(api)
+	_, r, err := fp.CallPolyRingMulHint(
+		[]emulated.Poly[emulated.BN254Fp]{e.ToPoly(&circuit.A), e.ToPoly(&circuit.B)},
+		fp.MakePoly([]interface{}{82, 0, 0, 0, 0, 0, -18, 0, 0, 0, 0, 0, 1}),
+	)
+	e.AssertIsEqual(e.FromPoly(r), &circuit.C)
+	return nil
+}
+
+func TestMulFp12PolyRing(t *testing.T) {
+
+	assert := test.NewAssert(t)
+	// witness values
+	var a, b, c bn254.E12
+	_, _ = a.SetRandom()
+	_, _ = b.SetRandom()
+	c.Mul(&a, &b)
+
+	witness := e12MulPolyRing{
+		A: FromE12(&a),
+		B: FromE12(&b),
+		C: FromE12(&c),
+	}
+
+	err := test.IsSolved(&e12MulPolyRing{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
 
 }

--- a/std/algebra/emulated/fields_bn254/e12_test.go
+++ b/std/algebra/emulated/fields_bn254/e12_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/test"
 )
 

--- a/std/algebra/emulated/fields_bn254/e12_test.go
+++ b/std/algebra/emulated/fields_bn254/e12_test.go
@@ -141,11 +141,11 @@ func (circuit *e12MulPolyRing) Define(api frontend.API) error {
 		return err
 	}
 	modPoly := fp.MakePoly([]interface{}{82, 0, 0, 0, 0, 0, -18, 0, 0, 0, 0, 0, 1})
-	fp.RegisterPolyRing("e12", modPoly)
+	ringGroup := fp.NewPolyRingCheck(modPoly)
 	e := NewExt12(api)
-	_, r, err := fp.CallPolyRingMulHint(
+	expected, err := fp.MulPolyRings(
 		[]*emulated.Poly[emulated.BN254Fp]{e.ToPoly(&circuit.A), e.ToPoly(&circuit.B)},
-		"e12",
+		ringGroup,
 	)
 	e.AssertIsEqual(e.FromPoly(r), &circuit.C)
 	return nil
@@ -169,6 +169,9 @@ func TestMulFp12PolyRing(t *testing.T) {
 	err := test.IsSolved(&e12MulPolyRing{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
 
+	scs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &witness)
+	assert.NoError(err)
+	println("Fp12 mul poly ring scs constraints:", scs.GetNbConstraints())
 }
 
 type e12Div struct {

--- a/std/algebra/emulated/fields_bn254/e12_test.go
+++ b/std/algebra/emulated/fields_bn254/e12_test.go
@@ -140,10 +140,12 @@ func (circuit *e12MulPolyRing) Define(api frontend.API) error {
 	if err != nil {
 		return err
 	}
+	modPoly := fp.MakePoly([]interface{}{82, 0, 0, 0, 0, 0, -18, 0, 0, 0, 0, 0, 1})
+	fp.RegisterPolyRing("e12", modPoly)
 	e := NewExt12(api)
 	_, r, err := fp.CallPolyRingMulHint(
-		[]emulated.Poly[emulated.BN254Fp]{e.ToPoly(&circuit.A), e.ToPoly(&circuit.B)},
-		fp.MakePoly([]interface{}{82, 0, 0, 0, 0, 0, -18, 0, 0, 0, 0, 0, 1}),
+		[]*emulated.Poly[emulated.BN254Fp]{e.ToPoly(&circuit.A), e.ToPoly(&circuit.B)},
+		"e12",
 	)
 	e.AssertIsEqual(e.FromPoly(r), &circuit.C)
 	return nil

--- a/std/algebra/emulated/fields_bn254/e2.go
+++ b/std/algebra/emulated/fields_bn254/e2.go
@@ -8,6 +8,7 @@ import (
 	"github.com/consensys/gnark/std/math/emulated"
 )
 
+type basePoly = emulated.Poly[emulated.BN254Fp]
 type curveF = emulated.Field[emulated.BN254Fp]
 type baseEl = emulated.Element[emulated.BN254Fp]
 

--- a/std/algebra/emulated/sw_bn254/hints.go
+++ b/std/algebra/emulated/sw_bn254/hints.go
@@ -133,39 +133,49 @@ func millerLoopAndCheckFinalExpHint(nativeMod *big.Int, nativeInputs, nativeOutp
 	// This follows section 4.3.2 of https://eprint.iacr.org/2024/640.pdf
 	return emulated.UnwrapHint(nativeInputs, nativeOutputs,
 		func(mod *big.Int, inputs, outputs []*big.Int) error {
+			var previous bn254.E12
 			var P bn254.G1Affine
 			var Q bn254.G2Affine
-			var previous bn254.E12
+			n := len(inputs)
+			nPt := n - 12 // inputs for points
+			p := make([]bn254.G1Affine, 0, nPt/6)
+			q := make([]bn254.G2Affine, 0, nPt/6)
+			for k := 0; k < nPt/6; k += 2 {
+				P.X.SetBigInt(inputs[k])
+				P.Y.SetBigInt(inputs[k+1])
+				p = append(p, P)
+			}
+			for k := nPt / 3; k < nPt/2+3; k += 4 {
+				Q.X.A0.SetBigInt(inputs[k])
+				Q.X.A1.SetBigInt(inputs[k+1])
+				Q.Y.A0.SetBigInt(inputs[k+2])
+				Q.Y.A1.SetBigInt(inputs[k+3])
+				q = append(q, Q)
+			}
 
-			P.X.SetBigInt(inputs[0])
-			P.Y.SetBigInt(inputs[1])
-			Q.X.A0.SetBigInt(inputs[2])
-			Q.X.A1.SetBigInt(inputs[3])
-			Q.Y.A0.SetBigInt(inputs[4])
-			Q.Y.A1.SetBigInt(inputs[5])
-
-			previous.C0.B0.A0.SetBigInt(inputs[6])
-			previous.C0.B0.A1.SetBigInt(inputs[7])
-			previous.C0.B1.A0.SetBigInt(inputs[8])
-			previous.C0.B1.A1.SetBigInt(inputs[9])
-			previous.C0.B2.A0.SetBigInt(inputs[10])
-			previous.C0.B2.A1.SetBigInt(inputs[11])
-			previous.C1.B0.A0.SetBigInt(inputs[12])
-			previous.C1.B0.A1.SetBigInt(inputs[13])
-			previous.C1.B1.A0.SetBigInt(inputs[14])
-			previous.C1.B1.A1.SetBigInt(inputs[15])
-			previous.C1.B2.A0.SetBigInt(inputs[16])
-			previous.C1.B2.A1.SetBigInt(inputs[17])
+			previous.C0.B0.A0.SetBigInt(inputs[n-12])
+			previous.C0.B0.A1.SetBigInt(inputs[n-11])
+			previous.C0.B1.A0.SetBigInt(inputs[n-10])
+			previous.C0.B1.A1.SetBigInt(inputs[n-9])
+			previous.C0.B2.A0.SetBigInt(inputs[n-8])
+			previous.C0.B2.A1.SetBigInt(inputs[n-7])
+			previous.C1.B0.A0.SetBigInt(inputs[n-6])
+			previous.C1.B0.A1.SetBigInt(inputs[n-5])
+			previous.C1.B1.A0.SetBigInt(inputs[n-4])
+			previous.C1.B1.A1.SetBigInt(inputs[n-3])
+			previous.C1.B2.A0.SetBigInt(inputs[n-2])
+			previous.C1.B2.A1.SetBigInt(inputs[n-1])
 
 			if previous.IsZero() {
 				return errors.New("previous Miller loop result is zero")
 			}
 
-			lines := bn254.PrecomputeLines(Q)
-			millerLoop, err := bn254.MillerLoopFixedQ(
-				[]bn254.G1Affine{P},
-				[][2][len(bn254.LoopCounter)]bn254.LineEvaluationAff{lines},
-			)
+			lines := make([][2][len(bn254.LoopCounter)]bn254.LineEvaluationAff, 0, len(q))
+			for _, qi := range q {
+				lines = append(lines, bn254.PrecomputeLines(qi))
+			}
+			millerLoop, err := bn254.MillerLoopFixedQ(p, lines)
+
 			if err != nil {
 				return err
 			}

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -309,7 +309,7 @@ func (pr *Pairing) PairingCheck(P []*G1Affine, Q []*G2Affine) error {
 	rwQ1 := pr.Frobenius(residueWitnessInv)
 	res.Mul(rwQ1.ToPoly())
 
-	pr.AssertIsEqual(pr.PolyToE12(res.Result()), pr.Ext12.One())
+	pr.AssertIsEqual(pr.PolyToE12(res.Eval()), pr.Ext12.One())
 
 	return nil
 }
@@ -548,7 +548,7 @@ func (pr *Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 		lines[i] = *Q[i].Lines
 	}
 	res, err := pr.millerLoopLines(P, lines, nil, nil, true)
-	return pr.PolyToE12(res.Result()), err
+	return pr.PolyToE12(res.Eval()), err
 }
 
 // millerLoopLines computes the multi-Miller loop from points in G1 and precomputed lines in G2
@@ -637,7 +637,7 @@ func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init,
 		default:
 			panic(fmt.Sprintf("invalid loop counter value %d", loopCounter[i]))
 		}
-		res.Result()
+		res.Eval()
 	}
 
 	// Compute  ℓ_{[6x₀+2]Q,π(Q)}(P) · ℓ_{[6x₀+2]Q+π(Q),-π²(Q)}(P)
@@ -911,7 +911,7 @@ func (pr *Pairing) millerLoopAndFinalExpResult(P *G1Affine, Q *G2Affine, previou
 	rwQ1 := pr.Frobenius(residueWitnessInv)
 	res.Mul(rwQ1.ToPoly())
 
-	return pr.PolyToE12(res.Result())
+	return pr.PolyToE12(res.Eval())
 }
 
 // IsMillerLoopAndFinalExpOne computes the Miller loop between P and Q,

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -242,6 +242,10 @@ func (pr *Pairing) PairingCheck(P []*G1Affine, Q []*G2Affine) error {
 		panic(err)
 	}
 	residueWitnessInv := pr.Ext12.FromTower([12]*baseEl{hint[0], hint[1], hint[2], hint[3], hint[4], hint[5], hint[6], hint[7], hint[8], hint[9], hint[10], hint[11]})
+	residueWitnessInvPoly := residueWitnessInv.ToPoly()
+
+	residueWitnessPoly := pr.InversePoly(residueWitnessInvPoly)
+	residueWitness := pr.Ext12.PolyToE12(residueWitnessPoly)
 
 	// constrain cubicNonResiduePower to be in Fp6
 	// that is: a100=a101=a110=a111=a120=a121=0
@@ -283,7 +287,7 @@ func (pr *Pairing) PairingCheck(P []*G1Affine, Q []*G2Affine) error {
 		lines[i] = *Q[i].Lines
 	}
 
-	res, err := pr.millerLoopLines(P, lines, residueWitnessInv, false)
+	res, err := pr.millerLoopLines(P, lines, residueWitnessInvPoly, residueWitnessPoly, false)
 	if err != nil {
 		return fmt.Errorf("miller loop: %w", err)
 	}
@@ -293,17 +297,19 @@ func (pr *Pairing) PairingCheck(P []*G1Affine, Q []*G2Affine) error {
 	// and residueWitnessInv, cubicNonResiduePower from the hint.
 	// Note that res is already MillerLoop(P,Q) * residueWitnessInv^{6x₀+2} since
 	// we initialized the Miller loop accumulator with residueWitnessInv.
-	t2 := pr.Ext12.Mul(&cubicNonResiduePower, res)
+	res.Mul(cubicNonResiduePower.ToPoly())
 
-	t1 := pr.FrobeniusCube(residueWitnessInv)
-	t0 := pr.FrobeniusSquare(residueWitnessInv)
-	t1 = pr.Ext12.DivUnchecked(t1, t0)
-	t0 = pr.Frobenius(residueWitnessInv)
-	t1 = pr.Ext12.Mul(t1, t0)
+	// residueWitnessInv^(q^3)
+	rwQ3 := pr.FrobeniusCube(residueWitnessInv)
+	res.Mul(rwQ3.ToPoly())
+	// residueWitnessInv^(-q^2) = residueWitness^(q^2)
+	rwQ2Inv := pr.FrobeniusSquare(residueWitness)
+	res.Mul(rwQ2Inv.ToPoly())
+	// residueWitnessInv^(q)
+	rwQ1 := pr.Frobenius(residueWitnessInv)
+	res.Mul(rwQ1.ToPoly())
 
-	t2 = pr.Ext12.Mul(t2, t1)
-
-	pr.AssertIsEqual(t2, pr.Ext12.One())
+	pr.AssertIsEqual(pr.PolyToE12(res.Result()), pr.Ext12.One())
 
 	return nil
 }
@@ -541,12 +547,12 @@ func (pr *Pairing) MillerLoop(P []*G1Affine, Q []*G2Affine) (*GTEl, error) {
 		}
 		lines[i] = *Q[i].Lines
 	}
-	return pr.millerLoopLines(P, lines, nil, true)
-
+	res, err := pr.millerLoopLines(P, lines, nil, nil, true)
+	return pr.PolyToE12(res.Result()), err
 }
 
 // millerLoopLines computes the multi-Miller loop from points in G1 and precomputed lines in G2
-func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init *GTEl, first bool) (*GTEl, error) {
+func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init, initInv *basePoly, first bool) (*emulated.PolyRingAccumulator[BaseField], error) {
 
 	// check input size match
 	n := len(P)
@@ -569,175 +575,70 @@ func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init 
 	}
 
 	// Compute f_{6x₀+2,Q}(P)
-	var prodLines [10]*baseEl
-	polyMulDefer := make([]*basePoly, 0, n/2+3)
-	res := pr.curveF.MakePoly(1)
+	res := pr.NewPolyRingAccumulator(69)
 
-	var initPoly *basePoly
-	var initInvPoly *basePoly
 	if init != nil {
-		initPoly = init.ToPoly()
-		initInvPoly = pr.Ext12.Inverse(init).ToPoly()
-		res = initPoly
+		if initInv == nil {
+			panic("initInv cannot be nil when init is not nil")
+		}
+		res.Mul(init)
 	}
 
 	j := len(loopCounter) - 2
-	if first {
-		// i = j
-		// k = 0
-		c3 := pr.Ext2.MulByElement(&lines[0][0][j].R0, xNegOverY[0])
-		c4 := pr.Ext2.MulByElement(&lines[0][0][j].R1, yInv[0])
-		nine := big.NewInt(9)
-		res = pr.curveF.MakePoly(
-			*pr.curveF.One(),
-			*pr.curveF.Sub(&c3.A0, pr.curveF.MulConst(&c3.A1, nine)),
-			nil,
-			*pr.curveF.Sub(&c4.A0, pr.curveF.MulConst(&c4.A1, nine)),
-			nil,
-			nil,
-			nil,
-			c3.A1,
-			nil,
-			c4.A1,
-		)
-
-		if n >= 2 {
-			// k = 1, separately to avoid MulBy01379 (res × ℓ)
-			// (res is also a line at this point, so we use Mul01379By01379 ℓ × ℓ)
-			// line evaluation at P[1]
-			prodLines = pr.Mul01379By01379(
-				pr.Ext2.MulByElement(&lines[1][0][j].R0, xNegOverY[1]), //nolint: gosec // incorrectly flagged by gosec as out of bounds read (G602)
-				pr.Ext2.MulByElement(&lines[1][0][j].R1, yInv[1]),      //nolint: gosec // incorrectly flagged by gosec as out of bounds read (G602)
-				c3,
-				c4,
-			)
-
-			res = pr.curveF.MakePoly(
-				*prodLines[0],
-				*prodLines[1],
-				*prodLines[2],
-				*prodLines[3],
-				*prodLines[4],
-				nil,
-				*prodLines[5],
-				*prodLines[6],
-				*prodLines[7],
-				*prodLines[8],
-				*prodLines[9],
-			)
-		}
-
-		polyMulDefer = append(polyMulDefer, res)
-
-		if n >= 3 {
-			// k >= 2: batch lines 2-by-2
-			for k := 3; k < n; k += 2 {
-				prodLines = pr.Mul01379By01379(
-					pr.Ext2.MulByElement(&lines[k][0][j].R0, xNegOverY[k]),
-					pr.Ext2.MulByElement(&lines[k][0][j].R1, yInv[k]),
-					pr.Ext2.MulByElement(&lines[k-1][0][j].R0, xNegOverY[k-1]),
-					pr.Ext2.MulByElement(&lines[k-1][0][j].R1, yInv[k-1]),
-				)
-				polyMulDefer = append(polyMulDefer, pr.ToPoly012346789(prodLines))
-			}
-			// Handle remaining line if (n-2) is odd
-			if (n-2)%2 != 0 {
-				polyMulDefer = append(
-					polyMulDefer,
-					pr.ToPoly01379(
-						pr.Ext2.MulByElement(&lines[n-1][0][j].R0, xNegOverY[n-1]),
-						pr.Ext2.MulByElement(&lines[n-1][0][j].R1, yInv[n-1]),
-					),
-				)
-			}
-		}
-		j--
-	}
-
-	if len(polyMulDefer) > 1 {
-		res = pr.MulPoly(polyMulDefer...)
-		polyMulDefer = polyMulDefer[:0]
-	}
 
 	for i := j; i >= 0; i-- {
 		// res²
-		polyMulDefer = append(polyMulDefer, res, res)
+		res.Sqr()
 
 		switch loopCounter[i] {
 		case 0:
 			// Batch lines 2-by-2 across pairs using sparse×sparse multiplication
-			for k := 1; k < n; k += 2 {
-				// prodLines = pr.Mul01379By01379(
-				// 	pr.Ext2.MulByElement(&lines[k][0][i].R0, xNegOverY[k]),
-				// 	pr.Ext2.MulByElement(&lines[k][0][i].R1, yInv[k]),
-				// 	pr.Ext2.MulByElement(&lines[k-1][0][i].R0, xNegOverY[k-1]),
-				// 	pr.Ext2.MulByElement(&lines[k-1][0][i].R1, yInv[k-1]),
-				// )
-				// polyMulDefer = append(polyMulDefer, pr.ToPoly012346789(prodLines))
-
-				polyMulDefer = append(
-					polyMulDefer,
-					pr.ToPoly01379(
-						pr.Ext2.MulByElement(&lines[k][0][i].R0, xNegOverY[k]),
-						pr.Ext2.MulByElement(&lines[k][0][i].R1, yInv[k]),
-					),
-					pr.ToPoly01379(
-						pr.Ext2.MulByElement(&lines[k-1][0][i].R0, xNegOverY[k-1]),
-						pr.Ext2.MulByElement(&lines[k-1][0][i].R1, yInv[k-1]),
-					),
-				)
-			}
-			// Handle odd remaining line
-			if n%2 != 0 {
-				polyMulDefer = append(polyMulDefer, pr.ToPoly01379(
-					pr.Ext2.MulByElement(&lines[n-1][0][i].R0, xNegOverY[n-1]),
-					pr.Ext2.MulByElement(&lines[n-1][0][i].R1, yInv[n-1]),
+			for k := 0; k < n; k += 1 {
+				res.Mul(pr.ToPoly01379(
+					pr.Ext2.MulByElement(&lines[k][0][i].R0, xNegOverY[k]),
+					pr.Ext2.MulByElement(&lines[k][0][i].R1, yInv[k]),
 				))
 			}
+			// return pr.Ext12.One(), nil
 		case 1:
 			if init != nil {
 				// multiply by init when bit=1
-				polyMulDefer = append(polyMulDefer, initPoly)
+				res.Mul(init)
 			}
-			// ℓ × ℓ
 			for k := 0; k < n; k++ {
-				prodLines := pr.Mul01379By01379(
+				// ℓ × res
+				res.Mul(pr.ToPoly01379(
 					pr.Ext2.MulByElement(&lines[k][0][i].R0, xNegOverY[k]),
 					pr.Ext2.MulByElement(&lines[k][0][i].R1, yInv[k]),
+				))
+				res.Mul(pr.ToPoly01379(
 					pr.Ext2.MulByElement(&lines[k][1][i].R0, xNegOverY[k]),
 					pr.Ext2.MulByElement(&lines[k][1][i].R1, yInv[k]),
-				)
-				// (ℓ × ℓ) × res
-				polyMulDefer = append(polyMulDefer, pr.ToPoly012346789(prodLines))
+				))
+				// (ℓ × ℓ)
 			}
 		case -1:
 			if init != nil {
 				// multiply by 1/init when bit=-1
-				polyMulDefer = append(polyMulDefer, initInvPoly)
+				res.Mul(initInv)
 			}
 			for k := 0; k < n; k++ {
-				// ℓ × ℓ
-				prodLines := pr.Mul01379By01379(
+				// ℓ × res
+				res.Mul(pr.ToPoly01379(
 					pr.Ext2.MulByElement(&lines[k][0][i].R0, xNegOverY[k]),
 					pr.Ext2.MulByElement(&lines[k][0][i].R1, yInv[k]),
+				))
+				res.Mul(pr.ToPoly01379(
 					pr.Ext2.MulByElement(&lines[k][1][i].R0, xNegOverY[k]),
 					pr.Ext2.MulByElement(&lines[k][1][i].R1, yInv[k]),
-				)
-				// (ℓ × ℓ) × res
-				polyMulDefer = append(polyMulDefer, pr.ToPoly012346789(prodLines))
+				))
+				// (ℓ × ℓ)
 			}
 		default:
 			panic(fmt.Sprintf("invalid loop counter value %d", loopCounter[i]))
 		}
-
-		if len(polyMulDefer) > 1 {
-			res = pr.MulPoly(polyMulDefer...)
-			polyMulDefer = polyMulDefer[:0]
-		}
-
+		res.Result()
 	}
-
-	polyMulDefer = append(polyMulDefer, res)
 
 	// Compute  ℓ_{[6x₀+2]Q,π(Q)}(P) · ℓ_{[6x₀+2]Q+π(Q),-π²(Q)}(P)
 	// lines evaluations at P
@@ -749,24 +650,21 @@ func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init 
 		// 	pr.Ext2.MulByElement(&lines[k][1][65].R0, xNegOverY[k]),
 		// 	pr.Ext2.MulByElement(&lines[k][1][65].R1, yInv[k]),
 		// )
-		polyMulDefer = append(
-			polyMulDefer,
+		res.Mul(
 			pr.ToPoly01379(
 				pr.Ext2.MulByElement(&lines[k][0][65].R0, xNegOverY[k]),
 				pr.Ext2.MulByElement(&lines[k][0][65].R1, yInv[k]),
 			),
+		)
+		res.Mul(
 			pr.ToPoly01379(
 				pr.Ext2.MulByElement(&lines[k][1][65].R0, xNegOverY[k]),
 				pr.Ext2.MulByElement(&lines[k][1][65].R1, yInv[k]),
 			),
 		)
 	}
-	if len(polyMulDefer) > 1 {
-		res = pr.MulPoly(polyMulDefer...)
-		polyMulDefer = polyMulDefer[:0]
-	}
 
-	return pr.PolyToE12(res), nil
+	return res, nil
 }
 
 // doubleAndAddStep doubles p1 and adds or subs p2 to the result in affine coordinates, based on the isSub boolean.
@@ -970,8 +868,10 @@ func (pr *Pairing) millerLoopAndFinalExpResult(P *G1Affine, Q *G2Affine, previou
 		A11: *pr.curveF.Zero(),
 	}
 
+	residueWitnessPoly := residueWitness.ToPoly()
 	// residueWitnessInv = 1 / residueWitness
-	residueWitnessInv := pr.Ext12.Inverse(residueWitness)
+	residueWitnessInvPoly := pr.Ext12.InversePoly(residueWitnessPoly)
+	residueWitnessInv := pr.Ext12.PolyToE12(residueWitnessInvPoly)
 
 	if Q.Lines == nil {
 		Qlines := pr.computeLines(&Q.P)
@@ -982,7 +882,8 @@ func (pr *Pairing) millerLoopAndFinalExpResult(P *G1Affine, Q *G2Affine, previou
 	res, err := pr.millerLoopLines(
 		[]*G1Affine{P},
 		[]lineEvaluations{lines},
-		residueWitnessInv,
+		residueWitnessInvPoly,
+		residueWitnessPoly,
 		false,
 	)
 	if err != nil {
@@ -990,24 +891,27 @@ func (pr *Pairing) millerLoopAndFinalExpResult(P *G1Affine, Q *G2Affine, previou
 	}
 
 	// multiply by previous multi-Miller function
-	res = pr.Ext12.Mul(res, previous)
+	res.Mul(previous.ToPoly())
 
 	// Check that  res * cubicNonResiduePower * residueWitnessInv^λ' == 1
 	// where λ' = q^3 - q^2 + q, with u the BN254 seed
 	// and residueWitnessInv, cubicNonResiduePower from the hint.
 	// Note that res is already MillerLoop(P,Q) * residueWitnessInv^{6x₀+2} since
 	// we initialized the Miller loop accumulator with residueWitnessInv.
-	t2 := pr.Ext12.Mul(&cubicNonResiduePower, res)
 
-	t1 := pr.FrobeniusCube(residueWitnessInv)
-	t0 := pr.FrobeniusSquare(residueWitness)
-	t1 = pr.Ext12.Mul(t1, t0)
-	t0 = pr.Frobenius(residueWitnessInv)
-	t1 = pr.Ext12.Mul(t1, t0)
+	res.Mul(cubicNonResiduePower.ToPoly())
 
-	t2 = pr.Ext12.Mul(t2, t1)
+	// residueWitnessInv^(q^3)
+	rwQ3 := pr.FrobeniusCube(residueWitnessInv)
+	res.Mul(rwQ3.ToPoly())
+	// residueWitnessInv^(-q^2) = residueWitness^(q^2)
+	rwQ2Inv := pr.FrobeniusSquare(residueWitness)
+	res.Mul(rwQ2Inv.ToPoly())
+	// residueWitnessInv^(q)
+	rwQ1 := pr.Frobenius(residueWitnessInv)
+	res.Mul(rwQ1.ToPoly())
 
-	return t2
+	return pr.PolyToE12(res.Result())
 }
 
 // IsMillerLoopAndFinalExpOne computes the Miller loop between P and Q,

--- a/std/algebra/emulated/sw_bn254/pairing.go
+++ b/std/algebra/emulated/sw_bn254/pairing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/consensys/gnark/std/math/emulated"
 )
 
+type basePoly = emulated.Poly[emulated.BN254Fp]
 type baseEl = emulated.Element[BaseField]
 type GTEl = fields_bn254.E12
 
@@ -569,12 +570,15 @@ func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init 
 
 	// Compute f_{6x₀+2,Q}(P)
 	var prodLines [10]*baseEl
-	res := pr.Ext12.One()
+	polyMulDefer := make([]*basePoly, 0, n/2+3)
+	res := pr.curveF.MakePoly(1)
 
-	var initInv GTEl
+	var initPoly *basePoly
+	var initInvPoly *basePoly
 	if init != nil {
-		res = init
-		initInv = *pr.Ext12.Inverse(init)
+		initPoly = init.ToPoly()
+		initInvPoly = pr.Ext12.Inverse(init).ToPoly()
+		res = initPoly
 	}
 
 	j := len(loopCounter) - 2
@@ -584,20 +588,18 @@ func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init 
 		c3 := pr.Ext2.MulByElement(&lines[0][0][j].R0, xNegOverY[0])
 		c4 := pr.Ext2.MulByElement(&lines[0][0][j].R1, yInv[0])
 		nine := big.NewInt(9)
-		res = &GTEl{
-			A0:  *pr.curveF.One(),
-			A1:  *pr.curveF.Sub(&c3.A0, pr.curveF.MulConst(&c3.A1, nine)),
-			A2:  *pr.curveF.Zero(),
-			A3:  *pr.curveF.Sub(&c4.A0, pr.curveF.MulConst(&c4.A1, nine)),
-			A4:  *pr.curveF.Zero(),
-			A5:  *pr.curveF.Zero(),
-			A6:  *pr.curveF.Zero(),
-			A7:  c3.A1,
-			A8:  *pr.curveF.Zero(),
-			A9:  c4.A1,
-			A10: *pr.curveF.Zero(),
-			A11: *pr.curveF.Zero(),
-		}
+		res = pr.curveF.MakePoly(
+			*pr.curveF.One(),
+			*pr.curveF.Sub(&c3.A0, pr.curveF.MulConst(&c3.A1, nine)),
+			nil,
+			*pr.curveF.Sub(&c4.A0, pr.curveF.MulConst(&c4.A1, nine)),
+			nil,
+			nil,
+			nil,
+			c3.A1,
+			nil,
+			c4.A1,
+		)
 
 		if n >= 2 {
 			// k = 1, separately to avoid MulBy01379 (res × ℓ)
@@ -609,21 +611,23 @@ func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init 
 				c3,
 				c4,
 			)
-			res = &GTEl{
-				A0:  *prodLines[0],
-				A1:  *prodLines[1],
-				A2:  *prodLines[2],
-				A3:  *prodLines[3],
-				A4:  *prodLines[4],
-				A5:  *pr.curveF.Zero(),
-				A6:  *prodLines[5],
-				A7:  *prodLines[6],
-				A8:  *prodLines[7],
-				A9:  *prodLines[8],
-				A10: *prodLines[9],
-				A11: *pr.curveF.Zero(),
-			}
+
+			res = pr.curveF.MakePoly(
+				*prodLines[0],
+				*prodLines[1],
+				*prodLines[2],
+				*prodLines[3],
+				*prodLines[4],
+				nil,
+				*prodLines[5],
+				*prodLines[6],
+				*prodLines[7],
+				*prodLines[8],
+				*prodLines[9],
+			)
 		}
+
+		polyMulDefer = append(polyMulDefer, res)
 
 		if n >= 3 {
 			// k >= 2: batch lines 2-by-2
@@ -634,47 +638,66 @@ func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init 
 					pr.Ext2.MulByElement(&lines[k-1][0][j].R0, xNegOverY[k-1]),
 					pr.Ext2.MulByElement(&lines[k-1][0][j].R1, yInv[k-1]),
 				)
-				res = pr.Ext12.MulBy012346789(res, prodLines)
+				polyMulDefer = append(polyMulDefer, pr.ToPoly012346789(prodLines))
 			}
 			// Handle remaining line if (n-2) is odd
 			if (n-2)%2 != 0 {
-				res = pr.MulBy01379(
-					res,
-					pr.Ext2.MulByElement(&lines[n-1][0][j].R0, xNegOverY[n-1]),
-					pr.Ext2.MulByElement(&lines[n-1][0][j].R1, yInv[n-1]),
+				polyMulDefer = append(
+					polyMulDefer,
+					pr.ToPoly01379(
+						pr.Ext2.MulByElement(&lines[n-1][0][j].R0, xNegOverY[n-1]),
+						pr.Ext2.MulByElement(&lines[n-1][0][j].R1, yInv[n-1]),
+					),
 				)
 			}
 		}
 		j--
 	}
 
+	if len(polyMulDefer) > 1 {
+		res = pr.MulPoly(polyMulDefer...)
+		polyMulDefer = polyMulDefer[:0]
+	}
+
 	for i := j; i >= 0; i-- {
-		res = pr.Ext12.Square(res)
+		// res²
+		polyMulDefer = append(polyMulDefer, res, res)
 
 		switch loopCounter[i] {
 		case 0:
 			// Batch lines 2-by-2 across pairs using sparse×sparse multiplication
 			for k := 1; k < n; k += 2 {
-				prodLines = pr.Mul01379By01379(
-					pr.Ext2.MulByElement(&lines[k][0][i].R0, xNegOverY[k]),
-					pr.Ext2.MulByElement(&lines[k][0][i].R1, yInv[k]),
-					pr.Ext2.MulByElement(&lines[k-1][0][i].R0, xNegOverY[k-1]),
-					pr.Ext2.MulByElement(&lines[k-1][0][i].R1, yInv[k-1]),
+				// prodLines = pr.Mul01379By01379(
+				// 	pr.Ext2.MulByElement(&lines[k][0][i].R0, xNegOverY[k]),
+				// 	pr.Ext2.MulByElement(&lines[k][0][i].R1, yInv[k]),
+				// 	pr.Ext2.MulByElement(&lines[k-1][0][i].R0, xNegOverY[k-1]),
+				// 	pr.Ext2.MulByElement(&lines[k-1][0][i].R1, yInv[k-1]),
+				// )
+				// polyMulDefer = append(polyMulDefer, pr.ToPoly012346789(prodLines))
+
+				polyMulDefer = append(
+					polyMulDefer,
+					pr.ToPoly01379(
+						pr.Ext2.MulByElement(&lines[k][0][i].R0, xNegOverY[k]),
+						pr.Ext2.MulByElement(&lines[k][0][i].R1, yInv[k]),
+					),
+					pr.ToPoly01379(
+						pr.Ext2.MulByElement(&lines[k-1][0][i].R0, xNegOverY[k-1]),
+						pr.Ext2.MulByElement(&lines[k-1][0][i].R1, yInv[k-1]),
+					),
 				)
-				res = pr.Ext12.MulBy012346789(res, prodLines)
 			}
 			// Handle odd remaining line
 			if n%2 != 0 {
-				res = pr.MulBy01379(
-					res,
+				polyMulDefer = append(polyMulDefer, pr.ToPoly01379(
 					pr.Ext2.MulByElement(&lines[n-1][0][i].R0, xNegOverY[n-1]),
 					pr.Ext2.MulByElement(&lines[n-1][0][i].R1, yInv[n-1]),
-				)
+				))
 			}
 		case 1:
 			if init != nil {
 				// multiply by init when bit=1
-				res = pr.Ext12.Mul(res, init)
+				polyMulDefer = append(polyMulDefer, initPoly)
 			}
 			// ℓ × ℓ
 			for k := 0; k < n; k++ {
@@ -685,12 +708,12 @@ func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init 
 					pr.Ext2.MulByElement(&lines[k][1][i].R1, yInv[k]),
 				)
 				// (ℓ × ℓ) × res
-				res = pr.Ext12.MulBy012346789(res, prodLines)
+				polyMulDefer = append(polyMulDefer, pr.ToPoly012346789(prodLines))
 			}
 		case -1:
 			if init != nil {
 				// multiply by 1/init when bit=-1
-				res = pr.Ext12.Mul(res, &initInv)
+				polyMulDefer = append(polyMulDefer, initInvPoly)
 			}
 			for k := 0; k < n; k++ {
 				// ℓ × ℓ
@@ -701,27 +724,49 @@ func (pr *Pairing) millerLoopLines(P []*G1Affine, lines []lineEvaluations, init 
 					pr.Ext2.MulByElement(&lines[k][1][i].R1, yInv[k]),
 				)
 				// (ℓ × ℓ) × res
-				res = pr.Ext12.MulBy012346789(res, prodLines)
+				polyMulDefer = append(polyMulDefer, pr.ToPoly012346789(prodLines))
 			}
 		default:
 			panic(fmt.Sprintf("invalid loop counter value %d", loopCounter[i]))
 		}
+
+		if len(polyMulDefer) > 1 {
+			res = pr.MulPoly(polyMulDefer...)
+			polyMulDefer = polyMulDefer[:0]
+		}
+
 	}
+
+	polyMulDefer = append(polyMulDefer, res)
 
 	// Compute  ℓ_{[6x₀+2]Q,π(Q)}(P) · ℓ_{[6x₀+2]Q+π(Q),-π²(Q)}(P)
 	// lines evaluations at P
 	// and ℓ × ℓ
 	for k := 0; k < n; k++ {
-		prodLines = pr.Mul01379By01379(
-			pr.Ext2.MulByElement(&lines[k][0][65].R0, xNegOverY[k]),
-			pr.Ext2.MulByElement(&lines[k][0][65].R1, yInv[k]),
-			pr.Ext2.MulByElement(&lines[k][1][65].R0, xNegOverY[k]),
-			pr.Ext2.MulByElement(&lines[k][1][65].R1, yInv[k]),
+		// prodLines = pr.Mul01379By01379(
+		// 	pr.Ext2.MulByElement(&lines[k][0][65].R0, xNegOverY[k]),
+		// 	pr.Ext2.MulByElement(&lines[k][0][65].R1, yInv[k]),
+		// 	pr.Ext2.MulByElement(&lines[k][1][65].R0, xNegOverY[k]),
+		// 	pr.Ext2.MulByElement(&lines[k][1][65].R1, yInv[k]),
+		// )
+		polyMulDefer = append(
+			polyMulDefer,
+			pr.ToPoly01379(
+				pr.Ext2.MulByElement(&lines[k][0][65].R0, xNegOverY[k]),
+				pr.Ext2.MulByElement(&lines[k][0][65].R1, yInv[k]),
+			),
+			pr.ToPoly01379(
+				pr.Ext2.MulByElement(&lines[k][1][65].R0, xNegOverY[k]),
+				pr.Ext2.MulByElement(&lines[k][1][65].R1, yInv[k]),
+			),
 		)
-		res = pr.Ext12.MulBy012346789(res, prodLines)
+	}
+	if len(polyMulDefer) > 1 {
+		res = pr.MulPoly(polyMulDefer...)
+		polyMulDefer = polyMulDefer[:0]
 	}
 
-	return res, nil
+	return pr.PolyToE12(res), nil
 }
 
 // doubleAndAddStep doubles p1 and adds or subs p2 to the result in affine coordinates, based on the isSub boolean.

--- a/std/math/emulated/field.go
+++ b/std/math/emulated/field.go
@@ -64,8 +64,8 @@ type Field[T FieldParams] struct {
 	checker          frontend.Rangechecker
 	nbRangeChecks    int
 
-	deferredChecks     []deferredChecker
-	deferredPolyChecks []polyRingMulCheck[T]
+	deferredChecks      []deferredChecker
+	deferredPolyChecker *polyRingCheckManager[T]
 
 	// smallFieldMode indicates that the emulated field is small enough that
 	// products fit in the native field and we can use scalar batched verification

--- a/std/math/emulated/field.go
+++ b/std/math/emulated/field.go
@@ -64,8 +64,8 @@ type Field[T FieldParams] struct {
 	checker          frontend.Rangechecker
 	nbRangeChecks    int
 
-	deferredChecks      []deferredChecker
-	deferredPolyChecker *polyRingCheckManager[T]
+	deferredChecks     []deferredChecker
+	deferredPolyChecks []*PolyRingGroupChecks[T]
 
 	// smallFieldMode indicates that the emulated field is small enough that
 	// products fit in the native field and we can use scalar batched verification
@@ -94,8 +94,6 @@ func NewField[T FieldParams](native frontend.API) (*Field[T], error) {
 		log:              logger.Logger(),
 		constrainedLimbs: make(map[[16]byte]int),
 		fParams:          newStaticFieldParams[T](native.Compiler().Field()),
-
-		deferredPolyChecker: &polyRingCheckManager[T]{},
 	}
 
 	// ring checks can add additional deferred checks, so run before other checks

--- a/std/math/emulated/field.go
+++ b/std/math/emulated/field.go
@@ -64,7 +64,8 @@ type Field[T FieldParams] struct {
 	checker          frontend.Rangechecker
 	nbRangeChecks    int
 
-	deferredChecks []deferredChecker
+	deferredChecks     []deferredChecker
+	deferredPolyChecks []polyRingMulCheck[T]
 
 	// smallFieldMode indicates that the emulated field is small enough that
 	// products fit in the native field and we can use scalar batched verification

--- a/std/math/emulated/field.go
+++ b/std/math/emulated/field.go
@@ -93,9 +93,17 @@ func NewField[T FieldParams](native frontend.API) (*Field[T], error) {
 		api:              native,
 		log:              logger.Logger(),
 		constrainedLimbs: make(map[[16]byte]int),
-		checker:          rangecheck.New(native),
 		fParams:          newStaticFieldParams[T](native.Compiler().Field()),
+
+		deferredPolyChecker: &polyRingCheckManager[T]{},
 	}
+
+	// ring checks can add additional deferred checks, so run before other checks
+	native.Compiler().Defer(f.performDeferredRingChecks)
+
+	// rangecheck also adds deferred checks
+	f.checker = rangecheck.New(native)
+
 	if smallfields.IsSmallField(native.Compiler().Field()) {
 		f.log.Debug().Msg("using small native field, multiplication checks will be performed in extension field")
 		extapi, err := fieldextension.NewExtension(native)

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -789,8 +789,10 @@ func (p *Poly[T]) ToPoly() *Poly[T] {
 }
 
 // PolyRingAccumulator is used to accumulate polynomial products
-// performs multiplications via MulPolyRings when target degree is
-// reached
+// represents queue of ∏_i state_i operations
+// optionally, performs multiplications via MulPolyRings when target
+// degree is reached; alternatively can be used without a target
+// degree, in which case it will only perform operations on Eval call
 type PolyRingAccumulator[T FieldParams] struct {
 	state      []*Poly[T] // current accumulated polynomials
 	f          *Field[T]
@@ -800,6 +802,9 @@ type PolyRingAccumulator[T FieldParams] struct {
 }
 
 // NewPolyRingAccumulator creates a new polynomial products accumulator
+// targetDeg can be set to limit the degree of the accumulated
+// polynomial targetDeg set to 0 means products will only happen
+// when Eval is called
 func (f *Field[T]) NewPolyRingAccumulator(checker *PolyRingGroupChecks[T], targetDeg int) *PolyRingAccumulator[T] {
 	return &PolyRingAccumulator[T]{
 		f:         f,
@@ -808,26 +813,32 @@ func (f *Field[T]) NewPolyRingAccumulator(checker *PolyRingGroupChecks[T], targe
 	}
 }
 
-// Mul adds a new polynomial to the accumulator
+// Mul adds a new polynomial to the accumulator, ∏_i state_i * poly
+// if targetDeg is set and the accumulated degree would exceed it, Eval
+// is called first to reduce the state before enqueuing
 func (acc *PolyRingAccumulator[T]) Mul(poly *Poly[T]) {
-	if acc.currentDeg+len(poly.Coeffs)-1 > acc.targetDeg {
-		acc.Result()
+	if acc.targetDeg != 0 && acc.currentDeg+len(poly.Coeffs)-1 > acc.targetDeg {
+		acc.Eval()
 	}
 	acc.currentDeg += len(poly.Coeffs) - 1
 	acc.state = append(acc.state, poly)
 }
 
-// Sqr squares the current accumulation doubling the degree
+// Sqr squares the current accumulation, i.e. ∏_i (state_i * state_i),
+// doubling the degree; if targetDeg is set and the accumulated degree
+// would exceed it, Eval is called to reduce the state before enqueuing
 func (acc *PolyRingAccumulator[T]) Sqr() {
-	if acc.currentDeg+acc.currentDeg > acc.targetDeg {
-		acc.Result()
+	if acc.targetDeg != 0 && acc.currentDeg+acc.currentDeg > acc.targetDeg {
+		acc.Eval()
 	}
 	acc.currentDeg += acc.currentDeg // degree doubles
 	acc.state = append(acc.state, acc.state...)
 }
 
-// Sqr squares the current accumulation doubling the degree
-func (acc *PolyRingAccumulator[T]) Result() (result *Poly[T]) {
+// Eval multiplies all queued factors via MulPolyRings, collapses the state
+// to the resulting polynomial, and returns it
+// called automatically by Queue and Sqr when targetDeg is set and would be exceeded.
+func (acc *PolyRingAccumulator[T]) Eval() (result *Poly[T]) {
 	if len(acc.state) == 1 {
 		return acc.state[0]
 	}

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -115,20 +115,10 @@ func (f *Field[T]) MulPolyRings(inputs []*Poly[T], group *PolyRingGroupChecks[T]
 
 	// loop through inputs to compute the number of terms
 	for _, inputPoly := range inputs {
-		// serialised as nbTerms|...terms
-		// add degree of each input polynomial
-		hintInputs = append(hintInputs, len(inputPoly.Coeffs))
-		// append each term from inputPoly polynomial
-		for _, coeff := range inputPoly.Coeffs {
-			hintInputs = append(hintInputs, coeff.Limbs...)
-		}
+		hintInputs = f.serialisePoly(inputPoly, hintInputs)
 	}
 
-	hintInputs = append(hintInputs, len(mod.Coeffs))
-	// append mod terms
-	for _, coeff := range mod.Coeffs {
-		hintInputs = append(hintInputs, coeff.Limbs...)
-	}
+	hintInputs = f.serialisePoly(&mod, hintInputs)
 
 	// call
 	ret, err := f.api.NewHint(polyRingMulHint, 1+nbQTermsLimbs+1+nbRemLimbs, hintInputs...)
@@ -343,16 +333,15 @@ func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q,
 }
 
 func (f *Field[T]) MakePoly(coeffs []interface{}) *Poly[T] {
-	nativeMod := f.api.Compiler().Field()
-
 	poly := &Poly[T]{}
 	poly.Coeffs = make([]*Element[T], len(coeffs))
 
 	for i, coeff := range coeffs {
-		emCoeff_ := ValueOf[T](coeff)
-		emCoeff := &emCoeff_
-		emCoeff.Initialize(nativeMod)
-		poly.Coeffs[i] = emCoeff
+		if coeff == 0 {
+			poly.Coeffs[i] = f.Zero()
+			continue
+		}
+		poly.Coeffs[i] = f.NewElement(coeff)
 	}
 
 	return poly
@@ -484,13 +473,12 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 		lhsRlc := f.InnerProductNoReduce(lhsEvals, zPowers)
 
 		// compute q_acc(x) * mod(x)
-		rhs := f.Mul(
+		rhs := f.MulNoReduce(
 			f.evalPolyWithChallenge(group.q_acc, xPowers),
 			f.evalPolyWithChallenge(group.mod, xPowers),
 		)
 
-		// f.AssertIsEqual(lhsRlc, rhs)
-		f.AssertIsDifferent(lhsRlc, rhs)
+		f.IsZero(f.Sub(lhsRlc, rhs))
 	}
 
 	return nil
@@ -524,10 +512,7 @@ func (f *Field[T]) callQuotientsRLCHint(quotients []*Poly[T], z frontend.Variabl
 	hintInputs = append(hintInputs, nbBits, nbLimbs, nbPolys, *f.fParams.Modulus(), z)
 
 	for _, q := range quotients {
-		hintInputs = append(hintInputs, len(q.Coeffs))
-		for _, coeff := range q.Coeffs {
-			hintInputs = append(hintInputs, coeff.Limbs...)
-		}
+		hintInputs = f.serialisePoly(q, hintInputs)
 	}
 
 	nbOutputs := maxTerms * nbLimbs
@@ -672,9 +657,9 @@ func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
 // NativeToEmulated decomposes a native field variable into an *Element[T] by
 // splitting its binary representation into emulated limbs of BitsPerLimb each.
 func (f *Field[T]) NativeToEmulated(nbLimbs int, v ...frontend.Variable) []*Element[T] {
-	nbBitsPerLimb := int(f.fParams.BitsPerLimb())
+	nbBits := f.fParams.BitsPerLimb()
 	hintInputs := make([]frontend.Variable, 0, 2+len(v))
-	hintInputs = append(hintInputs, nbLimbs, nbBitsPerLimb)
+	hintInputs = append(hintInputs, nbBits, nbLimbs)
 	hintInputs = append(hintInputs, v...)
 	ret, err := f.api.NewHint(splitNativeToLimbsHint, nbLimbs*len(v), hintInputs...)
 	if err != nil {
@@ -697,16 +682,36 @@ func splitNativeToLimbsHint(nativeMod *big.Int, inputs, outputs []*big.Int) erro
 	outptr := 0
 	for ptr := 2; ptr < len(inputs); ptr++ {
 		nativeEl := inputs[ptr]
-		coeffLimbs := make([]*big.Int, nbLimbs)
+		coeffLimbs := make([]*big.Int, nativeEl.BitLen()/nbBits+1)
 		for k := range coeffLimbs {
 			coeffLimbs[k] = new(big.Int)
 		}
 		if err := limbs.Decompose(nativeEl, uint(nbBits), coeffLimbs); err != nil {
 			return fmt.Errorf("decompose result[%d]: %w", ptr-2, err)
 		}
-		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs)
+		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs[0:nbLimbs])
 		outptr += nbLimbs
 	}
 
 	return nil
+}
+
+// serialisePoly converts a polynomial into a slice of frontend.Variable
+// suitable for hints. format is nbTerms|...terms
+func (f *Field[T]) serialisePoly(poly *Poly[T], inputs []frontend.Variable) []frontend.Variable {
+	nbLimbs := int(f.fParams.NbLimbs())
+	inputs = append(inputs, len(poly.Coeffs))
+	for _, coeff := range poly.Coeffs {
+		if coeff == nil || len(coeff.Limbs) == 0 {
+			for i := 0; i < nbLimbs; i++ {
+				inputs = append(inputs, 0)
+			}
+			continue
+		}
+		inputs = append(inputs, coeff.Limbs...)
+		for i := len(coeff.Limbs); i < nbLimbs; i++ {
+			inputs = append(inputs, 0)
+		}
+	}
+	return inputs
 }

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -616,25 +616,30 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 // where at[i] = at^i. Precomputing and sharing powers across multiple
 // polynomial evaluations at the same point avoids redundant multiplications.
 func (f *Field[T]) evalPolyWithChallenge(p *Poly[T], at []*Element[T]) *Element[T] {
-	if p.evaluation != nil {
-		return p.evaluation
+	if p.evaluation == nil {
+		p.evaluation = f.innerProduct(p.Coeffs, at)
 	}
+	return p.evaluation
+}
 
-	n := len(p.Coeffs)
+// evalPolyWithChallenge evaluates p at a point whose powers are given by at,
+// where at[i] = at^i. Precomputing and sharing powers across multiple
+// polynomial evaluations at the same point avoids redundant multiplications.
+func (f *Field[T]) innerProduct(a, b []*Element[T]) *Element[T] {
+	n := len(a)
 	terms := make([][]*Element[T], n)
 	scalars := make([]int, n)
-	for i, coeff := range p.Coeffs {
-		if i == 0 {
-			terms[i] = []*Element[T]{coeff}
+	for i := range a {
+		if b[i] == nil {
+			terms[i] = []*Element[T]{a[i]}
+		} else if a[i] == nil {
+			terms[i] = []*Element[T]{b[i]}
 		} else {
-			terms[i] = []*Element[T]{coeff, at[i]}
+			terms[i] = []*Element[T]{a[i], b[i]}
 		}
 		scalars[i] = 1
 	}
-	evaluation := f.Eval(terms, scalars)
-
-	p.evaluation = evaluation
-	return evaluation
+	return f.Eval(terms, scalars)
 }
 
 // NativeToEmulated decomposes a native field variable into an *Element[T] by

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -1,0 +1,47 @@
+package emulated
+
+// polyProdCheck represents a polynomial product check in a polynomial
+// Represents an element of a polynomial ring over the emulated field.
+type Poly[T FieldParams] []*Element[T]
+
+// polyRingMulCheck represents a polynomial product check in a polynomial
+// ring. Instead of computing the product and reducing it where called,
+// we compute the result using a hint and return it. Result is stored for
+// correctness check later to share the verifier challenge computation.
+//
+// We store the values poly, irr, r, q. They are as follows:
+//   - poly - the input polynomials whose product we are checking. Each
+//     polynomial is represented as a slice of [Element] coefficients. Elements
+//     have to be reduced.
+//   - irr - the irreducible polynomial defining the ring, i.e. the modulus for
+//     the Euclidean division. Treated as a constant.
+//   - r - the product reduced modulo irr, i.e. the remainder. This is the
+//     result returned to the caller.
+//   - q - the quotient of the product divided by irr.
+//
+// Given these values, the following holds as an identity of polynomials over
+// the emulated field:
+//
+//	∏_i inputs_i = r + q * mod
+//
+// For asserting that the previous identity holds, we evaluate both sides at a
+// single random challenge point α obtained via commitment to all coefficients.
+// If a polynomial f has coefficient elements (f_0, ..., f_n), its evaluation is
+//
+//	f(α) = ∑_i f_i(α) * α^i,
+//
+// where each f_i(α) is itself the Schwartz-Zippel evaluation of the limb
+// polynomial of the emulated element f_i. The product check then becomes
+//
+//	∏_i inputs_i(α) = r(α) + q(α) * mod(α),
+//
+// which can be verified at a single random point.
+type polyRingMulCheck[T FieldParams] struct {
+	f *Field[T]
+	// ∏_i inputs_i = r + q * mod
+	inputs []Poly[T] // input polynomials
+	mod    Poly[T]   // irreducible polynomial defining the ring
+	r      Poly[T]   // remainder
+	q      Poly[T]   // quotient
+}
+

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -405,7 +405,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	//    and prepare to commit
 
 	// z can be shared across all groups
-	var quotientbatchesCoeffCommits []frontend.Variable
+	quotientbatchesCoeffCommits := []frontend.Variable{z}
 	for _, group := range f.deferredPolyChecks {
 		quotients := make([]*Poly[T], len(group.checks))
 		for i, mulCheck := range group.checks {
@@ -445,7 +445,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	}
 
 	xPowers := make([]*Element[T], maxTerms)
-	xPowers[0] = f.One()
+	xPowers[0] = nil
 	if maxTerms > 1 {
 		xPowers[1] = xEmulated
 		for i := 2; i < maxTerms; i++ {
@@ -454,7 +454,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	}
 
 	zPowers := make([]*Element[T], maxChecks)
-	zPowers[0] = f.One()
+	zPowers[0] = nil
 	if maxChecks > 1 {
 		zPowers[1] = zEmulated
 		for i := 2; i < maxChecks; i++ {
@@ -465,7 +465,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	// 4. assert the ring check at x for each group
 	for _, group := range f.deferredPolyChecks {
 		// lhsRlc = ∑_i z^i * (∏_j inputs_i_j(x) - r_i(x))
-		lhsRlc := f.Zero()
+		lhsEvals := make([]*Element[T], len(group.checks))
 
 		for i, check := range group.checks {
 			// lhs = inputs_i_0(x)
@@ -478,8 +478,10 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 
 			// compute (∏_j inputs_j(x)) - r(x)
 			lhs = f.Sub(lhs, f.evalPolyWithChallenge(check.r, xPowers))
-			lhsRlc = f.Add(lhsRlc, f.Mul(zPowers[i], lhs))
+			lhsEvals[i] = lhs
 		}
+
+		lhsRlc := f.InnerProductNoReduce(lhsEvals, zPowers)
 
 		// compute q_acc(x) * mod(x)
 		rhs := f.Mul(
@@ -487,7 +489,8 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 			f.evalPolyWithChallenge(group.mod, xPowers),
 		)
 
-		f.AssertIsEqual(lhsRlc, rhs)
+		// f.AssertIsEqual(lhsRlc, rhs)
+		f.AssertIsDifferent(lhsRlc, rhs)
 	}
 
 	return nil
@@ -617,14 +620,12 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 // polynomial evaluations at the same point avoids redundant multiplications.
 func (f *Field[T]) evalPolyWithChallenge(p *Poly[T], at []*Element[T]) *Element[T] {
 	if p.evaluation == nil {
-		p.evaluation = f.innerProduct(p.Coeffs, at)
+		p.evaluation = f.InnerProductNoReduce(p.Coeffs, at)
 	}
 	return p.evaluation
 }
 
-// evalPolyWithChallenge evaluates p at a point whose powers are given by at,
-// where at[i] = at^i. Precomputing and sharing powers across multiple
-// polynomial evaluations at the same point avoids redundant multiplications.
+// innerProduct computes the inner product of two vectors of Element.
 func (f *Field[T]) innerProduct(a, b []*Element[T]) *Element[T] {
 	n := len(a)
 	terms := make([][]*Element[T], n)
@@ -640,6 +641,32 @@ func (f *Field[T]) innerProduct(a, b []*Element[T]) *Element[T] {
 		scalars[i] = 1
 	}
 	return f.Eval(terms, scalars)
+}
+
+// InnerProductNoReduce computes the inner product of two vectors of
+// *Element[T] without performing reduction.
+func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
+	n := len(a)
+	var eval *Element[T]
+	if b[0] == nil {
+		eval = a[0]
+	} else if a[0] == nil {
+		eval = b[0]
+	} else {
+		eval = f.MulNoReduce(a[0], b[0])
+	}
+
+	for i := 1; i < n; i++ {
+		if b[i] == nil {
+			eval = f.add(eval, a[i], max(eval.overflow, a[i].overflow)+1)
+		} else if a[i] == nil {
+			eval = f.add(eval, b[i], max(eval.overflow, b[i].overflow)+1)
+		} else {
+			prod := f.MulNoReduce(a[i], b[i])
+			eval = f.add(eval, prod, max(eval.overflow, prod.overflow)+1)
+		}
+	}
+	return eval
 }
 
 // NativeToEmulated decomposes a native field variable into an *Element[T] by

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -8,7 +8,9 @@ import (
 	limbs "github.com/consensys/gnark/std/internal/limbcomposition"
 )
 
-var NB_CHALLENGE_LIMBS = 2
+const nbChallengeLimbs = 2
+
+var one = big.NewInt(1)
 
 // Represents an element of a polynomial ring over the emulated field.
 type Poly[T FieldParams] struct {
@@ -60,7 +62,7 @@ type PolyRingGroupChecks[T FieldParams] struct {
 	mod       *Poly[T]              // polynomial defining the ring
 	modEvalFn EvalFnType[T]         // evaluation of mod at the challenge point, set at check time
 	checks    []polyRingMulCheck[T] // individual operations to check
-	q_acc     *Poly[T]              // random linear combination of quotients ∑_i z^i * q_i
+	qAcc      *Poly[T]              // random linear combination of quotients ∑_i z^i * q_i
 }
 
 // polyRingMulCheck is an individual deferred check.
@@ -71,7 +73,8 @@ type polyRingMulCheck[T FieldParams] struct {
 	q      *Poly[T]   // quotient
 }
 
-// NewPolyRingCheck registers a new polynomial ring group with the given modulus. The
+// NewPolyRingCheck registers a new polynomial ring group with the given modulus
+// and returns it. Pass nil for modEvalFn for default polynomial evaluation
 func (f *Field[T]) NewPolyRingCheck(mod *Poly[T], modEvalFn EvalFnType[T]) *PolyRingGroupChecks[T] {
 	groupCheck := &PolyRingGroupChecks[T]{
 		mod:       mod,
@@ -87,7 +90,8 @@ func (f *Field[T]) NewPolyRingCheck(mod *Poly[T], modEvalFn EvalFnType[T]) *Poly
 // is performed inside a hint, so it is the callers responsibility to perform
 // the deferred polynomial ring multiplication check.
 func (f *Field[T]) MulPolyRings(group *PolyRingGroupChecks[T], inputs_ ...*Poly[T]) (rem *Poly[T], err error) {
-	// defensive copy to prevent memory aliasing
+	// guards against replacing the entries in inputs_ slice but preserves
+	// pointers to each *Poly[T] for cached evaluations
 	inputs := make([]*Poly[T], len(inputs_))
 	copy(inputs, inputs_)
 
@@ -113,6 +117,9 @@ func (f *Field[T]) MulPolyRings(group *PolyRingGroupChecks[T], inputs_ ...*Poly[
 	totalDegree := nbTerms - nbPoly
 	// q degree is total degree minus the degree of the modulus polynomial
 	qDegree := totalDegree - modDegree
+	if qDegree < 0 {
+		qDegree = 0
+	}
 	nbQTermsLimbs := (1 + qDegree) * nbLimbs
 
 	// polynomials serialised as nbTerms|...terms. hintInputs contains
@@ -120,7 +127,7 @@ func (f *Field[T]) MulPolyRings(group *PolyRingGroupChecks[T], inputs_ ...*Poly[
 	// where inputs and mod are serialised as polynomials
 	hintInputs := make([]frontend.Variable, 0, 4+(nbPoly+nbTermsLimbs)+(1+nbModTermsLimbs))
 
-	hintInputs = append(hintInputs, nbBits, nbLimbs, nbPoly, *f.fParams.Modulus())
+	hintInputs = append(hintInputs, nbBits, nbLimbs, nbPoly, f.fParams.Modulus())
 
 	// loop through inputs to compute the number of terms
 	for _, inputPoly := range inputs {
@@ -248,7 +255,7 @@ func polyRingMulHint(mod *big.Int, inputs, outputs []*big.Int) error {
 // polyRingMul multiplies all polynomials in inputs and divides the product
 // by modPoly using polynomial Euclidean division. Coefficients are reduced
 // modulo fieldMod (the emulated field prime).
-func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q, r []*big.Int, err error) {
+func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (quotient, remainder []*big.Int, err error) {
 	if len(inputs) == 0 {
 		return nil, nil, fmt.Errorf("polyRingMul: no input polynomials")
 	}
@@ -267,10 +274,11 @@ func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q,
 		for i := range result {
 			result[i] = new(big.Int)
 		}
+		tmp := new(big.Int)
 		for i, ci := range product {
 			for j, cj := range b {
-				term := new(big.Int).Mul(ci, cj)
-				result[i+j].Add(result[i+j], term)
+				tmp.Mul(ci, cj)
+				result[i+j].Add(result[i+j], tmp)
 				result[i+j].Mod(result[i+j], fieldMod)
 			}
 		}
@@ -305,20 +313,22 @@ func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q,
 	}
 
 	qDeg := len(product) - 1 - divisorDeg
-	quotient := make([]*big.Int, qDeg+1)
+	quotient = make([]*big.Int, qDeg+1)
 	for i := range quotient {
 		quotient[i] = new(big.Int)
 	}
 
+	lc := new(big.Int)
+	term := new(big.Int)
 	for len(dividend) >= len(modPoly) {
 		d := len(dividend) - len(modPoly)
 		// leading quotient term at degree d
-		lc := new(big.Int).Mul(dividend[len(dividend)-1], lcInv)
+		lc = lc.Mul(dividend[len(dividend)-1], lcInv)
 		lc.Mod(lc, fieldMod)
 		quotient[d].Set(lc)
 		// subtract lc * x^d * modPoly from dividend
 		for i, c := range modPoly {
-			term := new(big.Int).Mul(lc, c)
+			term = term.Mul(lc, c)
 			dividend[i+d].Sub(dividend[i+d], term)
 			dividend[i+d].Mod(dividend[i+d], fieldMod)
 		}
@@ -329,7 +339,7 @@ func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q,
 	}
 
 	// pad remainder to divisorDeg terms
-	remainder := make([]*big.Int, divisorDeg)
+	remainder = make([]*big.Int, divisorDeg)
 	for i := range remainder {
 		if i < len(dividend) {
 			remainder[i] = new(big.Int).Set(dividend[i])
@@ -337,11 +347,10 @@ func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q,
 			remainder[i] = new(big.Int)
 		}
 	}
-
-	return quotient, remainder, nil
+	return
 }
 
-func (f *Field[T]) MakePoly(coeffs ...interface{}) *Poly[T] {
+func (f *Field[T]) MakePoly(coeffs ...any) *Poly[T] {
 	poly := &Poly[T]{}
 	poly.Coeffs = make([]*Element[T], len(coeffs))
 
@@ -404,8 +413,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 		return fmt.Errorf("deferredPolyCheck commit error: %w", err)
 	}
 
-	// 2. batch and store quotients from each group
-	//    and prepare to commit
+	// 2. batch and store quotients from each group and prepare to commit
 
 	// z can be shared across all groups
 	quotientbatchesCoeffCommits := []frontend.Variable{z}
@@ -416,19 +424,19 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 		}
 
 		// q_acc = ∑_i z^i * q_i
-		group.q_acc, err = f.callQuotientsRLCHint(quotients, z)
-
-		//
-		for _, rCoeff := range group.q_acc.Coeffs {
-			if rCoeff == nil {
-				println("nil coefficient")
-				continue
-			}
-			quotientbatchesCoeffCommits = append(quotientbatchesCoeffCommits, rCoeff.Limbs...)
-		}
+		group.qAcc, err = f.callQuotientsRLCHint(quotients, z)
 
 		if err != nil {
 			return fmt.Errorf("deferredPolyCheck callQuotientsRLCHint error: %w", err)
+		}
+
+		//
+		for _, qCoeff := range group.qAcc.Coeffs {
+			if qCoeff == nil {
+				println("nil coefficient")
+				continue
+			}
+			quotientbatchesCoeffCommits = append(quotientbatchesCoeffCommits, qCoeff.Limbs...)
 		}
 	}
 
@@ -439,15 +447,22 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	}
 
 	// Decompose challenges into emulated elements (full-width, multi-limb).
-	nativesToEl := f.NativeToEmulated(NB_CHALLENGE_LIMBS, z, x)
+	nativesToEl, err := f.NativeToEmulated(nbChallengeLimbs, z, x)
+	if err != nil {
+		return fmt.Errorf("NativeToEmulated error: %w", err)
+	}
 	zEmulated := nativesToEl[0]
 	xEmulated := nativesToEl[1]
 
-	maxTerms := 0
-	maxChecks := 0
+	maxTerms := 1
+	maxChecks := 1
 	for _, group := range f.deferredPolyChecks {
-		maxTerms = max(maxTerms, len(group.mod.Coeffs))
-		maxTerms = max(maxTerms, len(group.q_acc.Coeffs))
+		maxTerms = max(maxTerms, len(group.mod.Coeffs), len(group.qAcc.Coeffs))
+		for _, check := range group.checks {
+			for _, input := range check.inputs {
+				maxTerms = max(maxTerms, len(input.Coeffs))
+			}
+		}
 		maxChecks = max(maxChecks, len(group.checks))
 	}
 
@@ -500,31 +515,22 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 
 		// compute q_acc(x) * mod(x)
 		rhs := f.MulNoReduce(
-			f.evalPolyWithChallenge(group.q_acc, xPowers),
+			f.evalPolyWithChallenge(group.qAcc, xPowers),
 			group.modEvalFn(xPowers),
 		)
 
 		// AssertIsEqual reduces inputs for comparison
 		f.AssertIsEqual(lhsRlc, rhs)
-
-		// clean evaluations
-		f.deferredRingCheckCleanEvaluations(group)
 	}
 
+	// clean evaluations
+	f.deferredRingCheckCleanEvaluations()
 	return nil
 }
 
-func (f *Field[T]) deferredRingCheckCleanEvaluations(group *PolyRingGroupChecks[T]) {
-	// clean up evaluations to save memory, they are not needed after the check
-	// for _, check := range group.checks {
-	// 	check.r.evaluation = nil
-	// 	check.q.evaluation = nil
-	// 	for _, input := range check.inputs {
-	// 		input.evaluation = nil
-	// 	}
-	// }
-	// group.mod.evaluation = nil
-	// group.q_acc.evaluation = nil
+func (f *Field[T]) deferredRingCheckCleanEvaluations() {
+	// cleanup all deffered polynomial ring checks
+	f.deferredPolyChecks = nil
 }
 
 // callQuotientsRLCHint computes the random linear combination ∑_i z^i * q_i of
@@ -552,7 +558,7 @@ func (f *Field[T]) callQuotientsRLCHint(quotients []*Poly[T], z frontend.Variabl
 
 	// hint input layout: nbBits | nbLimbs | nbPolys | fieldMod | z | for each poly: nbTerms | limbs...
 	hintInputs := make([]frontend.Variable, 0, 6+nbPolys)
-	hintInputs = append(hintInputs, nbBits, nbLimbs, NB_CHALLENGE_LIMBS, nbPolys, *f.fParams.Modulus(), z)
+	hintInputs = append(hintInputs, nbBits, nbLimbs, nbChallengeLimbs, nbPolys, f.fParams.Modulus(), z)
 
 	for _, q := range quotients {
 		hintInputs = f.serialisePoly(q, hintInputs)
@@ -586,14 +592,14 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 	nbChallengeLimbs := int(inputs[2].Int64())
 	nbPolys := int(inputs[3].Int64())
 	fieldMod := new(big.Int).Set(inputs[4])
-	zLimbs := make([]*big.Int, nativeMod.BitLen()/(nbBits*nbChallengeLimbs)+1, nbLimbs)
-	for k := range zLimbs {
-		zLimbs[k] = new(big.Int)
-	}
-	if err := limbs.Decompose(inputs[5], uint(nbBits*nbChallengeLimbs), zLimbs); err != nil {
-		return fmt.Errorf("quotientsRLCHint: z decompose failed: %w", err)
-	}
-	z := zLimbs[0]
+	// we only use nbChallengeLimbs worth of the challenge
+	nbChallengeBits := uint(nbBits * nbChallengeLimbs)
+
+	z := new(big.Int) // full z
+	base := new(big.Int).Lsh(one, nbChallengeBits)
+	base.Sub(base, one)    // 0b111...1111 challenge bits
+	z.And(inputs[5], base) // mask z to nbChallengeLimbs bits
+
 	ptr := 6
 	polys := make([][]*big.Int, nbPolys)
 	for i := 0; i < nbPolys; i++ {
@@ -644,7 +650,6 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 	return nil
 }
 
-
 // evalPolyWithChallenge evaluates p at a point whose powers are given by at,
 // where at[i] = at^i. Precomputing and sharing powers across multiple
 // polynomial evaluations at the same point avoids redundant multiplications.
@@ -668,9 +673,9 @@ func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
 	for i := 0; i < n; i++ {
 		if a[i] == nil || b[i] == nil || b[i].isStrictZero() || a[i].isStrictZero() {
 			// don't add anything, one of the multiplier is zero
-		} else if bConstVal, bIsConst := f.constantValue(b[i]); bIsConst && bConstVal.Cmp(big.NewInt(1)) == 0 {
+		} else if bConstVal, bIsConst := f.constantValue(b[i]); bIsConst && bConstVal.Cmp(one) == 0 {
 			terms[i] = a[i]
-		} else if aConstVal, aIsConst := f.constantValue(a[i]); aIsConst && aConstVal.Cmp(big.NewInt(1)) == 0 {
+		} else if aConstVal, aIsConst := f.constantValue(a[i]); aIsConst && aConstVal.Cmp(one) == 0 {
 			terms[i] = b[i]
 		} else {
 			terms[i] = f.MulNoReduce(a[i], b[i])
@@ -683,10 +688,12 @@ func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
 				eval = term
 			} else {
 				nextOverflow := max(eval.overflow, term.overflow) + 1
-				// eval = f.Add(eval, term)
-				if nextOverflow+2 > f.maxOverflow() {
+				// if next overflow exceeds the maximum, reduce before adding
+				if nextOverflow+1 > f.maxOverflow() {
+					// add with input reduction
 					eval = f.Add(eval, term)
 				} else {
+					// add without overflow checks
 					eval = f.add(eval, term, nextOverflow)
 				}
 			}
@@ -700,7 +707,7 @@ func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
 
 // NativeToEmulated decomposes a native field var into FieldBitLen/nbBits
 // limbs, return Element[T] truncated to limitLimbs.
-func (f *Field[T]) NativeToEmulated(limitLimbs int, v ...frontend.Variable) []*Element[T] {
+func (f *Field[T]) NativeToEmulated(limitLimbs int, v ...frontend.Variable) ([]*Element[T], error) {
 	nbBits := int(f.fParams.BitsPerLimb())
 	nbLimbs := f.api.Compiler().FieldBitLen()/nbBits + 1
 	hintInputs := make([]frontend.Variable, 0, 2+len(v))
@@ -708,7 +715,7 @@ func (f *Field[T]) NativeToEmulated(limitLimbs int, v ...frontend.Variable) []*E
 	hintInputs = append(hintInputs, v...)
 	ret, err := f.api.NewHint(splitNativeToLimbsHint, nbLimbs*len(v), hintInputs...)
 	if err != nil {
-		panic(fmt.Sprintf("NativeToEmulated hint error: %v", err))
+		return nil, err
 	}
 	elements := make([]*Element[T], len(v))
 	for i := range elements {
@@ -725,7 +732,7 @@ func (f *Field[T]) NativeToEmulated(limitLimbs int, v ...frontend.Variable) []*E
 		f.api.AssertIsEqual(rebuildEl, v[i])
 		elements[i].Limbs = elements[i].Limbs[:limitLimbs]
 	}
-	return elements
+	return elements, nil
 }
 
 func splitNativeToLimbsHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -671,10 +671,11 @@ func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
 	return eval
 }
 
-// NativeToEmulated decomposes a native field variable into an *Element[T] by
-// splitting its binary representation into emulated limbs of BitsPerLimb each.
-func (f *Field[T]) NativeToEmulated(nbLimbs int, v ...frontend.Variable) []*Element[T] {
-	nbBits := f.fParams.BitsPerLimb()
+// NativeToEmulated decomposes a native field var into FieldBitLen/nbBits
+// limbs, return Element[T] truncated to limitLimbs.
+func (f *Field[T]) NativeToEmulated(limitLimbs int, v ...frontend.Variable) []*Element[T] {
+	nbBits := int(f.fParams.BitsPerLimb())
+	nbLimbs := f.api.Compiler().FieldBitLen()/nbBits + 1
 	hintInputs := make([]frontend.Variable, 0, 2+len(v))
 	hintInputs = append(hintInputs, nbBits, nbLimbs)
 	hintInputs = append(hintInputs, v...)
@@ -684,7 +685,18 @@ func (f *Field[T]) NativeToEmulated(nbLimbs int, v ...frontend.Variable) []*Elem
 	}
 	elements := make([]*Element[T], len(v))
 	for i := range elements {
+		// packLimbs performs range checks on limbs
 		elements[i] = f.packLimbs(ret[i*nbLimbs:(i+1)*nbLimbs], false)
+
+		rebuildEl := elements[i].Limbs[0]
+		placeValue := big.NewInt(1)
+		for j := 1; j < len(elements[i].Limbs); j++ {
+			placeValue.Lsh(placeValue, uint(nbBits))
+			rebuildEl = f.api.Add(rebuildEl, f.api.Mul(elements[i].Limbs[j], placeValue))
+		}
+		// assert correct decomposition
+		f.api.AssertIsEqual(rebuildEl, v[i])
+		elements[i].Limbs = elements[i].Limbs[:limitLimbs]
 	}
 	return elements
 }

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -11,7 +11,7 @@ import (
 // Represents an element of a polynomial ring over the emulated field.
 type Poly[T FieldParams] struct {
 	Coeffs     []*Element[T]
-	evaluation *big.Int // nil unless evaluated
+	evaluation *Element[T] // nil unless evaluated
 }
 
 // polyRingMulCheck represents a polynomial product check in a polynomial
@@ -457,9 +457,9 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	}
 
 	// Decompose challenges into emulated elements (full-width, multi-limb).
-	zEmulated := f.nativeToEmulated(z)
-	xEmulated := f.nativeToEmulated(x)
-	_ = zEmulated
+	nativesToEl := f.NativeToEmulated(2, z, x)
+	zEmulated := nativesToEl[0]
+	xEmulated := nativesToEl[1]
 
 	maxTerms := 0
 	maxChecks := 0
@@ -646,6 +646,11 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 // where at[i] = at^i. Precomputing and sharing powers across multiple
 // polynomial evaluations at the same point avoids redundant multiplications.
 func (f *Field[T]) evalPolyWithChallenge(p *Poly[T], at []*Element[T]) *Element[T] {
+	if p.evaluation != nil {
+		println("Already evaluated")
+		return p.evaluation
+	}
+
 	n := len(p.Coeffs)
 	terms := make([][]*Element[T], n)
 	scalars := make([]int, n)
@@ -657,26 +662,50 @@ func (f *Field[T]) evalPolyWithChallenge(p *Poly[T], at []*Element[T]) *Element[
 		}
 		scalars[i] = 1
 	}
-	return f.Eval(terms, scalars)
+	evaluation := f.Eval(terms, scalars)
+
+	p.evaluation = evaluation
+	return evaluation
 }
 
-// @TODO probably ugly, find something in gnark to do this
-// nativeToEmulated decomposes a native field variable into an *Element[T] by
+// NativeToEmulated decomposes a native field variable into an *Element[T] by
 // splitting its binary representation into emulated limbs of BitsPerLimb each.
-func (f *Field[T]) nativeToEmulated(v frontend.Variable) *Element[T] {
+func (f *Field[T]) NativeToEmulated(nbLimbs int, v ...frontend.Variable) []*Element[T] {
 	nbBitsPerLimb := int(f.fParams.BitsPerLimb())
-	nbLimbs := int(f.fParams.NbLimbs())
-	nativeBits := f.api.Compiler().FieldBitLen()
-	bits := f.api.ToBinary(v, nativeBits)
-	limbVars := make([]frontend.Variable, nbLimbs)
-	for i := 0; i < nbLimbs; i++ {
-		bi := i * nbBitsPerLimb
-		if bi+nbBitsPerLimb >= nativeBits {
-			limbVars[i] = f.api.FromBinary(bits[bi:]...)
-			break
-		} else {
-			limbVars[i] = f.api.FromBinary(bits[bi : bi+nbBitsPerLimb]...)
-		}
+	hintInputs := make([]frontend.Variable, 0, 2+len(v))
+	hintInputs = append(hintInputs, nbLimbs, nbBitsPerLimb)
+	hintInputs = append(hintInputs, v...)
+	ret, err := f.api.NewHint(splitNativeToLimbsHint, nbLimbs*len(v), hintInputs...)
+	if err != nil {
+		panic(fmt.Sprintf("NativeToEmulated hint error: %v", err))
 	}
-	return f.NewElement(limbVars)
+	elements := make([]*Element[T], len(v))
+	for i := range elements {
+		elements[i] = f.packLimbs(ret[i*nbLimbs:(i+1)*nbLimbs], false)
+	}
+	return elements
+}
+
+func splitNativeToLimbsHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
+	if len(inputs) < 3 {
+		return fmt.Errorf("splitNativeToLimbs: not enough inputs")
+	}
+
+	nbBits := int(inputs[0].Int64())
+	nbLimbs := int(inputs[1].Int64())
+	outptr := 0
+	for ptr := 2; ptr < len(inputs); ptr++ {
+		nativeEl := inputs[ptr]
+		coeffLimbs := make([]*big.Int, nbLimbs)
+		for k := range coeffLimbs {
+			coeffLimbs[k] = new(big.Int)
+		}
+		if err := limbs.Decompose(nativeEl, uint(nbBits), coeffLimbs); err != nil {
+			return fmt.Errorf("decompose result[%d]: %w", ptr-2, err)
+		}
+		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs)
+		outptr += nbLimbs
+	}
+
+	return nil
 }

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -501,3 +501,42 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 
 	return nil
 }
+
+// evalPolyWithChallenge evaluates p at a point whose powers are given by at,
+// where at[i] = at^i. Precomputing and sharing powers across multiple
+// polynomial evaluations at the same point avoids redundant multiplications.
+func (f *Field[T]) evalPolyWithChallenge(p *Poly[T], at []*Element[T]) *Element[T] {
+	n := len(p.Coeffs)
+	terms := make([][]*Element[T], n)
+	scalars := make([]int, n)
+	for i, coeff := range p.Coeffs {
+		if i == 0 {
+			terms[i] = []*Element[T]{coeff}
+		} else {
+			terms[i] = []*Element[T]{coeff, at[i]}
+		}
+		scalars[i] = 1
+	}
+	return f.Eval(terms, scalars)
+}
+
+// @TODO probably ugly, find something in gnark to do this
+// nativeToEmulated decomposes a native field variable into an *Element[T] by
+// splitting its binary representation into emulated limbs of BitsPerLimb each.
+func (f *Field[T]) nativeToEmulated(v frontend.Variable) *Element[T] {
+	nbBitsPerLimb := int(f.fParams.BitsPerLimb())
+	nbLimbs := int(f.fParams.NbLimbs())
+	nativeBits := f.api.Compiler().FieldBitLen()
+	bits := f.api.ToBinary(v, nativeBits)
+	limbVars := make([]frontend.Variable, nbLimbs)
+	for i := 0; i < nbLimbs; i++ {
+		bi := i * nbBitsPerLimb
+		if bi+nbBitsPerLimb >= nativeBits {
+			limbVars[i] = f.api.FromBinary(bits[bi:]...)
+			break
+		} else {
+			limbVars[i] = f.api.FromBinary(bits[bi : bi+nbBitsPerLimb]...)
+		}
+	}
+	return f.NewElement(limbVars)
+}

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -3,6 +3,9 @@ package emulated
 import (
 	"fmt"
 	"math/big"
+
+	"github.com/consensys/gnark/frontend"
+	limbs "github.com/consensys/gnark/std/internal/limbcomposition"
 )
 
 // Represents an element of a polynomial ring over the emulated field.
@@ -49,6 +52,166 @@ type polyRingMulCheck[T FieldParams] struct {
 	q      Poly[T]   // quotient
 }
 
+// CallPolyRingMulHint computes a polynomial product check in a polynomial ring,
+// returns the remainder (reduced result) and the quotient. The computation
+// is performed inside a hint, so it is the callers responsibility to perform
+// the deferred multiplication check.
+func (f *Field[T]) CallPolyRingMulHint(inputs []Poly[T], mod Poly[T]) (quo, rem Poly[T], err error) {
+	nbLimbs, nbBits := int(f.fParams.NbLimbs()), f.fParams.BitsPerLimb()
+
+	// total number of terms for all input polynomials
+	nbTerms := 0
+	// loop through inputs to compute the number of terms
+	for i := range inputs {
+		// add degree of each input polynomial
+		nbTerms += len(inputs[i])
+	}
+
+	// metadata for hint inputs
+	nbPoly := len(inputs)
+	nbTermsLimbs := nbTerms * nbLimbs
+	nbModTermsLimbs := len(mod) * nbLimbs
+
+	// metadata for outputs
+	modDegree := len(mod) - 1
+	nbRemLimbs := modDegree * nbLimbs
+	totalDegree := nbTerms - nbPoly
+	// q degree is total degree minus the degree of the modulus polynomial
+	qDegree := totalDegree - modDegree
+	nbQTermsLimbs := (1 + qDegree) * nbLimbs
+
+	// Polynomials serialised as nbTerms|...terms. hintInputs contains serialisation of,
+	// in order: nbBits|nbLimbs|nbPoly|fieldMod|...inputs|modPoly, where inputs and mod are serialised as polynomials
+	hintInputs := make([]frontend.Variable, 0, 4+(nbPoly+nbTermsLimbs)+(1+nbModTermsLimbs))
+
+	hintInputs = append(hintInputs, nbBits, nbLimbs, nbPoly, *f.fParams.Modulus())
+
+	// loop through inputs to compute the number of terms
+	for _, inputPoly := range inputs {
+		// serialised as nbTerms|...terms
+		// add degree of each input polynomial
+		hintInputs = append(hintInputs, len(inputPoly))
+		// append each term from inputPoly polynomial
+		for _, coeff := range inputPoly {
+			hintInputs = append(hintInputs, coeff.Limbs...)
+		}
+	}
+
+	hintInputs = append(hintInputs, len(mod))
+	// append mod terms
+	for _, coeff := range mod {
+		hintInputs = append(hintInputs, coeff.Limbs...)
+	}
+
+	// call
+	ret, err := f.api.NewHint(polyRingMulHint, 1+nbQTermsLimbs+1+nbRemLimbs, hintInputs...)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// unpack quotient: skip nbQTerms header, then read (1+qDegree) terms of nbLimbs each
+	quo = make(Poly[T], 1+qDegree)
+	retPtr := 1 // skip nbQTerms
+	for i := range quo {
+		termLimbs := ret[retPtr : retPtr+nbLimbs]
+		retPtr += nbLimbs
+		quo[i] = f.packLimbs(termLimbs, false)
+	}
+
+	// unpack remainder: skip nbRemTerms header, then read (len(mod)-1) terms of nbLimbs each
+	retPtr++ // skip nbRemTerms
+	rem = make(Poly[T], len(mod)-1)
+	for i := range rem {
+		termLimbs := ret[retPtr : retPtr+nbLimbs]
+		retPtr += nbLimbs
+		rem[i] = f.packLimbs(termLimbs, true)
+	}
+
+	return quo, rem, nil
+}
+
+// polyRingMulHint computes the multivariate evaluation as a hint. Should not be
+// called directly, but rather through [Field.callPolyRingMulHint] method which
+// handles the input packing and output unpacking.
+func polyRingMulHint(mod *big.Int, inputs, outputs []*big.Int) error {
+	nbBits := int(inputs[0].Int64())
+	nbLimbs := int(inputs[1].Int64())
+	nbPoly := int(inputs[2].Int64())
+
+	// extract the input polynomials
+	inputsPolys := make([][]*big.Int, nbPoly)
+	ptr := 3
+	fieldMod := new(big.Int).Set(inputs[ptr])
+	ptr++
+
+	for i := 0; i < nbPoly; i++ {
+		nbTerms := int(inputs[ptr].Int64())
+		ptr++
+		inputsPolys[i] = make([]*big.Int, nbTerms)
+		for j := 0; j < nbTerms; j++ {
+			coeffLimbs := inputs[ptr : ptr+nbLimbs]
+			ptr += nbLimbs
+			val := new(big.Int)
+			if err := limbs.Recompose(coeffLimbs, uint(nbBits), val); err != nil {
+				return fmt.Errorf("recompose input[%d][%d]: %w", i, j, err)
+			}
+			inputsPolys[i][j] = val
+		}
+	}
+
+	nbTerms := int(inputs[ptr].Int64())
+	ptr++
+	modPoly := make([]*big.Int, nbTerms)
+	for j := 0; j < nbTerms; j++ {
+		coeffLimbs := inputs[ptr : ptr+nbLimbs]
+		ptr += nbLimbs
+		val := new(big.Int)
+		if err := limbs.Recompose(coeffLimbs, uint(nbBits), val); err != nil {
+			return fmt.Errorf("recompose mod polynomial[%d]: %w", j, err)
+		}
+		modPoly[j] = val
+	}
+
+	// multiply inputs and divide by modPoly to obtain quotient and remainder
+	q, r, err := polyRingMul(fieldMod, inputsPolys, modPoly)
+	if err != nil {
+		return fmt.Errorf("polyRingMul: %w", err)
+	}
+
+	// serialize outputs: nbQTerms | q limbs... | nbRemTerms | r limbs...
+	nbBitsU := uint(nbBits)
+	outptr := 0
+	outputs[outptr].SetInt64(int64(len(q)))
+	outptr++
+	for _, coeff := range q {
+		coeffLimbs := make([]*big.Int, nbLimbs)
+		for i := range coeffLimbs {
+			coeffLimbs[i] = new(big.Int)
+		}
+		if err := limbs.Decompose(coeff, nbBitsU, coeffLimbs); err != nil {
+			return fmt.Errorf("decompose quotient coeff: %w", err)
+		}
+		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs)
+		outptr += nbLimbs
+	}
+	outputs[outptr].SetInt64(int64(len(r)))
+	outptr++
+	for _, coeff := range r {
+		coeffLimbs := make([]*big.Int, nbLimbs)
+		for i := range coeffLimbs {
+			coeffLimbs[i] = new(big.Int)
+		}
+		if err := limbs.Decompose(coeff, nbBitsU, coeffLimbs); err != nil {
+			return fmt.Errorf("decompose remainder coeff: %w", err)
+		}
+		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs)
+		outptr += nbLimbs
+	}
+
+	return nil
+}
+
 // polyRingMul multiplies all polynomials in inputs and divides the product
 // by modPoly using polynomial Euclidean division. Coefficients are reduced
 // modulo fieldMod (the emulated field prime).
@@ -59,9 +222,6 @@ func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q,
 	if len(modPoly) == 0 {
 		return nil, nil, fmt.Errorf("polyRingMul: modulus polynomial is empty")
 	}
-
-	fmt.Printf("inputs: %v\n", inputs)
-	fmt.Printf("modPoly: %v\n", modPoly)
 
 	// multiply all polynomials in inputs
 	product := make([]*big.Int, len(inputs[0]))
@@ -144,10 +304,6 @@ func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q,
 			remainder[i] = new(big.Int)
 		}
 	}
-
-	fmt.Printf("product: %v\n", product)
-	fmt.Printf("quotient: %v\n", quotient)
-	fmt.Printf("remainder: %v\n", remainder)
 
 	return quotient, remainder, nil
 }

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -10,6 +10,9 @@ import (
 
 const nbChallengeLimbs = 2
 
+// op degree -> number of checks of this degree
+var opsDegreeTracking map[int]int = map[int]int{}
+
 var one = big.NewInt(1)
 
 // Represents an element of a polynomial ring over the emulated field.
@@ -164,6 +167,9 @@ func (f *Field[T]) MulPolyRings(group *PolyRingGroupChecks[T], inputs_ ...*Poly[
 		retPtr += nbLimbs
 		rem.Coeffs[i] = f.packLimbs(termLimbs, true)
 	}
+
+	opDeg := len(quo.Coeffs) + len(rem.Coeffs) - 2
+	opsDegreeTracking[opDeg]++
 
 	group.checks = append(group.checks, polyRingMulCheck[T]{
 		inputs: inputs,
@@ -377,6 +383,9 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	if len(f.deferredPolyChecks) == 0 {
 		return nil
 	}
+
+	f.log.Printf("Poly Ring Multiplications by Degree: %v", opsDegreeTracking)
+	opsDegreeTracking = map[int]int{} // reset tracking for next run
 
 	// get committer from the api
 	committer, ok := api.(frontend.Committer)
@@ -769,4 +778,56 @@ type PolyConv[T FieldParams] interface {
 
 func (p *Poly[T]) ToPoly() *Poly[T] {
 	return p
+}
+
+// PolyRingAccumulator is used to accumulate polynomial products
+// performs multiplications via MulPolyRings when target degree is
+// reached
+type PolyRingAccumulator[T FieldParams] struct {
+	state      []*Poly[T] // current accumulated polynomials
+	f          *Field[T]
+	checker    *PolyRingGroupChecks[T]
+	targetDeg  int
+	currentDeg int
+}
+
+// NewPolyRingAccumulator creates a new polynomial products accumulator
+func (f *Field[T]) NewPolyRingAccumulator(checker *PolyRingGroupChecks[T], targetDeg int) *PolyRingAccumulator[T] {
+	return &PolyRingAccumulator[T]{
+		f:         f,
+		checker:   checker,
+		targetDeg: targetDeg,
+	}
+}
+
+// Mul adds a new polynomial to the accumulator
+func (acc *PolyRingAccumulator[T]) Mul(poly *Poly[T]) {
+	if acc.currentDeg+len(poly.Coeffs)-1 > acc.targetDeg {
+		acc.Result()
+	}
+	acc.currentDeg += len(poly.Coeffs) - 1
+	acc.state = append(acc.state, poly)
+}
+
+// Sqr squares the current accumulation doubling the degree
+func (acc *PolyRingAccumulator[T]) Sqr() {
+	if acc.currentDeg+acc.currentDeg > acc.targetDeg {
+		acc.Result()
+	}
+	acc.currentDeg += acc.currentDeg // degree doubles
+	acc.state = append(acc.state, acc.state...)
+}
+
+// Sqr squares the current accumulation doubling the degree
+func (acc *PolyRingAccumulator[T]) Result() (result *Poly[T]) {
+	if len(acc.state) == 1 {
+		return acc.state[0]
+	}
+	result, err := acc.f.MulPolyRings(acc.checker, acc.state...)
+	if err != nil {
+		panic(err)
+	}
+	acc.state = []*Poly[T]{result}
+	acc.currentDeg = len(result.Coeffs) - 1
+	return
 }

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -1,6 +1,10 @@
 package emulated
 
-// polyProdCheck represents a polynomial product check in a polynomial
+import (
+	"fmt"
+	"math/big"
+)
+
 // Represents an element of a polynomial ring over the emulated field.
 type Poly[T FieldParams] []*Element[T]
 
@@ -45,3 +49,105 @@ type polyRingMulCheck[T FieldParams] struct {
 	q      Poly[T]   // quotient
 }
 
+// polyRingMul multiplies all polynomials in inputs and divides the product
+// by modPoly using polynomial Euclidean division. Coefficients are reduced
+// modulo fieldMod (the emulated field prime).
+func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q, r []*big.Int, err error) {
+	if len(inputs) == 0 {
+		return nil, nil, fmt.Errorf("polyRingMul: no input polynomials")
+	}
+	if len(modPoly) == 0 {
+		return nil, nil, fmt.Errorf("polyRingMul: modulus polynomial is empty")
+	}
+
+	fmt.Printf("inputs: %v\n", inputs)
+	fmt.Printf("modPoly: %v\n", modPoly)
+
+	// multiply all polynomials in inputs
+	product := make([]*big.Int, len(inputs[0]))
+	for i, c := range inputs[0] {
+		product[i] = new(big.Int).Mod(c, fieldMod)
+	}
+	for k := 1; k < len(inputs); k++ {
+		b := inputs[k]
+		result := make([]*big.Int, len(product)+len(b)-1)
+		for i := range result {
+			result[i] = new(big.Int)
+		}
+		for i, ci := range product {
+			for j, cj := range b {
+				term := new(big.Int).Mul(ci, cj)
+				result[i+j].Add(result[i+j], term)
+				result[i+j].Mod(result[i+j], fieldMod)
+			}
+		}
+		product = result
+	}
+
+	// euclidean division: product = quotient * modPoly + remainder
+	divisorDeg := len(modPoly) - 1
+
+	// if product has lower degree than modPoly, quotient is 0 and remainder is product
+	if len(product)-1 < divisorDeg {
+		remainder := make([]*big.Int, divisorDeg)
+		for i := range remainder {
+			if i < len(product) {
+				remainder[i] = new(big.Int).Set(product[i])
+			} else {
+				remainder[i] = new(big.Int)
+			}
+		}
+		return []*big.Int{new(big.Int)}, remainder, nil
+	}
+
+	// leading coefficient inverse of modPoly modulo field modulus
+	lcInv := new(big.Int).ModInverse(modPoly[divisorDeg], fieldMod)
+	if lcInv == nil {
+		return nil, nil, fmt.Errorf("polyRingMul: leading coefficient of modulus polynomial is not invertible")
+	}
+
+	dividend := make([]*big.Int, len(product))
+	for i, c := range product {
+		dividend[i] = new(big.Int).Set(c)
+	}
+
+	qDeg := len(product) - 1 - divisorDeg
+	quotient := make([]*big.Int, qDeg+1)
+	for i := range quotient {
+		quotient[i] = new(big.Int)
+	}
+
+	for len(dividend) >= len(modPoly) {
+		d := len(dividend) - len(modPoly)
+		// leading quotient term at degree d
+		lc := new(big.Int).Mul(dividend[len(dividend)-1], lcInv)
+		lc.Mod(lc, fieldMod)
+		quotient[d].Set(lc)
+		// subtract lc * x^d * modPoly from dividend
+		for i, c := range modPoly {
+			term := new(big.Int).Mul(lc, c)
+			dividend[i+d].Sub(dividend[i+d], term)
+			dividend[i+d].Mod(dividend[i+d], fieldMod)
+		}
+		// trim leading zeros
+		for len(dividend) > 0 && dividend[len(dividend)-1].Sign() == 0 {
+			dividend = dividend[:len(dividend)-1]
+		}
+	}
+
+	// pad remainder to divisorDeg terms
+	remainder := make([]*big.Int, divisorDeg)
+	for i := range remainder {
+		if i < len(dividend) {
+			remainder[i] = new(big.Int).Set(dividend[i])
+		} else {
+			remainder[i] = new(big.Int)
+		}
+	}
+
+	fmt.Printf("product: %v\n", product)
+	fmt.Printf("quotient: %v\n", quotient)
+	fmt.Printf("remainder: %v\n", remainder)
+
+	return quotient, remainder, nil
+}

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -86,7 +86,11 @@ func (f *Field[T]) NewPolyRingCheck(mod *Poly[T], modEvalFn EvalFnType[T]) *Poly
 // returns the remainder (reduced result) and the quotient. The computation
 // is performed inside a hint, so it is the callers responsibility to perform
 // the deferred polynomial ring multiplication check.
-func (f *Field[T]) MulPolyRings(group *PolyRingGroupChecks[T], inputs ...*Poly[T]) (rem *Poly[T], err error) {
+func (f *Field[T]) MulPolyRings(group *PolyRingGroupChecks[T], inputs_ ...*Poly[T]) (rem *Poly[T], err error) {
+	// defensive copy to prevent memory aliasing
+	inputs := make([]*Poly[T], len(inputs_))
+	copy(inputs, inputs_)
+
 	mod := *group.mod
 	nbLimbs, nbBits := int(f.fParams.NbLimbs()), f.fParams.BitsPerLimb()
 
@@ -661,7 +665,13 @@ func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
 			if eval == nil {
 				eval = term
 			} else {
-				eval = f.add(eval, term, max(eval.overflow, term.overflow)+1)
+				nextOverflow := max(eval.overflow, term.overflow) + 1
+				// eval = f.Add(eval, term)
+				if nextOverflow+2 > f.maxOverflow() {
+					eval = f.Add(eval, term)
+				} else {
+					eval = f.add(eval, term, nextOverflow)
+				}
 			}
 		}
 	}

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -16,6 +16,8 @@ type Poly[T FieldParams] struct {
 	evaluation *Element[T] // nil unless evaluated
 }
 
+type EvalFnType[T FieldParams] = func([]*Element[T]) *Element[T]
+
 // polyRingMulCheck represents a polynomial product check in a polynomial
 // ring. Instead of computing the product and reducing it where called,
 // we compute the result using a hint and return it. Result is stored for
@@ -55,9 +57,10 @@ type Poly[T FieldParams] struct {
 // ∑_i z^i * q_i is computed outside the circuit, and evaluated inside the circuit
 // PolyRingGroupChecks binds a specific modulus to all of its checks.
 type PolyRingGroupChecks[T FieldParams] struct {
-	mod    *Poly[T]              // polynomial defining the ring
-	checks []polyRingMulCheck[T] // individual operations to check
-	q_acc  *Poly[T]              // random linear combination of quotients ∑_i z^i * q_i
+	mod       *Poly[T]              // polynomial defining the ring
+	modEvalFn EvalFnType[T]         // evaluation of mod at the challenge point, set at check time
+	checks    []polyRingMulCheck[T] // individual operations to check
+	q_acc     *Poly[T]              // random linear combination of quotients ∑_i z^i * q_i
 }
 
 // polyRingMulCheck is an individual deferred check.
@@ -69,10 +72,10 @@ type polyRingMulCheck[T FieldParams] struct {
 }
 
 // NewPolyRingCheck registers a new polynomial ring group with the given modulus. The
-func (f *Field[T]) NewPolyRingCheck(mod *Poly[T]) *PolyRingGroupChecks[T] {
+func (f *Field[T]) NewPolyRingCheck(mod *Poly[T], modEvalFn EvalFnType[T]) *PolyRingGroupChecks[T] {
 	groupCheck := &PolyRingGroupChecks[T]{
-		mod:    mod,
-		checks: []polyRingMulCheck[T]{},
+		mod:       mod,
+		modEvalFn: modEvalFn,
 	}
 	f.deferredPolyChecks = append(f.deferredPolyChecks, groupCheck)
 
@@ -483,10 +486,16 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 
 		lhsRlc := f.InnerProductNoReduce(lhsEvals, zPowers)
 
+		if group.modEvalFn == nil {
+			group.modEvalFn = func(xPowers []*Element[T]) *Element[T] {
+				return f.evalPolyWithChallenge(group.mod, xPowers)
+			}
+		}
+
 		// compute q_acc(x) * mod(x)
 		rhs := f.MulNoReduce(
 			f.evalPolyWithChallenge(group.q_acc, xPowers),
-			f.evalPolyWithChallenge(group.mod, xPowers),
+			group.modEvalFn(xPowers),
 		)
 
 		f.AssertIsEqual(lhsRlc, rhs)
@@ -623,7 +632,7 @@ func (f *Field[T]) evalPolyWithChallenge(p *Poly[T], at []*Element[T]) *Element[
 }
 
 // innerProduct computes the inner product of two vectors of Element.
-func (f *Field[T]) innerProduct(a, b []*Element[T]) *Element[T] {
+func (f *Field[T]) InnerProduct(a, b []*Element[T]) *Element[T] {
 	n := len(a)
 	terms := make([][]*Element[T], n)
 	scalars := make([]int, n)

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -381,3 +381,123 @@ func (f *Field[T]) MakePoly(coeffs []interface{}) *Poly[T] {
 
 	return poly
 }
+
+
+// callQuotientsRLCHint computes the random linear combination ∑_i z^i * q_i of
+// the provided quotient polynomials with the scalar challenge z. The result is
+// a single Poly[T] whose coefficients are emulated field elements reduced
+// modulo the emulated field prime. This is used in the deferred ring check to
+// batch multiple quotient polynomials together outside the circuit, saving
+// constraints by avoiding individual quotient evaluations.
+func (f *Field[T]) callQuotientsRLCHint(quotients []*Poly[T], z frontend.Variable) (*Poly[T], error) {
+	if len(quotients) == 0 {
+		return nil, fmt.Errorf("BatchPolyQuotients: no quotient polynomials")
+	}
+
+	nbLimbs, nbBits := int(f.fParams.NbLimbs()), f.fParams.BitsPerLimb()
+
+	// the output polynomial has the maximum number of terms among all inputs
+	maxTerms := 0
+	for _, q := range quotients {
+		if len(q.Coeffs) > maxTerms {
+			maxTerms = len(q.Coeffs)
+		}
+	}
+
+	nbPolys := len(quotients)
+
+	// hint input layout: nbBits | nbLimbs | nbPolys | fieldMod | z | for each poly: nbTerms | limbs...
+	hintInputs := make([]frontend.Variable, 0, 5+nbPolys)
+	hintInputs = append(hintInputs, nbBits, nbLimbs, nbPolys, *f.fParams.Modulus(), z)
+
+	for _, q := range quotients {
+		hintInputs = append(hintInputs, len(q.Coeffs))
+		for _, coeff := range q.Coeffs {
+			hintInputs = append(hintInputs, coeff.Limbs...)
+		}
+	}
+
+	nbOutputs := maxTerms * nbLimbs
+	ret, err := f.api.NewHint(quotientsRLCHint, nbOutputs, hintInputs...)
+	if err != nil {
+		return nil, fmt.Errorf("BatchPolyQuotients hint: %w", err)
+	}
+
+	result := &Poly[T]{Coeffs: make([]*Element[T], maxTerms)}
+	for i := range result.Coeffs {
+		termLimbs := ret[i*nbLimbs : (i+1)*nbLimbs]
+		result.Coeffs[i] = f.packLimbs(termLimbs, false)
+	}
+
+	return result, nil
+}
+
+// quotientsRLCHint computes ∑_i z^i * q_i for a list of quotient
+// polynomials and a scalar challenge z. Each output coefficient is
+// result[j] = ∑_i z^i * q_i[j] mod fieldMod, where fieldMod is the emulated
+// field prime. Should not be called directly; use [Field.BatchPolyQuotients].
+func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
+	if len(inputs) < 5 {
+		return fmt.Errorf("batchPolyQuotientsHint: not enough inputs")
+	}
+
+	nbBits := int(inputs[0].Int64())
+	nbLimbs := int(inputs[1].Int64())
+	nbPolys := int(inputs[2].Int64())
+	fieldMod := new(big.Int).Set(inputs[3])
+	z := new(big.Int).Mod(inputs[4], fieldMod)
+
+	ptr := 5
+	polys := make([][]*big.Int, nbPolys)
+	for i := 0; i < nbPolys; i++ {
+		nbTerms := int(inputs[ptr].Int64())
+		ptr++
+		polys[i] = make([]*big.Int, nbTerms)
+		for j := 0; j < nbTerms; j++ {
+			coeffLimbs := inputs[ptr : ptr+nbLimbs]
+			ptr += nbLimbs
+			val := new(big.Int)
+			if err := limbs.Recompose(coeffLimbs, uint(nbBits), val); err != nil {
+				return fmt.Errorf("recompose polys[%d][%d]: %w", i, j, err)
+			}
+			polys[i][j] = val
+		}
+	}
+
+	maxTerms := len(outputs) / nbLimbs
+
+	// accumulator: result[j] = ∑_i z^i * q_i[j] mod fieldMod
+	result := make([]*big.Int, maxTerms)
+	for i := range result {
+		result[i] = new(big.Int)
+	}
+
+	zPow := new(big.Int).SetInt64(1) // z^0 = 1
+	tmp := new(big.Int)
+	for _, poly := range polys {
+		for j, coeff := range poly {
+			tmp.Mul(zPow, coeff)
+			tmp.Mod(tmp, fieldMod)
+			result[j].Add(result[j], tmp)
+			result[j].Mod(result[j], fieldMod)
+		}
+		zPow.Mul(zPow, z)
+		zPow.Mod(zPow, fieldMod)
+	}
+
+	// serialize: maxTerms coefficients each decomposed into nbLimbs limbs
+	outptr := 0
+	for idx, coeff := range result {
+		coeffLimbs := make([]*big.Int, nbLimbs)
+		for k := range coeffLimbs {
+			coeffLimbs[k] = new(big.Int)
+		}
+		if err := limbs.Decompose(coeff, uint(nbBits), coeffLimbs); err != nil {
+			return fmt.Errorf("decompose result[%d]: %w", idx, err)
+		}
+		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs)
+		outptr += nbLimbs
+	}
+
+	return nil
+}

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -62,9 +62,9 @@ func (f *Field[T]) CallPolyRingMulHint(inputs []Poly[T], mod Poly[T]) (quo, rem 
 	// total number of terms for all input polynomials
 	nbTerms := 0
 	// loop through inputs to compute the number of terms
-	for i := range inputs {
+	for _, inputPoly := range inputs {
 		// add degree of each input polynomial
-		nbTerms += len(inputs[i])
+		nbTerms += len(inputPoly)
 	}
 
 	// metadata for hint inputs
@@ -138,12 +138,11 @@ func polyRingMulHint(mod *big.Int, inputs, outputs []*big.Int) error {
 	nbBits := int(inputs[0].Int64())
 	nbLimbs := int(inputs[1].Int64())
 	nbPoly := int(inputs[2].Int64())
+	fieldMod := new(big.Int).Set(inputs[3])
 
 	// extract the input polynomials
 	inputsPolys := make([][]*big.Int, nbPoly)
-	ptr := 3
-	fieldMod := new(big.Int).Set(inputs[ptr])
-	ptr++
+	ptr := 4
 
 	for i := 0; i < nbPoly; i++ {
 		nbTerms := int(inputs[ptr].Int64())
@@ -160,10 +159,10 @@ func polyRingMulHint(mod *big.Int, inputs, outputs []*big.Int) error {
 		}
 	}
 
-	nbTerms := int(inputs[ptr].Int64())
+	nbModPolyTerms := int(inputs[ptr].Int64())
 	ptr++
-	modPoly := make([]*big.Int, nbTerms)
-	for j := 0; j < nbTerms; j++ {
+	modPoly := make([]*big.Int, nbModPolyTerms)
+	for j := 0; j < nbModPolyTerms; j++ {
 		coeffLimbs := inputs[ptr : ptr+nbLimbs]
 		ptr += nbLimbs
 		val := new(big.Int)
@@ -306,4 +305,19 @@ func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q,
 	}
 
 	return quotient, remainder, nil
+}
+
+func (f *Field[T]) MakePoly(coeffs []interface{}) Poly[T] {
+	nativeMod := f.api.Compiler().Field()
+
+	poly := make(Poly[T], len(coeffs))
+
+	for i, coeff := range coeffs {
+		emCoeff_ := ValueOf[T](coeff)
+		emCoeff := &emCoeff_
+		emCoeff.Initialize(nativeMod)
+		poly[i] = emCoeff
+	}
+
+	return poly
 }

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -143,7 +143,9 @@ func (f *Field[T]) MulPolyRings(inputs []*Poly[T], group *PolyRingGroupChecks[T]
 	for i := range quo.Coeffs {
 		termLimbs := ret[retPtr : retPtr+nbLimbs]
 		retPtr += nbLimbs
-		quo.Coeffs[i] = f.packLimbs(termLimbs, false)
+		// quotient is only used by the prover to generate the rlc, so don't need
+		// rangechecks on these
+		quo.Coeffs[i] = f.newInternalElement(termLimbs, 0)
 	}
 
 	// unpack remainder: skip nbRemTerms header, then read len(mod)-1 terms of nbLimbs each

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -225,27 +225,17 @@ func polyRingMulHint(mod *big.Int, inputs, outputs []*big.Int) error {
 	outputs[outptr].SetInt64(int64(len(q)))
 	outptr++
 	for _, coeff := range q {
-		coeffLimbs := make([]*big.Int, nbLimbs)
-		for i := range coeffLimbs {
-			coeffLimbs[i] = new(big.Int)
-		}
-		if err := limbs.Decompose(coeff, nbBitsU, coeffLimbs); err != nil {
+		if err := limbs.Decompose(coeff, nbBitsU, outputs[outptr:outptr+nbLimbs]); err != nil {
 			return fmt.Errorf("decompose quotient coeff: %w", err)
 		}
-		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs)
 		outptr += nbLimbs
 	}
 	outputs[outptr].SetInt64(int64(len(r)))
 	outptr++
 	for _, coeff := range r {
-		coeffLimbs := make([]*big.Int, nbLimbs)
-		for i := range coeffLimbs {
-			coeffLimbs[i] = new(big.Int)
-		}
-		if err := limbs.Decompose(coeff, nbBitsU, coeffLimbs); err != nil {
+		if err := limbs.Decompose(coeff, nbBitsU, outputs[outptr:outptr+nbLimbs]); err != nil {
 			return fmt.Errorf("decompose remainder coeff: %w", err)
 		}
-		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs)
 		outptr += nbLimbs
 	}
 
@@ -430,10 +420,9 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 			return fmt.Errorf("deferredPolyCheck callQuotientsRLCHint error: %w", err)
 		}
 
-		//
+		// commit quotient rlc coefficients from each group
 		for _, qCoeff := range group.qAcc.Coeffs {
 			if qCoeff == nil {
-				println("nil coefficient")
 				continue
 			}
 			quotientbatchesCoeffCommits = append(quotientbatchesCoeffCommits, qCoeff.Limbs...)
@@ -523,14 +512,10 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 		f.AssertIsEqual(lhsRlc, rhs)
 	}
 
-	// clean evaluations
-	f.deferredRingCheckCleanEvaluations()
-	return nil
-}
-
-func (f *Field[T]) deferredRingCheckCleanEvaluations() {
 	// cleanup all deffered polynomial ring checks
 	f.deferredPolyChecks = nil
+
+	return nil
 }
 
 // callQuotientsRLCHint computes the random linear combination ∑_i z^i * q_i of
@@ -637,14 +622,9 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 	// serialize: maxTerms coefficients each decomposed into nbLimbs limbs
 	outptr := 0
 	for idx, coeff := range result {
-		coeffLimbs := make([]*big.Int, nbLimbs)
-		for k := range coeffLimbs {
-			coeffLimbs[k] = new(big.Int)
-		}
-		if err := limbs.Decompose(coeff, uint(nbBits), coeffLimbs); err != nil {
+		if err := limbs.Decompose(coeff, uint(nbBits), outputs[outptr:outptr+nbLimbs]); err != nil {
 			return fmt.Errorf("decompose result[%d]: %w", idx, err)
 		}
-		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs)
 		outptr += nbLimbs
 	}
 	return nil
@@ -745,14 +725,9 @@ func splitNativeToLimbsHint(nativeMod *big.Int, inputs, outputs []*big.Int) erro
 	outptr := 0
 	for ptr := 2; ptr < len(inputs); ptr++ {
 		nativeEl := inputs[ptr]
-		coeffLimbs := make([]*big.Int, nativeMod.BitLen()/nbBits+1)
-		for k := range coeffLimbs {
-			coeffLimbs[k] = new(big.Int)
-		}
-		if err := limbs.Decompose(nativeEl, uint(nbBits), coeffLimbs); err != nil {
+		if err := limbs.Decompose(nativeEl, uint(nbBits), outputs[outptr:outptr+nbLimbs]); err != nil {
 			return fmt.Errorf("decompose result[%d]: %w", ptr-2, err)
 		}
-		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs[0:nbLimbs])
 		outptr += nbLimbs
 	}
 

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -83,7 +83,7 @@ func (f *Field[T]) NewPolyRingCheck(mod *Poly[T]) *PolyRingGroupChecks[T] {
 // returns the remainder (reduced result) and the quotient. The computation
 // is performed inside a hint, so it is the callers responsibility to perform
 // the deferred polynomial ring multiplication check.
-func (f *Field[T]) MulPolyRings(inputs []*Poly[T], group *PolyRingGroupChecks[T]) (rem *Poly[T], err error) {
+func (f *Field[T]) MulPolyRings(group *PolyRingGroupChecks[T], inputs ...*Poly[T]) (rem *Poly[T], err error) {
 	mod := *group.mod
 	nbLimbs, nbBits := int(f.fParams.NbLimbs()), f.fParams.BitsPerLimb()
 
@@ -386,6 +386,11 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 		}
 	}
 
+	if len(remainderCoeffCommits) == 0 {
+		// nothing to do
+		return nil
+	}
+
 	// commit all remainders from each group at once
 	z, err := committer.Commit(remainderCoeffCommits...) // z = remainderCommitment
 	if err != nil {
@@ -408,6 +413,10 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 
 		//
 		for _, rCoeff := range group.q_acc.Coeffs {
+			if rCoeff == nil {
+				println("nil coefficient")
+				continue
+			}
 			quotientbatchesCoeffCommits = append(quotientbatchesCoeffCommits, rCoeff.Limbs...)
 		}
 
@@ -723,4 +732,12 @@ func (f *Field[T]) serialisePoly(poly *Poly[T], inputs []frontend.Variable) []fr
 		}
 	}
 	return inputs
+}
+
+type PolyConv[T FieldParams] interface {
+	ToPoly() *Poly[T]
+}
+
+func (p *Poly[T]) ToPoly() *Poly[T] {
+	return p
 }

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -51,19 +51,9 @@ type Poly[T FieldParams] struct {
 //
 // this allows skipping individual q evaluations in the circuit because,
 // ∑_i z^i * q_i is computed outside the circuit, and evaluated inside the circuit
-
-type GroupName string
-
-// polyRingCheckManager manages deferred polynomial ring checks
-type polyRingCheckManager[T FieldParams] struct {
-	groupsMapOrder []GroupName                     // deterministic order of map
-	groups         map[GroupName]*polyRingGroup[T] // groupName -> group -> checks
-}
-
-// polyRingGroup binds a specific modulus to all of its checks.
-type polyRingGroup[T FieldParams] struct {
+// PolyRingGroupChecks binds a specific modulus to all of its checks.
+type PolyRingGroupChecks[T FieldParams] struct {
 	mod    *Poly[T]              // polynomial defining the ring
-	rlen   int                   // length of the remainder
 	checks []polyRingMulCheck[T] // individual operations to check
 	q_acc  *Poly[T]              // random linear combination of quotients ∑_i z^i * q_i
 }
@@ -76,37 +66,23 @@ type polyRingMulCheck[T FieldParams] struct {
 	q      *Poly[T]   // quotient
 }
 
-// RegisterPolyRing registers a new polynomial ring group with the given name and modulus. The
-func (f *Field[T]) RegisterPolyRing(groupName GroupName, mod *Poly[T]) error {
-	if f.deferredPolyChecker.groups == nil {
-		f.deferredPolyChecker.groups = make(map[GroupName]*polyRingGroup[T])
-	}
-	if _, exists := f.deferredPolyChecker.groups[groupName]; exists {
-		return fmt.Errorf("Ring with name %s already registered", groupName)
-	}
-	f.deferredPolyChecker.groupsMapOrder = append(f.deferredPolyChecker.groupsMapOrder, groupName)
-	f.deferredPolyChecker.groups[groupName] = &polyRingGroup[T]{
+// NewPolyRingCheck registers a new polynomial ring group with the given modulus. The
+func (f *Field[T]) NewPolyRingCheck(mod *Poly[T]) *PolyRingGroupChecks[T] {
+	groupCheck := &PolyRingGroupChecks[T]{
 		mod:    mod,
 		checks: []polyRingMulCheck[T]{},
 	}
+	f.deferredPolyChecks = append(f.deferredPolyChecks, groupCheck)
 
-	return nil
+	return groupCheck
 }
 
-// CallPolyRingMulHint computes a polynomial product check in a polynomial ring,
+// MulPolyRings computes a polynomial product check in a polynomial ring,
 // returns the remainder (reduced result) and the quotient. The computation
 // is performed inside a hint, so it is the callers responsibility to perform
 // the deferred polynomial ring multiplication check.
-func (f *Field[T]) CallPolyRingMulHint(inputs []*Poly[T], groupName GroupName) (quo, rem *Poly[T], err error) {
-
-	group, ringGroupExists := f.deferredPolyChecker.groups[groupName]
-
-	if !ringGroupExists {
-		return nil, nil, fmt.Errorf("group with name %s does not exist", groupName)
-	}
-
+func (f *Field[T]) MulPolyRings(inputs []*Poly[T], group *PolyRingGroupChecks[T]) (rem *Poly[T], err error) {
 	mod := *group.mod
-
 	nbLimbs, nbBits := int(f.fParams.NbLimbs()), f.fParams.BitsPerLimb()
 
 	// total number of terms for all input polynomials
@@ -158,11 +134,11 @@ func (f *Field[T]) CallPolyRingMulHint(inputs []*Poly[T], groupName GroupName) (
 	ret, err := f.api.NewHint(polyRingMulHint, 1+nbQTermsLimbs+1+nbRemLimbs, hintInputs...)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// unpack quotient: skip nbQTerms header, then read (1+qDegree) terms of nbLimbs each
-	quo = &Poly[T]{Coeffs: make([]*Element[T], 1+qDegree)}
+	quo := &Poly[T]{Coeffs: make([]*Element[T], 1+qDegree)}
 	retPtr := 1 // skip nbQTerms
 	for i := range quo.Coeffs {
 		termLimbs := ret[retPtr : retPtr+nbLimbs]
@@ -185,11 +161,11 @@ func (f *Field[T]) CallPolyRingMulHint(inputs []*Poly[T], groupName GroupName) (
 		q:      quo,
 	})
 
-	return quo, rem, nil
+	return rem, nil
 }
 
 // polyRingMulHint computes the multivariate evaluation as a hint. Should not be
-// called directly, but rather through [Field.callPolyRingMulHint] method which
+// called directly, but rather through [Field.MulPolyRings] method which
 // handles the input packing and output unpacking.
 func polyRingMulHint(mod *big.Int, inputs, outputs []*big.Int) error {
 	nbBits := int(inputs[0].Int64())
@@ -395,7 +371,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	// use given api. We are in defer and API may be different to what we have
 	// stored.
 
-	if f.deferredPolyChecker == nil || len(f.deferredPolyChecker.groupsMapOrder) == 0 {
+	if len(f.deferredPolyChecks) == 0 {
 		return nil
 	}
 
@@ -409,8 +385,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 
 	// prepare all remainder coefficients to commit to from each group
 	var remainderCoeffCommits []frontend.Variable
-	for _, groupName := range f.deferredPolyChecker.groupsMapOrder {
-		group := f.deferredPolyChecker.groups[groupName]
+	for _, group := range f.deferredPolyChecks {
 		for _, mulCheck := range group.checks {
 			for _, rCoeff := range mulCheck.r.Coeffs {
 				remainderCoeffCommits = append(remainderCoeffCommits, rCoeff.Limbs...)
@@ -429,9 +404,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 
 	// z can be shared across all groups
 	var quotientbatchesCoeffCommits []frontend.Variable
-	for _, groupName := range f.deferredPolyChecker.groupsMapOrder {
-		group := f.deferredPolyChecker.groups[groupName]
-
+	for _, group := range f.deferredPolyChecks {
 		quotients := make([]*Poly[T], len(group.checks))
 		for i, mulCheck := range group.checks {
 			quotients[i] = mulCheck.q
@@ -463,14 +436,11 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 
 	maxTerms := 0
 	maxChecks := 0
-	for _, groupName := range f.deferredPolyChecker.groupsMapOrder {
-		group := f.deferredPolyChecker.groups[groupName]
+	for _, group := range f.deferredPolyChecks {
 		maxTerms = max(maxTerms, len(group.mod.Coeffs))
 		maxTerms = max(maxTerms, len(group.q_acc.Coeffs))
 		maxChecks = max(maxChecks, len(group.checks))
 	}
-
-	println("maxChecks, maxTerms", maxChecks, maxTerms)
 
 	xPowers := make([]*Element[T], maxTerms)
 	xPowers[0] = f.One()
@@ -491,9 +461,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	}
 
 	// 4. assert the ring check at x for each group
-	for _, groupName := range f.deferredPolyChecker.groupsMapOrder {
-		group := f.deferredPolyChecker.groups[groupName]
-
+	for _, group := range f.deferredPolyChecks {
 		// lhsRlc = ∑_i z^i * (∏_j inputs_i_j(x) - r_i(x))
 		lhsRlc := f.Zero()
 
@@ -647,7 +615,6 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 // polynomial evaluations at the same point avoids redundant multiplications.
 func (f *Field[T]) evalPolyWithChallenge(p *Poly[T], at []*Element[T]) *Element[T] {
 	if p.evaluation != nil {
-		println("Already evaluated")
 		return p.evaluation
 	}
 

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -470,6 +470,8 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 		// lhsRlc = ∑_i z^i * (∏_j inputs_i_j(x) - r_i(x))
 		lhsEvals := make([]*Element[T], len(group.checks))
 
+		// Evaluations don't need to be reduced, we can reduce at the very end to
+		// when asserting equality.
 		for i, check := range group.checks {
 			// lhs = inputs_i_0(x)
 			lhs := f.evalPolyWithChallenge(check.inputs[0], xPowers)
@@ -498,6 +500,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 			group.modEvalFn(xPowers),
 		)
 
+		// AssertIsEqual reduces inputs for comparison
 		f.AssertIsEqual(lhsRlc, rhs)
 	}
 
@@ -633,20 +636,7 @@ func (f *Field[T]) evalPolyWithChallenge(p *Poly[T], at []*Element[T]) *Element[
 
 // innerProduct computes the inner product of two vectors of Element.
 func (f *Field[T]) InnerProduct(a, b []*Element[T]) *Element[T] {
-	n := len(a)
-	terms := make([][]*Element[T], n)
-	scalars := make([]int, n)
-	for i := range a {
-		if b[i] == nil {
-			terms[i] = []*Element[T]{a[i]}
-		} else if a[i] == nil {
-			terms[i] = []*Element[T]{b[i]}
-		} else {
-			terms[i] = []*Element[T]{a[i], b[i]}
-		}
-		scalars[i] = 1
-	}
-	return f.Eval(terms, scalars)
+	return f.Reduce(f.InnerProductNoReduce(a, b))
 }
 
 // InnerProductNoReduce computes the inner product of two vectors of
@@ -655,11 +645,11 @@ func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
 	n := len(a)
 	terms := make([]*Element[T], n)
 	for i := 0; i < n; i++ {
-		if a[i] == nil || b[i] == nil || len(b[i].Limbs) == 0 || len(a[i].Limbs) == 0 {
+		if a[i] == nil || b[i] == nil || b[i].isStrictZero() || a[i].isStrictZero() {
 			// don't add anything, one of the multiplier is zero
-		} else if len(b[i].Limbs) == 1 && b[i].Limbs[0] == 1 {
+		} else if bConstVal, bIsConst := f.constantValue(b[i]); bIsConst && bConstVal.Cmp(big.NewInt(1)) == 0 {
 			terms[i] = a[i]
-		} else if len(a[i].Limbs) == 1 && a[i].Limbs[0] == 1 {
+		} else if aConstVal, aIsConst := f.constantValue(a[i]); aIsConst && aConstVal.Cmp(big.NewInt(1)) == 0 {
 			terms[i] = b[i]
 		} else {
 			terms[i] = f.MulNoReduce(a[i], b[i])

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -65,6 +65,7 @@ type polyRingGroup[T FieldParams] struct {
 	mod    *Poly[T]              // polynomial defining the ring
 	rlen   int                   // length of the remainder
 	checks []polyRingMulCheck[T] // individual operations to check
+	q_acc  *Poly[T]              // random linear combination of quotients ∑_i z^i * q_i
 }
 
 // polyRingMulCheck is an individual deferred check.
@@ -77,11 +78,8 @@ type polyRingMulCheck[T FieldParams] struct {
 
 // RegisterPolyRing registers a new polynomial ring group with the given name and modulus. The
 func (f *Field[T]) RegisterPolyRing(groupName GroupName, mod *Poly[T]) error {
-	if f.deferredPolyChecker == nil {
-		f.deferredPolyChecker = &polyRingCheckManager[T]{
-			groupsMapOrder: []GroupName{},
-			groups:         make(map[GroupName]*polyRingGroup[T]),
-		}
+	if f.deferredPolyChecker.groups == nil {
+		f.deferredPolyChecker.groups = make(map[GroupName]*polyRingGroup[T])
 	}
 	if _, exists := f.deferredPolyChecker.groups[groupName]; exists {
 		return fmt.Errorf("Ring with name %s already registered", groupName)
@@ -382,6 +380,148 @@ func (f *Field[T]) MakePoly(coeffs []interface{}) *Poly[T] {
 	return poly
 }
 
+// performDeferredRingChecks performs the deferred polynomial checks.
+// prover provides results of ring multiplications - remainders and quotients
+//  1. commit the remainders to obtain a random challenge z for random
+//     linear combination of all quotients
+//  2. batch the quotients with adjacent powers RLC using challenge z
+//     q_acc = ∑_i z^i * q_i
+//  3. commit the quotients rlc with challenge z to obtain challenge x
+//  4. assert equality of remainders and quotients rlc polynomials at x
+//     i.e. ∑_i z^i * ( ∏_j inputs_j(x) - r_i(x) ) == (∑_i z^i * q_i)(x) * mod_i(x)
+//
+// savings come from batching quotients outside the circuit – q_acc = ∑_i z^i * q_i
+func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
+	// use given api. We are in defer and API may be different to what we have
+	// stored.
+
+	if f.deferredPolyChecker == nil || len(f.deferredPolyChecker.groupsMapOrder) == 0 {
+		return nil
+	}
+
+	// get committer from the api
+	committer, ok := api.(frontend.Committer)
+	if !ok {
+		panic("compiler doesn't implement frontend.Committer")
+	}
+
+	// 1. commit the remainders
+
+	// prepare all remainder coefficients to commit to from each group
+	var remainderCoeffCommits []frontend.Variable
+	for _, groupName := range f.deferredPolyChecker.groupsMapOrder {
+		group := f.deferredPolyChecker.groups[groupName]
+		for _, mulCheck := range group.checks {
+			for _, rCoeff := range mulCheck.r.Coeffs {
+				remainderCoeffCommits = append(remainderCoeffCommits, rCoeff.Limbs...)
+			}
+		}
+	}
+
+	// commit all remainders from each group at once
+	z, err := committer.Commit(remainderCoeffCommits...) // z = remainderCommitment
+	if err != nil {
+		return fmt.Errorf("deferredPolyCheck commit error: %w", err)
+	}
+
+	// 2. batch and store quotients from each group
+	//    and prepare to commit
+
+	// z can be shared across all groups
+	var quotientbatchesCoeffCommits []frontend.Variable
+	for _, groupName := range f.deferredPolyChecker.groupsMapOrder {
+		group := f.deferredPolyChecker.groups[groupName]
+
+		quotients := make([]*Poly[T], len(group.checks))
+		for i, mulCheck := range group.checks {
+			quotients[i] = mulCheck.q
+		}
+
+		// q_acc = ∑_i z^i * q_i
+		group.q_acc, err = f.callQuotientsRLCHint(quotients, z)
+
+		//
+		for _, rCoeff := range group.q_acc.Coeffs {
+			quotientbatchesCoeffCommits = append(quotientbatchesCoeffCommits, rCoeff.Limbs...)
+		}
+
+		if err != nil {
+			return fmt.Errorf("deferredPolyCheck callQuotientsRLCHint error: %w", err)
+		}
+	}
+
+	// 3. commit the quotients
+	x, err := committer.Commit(quotientbatchesCoeffCommits...)
+	if err != nil {
+		return fmt.Errorf("deferredPolyCheck quotient commit error: %w", err)
+	}
+
+	// Decompose challenges into emulated elements (full-width, multi-limb).
+	zEmulated := f.nativeToEmulated(z)
+	xEmulated := f.nativeToEmulated(x)
+	_ = zEmulated
+
+	maxTerms := 0
+	maxChecks := 0
+	for _, groupName := range f.deferredPolyChecker.groupsMapOrder {
+		group := f.deferredPolyChecker.groups[groupName]
+		maxTerms = max(maxTerms, len(group.mod.Coeffs))
+		maxTerms = max(maxTerms, len(group.q_acc.Coeffs))
+		maxChecks = max(maxChecks, len(group.checks))
+	}
+
+	println("maxChecks, maxTerms", maxChecks, maxTerms)
+
+	xPowers := make([]*Element[T], maxTerms)
+	xPowers[0] = f.One()
+	if maxTerms > 1 {
+		xPowers[1] = xEmulated
+		for i := 2; i < maxTerms; i++ {
+			xPowers[i] = f.Mul(xPowers[i-1], xEmulated)
+		}
+	}
+
+	zPowers := make([]*Element[T], maxChecks)
+	zPowers[0] = f.One()
+	if maxChecks > 1 {
+		zPowers[1] = zEmulated
+		for i := 2; i < maxChecks; i++ {
+			zPowers[i] = f.Mul(zPowers[i-1], zEmulated)
+		}
+	}
+
+	// 4. assert the ring check at x for each group
+	for _, groupName := range f.deferredPolyChecker.groupsMapOrder {
+		group := f.deferredPolyChecker.groups[groupName]
+
+		// lhsRlc = ∑_i z^i * (∏_j inputs_i_j(x) - r_i(x))
+		lhsRlc := f.Zero()
+
+		for i, check := range group.checks {
+			// lhs = inputs_i_0(x)
+			lhs := f.evalPolyWithChallenge(check.inputs[0], xPowers)
+
+			// lhs = ∏_j inputs_j(x)
+			for j := 1; j < len(check.inputs); j++ {
+				lhs = f.Mul(lhs, f.evalPolyWithChallenge(check.inputs[j], xPowers))
+			}
+
+			// compute (∏_j inputs_j(x)) - r(x)
+			lhs = f.Sub(lhs, f.evalPolyWithChallenge(check.r, xPowers))
+			lhsRlc = f.Add(lhsRlc, f.Mul(zPowers[i], lhs))
+		}
+
+		// compute q_acc(x) * mod(x)
+		rhs := f.Mul(
+			f.evalPolyWithChallenge(group.q_acc, xPowers),
+			f.evalPolyWithChallenge(group.mod, xPowers),
+		)
+
+		f.AssertIsEqual(lhsRlc, rhs)
+	}
+
+	return nil
+}
 
 // callQuotientsRLCHint computes the random linear combination ∑_i z^i * q_i of
 // the provided quotient polynomials with the scalar challenge z. The result is

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -3,6 +3,7 @@ package emulated
 import (
 	"fmt"
 	"math/big"
+	"math/bits"
 
 	"github.com/consensys/gnark/frontend"
 	limbs "github.com/consensys/gnark/std/internal/limbcomposition"
@@ -680,12 +681,19 @@ func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
 		}
 	}
 	var eval *Element[T]
+	var maxTermOverflow uint = 0
+	// adding n terms can result in an overflow of log2(n) bits
+	var additionOverflow uint = uint(bits.Len(uint(n-1))) + 1
+
 	for _, term := range terms {
 		if term != nil {
 			if eval == nil {
 				eval = term
 			} else {
-				nextOverflow := max(eval.overflow, term.overflow) + 1
+				if maxTermOverflow < term.overflow {
+					maxTermOverflow = term.overflow
+				}
+				nextOverflow := maxTermOverflow + additionOverflow
 				// if next overflow exceeds the maximum, reduce before adding
 				if nextOverflow+1 > f.maxOverflow() {
 					// add with input reduction

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -386,8 +386,8 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	// prepare all remainder coefficients to commit to from each group
 	var remainderCoeffCommits []frontend.Variable
 	for _, group := range f.deferredPolyChecks {
-		for _, mulCheck := range group.checks {
-			for _, rCoeff := range mulCheck.r.Coeffs {
+		for _, check := range group.checks {
+			for _, rCoeff := range check.r.Coeffs {
 				remainderCoeffCommits = append(remainderCoeffCommits, rCoeff.Limbs...)
 			}
 		}
@@ -411,8 +411,8 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	quotientbatchesCoeffCommits := []frontend.Variable{z}
 	for _, group := range f.deferredPolyChecks {
 		quotients := make([]*Poly[T], len(group.checks))
-		for i, mulCheck := range group.checks {
-			quotients[i] = mulCheck.q
+		for i, check := range group.checks {
+			quotients[i] = check.q
 		}
 
 		// q_acc = ∑_i z^i * q_i
@@ -506,9 +506,25 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 
 		// AssertIsEqual reduces inputs for comparison
 		f.AssertIsEqual(lhsRlc, rhs)
+
+		// clean evaluations
+		f.deferredRingCheckCleanEvaluations(group)
 	}
 
 	return nil
+}
+
+func (f *Field[T]) deferredRingCheckCleanEvaluations(group *PolyRingGroupChecks[T]) {
+	// clean up evaluations to save memory, they are not needed after the check
+	// for _, check := range group.checks {
+	// 	check.r.evaluation = nil
+	// 	check.q.evaluation = nil
+	// 	for _, input := range check.inputs {
+	// 		input.evaluation = nil
+	// 	}
+	// }
+	// group.mod.evaluation = nil
+	// group.q_acc.evaluation = nil
 }
 
 // callQuotientsRLCHint computes the random linear combination ∑_i z^i * q_i of
@@ -628,6 +644,7 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 	return nil
 }
 
+
 // evalPolyWithChallenge evaluates p at a point whose powers are given by at,
 // where at[i] = at^i. Precomputing and sharing powers across multiple
 // polynomial evaluations at the same point avoids redundant multiplications.
@@ -721,7 +738,7 @@ func splitNativeToLimbsHint(nativeMod *big.Int, inputs, outputs []*big.Int) erro
 	outptr := 0
 	for ptr := 2; ptr < len(inputs); ptr++ {
 		nativeEl := inputs[ptr]
-		coeffLimbs := make([]*big.Int, nativeEl.BitLen()/nbBits+1)
+		coeffLimbs := make([]*big.Int, nativeMod.BitLen()/nbBits+1)
 		for k := range coeffLimbs {
 			coeffLimbs[k] = new(big.Int)
 		}

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -434,7 +434,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	}
 
 	xPowers := make([]*Element[T], maxTerms)
-	xPowers[0] = nil
+	xPowers[0] = f.One()
 	if maxTerms > 1 {
 		xPowers[1] = xEmulated
 		for i := 2; i < maxTerms; i++ {
@@ -443,7 +443,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	}
 
 	zPowers := make([]*Element[T], maxChecks)
-	zPowers[0] = nil
+	zPowers[0] = f.One()
 	if maxChecks > 1 {
 		zPowers[1] = zEmulated
 		for i := 2; i < maxChecks; i++ {
@@ -632,24 +632,33 @@ func (f *Field[T]) innerProduct(a, b []*Element[T]) *Element[T] {
 // *Element[T] without performing reduction.
 func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
 	n := len(a)
-	var eval *Element[T]
-	if b[0] == nil {
-		eval = a[0]
-	} else if a[0] == nil {
-		eval = b[0]
-	} else {
-		eval = f.MulNoReduce(a[0], b[0])
-	}
-
-	for i := 1; i < n; i++ {
-		if b[i] == nil {
-			eval = f.add(eval, a[i], max(eval.overflow, a[i].overflow)+1)
-		} else if a[i] == nil {
-			eval = f.add(eval, b[i], max(eval.overflow, b[i].overflow)+1)
-		} else {
-			prod := f.MulNoReduce(a[i], b[i])
-			eval = f.add(eval, prod, max(eval.overflow, prod.overflow)+1)
+	terms := make([]*Element[T], n)
+	for i := 0; i < n; i++ {
+		if a[i] == nil || b[i] == nil || len(b[i].Limbs) == 0 || len(a[i].Limbs) == 0 {
+			continue
 		}
+		if len(b[i].Limbs) == 1 && b[i].Limbs[0] == 1 {
+			terms[i] = a[i]
+			continue
+		} else if len(a[i].Limbs) == 1 && a[i].Limbs[0] == 1 {
+			terms[i] = b[i]
+			continue
+		} else {
+			terms[i] = f.MulNoReduce(a[i], b[i])
+		}
+	}
+	var eval *Element[T]
+	for _, term := range terms {
+		if term != nil {
+			if eval == nil {
+				eval = term
+			} else {
+				eval = f.add(eval, term, max(eval.overflow, term.overflow)+1)
+			}
+		}
+	}
+	if eval == nil {
+		return f.Zero()
 	}
 	return eval
 }

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -337,7 +337,7 @@ func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q,
 	return quotient, remainder, nil
 }
 
-func (f *Field[T]) MakePoly(coeffs []interface{}) *Poly[T] {
+func (f *Field[T]) MakePoly(coeffs ...interface{}) *Poly[T] {
 	poly := &Poly[T]{}
 	poly.Coeffs = make([]*Element[T], len(coeffs))
 

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -20,11 +20,11 @@ type Poly[T FieldParams] []*Element[T]
 //   - poly - the input polynomials whose product we are checking. Each
 //     polynomial is represented as a slice of [Element] coefficients. Elements
 //     have to be reduced.
-//   - irr - the irreducible polynomial defining the ring, i.e. the modulus for
-//     the Euclidean division. Treated as a constant.
-//   - r - the product reduced modulo irr, i.e. the remainder. This is the
+//   - mod - the polynomial defining the ring, i.e. the modulus for the Euclidean
+//     division. Treated as a constant.
+//   - r - the product reduced modulo mod, i.e. the remainder. This is the
 //     result returned to the caller.
-//   - q - the quotient of the product divided by irr.
+//   - q - the quotient of the product divided by mod.
 //
 // Given these values, the following holds as an identity of polynomials over
 // the emulated field:
@@ -55,7 +55,7 @@ type polyRingMulCheck[T FieldParams] struct {
 // CallPolyRingMulHint computes a polynomial product check in a polynomial ring,
 // returns the remainder (reduced result) and the quotient. The computation
 // is performed inside a hint, so it is the callers responsibility to perform
-// the deferred multiplication check.
+// the deferred polynomial ring multiplication check.
 func (f *Field[T]) CallPolyRingMulHint(inputs []Poly[T], mod Poly[T]) (quo, rem Poly[T], err error) {
 	nbLimbs, nbBits := int(f.fParams.NbLimbs()), f.fParams.BitsPerLimb()
 
@@ -127,6 +127,14 @@ func (f *Field[T]) CallPolyRingMulHint(inputs []Poly[T], mod Poly[T]) (quo, rem 
 		retPtr += nbLimbs
 		rem[i] = f.packLimbs(termLimbs, true)
 	}
+
+	f.deferredPolyChecks = append(f.deferredPolyChecks, polyRingMulCheck[T]{
+		f:      f,
+		inputs: inputs,
+		mod:    mod,
+		r:      rem,
+		q:      quo,
+	})
 
 	return quo, rem, nil
 }

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -122,12 +122,14 @@ func (f *Field[T]) MulPolyRings(group *PolyRingGroupChecks[T], inputs_ ...*Poly[
 	}
 	nbQTermsLimbs := (1 + qDegree) * nbLimbs
 
+	nbMetaDataVars := 3 + int(nbBits)
 	// polynomials serialised as nbTerms|...terms. hintInputs contains
 	// serialisation of: nbBits|nbLimbs|nbPoly|fieldMod|...inputs|modPoly,
 	// where inputs and mod are serialised as polynomials
-	hintInputs := make([]frontend.Variable, 0, 4+(nbPoly+nbTermsLimbs)+(1+nbModTermsLimbs))
+	hintInputs := make([]frontend.Variable, 0, nbMetaDataVars+(nbPoly+nbTermsLimbs)+(1+nbModTermsLimbs))
 
-	hintInputs = append(hintInputs, nbBits, nbLimbs, nbPoly, f.fParams.Modulus())
+	hintInputs = append(hintInputs, nbBits, nbLimbs, nbPoly)
+	hintInputs = append(hintInputs, f.Modulus().Limbs...)
 
 	// loop through inputs to compute the number of terms
 	for _, inputPoly := range inputs {
@@ -179,11 +181,13 @@ func polyRingMulHint(mod *big.Int, inputs, outputs []*big.Int) error {
 	nbBits := int(inputs[0].Int64())
 	nbLimbs := int(inputs[1].Int64())
 	nbPoly := int(inputs[2].Int64())
-	fieldMod := new(big.Int).Set(inputs[3])
+	fieldMod := new(big.Int)
+	nbMetaDataVars := 3 + int(nbLimbs)
+	limbs.Recompose(inputs[3:nbMetaDataVars], uint(nbBits), fieldMod)
 
 	// extract the input polynomials
 	inputsPolys := make([][]*big.Int, nbPoly)
-	ptr := 4
+	ptr := nbMetaDataVars // skip metadata and modulus limbs
 
 	for i := 0; i < nbPoly; i++ {
 		nbTerms := int(inputs[ptr].Int64())
@@ -542,8 +546,9 @@ func (f *Field[T]) callQuotientsRLCHint(quotients []*Poly[T], z frontend.Variabl
 	nbPolys := len(quotients)
 
 	// hint input layout: nbBits | nbLimbs | nbPolys | fieldMod | z | for each poly: nbTerms | limbs...
-	hintInputs := make([]frontend.Variable, 0, 6+nbPolys)
-	hintInputs = append(hintInputs, nbBits, nbLimbs, nbChallengeLimbs, nbPolys, f.fParams.Modulus(), z)
+	hintInputs := make([]frontend.Variable, 0, 5+nbLimbs+nbPolys) // nbLimbs from modulus Element
+	hintInputs = append(hintInputs, nbBits, nbLimbs, nbChallengeLimbs, nbPolys, z)
+	hintInputs = append(hintInputs, f.Modulus().Limbs...)
 
 	for _, q := range quotients {
 		hintInputs = f.serialisePoly(q, hintInputs)
@@ -576,16 +581,20 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 	nbLimbs := int(inputs[1].Int64())
 	nbChallengeLimbs := int(inputs[2].Int64())
 	nbPolys := int(inputs[3].Int64())
-	fieldMod := new(big.Int).Set(inputs[4])
 	// we only use nbChallengeLimbs worth of the challenge
 	nbChallengeBits := uint(nbBits * nbChallengeLimbs)
 
 	z := new(big.Int) // full z
 	base := new(big.Int).Lsh(one, nbChallengeBits)
 	base.Sub(base, one)    // 0b111...1111 challenge bits
-	z.And(inputs[5], base) // mask z to nbChallengeLimbs bits
+	z.And(inputs[4], base) // mask z to nbChallengeLimbs bits
 
-	ptr := 6
+	nbMetaDataVars := 5 + int(nbLimbs)
+
+	fieldMod := new(big.Int)
+	limbs.Recompose(inputs[5:nbMetaDataVars], uint(nbBits), fieldMod)
+
+	ptr := nbMetaDataVars // skip metadata and modulus limbs
 	polys := make([][]*big.Int, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		nbTerms := int(inputs[ptr].Int64())

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -8,6 +8,8 @@ import (
 	limbs "github.com/consensys/gnark/std/internal/limbcomposition"
 )
 
+var NB_CHALLENGE_LIMBS = 2
+
 // Represents an element of a polynomial ring over the emulated field.
 type Poly[T FieldParams] struct {
 	Coeffs     []*Element[T]
@@ -421,7 +423,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 	}
 
 	// Decompose challenges into emulated elements (full-width, multi-limb).
-	nativesToEl := f.NativeToEmulated(2, z, x)
+	nativesToEl := f.NativeToEmulated(NB_CHALLENGE_LIMBS, z, x)
 	zEmulated := nativesToEl[0]
 	xEmulated := nativesToEl[1]
 
@@ -478,7 +480,7 @@ func (f *Field[T]) performDeferredRingChecks(api frontend.API) error {
 			f.evalPolyWithChallenge(group.mod, xPowers),
 		)
 
-		f.IsZero(f.Sub(lhsRlc, rhs))
+		f.AssertIsEqual(lhsRlc, rhs)
 	}
 
 	return nil
@@ -508,8 +510,8 @@ func (f *Field[T]) callQuotientsRLCHint(quotients []*Poly[T], z frontend.Variabl
 	nbPolys := len(quotients)
 
 	// hint input layout: nbBits | nbLimbs | nbPolys | fieldMod | z | for each poly: nbTerms | limbs...
-	hintInputs := make([]frontend.Variable, 0, 5+nbPolys)
-	hintInputs = append(hintInputs, nbBits, nbLimbs, nbPolys, *f.fParams.Modulus(), z)
+	hintInputs := make([]frontend.Variable, 0, 6+nbPolys)
+	hintInputs = append(hintInputs, nbBits, nbLimbs, NB_CHALLENGE_LIMBS, nbPolys, *f.fParams.Modulus(), z)
 
 	for _, q := range quotients {
 		hintInputs = f.serialisePoly(q, hintInputs)
@@ -538,14 +540,20 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 	if len(inputs) < 5 {
 		return fmt.Errorf("batchPolyQuotientsHint: not enough inputs")
 	}
-
 	nbBits := int(inputs[0].Int64())
 	nbLimbs := int(inputs[1].Int64())
-	nbPolys := int(inputs[2].Int64())
-	fieldMod := new(big.Int).Set(inputs[3])
-	z := new(big.Int).Mod(inputs[4], fieldMod)
-
-	ptr := 5
+	nbChallengeLimbs := int(inputs[2].Int64())
+	nbPolys := int(inputs[3].Int64())
+	fieldMod := new(big.Int).Set(inputs[4])
+	zLimbs := make([]*big.Int, nativeMod.BitLen()/(nbBits*nbChallengeLimbs)+1, nbLimbs)
+	for k := range zLimbs {
+		zLimbs[k] = new(big.Int)
+	}
+	if err := limbs.Decompose(inputs[5], uint(nbBits*nbChallengeLimbs), zLimbs); err != nil {
+		return fmt.Errorf("quotientsRLCHint: z decompose failed: %w", err)
+	}
+	z := zLimbs[0]
+	ptr := 6
 	polys := make([][]*big.Int, nbPolys)
 	for i := 0; i < nbPolys; i++ {
 		nbTerms := int(inputs[ptr].Int64())
@@ -561,15 +569,12 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 			polys[i][j] = val
 		}
 	}
-
 	maxTerms := len(outputs) / nbLimbs
-
 	// accumulator: result[j] = ∑_i z^i * q_i[j] mod fieldMod
 	result := make([]*big.Int, maxTerms)
 	for i := range result {
 		result[i] = new(big.Int)
 	}
-
 	zPow := new(big.Int).SetInt64(1) // z^0 = 1
 	tmp := new(big.Int)
 	for _, poly := range polys {
@@ -582,7 +587,6 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 		zPow.Mul(zPow, z)
 		zPow.Mod(zPow, fieldMod)
 	}
-
 	// serialize: maxTerms coefficients each decomposed into nbLimbs limbs
 	outptr := 0
 	for idx, coeff := range result {
@@ -596,7 +600,6 @@ func quotientsRLCHint(nativeMod *big.Int, inputs, outputs []*big.Int) error {
 		copy(outputs[outptr:outptr+nbLimbs], coeffLimbs)
 		outptr += nbLimbs
 	}
-
 	return nil
 }
 
@@ -635,14 +638,11 @@ func (f *Field[T]) InnerProductNoReduce(a, b []*Element[T]) *Element[T] {
 	terms := make([]*Element[T], n)
 	for i := 0; i < n; i++ {
 		if a[i] == nil || b[i] == nil || len(b[i].Limbs) == 0 || len(a[i].Limbs) == 0 {
-			continue
-		}
-		if len(b[i].Limbs) == 1 && b[i].Limbs[0] == 1 {
+			// don't add anything, one of the multiplier is zero
+		} else if len(b[i].Limbs) == 1 && b[i].Limbs[0] == 1 {
 			terms[i] = a[i]
-			continue
 		} else if len(a[i].Limbs) == 1 && a[i].Limbs[0] == 1 {
 			terms[i] = b[i]
-			continue
 		} else {
 			terms[i] = f.MulNoReduce(a[i], b[i])
 		}

--- a/std/math/emulated/field_polyring.go
+++ b/std/math/emulated/field_polyring.go
@@ -9,7 +9,10 @@ import (
 )
 
 // Represents an element of a polynomial ring over the emulated field.
-type Poly[T FieldParams] []*Element[T]
+type Poly[T FieldParams] struct {
+	Coeffs     []*Element[T]
+	evaluation *big.Int // nil unless evaluated
+}
 
 // polyRingMulCheck represents a polynomial product check in a polynomial
 // ring. Instead of computing the product and reducing it where called,
@@ -43,20 +46,69 @@ type Poly[T FieldParams] []*Element[T]
 //	∏_i inputs_i(α) = r(α) + q(α) * mod(α),
 //
 // which can be verified at a single random point.
+//
+// we verify rlc, ∑_i z^i * ( ∏_j inputs_j(x) - r_i(x) ) == ∑_i z^i * q_i(x) * mod_i(x)
+//
+// this allows skipping individual q evaluations in the circuit because,
+// ∑_i z^i * q_i is computed outside the circuit, and evaluated inside the circuit
+
+type GroupName string
+
+// polyRingCheckManager manages deferred polynomial ring checks
+type polyRingCheckManager[T FieldParams] struct {
+	groupsMapOrder []GroupName                     // deterministic order of map
+	groups         map[GroupName]*polyRingGroup[T] // groupName -> group -> checks
+}
+
+// polyRingGroup binds a specific modulus to all of its checks.
+type polyRingGroup[T FieldParams] struct {
+	mod    *Poly[T]              // polynomial defining the ring
+	rlen   int                   // length of the remainder
+	checks []polyRingMulCheck[T] // individual operations to check
+}
+
+// polyRingMulCheck is an individual deferred check.
 type polyRingMulCheck[T FieldParams] struct {
-	f *Field[T]
 	// ∏_i inputs_i = r + q * mod
-	inputs []Poly[T] // input polynomials
-	mod    Poly[T]   // irreducible polynomial defining the ring
-	r      Poly[T]   // remainder
-	q      Poly[T]   // quotient
+	inputs []*Poly[T] // input polynomials
+	r      *Poly[T]   // remainder
+	q      *Poly[T]   // quotient
+}
+
+// RegisterPolyRing registers a new polynomial ring group with the given name and modulus. The
+func (f *Field[T]) RegisterPolyRing(groupName GroupName, mod *Poly[T]) error {
+	if f.deferredPolyChecker == nil {
+		f.deferredPolyChecker = &polyRingCheckManager[T]{
+			groupsMapOrder: []GroupName{},
+			groups:         make(map[GroupName]*polyRingGroup[T]),
+		}
+	}
+	if _, exists := f.deferredPolyChecker.groups[groupName]; exists {
+		return fmt.Errorf("Ring with name %s already registered", groupName)
+	}
+	f.deferredPolyChecker.groupsMapOrder = append(f.deferredPolyChecker.groupsMapOrder, groupName)
+	f.deferredPolyChecker.groups[groupName] = &polyRingGroup[T]{
+		mod:    mod,
+		checks: []polyRingMulCheck[T]{},
+	}
+
+	return nil
 }
 
 // CallPolyRingMulHint computes a polynomial product check in a polynomial ring,
 // returns the remainder (reduced result) and the quotient. The computation
 // is performed inside a hint, so it is the callers responsibility to perform
 // the deferred polynomial ring multiplication check.
-func (f *Field[T]) CallPolyRingMulHint(inputs []Poly[T], mod Poly[T]) (quo, rem Poly[T], err error) {
+func (f *Field[T]) CallPolyRingMulHint(inputs []*Poly[T], groupName GroupName) (quo, rem *Poly[T], err error) {
+
+	group, ringGroupExists := f.deferredPolyChecker.groups[groupName]
+
+	if !ringGroupExists {
+		return nil, nil, fmt.Errorf("group with name %s does not exist", groupName)
+	}
+
+	mod := *group.mod
+
 	nbLimbs, nbBits := int(f.fParams.NbLimbs()), f.fParams.BitsPerLimb()
 
 	// total number of terms for all input polynomials
@@ -64,24 +116,25 @@ func (f *Field[T]) CallPolyRingMulHint(inputs []Poly[T], mod Poly[T]) (quo, rem 
 	// loop through inputs to compute the number of terms
 	for _, inputPoly := range inputs {
 		// add degree of each input polynomial
-		nbTerms += len(inputPoly)
+		nbTerms += len(inputPoly.Coeffs)
 	}
 
 	// metadata for hint inputs
 	nbPoly := len(inputs)
 	nbTermsLimbs := nbTerms * nbLimbs
-	nbModTermsLimbs := len(mod) * nbLimbs
+	nbModTermsLimbs := len(mod.Coeffs) * nbLimbs
 
 	// metadata for outputs
-	modDegree := len(mod) - 1
+	modDegree := len(mod.Coeffs) - 1
 	nbRemLimbs := modDegree * nbLimbs
 	totalDegree := nbTerms - nbPoly
 	// q degree is total degree minus the degree of the modulus polynomial
 	qDegree := totalDegree - modDegree
 	nbQTermsLimbs := (1 + qDegree) * nbLimbs
 
-	// Polynomials serialised as nbTerms|...terms. hintInputs contains serialisation of,
-	// in order: nbBits|nbLimbs|nbPoly|fieldMod|...inputs|modPoly, where inputs and mod are serialised as polynomials
+	// polynomials serialised as nbTerms|...terms. hintInputs contains
+	// serialisation of: nbBits|nbLimbs|nbPoly|fieldMod|...inputs|modPoly,
+	// where inputs and mod are serialised as polynomials
 	hintInputs := make([]frontend.Variable, 0, 4+(nbPoly+nbTermsLimbs)+(1+nbModTermsLimbs))
 
 	hintInputs = append(hintInputs, nbBits, nbLimbs, nbPoly, *f.fParams.Modulus())
@@ -90,16 +143,16 @@ func (f *Field[T]) CallPolyRingMulHint(inputs []Poly[T], mod Poly[T]) (quo, rem 
 	for _, inputPoly := range inputs {
 		// serialised as nbTerms|...terms
 		// add degree of each input polynomial
-		hintInputs = append(hintInputs, len(inputPoly))
+		hintInputs = append(hintInputs, len(inputPoly.Coeffs))
 		// append each term from inputPoly polynomial
-		for _, coeff := range inputPoly {
+		for _, coeff := range inputPoly.Coeffs {
 			hintInputs = append(hintInputs, coeff.Limbs...)
 		}
 	}
 
-	hintInputs = append(hintInputs, len(mod))
+	hintInputs = append(hintInputs, len(mod.Coeffs))
 	// append mod terms
-	for _, coeff := range mod {
+	for _, coeff := range mod.Coeffs {
 		hintInputs = append(hintInputs, coeff.Limbs...)
 	}
 
@@ -111,27 +164,25 @@ func (f *Field[T]) CallPolyRingMulHint(inputs []Poly[T], mod Poly[T]) (quo, rem 
 	}
 
 	// unpack quotient: skip nbQTerms header, then read (1+qDegree) terms of nbLimbs each
-	quo = make(Poly[T], 1+qDegree)
+	quo = &Poly[T]{Coeffs: make([]*Element[T], 1+qDegree)}
 	retPtr := 1 // skip nbQTerms
-	for i := range quo {
+	for i := range quo.Coeffs {
 		termLimbs := ret[retPtr : retPtr+nbLimbs]
 		retPtr += nbLimbs
-		quo[i] = f.packLimbs(termLimbs, false)
+		quo.Coeffs[i] = f.packLimbs(termLimbs, false)
 	}
 
-	// unpack remainder: skip nbRemTerms header, then read (len(mod)-1) terms of nbLimbs each
+	// unpack remainder: skip nbRemTerms header, then read len(mod)-1 terms of nbLimbs each
 	retPtr++ // skip nbRemTerms
-	rem = make(Poly[T], len(mod)-1)
-	for i := range rem {
+	rem = &Poly[T]{Coeffs: make([]*Element[T], len(mod.Coeffs)-1)}
+	for i := range rem.Coeffs {
 		termLimbs := ret[retPtr : retPtr+nbLimbs]
 		retPtr += nbLimbs
-		rem[i] = f.packLimbs(termLimbs, true)
+		rem.Coeffs[i] = f.packLimbs(termLimbs, true)
 	}
 
-	f.deferredPolyChecks = append(f.deferredPolyChecks, polyRingMulCheck[T]{
-		f:      f,
+	group.checks = append(group.checks, polyRingMulCheck[T]{
 		inputs: inputs,
-		mod:    mod,
 		r:      rem,
 		q:      quo,
 	})
@@ -315,16 +366,17 @@ func polyRingMul(fieldMod *big.Int, inputs [][]*big.Int, modPoly []*big.Int) (q,
 	return quotient, remainder, nil
 }
 
-func (f *Field[T]) MakePoly(coeffs []interface{}) Poly[T] {
+func (f *Field[T]) MakePoly(coeffs []interface{}) *Poly[T] {
 	nativeMod := f.api.Compiler().Field()
 
-	poly := make(Poly[T], len(coeffs))
+	poly := &Poly[T]{}
+	poly.Coeffs = make([]*Element[T], len(coeffs))
 
 	for i, coeff := range coeffs {
 		emCoeff_ := ValueOf[T](coeff)
 		emCoeff := &emCoeff_
 		emCoeff.Initialize(nativeMod)
-		poly[i] = emCoeff
+		poly.Coeffs[i] = emCoeff
 	}
 
 	return poly

--- a/std/math/emulated/hints.go
+++ b/std/math/emulated/hints.go
@@ -26,6 +26,9 @@ func GetHints() []solver.Hint {
 		mulHint,
 		subPaddingHint,
 		polyMvHint,
+		polyRingMulHint,
+		quotientsRLCHint,
+		splitNativeToLimbsHint,
 		smallMulHint,
 		smallCheckZeroHint,
 	}


### PR DESCRIPTION
# Description

This PR introduces a **polynomial ring arithmetic system** (`emulated/polyring`) for the `std/math/emulated` package and wires it into the BN254 pairing pipeline. The core idea is to defer and batch expensive `E12` field multiplications during Miller loop and final exponentiation as polynomial ring multiplications, reducing the number of in-circuit modular reductions required.

## Key changes

### `std/math/emulated/field_polyring.go` (new, +852 lines)
Adds a full polynomial ring multiplication and verification subsystem:
- **`Poly[T]`** — sparse/dense polynomial type whose coefficients are emulated field elements; `nil` coefficients are treated as zero.
- **`PolyRingGroupChecks[T]`** — holds the ring modulus polynomial and a custom modular-evaluation function (`modEvalFn`). Created via `Field.NewPolyRingCheck`.
- **`PolyRingAccumulator[T]`** — accumulates a chain of polynomial multiplications lazily (via `Mul` / `Sqr`), flushing intermediate products with `Eval`. Batches deferred checks with RLC (random linear combination) to amortise constraint cost.
- **`MulPolyRings`** — multiplies two or more polynomials modulo the ring modulus and emits deferred quotient-validity constraints.
- **Hints**: `polyRingMulHint` (computes quotient & remainder for the polynomial product), `quotientsRLCHint` (batches quotient checks with a random challenge), `splitNativeToLimbsHint` (converts native `big.Int` limbs to emulated elements).
- **Optimisations**: sparse polynomial evaluation, inner-product without intermediate reductions, caching of native-to-emulated conversions, no range check on quotient coefficients.

### `std/math/emulated/field.go`
- Adds a `deferredPolyChecks` slice to `Field[T]` alongside the existing `deferredChecks`.
- Registers `performDeferredRingChecks` as a compiler-level deferred callback that runs **before** the existing range-check deferred hook, so ring quotient constraints are emitted at the correct time.

### `std/math/emulated/hints.go`
- Registers the three new hints (`polyRingMulHint`, `quotientsRLCHint`, `splitNativeToLimbsHint`) in `GetHints()`.

### `std/algebra/emulated/fields_bn254/e12.go`
- `E12` gains a cached `poly *basePoly` field and a `ToPoly() / PolyToE12()` round-trip.
- `Ext12` now holds a `*emulated.PolyRingGroupChecks[BN254Fp]` ring handle (the BN254 `Fp12` cyclotomic modulus `X¹² − 18X⁶ + 82`).
- `Ext12.Mul` is redirected to `MulPoly` — the polynomial ring path — replacing the old direct schoolbook multiplication.
- `InversePoly` computes `E12` inversion via hint and verifies `inv × x = 1` using the poly-ring multiplier.
- Adds `NewPolyRingAccumulator` helper for callers that need an accumulator scoped to the BN254 `Fp12` ring.

### `std/algebra/emulated/fields_bn254/e12_pairing.go`
- Adds `ToPoly01379` — converts a sparse `01379` line-evaluation element (degree-9 polynomial) to `*basePoly` with `nil` zero coefficients.
- Adds `ToPoly012346789` — converts a `012346789` sparse element (degree-10 polynomial) to `*basePoly`.
- These replace the previous `MulBy01379` / `MulBy012346789` in-circuit multiplications with lazy poly-ring accumulator calls.

### `std/algebra/emulated/fields_bn254/e2.go`
- Exports `basePoly = emulated.Poly[BN254Fp]` type alias so it can be shared across the `fields_bn254` package.

### `std/algebra/emulated/sw_bn254/pairing.go`
- `millerLoopLines` signature changes: `init *GTEl` → `init, initInv *basePoly`; return type changes from `*GTEl` to `*emulated.PolyRingAccumulator[BaseField]`.
- The entire Miller loop body now uses `res.Mul(poly)` / `res.Sqr()` accumulator calls instead of explicit `Ext12.Mul` / `Ext12.Square`, significantly reducing constraint count for multi-pair pairings.
- `PairingCheck` and `millerLoopAndFinalExpResult` updated to work with the new accumulator return type and to push the final Frobenius-based residue-witness multiplications through the accumulator before a single `res.Eval()` call.
- `MillerLoop` (public API) unchanged in signature; internally calls the new path and evaluates the accumulator.

### `std/algebra/emulated/sw_bn254/hints.go`
- `millerLoopAndCheckFinalExpHint` generalised from a single `(P, Q)` pair to **multiple pairs** (`[]G1Affine`, `[]G2Affine`), matching the updated `millerLoopLines` signature.
- Input parsing updated accordingly: G1/G2 points are read from the front of the input slice; the previous `E12` accumulator is always the last 12 elements.

### `std/algebra/emulated/fields_bn254/e12_test.go`
- Adds `TestMulFp12PolyRing` — a standalone circuit test that verifies `E12` multiplication via the new poly-ring path produces the correct result for random field elements.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

Fixes related to hardening: nil dereference on `qAcc` before error check; negative `qDegree` clamp; `NativeToEmulated` panic → return error; addition overflow tracking to avoid premature reduction; `update outputs don't copy` fix; emulated field mod passed as element in hints.

## How has this been tested?

- [x] `TestMulFp12PolyRing` — unit test for `E12` polynomial ring multiplication
- [x] `TestMulFp12` — existing E12 multiplication test passes through new code path
- [x] `test(bn254): e12 poly ring mul` commit validates the full polynomial ring integration on BN254

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core BN254 pairing and `Fp12` arithmetic and adds new hint/deferred-check machinery; any mismatch in ring modulus/evaluation or accumulator usage could silently break pairing verification or soundness.
> 
> **Overview**
> Introduces **deferred polynomial-ring arithmetic** to `std/math/emulated` via a new `Poly` type, `MulPolyRings` hint-based multiplication (returning quotient+remainder), and a compiler-deferred `performDeferredRingChecks` that batches ring-mul correctness checks using commitments and random-linear-combination of quotients.
> 
> Wires this into BN254: `E12` gains poly conversions/caching and `Ext12.Mul`/`Inverse` paths are redirected through the new ring-mul API with modulus `X^12 - 18X^6 + 82`; the pairing Miller loop and final-exp-equivalence checks are refactored to accumulate sparse line multiplications in a `PolyRingAccumulator` and evaluate/reduce only at controlled points. Pairing-related hints are updated to support multi-pair inputs, and a new unit test validates `Fp12` multiplication through the poly-ring path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aa45413a52063ff8e7519b2f5744e889e374302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->