### PR TITLE
fix: plonk commitment input deduplicate effective constants

### DIFF
--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -720,6 +720,11 @@ func (builder *builder[E]) Commit(v ...frontend.Variable) (frontend.Variable, er
 			// constants (or other non-term variables) are not committed, so we skip them here
 			continue
 		}
+		if viTerm.Coeff.IsZero() {
+			// if the variable has a zero coefficient, then it is effectively a
+			// constant and we don't need to commit to it, so we skip it here
+			continue
+		}
 		if _, found := isCommitted[viTerm.VID]; found {
 			// skip duplicated committed value
 			continue

--- a/frontend/cs/scs/api_test.go
+++ b/frontend/cs/scs/api_test.go
@@ -397,3 +397,29 @@ func TestDeduplicateCommitments(t *testing.T) {
 
 	assert.Equal(ccsCmts1.GetNbConstraints(), ccsCmts5.GetNbConstraints(), "expected same number of constraints")
 }
+
+type zeroCoeffCommitmentCircuit struct {
+	A frontend.Variable
+}
+
+func (c *zeroCoeffCommitmentCircuit) Define(api frontend.API) error {
+	cmter, ok := api.(frontend.Committer)
+	if !ok {
+		return fmt.Errorf("expected Committer interface")
+	}
+	_, err := cmter.Commit(api.Div(0, c.A), c.A)
+	return err
+}
+
+func TestCommitSkipsZeroCoeffTerms(t *testing.T) {
+	assert := test.NewAssert(t)
+
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &zeroCoeffCommitmentCircuit{})
+	assert.NoError(err)
+
+	w, err := frontend.NewWitness(&zeroCoeffCommitmentCircuit{A: 3}, ecc.BN254.ScalarField())
+	assert.NoError(err)
+
+	_, err = ccs.Solve(w)
+	assert.NoError(err)
+}

--- a/frontend/cs/scs/builder.go
+++ b/frontend/cs/scs/builder.go
@@ -198,19 +198,6 @@ func (builder *builder[E]) addBoolGate(c sparseR1C[E], debugInfo ...constraint.D
 
 // addPlonkConstraint adds a sparseR1C to the underlying constraint system
 func (builder *builder[E]) addPlonkConstraint(c sparseR1C[E], debugInfo ...constraint.DebugInfo) {
-	if !c.qM.IsZero() && (c.xa == 0 || c.xb == 0) {
-		// TODO this is internal but not easy to detect; if qM is set, but one or both of xa / xb is not,
-		// since wireID == 0 is a valid wire, it may trigger unexpected behavior.
-		//
-		// ivokub: This essentially means we add a constraint which is always
-		// satisfied for any input. It only increases the number of constraints
-		// without adding any real constraints on the inputs. But this is good
-		// to catch unoptimal code on the caller side -- we have found a few
-		// multiplications by zero in field emulation and emulated group
-		// arithmetic. And this has allowed to optimize the implementation.
-		log := logger.Logger()
-		log.Warn().Msg("adding a plonk constraint with qM set but xa or xb == 0 (wire 0)")
-	}
 	QL := builder.cs.AddCoeff(c.qL)
 	QR := builder.cs.AddCoeff(c.qR)
 	QO := builder.cs.AddCoeff(c.qO)


### PR DESCRIPTION
# Description

In PLONK commit schema we perform filtering of inputs we commit to:
* do not commit to constants
* deduplicate committed values

First one is because there is no reason to commit to circuit constants as the prover cannot choose the constants, so omitting them doesn't give any more advantage in predicting FS result.

The second one is an optimization as committing to `x` and `coeff * x` is redundant, and we can only commit to a first variable with `x`. The optimization comes from avoiding to add copy constraints to copy the value into the commitment column.

Now, this filtering still committed to values `0 * x`, but we had additional check that we wouldn't commit to effectively constant values `builder.constantValue(var)` returning true. And when `coeff == 0` then `builder.constantValue` indeed returns it to be a constant.

Keep in mind that when later we have some other `coeff * x` then eventually still commit to `x` as the filtering only skips the input before storing in the deduplication table.

I also removed logging `adding a plonk constraint with qM set but xa or xb == 0 (wire 0)` -- this is not relevant in PLONK setting as xa and xb refer to the first input wire which in PLONK is not necessarily constant (as in R1CS) but rather first input variables.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] zeroCoeffCommitmentCircuit

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PLONK commitment input filtering and constraint builder behavior; bugs here can change constraint counts/commitment transcript inputs and affect prover/verifier consistency, though the change is narrow and covered by a regression test.
> 
> **Overview**
> Fixes PLONK `Commit` input filtering to **treat zero-coefficient terms as effective constants** and skip committing to them, avoiding redundant copy/commitment constraints.
> 
> Adds a regression test (`TestCommitSkipsZeroCoeffTerms`) that commits to `0/a` alongside `a` and asserts the circuit compiles and solves.
> 
> Removes the warning log in `addPlonkConstraint` about `qM` with `xa`/`xb` equal to wire `0`, since wire `0` is valid in this PLONKish SCS setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee342fd525f78314bb9a187bd575753d46c99ddf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->