### PR TITLE
Three pairing bug

### DIFF
--- a/std/algebra/emulated/sw_bls12381/hints.go
+++ b/std/algebra/emulated/sw_bls12381/hints.go
@@ -88,11 +88,13 @@ func pairingCheckHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int
 			n := len(inputs)
 			p := make([]bls12381.G1Affine, 0, n/6)
 			q := make([]bls12381.G2Affine, 0, n/6)
+			// first one-third is G1 points
 			for k := 0; k < n/3; k += 2 {
 				P.X.SetBigInt(inputs[k])
 				P.Y.SetBigInt(inputs[k+1])
 				p = append(p, P)
 			}
+			// subsequent two-thirds are G2 points
 			for k := n / 3; k < n; k += 4 {
 				Q.X.A0.SetBigInt(inputs[k])
 				Q.X.A1.SetBigInt(inputs[k+1])

--- a/std/algebra/emulated/sw_bls12381/hints.go
+++ b/std/algebra/emulated/sw_bls12381/hints.go
@@ -88,12 +88,12 @@ func pairingCheckHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int
 			n := len(inputs)
 			p := make([]bls12381.G1Affine, 0, n/6)
 			q := make([]bls12381.G2Affine, 0, n/6)
-			for k := 0; k < n/6+1; k += 2 {
+			for k := 0; k < n/3; k += 2 {
 				P.X.SetBigInt(inputs[k])
 				P.Y.SetBigInt(inputs[k+1])
 				p = append(p, P)
 			}
-			for k := n / 3; k < n/2+3; k += 4 {
+			for k := n / 3; k < n; k += 4 {
 				Q.X.A0.SetBigInt(inputs[k])
 				Q.X.A1.SetBigInt(inputs[k+1])
 				Q.Y.A0.SetBigInt(inputs[k+2])

--- a/std/algebra/emulated/sw_bls12381/pairing_test.go
+++ b/std/algebra/emulated/sw_bls12381/pairing_test.go
@@ -360,6 +360,56 @@ func TestPairingCheckTestSolve(t *testing.T) {
 	assert.NoError(err)
 }
 
+type ThreePairingCheckCircuit struct {
+	In1G1 G1Affine
+	In2G1 G1Affine
+	In3G1 G1Affine
+	In1G2 G2Affine
+	In2G2 G2Affine
+	In3G2 G2Affine
+}
+
+func (c *ThreePairingCheckCircuit) Define(api frontend.API) error {
+	pairing, err := NewPairing(api)
+	if err != nil {
+		return fmt.Errorf("new pairing: %w", err)
+	}
+	err = pairing.PairingCheck(
+		[]*G1Affine{&c.In1G1, &c.In2G1, &c.In3G1},
+		[]*G2Affine{&c.In1G2, &c.In2G2, &c.In3G2},
+	)
+	if err != nil {
+		return fmt.Errorf("pair: %w", err)
+	}
+	return nil
+}
+
+func TestThreePairingCheckTestSolve(t *testing.T) {
+	assert := test.NewAssert(t)
+	// e(2a, 2b) * e(-2a, b) * e(a, -2b) == 1
+
+	p, q := randomG1G2Affines()
+	var p1, p2, p3 bls12381.G1Affine
+	var q1, q2, q3 bls12381.G2Affine
+	p1.Double(&p)
+	q1.Double(&q)
+	p2.Neg(&p1)
+	q2.Set(&q)
+	p3.Set(&p)
+	q3.Neg(&q1)
+
+	witness := ThreePairingCheckCircuit{
+		In1G1: NewG1Affine(p1), // 2p
+		In1G2: NewG2Affine(q1), // 2q
+		In2G1: NewG1Affine(p2), // -2p
+		In2G2: NewG2Affine(q2), // q
+		In3G1: NewG1Affine(p3), // p
+		In3G2: NewG2Affine(q3), // -2q
+	}
+	err := test.IsSolved(&ThreePairingCheckCircuit{}, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}
+
 type GroupMembershipCircuit struct {
 	InG1 G1Affine
 	InG2 G2Affine

--- a/std/algebra/emulated/sw_bn254/hints.go
+++ b/std/algebra/emulated/sw_bn254/hints.go
@@ -78,12 +78,12 @@ func pairingCheckHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int
 			n := len(inputs)
 			p := make([]bn254.G1Affine, 0, n/6)
 			q := make([]bn254.G2Affine, 0, n/6)
-			for k := 0; k < n/6+1; k += 2 {
+			for k := 0; k < n/3; k += 2 {
 				P.X.SetBigInt(inputs[k])
 				P.Y.SetBigInt(inputs[k+1])
 				p = append(p, P)
 			}
-			for k := n / 3; k < n/2+3; k += 4 {
+			for k := n / 3; k < n; k += 4 {
 				Q.X.A0.SetBigInt(inputs[k])
 				Q.X.A1.SetBigInt(inputs[k+1])
 				Q.Y.A0.SetBigInt(inputs[k+2])

--- a/std/algebra/emulated/sw_bn254/hints.go
+++ b/std/algebra/emulated/sw_bn254/hints.go
@@ -78,11 +78,13 @@ func pairingCheckHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int
 			n := len(inputs)
 			p := make([]bn254.G1Affine, 0, n/6)
 			q := make([]bn254.G2Affine, 0, n/6)
+			// first one-third is G1 points
 			for k := 0; k < n/3; k += 2 {
 				P.X.SetBigInt(inputs[k])
 				P.Y.SetBigInt(inputs[k+1])
 				p = append(p, P)
 			}
+			// subsequent two-thirds are G2 points
 			for k := n / 3; k < n; k += 4 {
 				Q.X.A0.SetBigInt(inputs[k])
 				Q.X.A1.SetBigInt(inputs[k+1])

--- a/std/algebra/emulated/sw_bn254/pairing_test.go
+++ b/std/algebra/emulated/sw_bn254/pairing_test.go
@@ -357,6 +357,56 @@ func TestPairingCheckTestSolve(t *testing.T) {
 	assert.NoError(err)
 }
 
+type ThreePairingCheckCircuit struct {
+	In1G1 G1Affine
+	In2G1 G1Affine
+	In3G1 G1Affine
+	In1G2 G2Affine
+	In2G2 G2Affine
+	In3G2 G2Affine
+}
+
+func (c *ThreePairingCheckCircuit) Define(api frontend.API) error {
+	pairing, err := NewPairing(api)
+	if err != nil {
+		return fmt.Errorf("new pairing: %w", err)
+	}
+	err = pairing.PairingCheck(
+		[]*G1Affine{&c.In1G1, &c.In2G1, &c.In3G1},
+		[]*G2Affine{&c.In1G2, &c.In2G2, &c.In3G2},
+	)
+	if err != nil {
+		return fmt.Errorf("pair: %w", err)
+	}
+	return nil
+}
+
+func TestThreePairingCheckTestSolve(t *testing.T) {
+	assert := test.NewAssert(t)
+	// e(2a, 2b) * e(-2a, b) * e(a, -2b) == 1
+
+	p, q := randomG1G2Affines()
+	var p1, p2, p3 bn254.G1Affine
+	var q1, q2, q3 bn254.G2Affine
+	p1.Double(&p)
+	q1.Double(&q)
+	p2.Neg(&p1)
+	q2.Set(&q)
+	p3.Set(&p)
+	q3.Neg(&q1)
+
+	witness := ThreePairingCheckCircuit{
+		In1G1: NewG1Affine(p1), // 2p
+		In1G2: NewG2Affine(q1), // 2q
+		In2G1: NewG1Affine(p2), // -2p
+		In2G2: NewG2Affine(q2), // q
+		In3G1: NewG1Affine(p3), // p
+		In3G2: NewG2Affine(q3), // -2q
+	}
+	err := test.IsSolved(&ThreePairingCheckCircuit{}, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}
+
 type GroupMembershipCircuit struct {
 	InG1 G1Affine
 	InG2 G2Affine

--- a/std/algebra/emulated/sw_bw6761/hints.go
+++ b/std/algebra/emulated/sw_bw6761/hints.go
@@ -60,7 +60,7 @@ func pairingCheckHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int
 			n := len(inputs)
 			p := make([]bw6761.G1Affine, 0, n/4)
 			q := make([]bw6761.G2Affine, 0, n/4)
-			for k := 0; k < n/4+1; k += 2 {
+			for k := 0; k < n/2; k += 2 {
 				P.X.SetBigInt(inputs[k])
 				P.Y.SetBigInt(inputs[k+1])
 				p = append(p, P)

--- a/std/algebra/emulated/sw_bw6761/hints.go
+++ b/std/algebra/emulated/sw_bw6761/hints.go
@@ -60,11 +60,13 @@ func pairingCheckHint(nativeMod *big.Int, nativeInputs, nativeOutputs []*big.Int
 			n := len(inputs)
 			p := make([]bw6761.G1Affine, 0, n/4)
 			q := make([]bw6761.G2Affine, 0, n/4)
+			// first half is G1 points
 			for k := 0; k < n/2; k += 2 {
 				P.X.SetBigInt(inputs[k])
 				P.Y.SetBigInt(inputs[k+1])
 				p = append(p, P)
 			}
+			// second half are G2 points
 			for k := n / 2; k < n; k += 2 {
 				Q.X.SetBigInt(inputs[k])
 				Q.Y.SetBigInt(inputs[k+1])

--- a/std/algebra/emulated/sw_bw6761/pairing_test.go
+++ b/std/algebra/emulated/sw_bw6761/pairing_test.go
@@ -241,6 +241,56 @@ func TestPairingCheckTestSolve(t *testing.T) {
 	assert.NoError(err)
 }
 
+type ThreePairingCheckCircuit struct {
+	In1G1 G1Affine
+	In2G1 G1Affine
+	In3G1 G1Affine
+	In1G2 G2Affine
+	In2G2 G2Affine
+	In3G2 G2Affine
+}
+
+func (c *ThreePairingCheckCircuit) Define(api frontend.API) error {
+	pairing, err := NewPairing(api)
+	if err != nil {
+		return fmt.Errorf("new pairing: %w", err)
+	}
+	err = pairing.PairingCheck(
+		[]*G1Affine{&c.In1G1, &c.In2G1, &c.In3G1},
+		[]*G2Affine{&c.In1G2, &c.In2G2, &c.In3G2},
+	)
+	if err != nil {
+		return fmt.Errorf("pair: %w", err)
+	}
+	return nil
+}
+
+func TestThreePairingCheckTestSolve(t *testing.T) {
+	assert := test.NewAssert(t)
+	// e(2a, 2b) * e(-2a, b) * e(a, -2b) == 1
+
+	p, q := randomG1G2Affines()
+	var p1, p2, p3 bw6761.G1Affine
+	var q1, q2, q3 bw6761.G2Affine
+	p1.Double(&p)
+	q1.Double(&q)
+	p2.Neg(&p1)
+	q2.Set(&q)
+	p3.Set(&p)
+	q3.Neg(&q1)
+
+	witness := ThreePairingCheckCircuit{
+		In1G1: NewG1Affine(p1), // 2p
+		In1G2: NewG2Affine(q1), // 2q
+		In2G1: NewG1Affine(p2), // -2p
+		In2G2: NewG2Affine(q2), // q
+		In3G1: NewG1Affine(p3), // p
+		In3G2: NewG2Affine(q3), // -2q
+	}
+	err := test.IsSolved(&ThreePairingCheckCircuit{}, &witness, ecc.BN254.ScalarField())
+	assert.NoError(err)
+}
+
 type GroupMembershipCircuit struct {
 	InG1 G1Affine
 	InG2 G2Affine

--- a/std/algebra/native/sw_bls12377/hints.go
+++ b/std/algebra/native/sw_bls12377/hints.go
@@ -139,12 +139,12 @@ func pairingCheckHint(scalarField *big.Int, inputs, outputs []*big.Int) error {
 	n := len(inputs)
 	p := make([]bls12377.G1Affine, 0, n/6)
 	q := make([]bls12377.G2Affine, 0, n/6)
-	for k := 0; k < n/6+1; k += 2 {
+	for k := 0; k < n/3; k += 2 {
 		P.X.SetBigInt(inputs[k])
 		P.Y.SetBigInt(inputs[k+1])
 		p = append(p, P)
 	}
-	for k := n / 3; k < n/2+3; k += 4 {
+	for k := n / 3; k < n; k += 4 {
 		Q.X.A0.SetBigInt(inputs[k])
 		Q.X.A1.SetBigInt(inputs[k+1])
 		Q.Y.A0.SetBigInt(inputs[k+2])

--- a/std/algebra/native/sw_bls12377/hints.go
+++ b/std/algebra/native/sw_bls12377/hints.go
@@ -139,11 +139,13 @@ func pairingCheckHint(scalarField *big.Int, inputs, outputs []*big.Int) error {
 	n := len(inputs)
 	p := make([]bls12377.G1Affine, 0, n/6)
 	q := make([]bls12377.G2Affine, 0, n/6)
+	// first one-third is G1 points
 	for k := 0; k < n/3; k += 2 {
 		P.X.SetBigInt(inputs[k])
 		P.Y.SetBigInt(inputs[k+1])
 		p = append(p, P)
 	}
+	// subsequent two-thirds are G2 points
 	for k := n / 3; k < n; k += 4 {
 		Q.X.A0.SetBigInt(inputs[k])
 		Q.X.A1.SetBigInt(inputs[k+1])

--- a/std/algebra/native/sw_bls12377/pairing_test.go
+++ b/std/algebra/native/sw_bls12377/pairing_test.go
@@ -241,6 +241,67 @@ func (circuit *groupMembership) Define(api frontend.API) error {
 	return nil
 }
 
+type threePairingCheckBLS377 struct {
+	P1, P2, P3 G1Affine
+	Q1, Q2, Q3 G2Affine
+}
+
+func (circuit *threePairingCheckBLS377) Define(api frontend.API) error {
+
+	err := pairingCheckClassical(api, []G1Affine{circuit.P1, circuit.P2, circuit.P3}, []G2Affine{circuit.Q1, circuit.Q2, circuit.Q3})
+
+	if err != nil {
+		return fmt.Errorf("pair: %w", err)
+	}
+
+	return nil
+}
+
+func TestThreePairingCheckBLS377(t *testing.T) {
+
+	// pairing test data
+	P, Q := threePairingCheckData()
+	witness := threePairingCheckBLS377{
+		P1: NewG1Affine(P[0]),
+		P2: NewG1Affine(P[1]),
+		P3: NewG1Affine(P[2]),
+		Q1: NewG2Affine(Q[0]),
+		Q2: NewG2Affine(Q[1]),
+		Q3: NewG2Affine(Q[2]),
+	}
+	assert := test.NewAssert(t)
+	assert.CheckCircuit(&threePairingCheckBLS377{}, test.WithValidAssignment(&witness), test.WithCurves(ecc.BW6_761), test.NoProverChecks())
+
+}
+
+type threePairingCheckTorusBLS377 struct {
+	P1, P2, P3 G1Affine
+	Q1, Q2, Q3 G2Affine
+}
+
+func (circuit *threePairingCheckTorusBLS377) Define(api frontend.API) error {
+	err := pairingCheckTorus(api, []G1Affine{circuit.P1, circuit.P2, circuit.P3}, []G2Affine{circuit.Q1, circuit.Q2, circuit.Q3})
+	if err != nil {
+		return fmt.Errorf("pair: %w", err)
+	}
+	return nil
+}
+
+func TestThreePairingCheckTorusBLS377(t *testing.T) {
+	// pairing test data
+	P, Q := threePairingCheckData()
+	witness := threePairingCheckTorusBLS377{
+		P1: NewG1Affine(P[0]),
+		P2: NewG1Affine(P[1]),
+		P3: NewG1Affine(P[2]),
+		Q1: NewG2Affine(Q[0]),
+		Q2: NewG2Affine(Q[1]),
+		Q3: NewG2Affine(Q[2]),
+	}
+	assert := test.NewAssert(t)
+	assert.CheckCircuit(&threePairingCheckTorusBLS377{}, test.WithValidAssignment(&witness), test.WithCurves(ecc.BW6_761), test.NoProverChecks())
+}
+
 func TestGroupMembership(t *testing.T) {
 
 	// pairing test data
@@ -269,6 +330,21 @@ func pairingCheckData() (P [2]bls12377.G1Affine, Q [2]bls12377.G2Affine) {
 	P[1].Double(&P[0]).Neg(&P[1])
 	Q[1].Set(&Q[0])
 	Q[0].Double(&Q[0])
+
+	return
+}
+
+func threePairingCheckData() (P [3]bls12377.G1Affine, Q [3]bls12377.G2Affine) {
+	// e(2a, 2b) * e(-2a, b) * e(a, -2b) == 1
+
+	_, _, p, q := bls12377.Generators()
+
+	P[0].Double(&p)
+	Q[0].Double(&q)
+	P[1].Neg(&P[0])
+	Q[1].Set(&q)
+	P[2].Set(&p)
+	Q[2].Neg(&Q[0])
 
 	return
 }


### PR DESCRIPTION
# Description

Correct input parsing loop bounds for `pairingCheckHint` across three curves BN254, BLS12-381, BW6-761 and BLS12-377.

Fixes #1747


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] New test added for BN254 with 3 pairings which fails without latest fixing commits.

# How has this been benchmarked?

<!-- Please describe the benchmarks that you ran to verify your changes. -->

- [x] Regular pairing benchmark on Mac M3 36gb

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pairing-check hint parsing for multiple curves; a bounds/ordering bug here can silently produce incorrect pairing witnesses and break proofs, but the fix is small and covered by new multi-pair tests.
> 
> **Overview**
> Fixes `pairingCheckHint` input parsing across BN254, BLS12-381, BW6-761, and native BLS12-377 by correcting the loop bounds used to split the flattened input into G1 vs G2 point slices (first segment for G1, remaining for G2), enabling correct handling of 3+ pairings.
> 
> Adds new 3-pairing pairing-check test circuits for the emulated curves (BN254/BLS12-381/BW6-761) and for native BLS12-377 (both classical and torus variants), plus shared 3-pairing test data, to catch regressions where multi-pair parsing would previously fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7e5bc1305204c33f55064f0d3491a6c20fcc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->