### PR TITLE
perf(bls12-377): randomized Schwartz-Zippel in native Fp6 and Fp12

### DIFF
--- a/internal/stats/latest_stats.csv
+++ b/internal/stats/latest_stats.csv
@@ -88,7 +88,7 @@ math/emulated/secp256k1_64,bls12_377,plonk,4025,3923
 math/emulated/secp256k1_64,bls12_381,plonk,4025,3923
 math/emulated/secp256k1_64,bw6_761,plonk,4025,3923
 pairing_bls12377,bw6_761,groth16,11876,11876
-pairing_bls12377,bw6_761,plonk,45565,45565
+pairing_bls12377,bw6_761,plonk,40681,40679
 pairing_bls12381,bn254,groth16,756837,1242260
 pairing_bls12381,bn254,plonk,2529578,2413653
 pairing_bn254,bn254,groth16,506052,823961

--- a/internal/stats/latest_stats.csv
+++ b/internal/stats/latest_stats.csv
@@ -94,7 +94,7 @@ pairing_bls12377,bw6_761,groth16,11876,11876
 pairing_bls12377,bn254,plonk,0,0
 pairing_bls12377,bls12_377,plonk,0,0
 pairing_bls12377,bls12_381,plonk,0,0
-pairing_bls12377,bw6_761,plonk,48130,48130
+pairing_bls12377,bw6_761,plonk,40681,40679
 pairing_bls12381,bn254,groth16,756837,1242260
 pairing_bls12381,bls12_377,groth16,0,0
 pairing_bls12381,bls12_381,groth16,0,0

--- a/internal/stats/latest_stats.csv
+++ b/internal/stats/latest_stats.csv
@@ -88,7 +88,7 @@ math/emulated/secp256k1_64,bls12_377,plonk,4025,3923
 math/emulated/secp256k1_64,bls12_381,plonk,4025,3923
 math/emulated/secp256k1_64,bw6_761,plonk,4025,3923
 pairing_bls12377,bw6_761,groth16,11876,11876
-pairing_bls12377,bw6_761,plonk,40433,40431
+pairing_bls12377,bw6_761,plonk,41914,40431
 pairing_bls12381,bn254,groth16,756837,1242260
 pairing_bls12381,bn254,plonk,2529578,2413653
 pairing_bn254,bn254,groth16,506052,823961

--- a/std/algebra/native/fields_bls12377/e12.go
+++ b/std/algebra/native/fields_bls12377/e12.go
@@ -193,8 +193,7 @@ func (e *E12) mulSZ(api frontend.API, e1, e2 E12) *E12 {
 	bMono := towerToMonomial12(bCoeffs)
 	cMono := towerToMonomial12(e12Coeffs(e))
 
-	ch := getE12SZChecker(api)
-	ch.addCheck(aMono, bMono, cMono, q)
+	addSZCheck(api, aMono[:], bMono[:], cMono[:], q[:])
 
 	return e
 }
@@ -246,8 +245,7 @@ func (e *E12) squareSZ(api frontend.API, x E12) *E12 {
 	aMono := towerToMonomial12(aCoeffs)
 	cMono := towerToMonomial12(e12Coeffs(e))
 
-	ch := getE12SZChecker(api)
-	ch.addSquareCheck(aMono, cMono, q)
+	addSZSquareCheck(api, aMono[:], cMono[:], q[:])
 
 	return e
 }

--- a/std/algebra/native/fields_bls12377/e12.go
+++ b/std/algebra/native/fields_bls12377/e12.go
@@ -9,6 +9,7 @@ import (
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
 
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/internal/frontendtype"
 )
 
 // Extension stores the non residue elmt for an extension of type Fp->Fp2->Fp6->Fp12 (Fp2 = Fp(u), Fp6 = Fp2(v), Fp12 = Fp6(w))
@@ -137,7 +138,18 @@ func (e *E12) Neg(api frontend.API, e1 E12) *E12 {
 
 // Mul multiplies 2 elmts in Fp12
 func (e *E12) Mul(api frontend.API, e1, e2 E12) *E12 {
+	if ft, ok := api.Compiler().(frontendtype.FrontendTyper); ok {
+		if ft.FrontendType() == frontendtype.SCS {
+			if _, ok := api.(frontend.Committer); ok {
+				return e.mulSZ(api, e1, e2)
+			}
+		}
+	}
+	return e.mulKaratsuba(api, e1, e2)
+}
 
+// mulKaratsuba computes e = e1 * e2 using the Karatsuba tower (3 E6 muls).
+func (e *E12) mulKaratsuba(api frontend.API, e1, e2 E12) *E12 {
 	var u, v, ac, bd E6
 	u.Add(api, e1.C0, e1.C1)
 	v.Add(api, e2.C0, e2.C1)
@@ -153,9 +165,53 @@ func (e *E12) Mul(api frontend.API, e1, e2 E12) *E12 {
 	return e
 }
 
+// mulSZ computes e = e1 * e2 using the Schwartz-Zippel technique.
+// The prover witnesses the result c and quotient q, then defers a check
+// a(r)*b(r) = q(r)*P(r) + c(r) at a random challenge r, where P(X) = X^12 + 5.
+// Soundness: 22/p ≈ 2^{-372} per check.
+func (e *E12) mulSZ(api frontend.API, e1, e2 E12) *E12 {
+	aCoeffs := e12Coeffs(&e1)
+	bCoeffs := e12Coeffs(&e2)
+	in := make([]frontend.Variable, 24)
+	copy(in[:12], aCoeffs[:])
+	copy(in[12:], bCoeffs[:])
+
+	out, err := api.Compiler().NewHint(mulE12SZHint, 23, in...)
+	if err != nil {
+		panic(err)
+	}
+
+	// first 12 outputs: c in tower basis
+	assignE12(e, out[:12])
+
+	// last 11 outputs: q in monomial basis
+	var q [11]frontend.Variable
+	copy(q[:], out[12:23])
+
+	// convert a, b, c to monomial
+	aMono := towerToMonomial12(aCoeffs)
+	bMono := towerToMonomial12(bCoeffs)
+	cMono := towerToMonomial12(e12Coeffs(e))
+
+	ch := getE12SZChecker(api)
+	ch.addCheck(aMono, bMono, cMono, q)
+
+	return e
+}
+
 // Square squares an element in Fp12
 func (e *E12) Square(api frontend.API, x E12) *E12 {
+	if ft, ok := api.Compiler().(frontendtype.FrontendTyper); ok {
+		if ft.FrontendType() == frontendtype.SCS {
+			if _, ok := api.(frontend.Committer); ok {
+				return e.squareSZ(api, x)
+			}
+		}
+	}
+	return e.squareKaratsuba(api, x)
+}
 
+func (e *E12) squareKaratsuba(api frontend.API, x E12) *E12 {
 	//Algorithm 22 from https://eprint.iacr.org/2010/354.pdf
 	var c0, c2, c3 E6
 	c0.Sub(api, x.C0, x.C1)
@@ -166,6 +222,32 @@ func (e *E12) Square(api frontend.API, x E12) *E12 {
 	e.C1.Double(api, c2)
 	c2.MulByNonResidue(api, c2)
 	e.C0.Add(api, c0, c2)
+
+	return e
+}
+
+// squareSZ computes e = x² using the Schwartz-Zippel technique.
+// Like mulSZ but evaluates a(r) only once (saving 11 gates vs mulSZ).
+func (e *E12) squareSZ(api frontend.API, x E12) *E12 {
+	aCoeffs := e12Coeffs(&x)
+	in := make([]frontend.Variable, 12)
+	copy(in, aCoeffs[:])
+
+	out, err := api.Compiler().NewHint(squareE12SZHint, 23, in...)
+	if err != nil {
+		panic(err)
+	}
+
+	assignE12(e, out[:12])
+
+	var q [11]frontend.Variable
+	copy(q[:], out[12:23])
+
+	aMono := towerToMonomial12(aCoeffs)
+	cMono := towerToMonomial12(e12Coeffs(e))
+
+	ch := getE12SZChecker(api)
+	ch.addSquareCheck(aMono, cMono, q)
 
 	return e
 }

--- a/std/algebra/native/fields_bls12377/e12_pairing.go
+++ b/std/algebra/native/fields_bls12377/e12_pairing.go
@@ -2,6 +2,7 @@ package fields_bls12377
 
 import (
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/internal/frontendtype"
 )
 
 // nSquareKarabina2345 repeated compressed cyclotmic square
@@ -47,7 +48,17 @@ func (e *E12) Square034(api frontend.API, x E12) *E12 {
 
 // MulBy034 multiplication by sparse element
 func (e *E12) MulBy034(api frontend.API, c3, c4 E2) *E12 {
+	if ft, ok := api.Compiler().(frontendtype.FrontendTyper); ok {
+		if ft.FrontendType() == frontendtype.SCS {
+			if _, ok := api.(frontend.Committer); ok {
+				return e.mulBy034SZ(api, c3, c4)
+			}
+		}
+	}
+	return e.mulBy034Karatsuba(api, c3, c4)
+}
 
+func (e *E12) mulBy034Karatsuba(api frontend.API, c3, c4 E2) *E12 {
 	var d E6
 
 	a := e.C0
@@ -60,6 +71,51 @@ func (e *E12) MulBy034(api frontend.API, c3, c4 E2) *E12 {
 
 	e.C1.Add(api, a, b).Neg(api, e.C1).Add(api, e.C1, d)
 	e.C0.MulByNonResidue(api, b).Add(api, e.C0, a)
+
+	return e
+}
+
+// mulBy034SZ computes e = e * sparse(1,0,0,c3,c4,0) using SZ.
+// The sparse element has only 5 nonzero monomial coefficients:
+// mono[0]=1 (const), mono[1]=c3.A0, mono[3]=c4.A0, mono[7]=c3.A1, mono[9]=c4.A1.
+func (e *E12) mulBy034SZ(api frontend.API, c3, c4 E2) *E12 {
+	aCoeffs := e12Coeffs(e)
+	in := make([]frontend.Variable, 16)
+	copy(in[:12], aCoeffs[:])
+	in[12] = c3.A0
+	in[13] = c3.A1
+	in[14] = c4.A0
+	in[15] = c4.A1
+
+	out, err := api.Compiler().NewHint(mulBy034E12SZHint, 23, in...)
+	if err != nil {
+		panic(err)
+	}
+
+	assignE12(e, out[:12])
+
+	var q [11]frontend.Variable
+	copy(q[:], out[12:23])
+
+	aMono := towerToMonomial12(aCoeffs)
+	cMono := towerToMonomial12(e12Coeffs(e))
+
+	// build sparse b in monomial form
+	var bMono [12]frontend.Variable
+	for i := range bMono {
+		bMono[i] = 0
+	}
+	bMono[0] = frontend.Variable(1) // constant 1
+	bMono[1] = c3.A0
+	bMono[3] = c4.A0
+	bMono[7] = c3.A1
+	bMono[9] = c4.A1
+
+	ch := getE12SZChecker(api)
+	ch.addSparseCheck(aMono, bMono, cMono, q,
+		[]int{1, 3, 7, 9}, // variable indices
+		[]int{0},          // constant indices (mono[0] = 1)
+	)
 
 	return e
 }
@@ -107,6 +163,30 @@ func Mul01234By034(api frontend.API, x [5]E2, z3, z4 E2) *E12 {
 }
 
 func (e *E12) MulBy01234(api frontend.API, x [5]E2) *E12 {
+	if ft, ok := api.Compiler().(frontendtype.FrontendTyper); ok {
+		if ft.FrontendType() == frontendtype.SCS {
+			if _, ok := api.(frontend.Committer); ok {
+				return e.mulBy01234SZ(api, x)
+			}
+		}
+	}
+	return e.mulBy01234Karatsuba(api, x)
+}
+
+func (e *E12) mulBy01234SZ(api frontend.API, x [5]E2) *E12 {
+	// reconstruct sparse E12: C0=(x[0],x[1],x[2]), C1=(x[3],x[4],0)
+	var b E12
+	b.C0.B0 = x[0]
+	b.C0.B1 = x[1]
+	b.C0.B2 = x[2]
+	b.C1.B0 = x[3]
+	b.C1.B1 = x[4]
+	b.C1.B2.SetZero()
+	// use generic mulSZ — the b is almost dense (10/12 nonzero)
+	return e.mulSZ(api, *e, b)
+}
+
+func (e *E12) mulBy01234Karatsuba(api frontend.API, x [5]E2) *E12 {
 	var a, b, c, z1, z0 E6
 	c0 := &E6{B0: x[0], B1: x[1], B2: x[2]}
 	a.Add(api, e.C0, e.C1)

--- a/std/algebra/native/fields_bls12377/e12_pairing.go
+++ b/std/algebra/native/fields_bls12377/e12_pairing.go
@@ -111,11 +111,7 @@ func (e *E12) mulBy034SZ(api frontend.API, c3, c4 E2) *E12 {
 	bMono[7] = c3.A1
 	bMono[9] = c4.A1
 
-	ch := getE12SZChecker(api)
-	ch.addSparseCheck(aMono, bMono, cMono, q,
-		[]int{1, 3, 7, 9}, // variable indices
-		[]int{0},          // constant indices (mono[0] = 1)
-	)
+	addSZCheck(api, aMono[:], bMono[:], cMono[:], q[:])
 
 	return e
 }

--- a/std/algebra/native/fields_bls12377/e12_sz.go
+++ b/std/algebra/native/fields_bls12377/e12_sz.go
@@ -6,14 +6,9 @@ import (
 	"sync"
 
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
-	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/multicommit"
 )
-
-func init() {
-	solver.RegisterHint(mulE12SZHint, squareE12SZHint, mulBy034E12SZHint)
-}
 
 // Schwartz-Zippel based E12 multiplication for SCS.
 //
@@ -156,8 +151,8 @@ func (ch *e12SZChecker) resolve(api frontend.API) error {
 		// P(r) = r^12 + 5
 		pEval := api.Add(rPow[12], 5)
 
-		// Batching coefficient: α = r^13
-		alpha := api.Mul(rPow[12], r)
+		// Batching coefficient: r^23 ensures non-overlapping degree ranges (deg(e_i)=22)
+		alpha := api.Mul(rPow[12], rPow[11]) // r^23
 
 		lhsAcc := frontend.Variable(0)
 		rhsAcc := frontend.Variable(0)
@@ -209,12 +204,11 @@ func evalAtPowers12(api frontend.API, coeffs []frontend.Variable, rPow []fronten
 }
 
 // evalSparse12 evaluates a polynomial where only some coefficients are nonzero.
-// varIdx: indices with circuit variable coefficients (need api.Mul)
-// constIdx: indices with constant coefficients (api.Mul by constant is free, just api.Add)
+// varIdx: indices with circuit variable coefficients (multiplication gate required)
+// constIdx: indices with constant coefficients (scalar multiplication, no gate in SCS)
 func evalSparse12(api frontend.API, coeffs []frontend.Variable, rPow []frontend.Variable, varIdx, constIdx []int) frontend.Variable {
 	var result frontend.Variable = 0
 	for _, i := range constIdx {
-		// constant * r^i: the Mul is free (constant multiplication)
 		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
 	}
 	for _, i := range varIdx {

--- a/std/algebra/native/fields_bls12377/e12_sz.go
+++ b/std/algebra/native/fields_bls12377/e12_sz.go
@@ -3,11 +3,9 @@ package fields_bls12377
 import (
 	"fmt"
 	"math/big"
-	"sync"
 
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/std/multicommit"
 )
 
 // Schwartz-Zippel based E12 multiplication for SCS.
@@ -23,7 +21,8 @@ import (
 // BLS12-377's base field is ~377 bits, so a single Fp evaluation point gives
 // ~372 bits of soundness (deg(a*b)/p = 22/p ≈ 2^{-372}), well above 128 bits.
 //
-// Gate cost: ~49 SCS gates per multiplication (vs ~264 for Karatsuba).
+// The exact SCS cost depends on commitment inputs and batching; see the
+// constraint-count tests for current numbers.
 
 // towerToMonomial12 reorders tower-basis coefficients to monomial-basis.
 //
@@ -59,162 +58,6 @@ func assignE12(e *E12, v []frontend.Variable) {
 	e.C1.B0.A0, e.C1.B0.A1 = v[6], v[7]
 	e.C1.B1.A0, e.C1.B1.A1 = v[8], v[9]
 	e.C1.B2.A0, e.C1.B2.A1 = v[10], v[11]
-}
-
-// e12MulCheck stores one deferred a*b=c check in monomial form.
-type e12MulCheck struct {
-	a, b, c    [12]frontend.Variable // monomial coefficients (degree 11)
-	q          [11]frontend.Variable // quotient monomial coefficients (degree 10)
-	isSquare   bool                  // if true, b is ignored and a(r)² is checked
-	bSparseIdx []int                 // if non-nil, only these indices of b are nonzero variables
-	bConstIdx  []int                 // indices of b that are constants (e.g., 1)
-}
-
-// e12SZChecker accumulates E12 multiplication checks and resolves them
-// in a single deferred callback using a shared Fiat-Shamir challenge.
-type e12SZChecker struct {
-	checks []e12MulCheck
-}
-
-var (
-	e12szMu       sync.Mutex
-	e12szCheckers = map[frontend.Compiler]*e12SZChecker{}
-)
-
-func getE12SZChecker(api frontend.API) *e12SZChecker {
-	compiler := api.Compiler()
-
-	e12szMu.Lock()
-	ch, ok := e12szCheckers[compiler]
-	if ok {
-		e12szMu.Unlock()
-		return ch
-	}
-	ch = &e12SZChecker{}
-	e12szCheckers[compiler] = ch
-	e12szMu.Unlock()
-
-	compiler.Defer(func(api frontend.API) error {
-		defer func() {
-			e12szMu.Lock()
-			delete(e12szCheckers, compiler)
-			e12szMu.Unlock()
-		}()
-		return ch.resolve(api)
-	})
-	return ch
-}
-
-func (ch *e12SZChecker) addCheck(a, b, c [12]frontend.Variable, q [11]frontend.Variable) {
-	ch.checks = append(ch.checks, e12MulCheck{a: a, b: b, c: c, q: q, isSquare: false})
-}
-
-func (ch *e12SZChecker) addSquareCheck(a, c [12]frontend.Variable, q [11]frontend.Variable) {
-	ch.checks = append(ch.checks, e12MulCheck{a: a, c: c, q: q, isSquare: true})
-}
-
-// addSparseCheck registers a check where b has only some nonzero coefficients.
-// sparseVarIdx: indices of b that are circuit variables
-// sparseConstIdx: indices of b that are known constants (e.g., index 0 = 1 for MulBy034)
-func (ch *e12SZChecker) addSparseCheck(a, b, c [12]frontend.Variable, q [11]frontend.Variable, sparseVarIdx, sparseConstIdx []int) {
-	ch.checks = append(ch.checks, e12MulCheck{
-		a: a, b: b, c: c, q: q,
-		bSparseIdx: sparseVarIdx, bConstIdx: sparseConstIdx,
-	})
-}
-
-// resolve performs all accumulated checks using a single commitment challenge.
-func (ch *e12SZChecker) resolve(api frontend.API) error {
-	if len(ch.checks) == 0 {
-		return nil
-	}
-
-	var toCommit []frontend.Variable
-	for i := range ch.checks {
-		toCommit = append(toCommit, ch.checks[i].c[:]...)
-		toCommit = append(toCommit, ch.checks[i].q[:]...)
-	}
-
-	// BLS12-377 is a large field — use plain WithCommitment (single Fp challenge).
-	// Soundness: 22/p ≈ 2^{-372}.
-	multicommit.WithCommitment(api, func(api frontend.API, commitment frontend.Variable) error {
-		r := commitment
-
-		// Precompute r², ..., r¹² (11 gates, shared across all checks)
-		rPow := make([]frontend.Variable, 13)
-		rPow[0] = frontend.Variable(1)
-		rPow[1] = r
-		for i := 2; i <= 12; i++ {
-			rPow[i] = api.Mul(rPow[i-1], r)
-		}
-
-		// P(r) = r^12 + 5
-		pEval := api.Add(rPow[12], 5)
-
-		// Batching coefficient: r^23 ensures non-overlapping degree ranges (deg(e_i)=22)
-		alpha := api.Mul(rPow[12], rPow[11]) // r^23
-
-		lhsAcc := frontend.Variable(0)
-		rhsAcc := frontend.Variable(0)
-		alphaPow := frontend.Variable(1)
-
-		for i := range ch.checks {
-			chk := &ch.checks[i]
-
-			aEval := evalAtPowers12(api, chk.a[:], rPow)
-			var abEval frontend.Variable
-			if chk.isSquare {
-				abEval = api.Mul(aEval, aEval)
-			} else if chk.bSparseIdx != nil {
-				// sparse b: only evaluate nonzero terms
-				bEval := evalSparse12(api, chk.b[:], rPow, chk.bSparseIdx, chk.bConstIdx)
-				abEval = api.Mul(aEval, bEval)
-			} else {
-				bEval := evalAtPowers12(api, chk.b[:], rPow)
-				abEval = api.Mul(aEval, bEval)
-			}
-			cEval := evalAtPowers12(api, chk.c[:], rPow)
-			qEval := evalAtPowers12(api, chk.q[:], rPow)
-			qpEval := api.Mul(qEval, pEval)
-			rhs := api.Add(qpEval, cEval)
-
-			lhsAcc = api.Add(lhsAcc, api.Mul(alphaPow, abEval))
-			rhsAcc = api.Add(rhsAcc, api.Mul(alphaPow, rhs))
-
-			if i < len(ch.checks)-1 {
-				alphaPow = api.Mul(alphaPow, alpha)
-			}
-		}
-
-		api.AssertIsEqual(lhsAcc, rhsAcc)
-		return nil
-	}, toCommit...)
-
-	return nil
-}
-
-// evalAtPowers12 evaluates coeffs[0] + coeffs[1]*r + ... + coeffs[n-1]*r^(n-1)
-// using precomputed powers.
-func evalAtPowers12(api frontend.API, coeffs []frontend.Variable, rPow []frontend.Variable) frontend.Variable {
-	result := coeffs[0]
-	for i := 1; i < len(coeffs); i++ {
-		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
-	}
-	return result
-}
-
-// evalSparse12 evaluates a polynomial where only some coefficients are nonzero.
-// varIdx: indices with circuit variable coefficients (multiplication gate required)
-// constIdx: indices with constant coefficients (scalar multiplication, no gate in SCS)
-func evalSparse12(api frontend.API, coeffs []frontend.Variable, rPow []frontend.Variable, varIdx, constIdx []int) frontend.Variable {
-	var result frontend.Variable = 0
-	for _, i := range constIdx {
-		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
-	}
-	for _, i := range varIdx {
-		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
-	}
-	return result
 }
 
 // mulBy034E12SZHint computes c = a * sparse(1,0,0,c3,c4,0) in Fp12.

--- a/std/algebra/native/fields_bls12377/e12_sz.go
+++ b/std/algebra/native/fields_bls12377/e12_sz.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
+	"github.com/consensys/gnark-crypto/ecc/bls12-377/fp"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -60,7 +61,8 @@ func assignE12(e *E12, v []frontend.Variable) {
 	e.C1.B2.A0, e.C1.B2.A1 = v[10], v[11]
 }
 
-// mulBy034E12SZHint computes c = a * sparse(1,0,0,c3,c4,0) in Fp12.
+// mulBy034E12SZHint computes c = a * sparse(1,0,0,c3,c4,0) in Fp12 and the
+// quotient q such that a(X)*b(X) = q(X)*(X^12+5) + c(X) in Fp[X].
 //
 // inputs:  16 big.Ints (12 for a in tower, 2 for c3, 2 for c4)
 // outputs: 23 big.Ints (12 for c in tower, 11 for q in monomial)
@@ -84,33 +86,9 @@ func mulBy034E12SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error 
 
 	getNativeE12(&c, outputs[:12])
 
-	aMono := e12TowerToMonomialBigInt(&a)
-	bMono := e12TowerToMonomialBigInt(&b)
-
-	p := bls12377.ID.BaseField()
-	var prod [23]big.Int
-	for i := 0; i < 12; i++ {
-		for j := 0; j < 12; j++ {
-			var t big.Int
-			t.Mul(&aMono[i], &bMono[j])
-			prod[i+j].Add(&prod[i+j], &t)
-			prod[i+j].Mod(&prod[i+j], p)
-		}
-	}
-
-	five := big.NewInt(5)
-	var q [11]big.Int
-	for i := 10; i >= 0; i-- {
-		q[i].Set(&prod[i+12])
-		q[i].Mod(&q[i], p)
-		var t big.Int
-		t.Mul(&q[i], five)
-		prod[i].Sub(&prod[i], &t)
-		prod[i].Mod(&prod[i], p)
-	}
-
+	q := e12SZQuotient(e12TowerToMonomialFpElement(&a), e12TowerToMonomialFpElement(&b))
 	for i := 0; i < 11; i++ {
-		outputs[12+i].Set(&q[i])
+		q[i].BigInt(outputs[12+i])
 	}
 	return nil
 }
@@ -136,39 +114,10 @@ func mulE12SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
 	// output c in tower basis (first 12 outputs)
 	getNativeE12(&c, outputs[:12])
 
-	// convert a, b to monomial form for polynomial multiplication
-	aMono := e12TowerToMonomialBigInt(&a)
-	bMono := e12TowerToMonomialBigInt(&b)
-
-	// polynomial multiply: prod = aMono * bMono (degree 22, 23 coefficients)
-	p := bls12377.ID.BaseField()
-	var prod [23]big.Int
-	for i := 0; i < 12; i++ {
-		for j := 0; j < 12; j++ {
-			var t big.Int
-			t.Mul(&aMono[i], &bMono[j])
-			prod[i+j].Add(&prod[i+j], &t)
-			prod[i+j].Mod(&prod[i+j], p)
-		}
-	}
-
-	// divide by P(X) = X^12 + 5 (monic degree 12)
-	// q[i] = prod[i+12] for i = 10..0, then fold: prod[i] += prod[i+12]*(-5)
-	five := big.NewInt(5)
-	var q [11]big.Int
-	for i := 10; i >= 0; i-- {
-		q[i].Set(&prod[i+12])
-		q[i].Mod(&q[i], p)
-		// subtract q[i] * 5 from prod[i] (since P = X^12 + 5, constant term is +5)
-		var t big.Int
-		t.Mul(&q[i], five)
-		prod[i].Sub(&prod[i], &t)
-		prod[i].Mod(&prod[i], p)
-	}
-
+	q := e12SZQuotient(e12TowerToMonomialFpElement(&a), e12TowerToMonomialFpElement(&b))
 	// output q in monomial basis (last 11 outputs)
 	for i := 0; i < 11; i++ {
-		outputs[12+i].Set(&q[i])
+		q[i].BigInt(outputs[12+i])
 	}
 	return nil
 }
@@ -192,34 +141,35 @@ func squareE12SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
 
 	getNativeE12(&c, outputs[:12])
 
-	aMono := e12TowerToMonomialBigInt(&a)
+	aMono := e12TowerToMonomialFpElement(&a)
+	q := e12SZQuotient(aMono, aMono)
+	for i := 0; i < 11; i++ {
+		q[i].BigInt(outputs[12+i])
+	}
+	return nil
+}
 
-	p := bls12377.ID.BaseField()
-	var prod [23]big.Int
+func e12SZQuotient(aMono, bMono [12]fp.Element) [11]fp.Element {
+	var prod [23]fp.Element
 	for i := 0; i < 12; i++ {
 		for j := 0; j < 12; j++ {
-			var t big.Int
-			t.Mul(&aMono[i], &aMono[j])
+			var t fp.Element
+			t.Mul(&aMono[i], &bMono[j])
 			prod[i+j].Add(&prod[i+j], &t)
-			prod[i+j].Mod(&prod[i+j], p)
 		}
 	}
 
-	five := big.NewInt(5)
-	var q [11]big.Int
+	var five fp.Element
+	five.SetUint64(5)
+	var q [11]fp.Element
+	// Compute q such that a*b = c + q*(X^12+5).
 	for i := 10; i >= 0; i-- {
 		q[i].Set(&prod[i+12])
-		q[i].Mod(&q[i], p)
-		var t big.Int
-		t.Mul(&q[i], five)
+		var t fp.Element
+		t.Mul(&q[i], &five)
 		prod[i].Sub(&prod[i], &t)
-		prod[i].Mod(&prod[i], p)
 	}
-
-	for i := 0; i < 11; i++ {
-		outputs[12+i].Set(&q[i])
-	}
-	return nil
+	return q
 }
 
 func setNativeE12(dst *bls12377.E12, inputs []*big.Int) {
@@ -252,24 +202,11 @@ func getNativeE12(src *bls12377.E12, outputs []*big.Int) {
 	src.C1.B2.A1.BigInt(outputs[11])
 }
 
-// e12TowerToMonomialBigInt converts tower-basis E12 to monomial-basis big.Ints.
-func e12TowerToMonomialBigInt(e *bls12377.E12) [12]big.Int {
-	var tower [12]big.Int
-	e.C0.B0.A0.BigInt(&tower[0])
-	e.C0.B0.A1.BigInt(&tower[1])
-	e.C0.B1.A0.BigInt(&tower[2])
-	e.C0.B1.A1.BigInt(&tower[3])
-	e.C0.B2.A0.BigInt(&tower[4])
-	e.C0.B2.A1.BigInt(&tower[5])
-	e.C1.B0.A0.BigInt(&tower[6])
-	e.C1.B0.A1.BigInt(&tower[7])
-	e.C1.B1.A0.BigInt(&tower[8])
-	e.C1.B1.A1.BigInt(&tower[9])
-	e.C1.B2.A0.BigInt(&tower[10])
-	e.C1.B2.A1.BigInt(&tower[11])
+// e12TowerToMonomialFpElement converts tower-basis E12 to monomial-basis elements.
+func e12TowerToMonomialFpElement(e *bls12377.E12) [12]fp.Element {
 	// permutation: mono[degree] = tower[index]
-	return [12]big.Int{
-		tower[0], tower[6], tower[2], tower[8], tower[4], tower[10],
-		tower[1], tower[7], tower[3], tower[9], tower[5], tower[11],
+	return [12]fp.Element{
+		e.C0.B0.A0, e.C1.B0.A0, e.C0.B1.A0, e.C1.B1.A0, e.C0.B2.A0, e.C1.B2.A0,
+		e.C0.B0.A1, e.C1.B0.A1, e.C0.B1.A1, e.C1.B1.A1, e.C0.B2.A1, e.C1.B2.A1,
 	}
 }

--- a/std/algebra/native/fields_bls12377/e12_sz.go
+++ b/std/algebra/native/fields_bls12377/e12_sz.go
@@ -1,0 +1,438 @@
+package fields_bls12377
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+
+	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
+	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/multicommit"
+)
+
+func init() {
+	solver.RegisterHint(mulE12SZHint, squareE12SZHint, mulBy034E12SZHint)
+}
+
+// Schwartz-Zippel based E12 multiplication for SCS.
+//
+// Instead of computing c = a * b via the Karatsuba tower (~264 SCS gates),
+// the prover witnesses c and a quotient polynomial q via a hint, then verifies:
+//
+//	a(r) * b(r) = q(r) * P(r) + c(r)   in Fp
+//
+// where P(X) = X^12 + 5 is the irreducible polynomial for Fp12 over Fp, and r
+// is a Fiat-Shamir challenge from multicommit.WithCommitment.
+//
+// BLS12-377's base field is ~377 bits, so a single Fp evaluation point gives
+// ~372 bits of soundness (deg(a*b)/p = 22/p ≈ 2^{-372}), well above 128 bits.
+//
+// Gate cost: ~49 SCS gates per multiplication (vs ~264 for Karatsuba).
+
+// towerToMonomial12 reorders tower-basis coefficients to monomial-basis.
+//
+// Tower basis: {1, u, v, uv, v², uv², w, uw, vw, uvw, v²w, uv²w}
+// where u²=-5, v³=u, w²=v. With w=X: u=X⁶, v=X², w=X.
+//
+//	tower[0]=1     → X⁰    tower[6]=w     → X¹
+//	tower[2]=v     → X²    tower[8]=vw    → X³
+//	tower[4]=v²    → X⁴    tower[10]=v²w  → X⁵
+//	tower[1]=u     → X⁶    tower[7]=uw    → X⁷
+//	tower[3]=uv    → X⁸    tower[9]=uvw   → X⁹
+//	tower[5]=uv²   → X¹⁰   tower[11]=uv²w → X¹¹
+func towerToMonomial12(t [12]frontend.Variable) [12]frontend.Variable {
+	return [12]frontend.Variable{
+		t[0], t[6], t[2], t[8], t[4], t[10],
+		t[1], t[7], t[3], t[9], t[5], t[11],
+	}
+}
+
+// e12Coeffs returns the 12 tower-basis coefficients of an E12 element.
+func e12Coeffs(e *E12) [12]frontend.Variable {
+	return [12]frontend.Variable{
+		e.C0.B0.A0, e.C0.B0.A1, e.C0.B1.A0, e.C0.B1.A1, e.C0.B2.A0, e.C0.B2.A1,
+		e.C1.B0.A0, e.C1.B0.A1, e.C1.B1.A0, e.C1.B1.A1, e.C1.B2.A0, e.C1.B2.A1,
+	}
+}
+
+// assignE12 sets the 12 tower-basis coefficients of an E12 element.
+func assignE12(e *E12, v []frontend.Variable) {
+	e.C0.B0.A0, e.C0.B0.A1 = v[0], v[1]
+	e.C0.B1.A0, e.C0.B1.A1 = v[2], v[3]
+	e.C0.B2.A0, e.C0.B2.A1 = v[4], v[5]
+	e.C1.B0.A0, e.C1.B0.A1 = v[6], v[7]
+	e.C1.B1.A0, e.C1.B1.A1 = v[8], v[9]
+	e.C1.B2.A0, e.C1.B2.A1 = v[10], v[11]
+}
+
+// e12MulCheck stores one deferred a*b=c check in monomial form.
+type e12MulCheck struct {
+	a, b, c    [12]frontend.Variable // monomial coefficients (degree 11)
+	q          [11]frontend.Variable // quotient monomial coefficients (degree 10)
+	isSquare   bool                  // if true, b is ignored and a(r)² is checked
+	bSparseIdx []int                 // if non-nil, only these indices of b are nonzero variables
+	bConstIdx  []int                 // indices of b that are constants (e.g., 1)
+}
+
+// e12SZChecker accumulates E12 multiplication checks and resolves them
+// in a single deferred callback using a shared Fiat-Shamir challenge.
+type e12SZChecker struct {
+	checks []e12MulCheck
+}
+
+var (
+	e12szMu       sync.Mutex
+	e12szCheckers = map[frontend.Compiler]*e12SZChecker{}
+)
+
+func getE12SZChecker(api frontend.API) *e12SZChecker {
+	compiler := api.Compiler()
+
+	e12szMu.Lock()
+	ch, ok := e12szCheckers[compiler]
+	if ok {
+		e12szMu.Unlock()
+		return ch
+	}
+	ch = &e12SZChecker{}
+	e12szCheckers[compiler] = ch
+	e12szMu.Unlock()
+
+	compiler.Defer(func(api frontend.API) error {
+		defer func() {
+			e12szMu.Lock()
+			delete(e12szCheckers, compiler)
+			e12szMu.Unlock()
+		}()
+		return ch.resolve(api)
+	})
+	return ch
+}
+
+func (ch *e12SZChecker) addCheck(a, b, c [12]frontend.Variable, q [11]frontend.Variable) {
+	ch.checks = append(ch.checks, e12MulCheck{a: a, b: b, c: c, q: q, isSquare: false})
+}
+
+func (ch *e12SZChecker) addSquareCheck(a, c [12]frontend.Variable, q [11]frontend.Variable) {
+	ch.checks = append(ch.checks, e12MulCheck{a: a, c: c, q: q, isSquare: true})
+}
+
+// addSparseCheck registers a check where b has only some nonzero coefficients.
+// sparseVarIdx: indices of b that are circuit variables
+// sparseConstIdx: indices of b that are known constants (e.g., index 0 = 1 for MulBy034)
+func (ch *e12SZChecker) addSparseCheck(a, b, c [12]frontend.Variable, q [11]frontend.Variable, sparseVarIdx, sparseConstIdx []int) {
+	ch.checks = append(ch.checks, e12MulCheck{
+		a: a, b: b, c: c, q: q,
+		bSparseIdx: sparseVarIdx, bConstIdx: sparseConstIdx,
+	})
+}
+
+// resolve performs all accumulated checks using a single commitment challenge.
+func (ch *e12SZChecker) resolve(api frontend.API) error {
+	if len(ch.checks) == 0 {
+		return nil
+	}
+
+	var toCommit []frontend.Variable
+	for i := range ch.checks {
+		toCommit = append(toCommit, ch.checks[i].c[:]...)
+		toCommit = append(toCommit, ch.checks[i].q[:]...)
+	}
+
+	// BLS12-377 is a large field — use plain WithCommitment (single Fp challenge).
+	// Soundness: 22/p ≈ 2^{-372}.
+	multicommit.WithCommitment(api, func(api frontend.API, commitment frontend.Variable) error {
+		r := commitment
+
+		// Precompute r², ..., r¹² (11 gates, shared across all checks)
+		rPow := make([]frontend.Variable, 13)
+		rPow[0] = frontend.Variable(1)
+		rPow[1] = r
+		for i := 2; i <= 12; i++ {
+			rPow[i] = api.Mul(rPow[i-1], r)
+		}
+
+		// P(r) = r^12 + 5
+		pEval := api.Add(rPow[12], 5)
+
+		// Batching coefficient: α = r^13
+		alpha := api.Mul(rPow[12], r)
+
+		lhsAcc := frontend.Variable(0)
+		rhsAcc := frontend.Variable(0)
+		alphaPow := frontend.Variable(1)
+
+		for i := range ch.checks {
+			chk := &ch.checks[i]
+
+			aEval := evalAtPowers12(api, chk.a[:], rPow)
+			var abEval frontend.Variable
+			if chk.isSquare {
+				abEval = api.Mul(aEval, aEval)
+			} else if chk.bSparseIdx != nil {
+				// sparse b: only evaluate nonzero terms
+				bEval := evalSparse12(api, chk.b[:], rPow, chk.bSparseIdx, chk.bConstIdx)
+				abEval = api.Mul(aEval, bEval)
+			} else {
+				bEval := evalAtPowers12(api, chk.b[:], rPow)
+				abEval = api.Mul(aEval, bEval)
+			}
+			cEval := evalAtPowers12(api, chk.c[:], rPow)
+			qEval := evalAtPowers12(api, chk.q[:], rPow)
+			qpEval := api.Mul(qEval, pEval)
+			rhs := api.Add(qpEval, cEval)
+
+			lhsAcc = api.Add(lhsAcc, api.Mul(alphaPow, abEval))
+			rhsAcc = api.Add(rhsAcc, api.Mul(alphaPow, rhs))
+
+			if i < len(ch.checks)-1 {
+				alphaPow = api.Mul(alphaPow, alpha)
+			}
+		}
+
+		api.AssertIsEqual(lhsAcc, rhsAcc)
+		return nil
+	}, toCommit...)
+
+	return nil
+}
+
+// evalAtPowers12 evaluates coeffs[0] + coeffs[1]*r + ... + coeffs[n-1]*r^(n-1)
+// using precomputed powers.
+func evalAtPowers12(api frontend.API, coeffs []frontend.Variable, rPow []frontend.Variable) frontend.Variable {
+	result := coeffs[0]
+	for i := 1; i < len(coeffs); i++ {
+		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
+	}
+	return result
+}
+
+// evalSparse12 evaluates a polynomial where only some coefficients are nonzero.
+// varIdx: indices with circuit variable coefficients (need api.Mul)
+// constIdx: indices with constant coefficients (api.Mul by constant is free, just api.Add)
+func evalSparse12(api frontend.API, coeffs []frontend.Variable, rPow []frontend.Variable, varIdx, constIdx []int) frontend.Variable {
+	var result frontend.Variable = 0
+	for _, i := range constIdx {
+		// constant * r^i: the Mul is free (constant multiplication)
+		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
+	}
+	for _, i := range varIdx {
+		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
+	}
+	return result
+}
+
+// mulBy034E12SZHint computes c = a * sparse(1,0,0,c3,c4,0) in Fp12.
+//
+// inputs:  16 big.Ints (12 for a in tower, 2 for c3, 2 for c4)
+// outputs: 23 big.Ints (12 for c in tower, 11 for q in monomial)
+func mulBy034E12SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	if len(inputs) != 16 {
+		return fmt.Errorf("mulBy034E12SZHint: expected 16 inputs, got %d", len(inputs))
+	}
+	if len(outputs) != 23 {
+		return fmt.Errorf("mulBy034E12SZHint: expected 23 outputs, got %d", len(outputs))
+	}
+
+	var a, b, c bls12377.E12
+	setNativeE12(&a, inputs[:12])
+	// b = (1, 0, 0, c3, c4, 0) in tower form
+	b.C0.B0.SetOne()
+	b.C1.B0.A0.SetBigInt(inputs[12])
+	b.C1.B0.A1.SetBigInt(inputs[13])
+	b.C1.B1.A0.SetBigInt(inputs[14])
+	b.C1.B1.A1.SetBigInt(inputs[15])
+	c.Mul(&a, &b)
+
+	getNativeE12(&c, outputs[:12])
+
+	aMono := e12TowerToMonomialBigInt(&a)
+	bMono := e12TowerToMonomialBigInt(&b)
+
+	p := bls12377.ID.BaseField()
+	var prod [23]big.Int
+	for i := 0; i < 12; i++ {
+		for j := 0; j < 12; j++ {
+			var t big.Int
+			t.Mul(&aMono[i], &bMono[j])
+			prod[i+j].Add(&prod[i+j], &t)
+			prod[i+j].Mod(&prod[i+j], p)
+		}
+	}
+
+	five := big.NewInt(5)
+	var q [11]big.Int
+	for i := 10; i >= 0; i-- {
+		q[i].Set(&prod[i+12])
+		q[i].Mod(&q[i], p)
+		var t big.Int
+		t.Mul(&q[i], five)
+		prod[i].Sub(&prod[i], &t)
+		prod[i].Mod(&prod[i], p)
+	}
+
+	for i := 0; i < 11; i++ {
+		outputs[12+i].Set(&q[i])
+	}
+	return nil
+}
+
+// mulE12SZHint computes c = a*b in Fp12 and the quotient q such that
+// a(X)*b(X) = q(X)*(X^12+5) + c(X) in Fp[X].
+//
+// inputs:  24 big.Ints (12 for a, 12 for b, both in tower basis)
+// outputs: 23 big.Ints (12 for c in tower basis, 11 for q in monomial basis)
+func mulE12SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	if len(inputs) != 24 {
+		return fmt.Errorf("mulE12SZHint: expected 24 inputs, got %d", len(inputs))
+	}
+	if len(outputs) != 23 {
+		return fmt.Errorf("mulE12SZHint: expected 23 outputs, got %d", len(outputs))
+	}
+
+	var a, b, c bls12377.E12
+	setNativeE12(&a, inputs[:12])
+	setNativeE12(&b, inputs[12:])
+	c.Mul(&a, &b)
+
+	// output c in tower basis (first 12 outputs)
+	getNativeE12(&c, outputs[:12])
+
+	// convert a, b to monomial form for polynomial multiplication
+	aMono := e12TowerToMonomialBigInt(&a)
+	bMono := e12TowerToMonomialBigInt(&b)
+
+	// polynomial multiply: prod = aMono * bMono (degree 22, 23 coefficients)
+	p := bls12377.ID.BaseField()
+	var prod [23]big.Int
+	for i := 0; i < 12; i++ {
+		for j := 0; j < 12; j++ {
+			var t big.Int
+			t.Mul(&aMono[i], &bMono[j])
+			prod[i+j].Add(&prod[i+j], &t)
+			prod[i+j].Mod(&prod[i+j], p)
+		}
+	}
+
+	// divide by P(X) = X^12 + 5 (monic degree 12)
+	// q[i] = prod[i+12] for i = 10..0, then fold: prod[i] += prod[i+12]*(-5)
+	five := big.NewInt(5)
+	var q [11]big.Int
+	for i := 10; i >= 0; i-- {
+		q[i].Set(&prod[i+12])
+		q[i].Mod(&q[i], p)
+		// subtract q[i] * 5 from prod[i] (since P = X^12 + 5, constant term is +5)
+		var t big.Int
+		t.Mul(&q[i], five)
+		prod[i].Sub(&prod[i], &t)
+		prod[i].Mod(&prod[i], p)
+	}
+
+	// output q in monomial basis (last 11 outputs)
+	for i := 0; i < 11; i++ {
+		outputs[12+i].Set(&q[i])
+	}
+	return nil
+}
+
+// squareE12SZHint computes c = a² in Fp12 and the quotient q such that
+// a(X)² = q(X)*(X^12+5) + c(X) in Fp[X].
+//
+// inputs:  12 big.Ints (a in tower basis)
+// outputs: 23 big.Ints (12 for c in tower basis, 11 for q in monomial basis)
+func squareE12SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	if len(inputs) != 12 {
+		return fmt.Errorf("squareE12SZHint: expected 12 inputs, got %d", len(inputs))
+	}
+	if len(outputs) != 23 {
+		return fmt.Errorf("squareE12SZHint: expected 23 outputs, got %d", len(outputs))
+	}
+
+	var a, c bls12377.E12
+	setNativeE12(&a, inputs)
+	c.Square(&a)
+
+	getNativeE12(&c, outputs[:12])
+
+	aMono := e12TowerToMonomialBigInt(&a)
+
+	p := bls12377.ID.BaseField()
+	var prod [23]big.Int
+	for i := 0; i < 12; i++ {
+		for j := 0; j < 12; j++ {
+			var t big.Int
+			t.Mul(&aMono[i], &aMono[j])
+			prod[i+j].Add(&prod[i+j], &t)
+			prod[i+j].Mod(&prod[i+j], p)
+		}
+	}
+
+	five := big.NewInt(5)
+	var q [11]big.Int
+	for i := 10; i >= 0; i-- {
+		q[i].Set(&prod[i+12])
+		q[i].Mod(&q[i], p)
+		var t big.Int
+		t.Mul(&q[i], five)
+		prod[i].Sub(&prod[i], &t)
+		prod[i].Mod(&prod[i], p)
+	}
+
+	for i := 0; i < 11; i++ {
+		outputs[12+i].Set(&q[i])
+	}
+	return nil
+}
+
+func setNativeE12(dst *bls12377.E12, inputs []*big.Int) {
+	dst.C0.B0.A0.SetBigInt(inputs[0])
+	dst.C0.B0.A1.SetBigInt(inputs[1])
+	dst.C0.B1.A0.SetBigInt(inputs[2])
+	dst.C0.B1.A1.SetBigInt(inputs[3])
+	dst.C0.B2.A0.SetBigInt(inputs[4])
+	dst.C0.B2.A1.SetBigInt(inputs[5])
+	dst.C1.B0.A0.SetBigInt(inputs[6])
+	dst.C1.B0.A1.SetBigInt(inputs[7])
+	dst.C1.B1.A0.SetBigInt(inputs[8])
+	dst.C1.B1.A1.SetBigInt(inputs[9])
+	dst.C1.B2.A0.SetBigInt(inputs[10])
+	dst.C1.B2.A1.SetBigInt(inputs[11])
+}
+
+func getNativeE12(src *bls12377.E12, outputs []*big.Int) {
+	src.C0.B0.A0.BigInt(outputs[0])
+	src.C0.B0.A1.BigInt(outputs[1])
+	src.C0.B1.A0.BigInt(outputs[2])
+	src.C0.B1.A1.BigInt(outputs[3])
+	src.C0.B2.A0.BigInt(outputs[4])
+	src.C0.B2.A1.BigInt(outputs[5])
+	src.C1.B0.A0.BigInt(outputs[6])
+	src.C1.B0.A1.BigInt(outputs[7])
+	src.C1.B1.A0.BigInt(outputs[8])
+	src.C1.B1.A1.BigInt(outputs[9])
+	src.C1.B2.A0.BigInt(outputs[10])
+	src.C1.B2.A1.BigInt(outputs[11])
+}
+
+// e12TowerToMonomialBigInt converts tower-basis E12 to monomial-basis big.Ints.
+func e12TowerToMonomialBigInt(e *bls12377.E12) [12]big.Int {
+	var tower [12]big.Int
+	e.C0.B0.A0.BigInt(&tower[0])
+	e.C0.B0.A1.BigInt(&tower[1])
+	e.C0.B1.A0.BigInt(&tower[2])
+	e.C0.B1.A1.BigInt(&tower[3])
+	e.C0.B2.A0.BigInt(&tower[4])
+	e.C0.B2.A1.BigInt(&tower[5])
+	e.C1.B0.A0.BigInt(&tower[6])
+	e.C1.B0.A1.BigInt(&tower[7])
+	e.C1.B1.A0.BigInt(&tower[8])
+	e.C1.B1.A1.BigInt(&tower[9])
+	e.C1.B2.A0.BigInt(&tower[10])
+	e.C1.B2.A1.BigInt(&tower[11])
+	// permutation: mono[degree] = tower[index]
+	return [12]big.Int{
+		tower[0], tower[6], tower[2], tower[8], tower[4], tower[10],
+		tower[1], tower[7], tower[3], tower[9], tower[5], tower[11],
+	}
+}

--- a/std/algebra/native/fields_bls12377/e12_sz_test.go
+++ b/std/algebra/native/fields_bls12377/e12_sz_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
-	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs"
@@ -57,7 +56,7 @@ func TestE12MulSZCorrectness(t *testing.T) {
 	c.Mul(&a, &b)
 
 	circuit := newE12MulNCircuit(1)
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -101,7 +100,7 @@ func TestE12MulSZRejectsCorruptedQuotientHint(t *testing.T) {
 	c.Mul(&a, &b)
 
 	circuit := newE12MulNCircuit(1)
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +130,7 @@ func TestE12MulSZRejectsForgedInputsWhenCommitted(t *testing.T) {
 	field := ecc.BW6_761.ScalarField()
 
 	circuit := newE12MulNCircuit(1)
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +168,7 @@ func TestE12MulSZMultiple(t *testing.T) {
 
 	n := 4
 	circuit := newE12MulNCircuit(n)
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -202,7 +201,7 @@ func TestE12SquareSZCorrectness(t *testing.T) {
 	c.Square(&a)
 
 	circuit := &e12SquareNCircuit{N: 1, A: make([]E12, 1), C: make([]E12, 1)}
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -301,7 +300,7 @@ func TestE12MulBy034SZCorrectness(t *testing.T) {
 	res.Mul(&a, &sparse)
 
 	circuit := &e12MulBy034SZCircuit{}
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +361,7 @@ func TestE12MulBy01234SZCorrectness(t *testing.T) {
 	res.Mul(&a, &sparse)
 
 	circuit := &e12MulBy01234SZCircuit{}
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,7 +397,7 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 
 	for _, n := range []int{1, 2, 4, 8, 16} {
 		circuit := newE12MulNCircuit(n)
-		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+		ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 		if err != nil {
 			t.Fatalf("compile N=%d: %v", n, err)
 		}
@@ -406,7 +405,7 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 		if n == 1 {
 			t.Logf("  N=%2d: total=%d SCS", n, nb)
 		} else {
-			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, newE12MulNCircuit(1))
+			ccs1, _ := frontend.Compile(field, scs.NewBuilder, newE12MulNCircuit(1))
 			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
 			t.Logf("  N=%2d: total=%d SCS, marginal/mul=%d", n, nb, marginal)
 		}
@@ -415,7 +414,7 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 	t.Log("=== E12 MulBy01234 SCS Constraint Counts (Schwartz-Zippel) ===")
 	for _, n := range []int{1, 2, 4} {
 		circuit := &e12MulBy01234NCircuit{N: n, A: make([]E12, n), X: make([][5]E2, n)}
-		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+		ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 		if err != nil {
 			t.Fatalf("compile mulby01234 N=%d: %v", n, err)
 		}
@@ -423,7 +422,7 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 		if n == 1 {
 			t.Logf("  N=%2d: total=%d SCS", n, nb)
 		} else {
-			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, &e12MulBy01234NCircuit{N: 1, A: make([]E12, 1), X: make([][5]E2, 1)})
+			ccs1, _ := frontend.Compile(field, scs.NewBuilder, &e12MulBy01234NCircuit{N: 1, A: make([]E12, 1), X: make([][5]E2, 1)})
 			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
 			t.Logf("  N=%2d: total=%d SCS, marginal/op=%d", n, nb, marginal)
 		}
@@ -432,7 +431,7 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 	t.Log("=== E12 MulBy034 SCS Constraint Counts (Schwartz-Zippel) ===")
 	for _, n := range []int{1, 2, 4, 8} {
 		circuit := &e12MulBy034NCircuit{N: n, A: make([]E12, n), C3: make([]E2, n), C4: make([]E2, n)}
-		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+		ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 		if err != nil {
 			t.Fatalf("compile mulby034 N=%d: %v", n, err)
 		}
@@ -440,7 +439,7 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 		if n == 1 {
 			t.Logf("  N=%2d: total=%d SCS", n, nb)
 		} else {
-			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, &e12MulBy034NCircuit{N: 1, A: make([]E12, 1), C3: make([]E2, 1), C4: make([]E2, 1)})
+			ccs1, _ := frontend.Compile(field, scs.NewBuilder, &e12MulBy034NCircuit{N: 1, A: make([]E12, 1), C3: make([]E2, 1), C4: make([]E2, 1)})
 			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
 			t.Logf("  N=%2d: total=%d SCS, marginal/op=%d", n, nb, marginal)
 		}
@@ -449,7 +448,7 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 	t.Log("=== E12 Square SCS Constraint Counts (Schwartz-Zippel) ===")
 	for _, n := range []int{1, 2, 4, 8} {
 		circuit := &e12SquareNCircuit{N: n, A: make([]E12, n), C: make([]E12, n)}
-		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+		ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 		if err != nil {
 			t.Fatalf("compile square N=%d: %v", n, err)
 		}
@@ -457,7 +456,7 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 		if n == 1 {
 			t.Logf("  N=%2d: total=%d SCS", n, nb)
 		} else {
-			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, &e12SquareNCircuit{N: 1, A: make([]E12, 1), C: make([]E12, 1)})
+			ccs1, _ := frontend.Compile(field, scs.NewBuilder, &e12SquareNCircuit{N: 1, A: make([]E12, 1), C: make([]E12, 1)})
 			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
 			t.Logf("  N=%2d: total=%d SCS, marginal/sq=%d", n, nb, marginal)
 		}

--- a/std/algebra/native/fields_bls12377/e12_sz_test.go
+++ b/std/algebra/native/fields_bls12377/e12_sz_test.go
@@ -1,0 +1,395 @@
+package fields_bls12377
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
+	"github.com/consensys/gnark/constraint"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/scs"
+)
+
+type e12MulNCircuit struct {
+	N    int
+	A, B []E12
+	C    []E12
+}
+
+func (c *e12MulNCircuit) Define(api frontend.API) error {
+	for i := 0; i < c.N; i++ {
+		var r E12
+		r.Mul(api, c.A[i], c.B[i])
+		r.AssertIsEqual(api, c.C[i])
+	}
+	return nil
+}
+
+func newE12MulNCircuit(n int) *e12MulNCircuit {
+	return &e12MulNCircuit{N: n, A: make([]E12, n), B: make([]E12, n), C: make([]E12, n)}
+}
+
+func randomE12() bls12377.E12 {
+	var e bls12377.E12
+	e.SetRandom()
+	return e
+}
+
+func assignE12Circuit(a, b, c bls12377.E12) (aCirc, bCirc, cCirc E12) {
+	aCirc.Assign(&a)
+	bCirc.Assign(&b)
+	cCirc.Assign(&c)
+	return
+}
+
+// TestE12MulSZCorrectness verifies that the SZ multiplication path produces
+// correct results by compiling with scs.NewBuilder (which supports Committer,
+// triggering the SZ path) and solving with native gnark-crypto values.
+func TestE12MulSZCorrectness(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+
+	// random test vectors
+	a := randomE12()
+	b := randomE12()
+	var c bls12377.E12
+	c.Mul(&a, &b)
+
+	circuit := newE12MulNCircuit(1)
+	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	aCirc, bCirc, cCirc := assignE12Circuit(a, b, c)
+	witness := &e12MulNCircuit{
+		N: 1,
+		A: []E12{aCirc},
+		B: []E12{bCirc},
+		C: []E12{cCirc},
+	}
+	w, err := frontend.NewWitness(witness, field)
+	if err != nil {
+		t.Fatalf("witness: %v", err)
+	}
+	if err := ccs.IsSolved(w); err != nil {
+		t.Fatalf("SZ mul solve failed: %v", err)
+	}
+
+	// also test with wrong result (should fail)
+	var cWrong bls12377.E12
+	cWrong.SetRandom()
+	_, _, cWrongCirc := assignE12Circuit(a, b, cWrong)
+	badWitness := &e12MulNCircuit{
+		N: 1,
+		A: []E12{aCirc},
+		B: []E12{bCirc},
+		C: []E12{cWrongCirc},
+	}
+	w2, _ := frontend.NewWitness(badWitness, field)
+	if err := ccs.IsSolved(w2); err == nil {
+		t.Fatal("SZ mul should reject wrong result")
+	}
+}
+
+// TestE12MulSZMultiple verifies multiple SZ multiplications batched with
+// a single commitment.
+func TestE12MulSZMultiple(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+
+	n := 4
+	circuit := newE12MulNCircuit(n)
+	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	witness := newE12MulNCircuit(n)
+	for i := 0; i < n; i++ {
+		a := randomE12()
+		b := randomE12()
+		var c bls12377.E12
+		c.Mul(&a, &b)
+		witness.A[i].Assign(&a)
+		witness.B[i].Assign(&b)
+		witness.C[i].Assign(&c)
+	}
+	w, err := frontend.NewWitness(witness, field)
+	if err != nil {
+		t.Fatalf("witness: %v", err)
+	}
+	if err := ccs.IsSolved(w); err != nil {
+		t.Fatalf("SZ mul multiple solve failed: %v", err)
+	}
+}
+
+// TestE12SquareSZCorrectness verifies the SZ square path.
+func TestE12SquareSZCorrectness(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+
+	a := randomE12()
+	var c bls12377.E12
+	c.Square(&a)
+
+	circuit := &e12SquareNCircuit{N: 1, A: make([]E12, 1), C: make([]E12, 1)}
+	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	witness := &e12SquareNCircuit{N: 1, A: make([]E12, 1), C: make([]E12, 1)}
+	witness.A[0].Assign(&a)
+	witness.C[0].Assign(&c)
+	w, err := frontend.NewWitness(witness, field)
+	if err != nil {
+		t.Fatalf("witness: %v", err)
+	}
+	if err := ccs.IsSolved(w); err != nil {
+		t.Fatalf("SZ square solve failed: %v", err)
+	}
+
+	// wrong result should fail
+	var cWrong bls12377.E12
+	cWrong.SetRandom()
+	bad := &e12SquareNCircuit{N: 1, A: make([]E12, 1), C: make([]E12, 1)}
+	bad.A[0].Assign(&a)
+	bad.C[0].Assign(&cWrong)
+	w2, _ := frontend.NewWitness(bad, field)
+	if err := ccs.IsSolved(w2); err == nil {
+		t.Fatal("SZ square should reject wrong result")
+	}
+}
+
+type e12SquareNCircuit struct {
+	N int
+	A []E12
+	C []E12
+}
+
+func (c *e12SquareNCircuit) Define(api frontend.API) error {
+	for i := 0; i < c.N; i++ {
+		var r E12
+		r.Square(api, c.A[i])
+		r.AssertIsEqual(api, c.C[i])
+	}
+	return nil
+}
+
+type e12MulBy01234NCircuit struct {
+	N int
+	A []E12
+	X [][5]E2
+}
+
+func (c *e12MulBy01234NCircuit) Define(api frontend.API) error {
+	for i := 0; i < c.N; i++ {
+		c.A[i].MulBy01234(api, c.X[i])
+	}
+	return nil
+}
+
+type e12MulBy034NCircuit struct {
+	N      int
+	A      []E12
+	C3, C4 []E2
+}
+
+func (c *e12MulBy034NCircuit) Define(api frontend.API) error {
+	for i := 0; i < c.N; i++ {
+		c.A[i].MulBy034(api, c.C3[i], c.C4[i])
+	}
+	return nil
+}
+
+// --- E12.MulBy034 SZ correctness ---
+
+type e12MulBy034SZCircuit struct {
+	A      E12
+	C3, C4 E2
+	Res    E12
+}
+
+func (c *e12MulBy034SZCircuit) Define(api frontend.API) error {
+	r := c.A
+	r.MulBy034(api, c.C3, c.C4)
+	r.AssertIsEqual(api, c.Res)
+	return nil
+}
+
+func TestE12MulBy034SZCorrectness(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+	a := randomE12()
+	var c3, c4 bls12377.E2
+	c3.SetRandom()
+	c4.SetRandom()
+
+	var sparse bls12377.E12
+	sparse.C0.B0.SetOne()
+	sparse.C1.B0 = c3
+	sparse.C1.B1 = c4
+	var res bls12377.E12
+	res.Mul(&a, &sparse)
+
+	circuit := &e12MulBy034SZCircuit{}
+	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witness := &e12MulBy034SZCircuit{}
+	witness.A.Assign(&a)
+	witness.C3.Assign(&c3)
+	witness.C4.Assign(&c4)
+	witness.Res.Assign(&res)
+	w, _ := frontend.NewWitness(witness, field)
+	if err := ccs.IsSolved(w); err != nil {
+		t.Fatalf("E12.MulBy034 SZ solve failed: %v", err)
+	}
+
+	var resWrong bls12377.E12
+	resWrong.SetRandom()
+	bad := &e12MulBy034SZCircuit{}
+	bad.A.Assign(&a)
+	bad.C3.Assign(&c3)
+	bad.C4.Assign(&c4)
+	bad.Res.Assign(&resWrong)
+	w2, _ := frontend.NewWitness(bad, field)
+	if err := ccs.IsSolved(w2); err == nil {
+		t.Fatal("E12.MulBy034 SZ should reject wrong result")
+	}
+}
+
+// --- E12.MulBy01234 SZ correctness ---
+
+type e12MulBy01234SZCircuit struct {
+	A   E12
+	X   [5]E2
+	Res E12
+}
+
+func (c *e12MulBy01234SZCircuit) Define(api frontend.API) error {
+	r := c.A
+	r.MulBy01234(api, c.X)
+	r.AssertIsEqual(api, c.Res)
+	return nil
+}
+
+func TestE12MulBy01234SZCorrectness(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+	a := randomE12()
+	var x [5]bls12377.E2
+	for i := range x {
+		x[i].SetRandom()
+	}
+
+	var sparse bls12377.E12
+	sparse.C0.B0 = x[0]
+	sparse.C0.B1 = x[1]
+	sparse.C0.B2 = x[2]
+	sparse.C1.B0 = x[3]
+	sparse.C1.B1 = x[4]
+	var res bls12377.E12
+	res.Mul(&a, &sparse)
+
+	circuit := &e12MulBy01234SZCircuit{}
+	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witness := &e12MulBy01234SZCircuit{}
+	witness.A.Assign(&a)
+	for i := range x {
+		witness.X[i].Assign(&x[i])
+	}
+	witness.Res.Assign(&res)
+	w, _ := frontend.NewWitness(witness, field)
+	if err := ccs.IsSolved(w); err != nil {
+		t.Fatalf("E12.MulBy01234 SZ solve failed: %v", err)
+	}
+
+	var resWrong bls12377.E12
+	resWrong.SetRandom()
+	bad := &e12MulBy01234SZCircuit{}
+	bad.A.Assign(&a)
+	for i := range x {
+		bad.X[i].Assign(&x[i])
+	}
+	bad.Res.Assign(&resWrong)
+	w2, _ := frontend.NewWitness(bad, field)
+	if err := ccs.IsSolved(w2); err == nil {
+		t.Fatal("E12.MulBy01234 SZ should reject wrong result")
+	}
+}
+
+func TestE12MulSZConstraintCount(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+	fmt.Println("=== E12 Multiplication SCS Constraint Counts (Schwartz-Zippel) ===")
+
+	for _, n := range []int{1, 2, 4, 8, 16} {
+		circuit := newE12MulNCircuit(n)
+		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+		if err != nil {
+			t.Fatalf("compile N=%d: %v", n, err)
+		}
+		nb := ccs.GetNbConstraints()
+		if n == 1 {
+			fmt.Printf("  N=%2d: total=%d SCS\n", n, nb)
+		} else {
+			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, newE12MulNCircuit(1))
+			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
+			fmt.Printf("  N=%2d: total=%d SCS, marginal/mul=%d\n", n, nb, marginal)
+		}
+	}
+
+	fmt.Println("\n=== E12 MulBy01234 SCS Constraint Counts (Schwartz-Zippel) ===")
+	for _, n := range []int{1, 2, 4} {
+		circuit := &e12MulBy01234NCircuit{N: n, A: make([]E12, n), X: make([][5]E2, n)}
+		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+		if err != nil {
+			t.Fatalf("compile mulby01234 N=%d: %v", n, err)
+		}
+		nb := ccs.GetNbConstraints()
+		if n == 1 {
+			fmt.Printf("  N=%2d: total=%d SCS\n", n, nb)
+		} else {
+			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, &e12MulBy01234NCircuit{N: 1, A: make([]E12, 1), X: make([][5]E2, 1)})
+			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
+			fmt.Printf("  N=%2d: total=%d SCS, marginal/op=%d\n", n, nb, marginal)
+		}
+	}
+
+	fmt.Println("\n=== E12 MulBy034 SCS Constraint Counts (Schwartz-Zippel) ===")
+	for _, n := range []int{1, 2, 4, 8} {
+		circuit := &e12MulBy034NCircuit{N: n, A: make([]E12, n), C3: make([]E2, n), C4: make([]E2, n)}
+		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+		if err != nil {
+			t.Fatalf("compile mulby034 N=%d: %v", n, err)
+		}
+		nb := ccs.GetNbConstraints()
+		if n == 1 {
+			fmt.Printf("  N=%2d: total=%d SCS\n", n, nb)
+		} else {
+			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, &e12MulBy034NCircuit{N: 1, A: make([]E12, 1), C3: make([]E2, 1), C4: make([]E2, 1)})
+			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
+			fmt.Printf("  N=%2d: total=%d SCS, marginal/op=%d\n", n, nb, marginal)
+		}
+	}
+
+	fmt.Println("\n=== E12 Square SCS Constraint Counts (Schwartz-Zippel) ===")
+	for _, n := range []int{1, 2, 4, 8} {
+		circuit := &e12SquareNCircuit{N: n, A: make([]E12, n), C: make([]E12, n)}
+		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+		if err != nil {
+			t.Fatalf("compile square N=%d: %v", n, err)
+		}
+		nb := ccs.GetNbConstraints()
+		if n == 1 {
+			fmt.Printf("  N=%2d: total=%d SCS\n", n, nb)
+		} else {
+			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, &e12SquareNCircuit{N: 1, A: make([]E12, 1), C: make([]E12, 1)})
+			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
+			fmt.Printf("  N=%2d: total=%d SCS, marginal/sq=%d\n", n, nb, marginal)
+		}
+	}
+}

--- a/std/algebra/native/fields_bls12377/e12_sz_test.go
+++ b/std/algebra/native/fields_bls12377/e12_sz_test.go
@@ -1,7 +1,6 @@
 package fields_bls12377
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -9,6 +8,7 @@ import (
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs"
 	"github.com/consensys/gnark/frontend/cs/scs"
 )
 
@@ -124,6 +124,41 @@ func TestE12MulSZRejectsCorruptedQuotientHint(t *testing.T) {
 	))
 	if err == nil {
 		t.Fatal("E12.Mul SZ should reject a corrupted quotient hint")
+	}
+}
+
+func TestE12MulSZRejectsForgedInputsWhenCommitted(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+
+	circuit := newE12MulNCircuit(1)
+	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Before committing a and b, the commitment hint sees depth + c + q:
+	// 1 + 12 + 11 inputs. The forged a(X)=X-r, b(X)=1, c=q=0 would pass.
+	const oldChallenge = 24
+	var a, b, c bls12377.E12
+	a.C0.B0.A0.SetBigInt(negBLS12377Base(oldChallenge))
+	a.C1.B0.A0.SetOne()
+	b.SetOne()
+
+	witness := newE12MulNCircuit(1)
+	witness.A[0].Assign(&a)
+	witness.B[0].Assign(&b)
+	witness.C[0].Assign(&c)
+	w, err := frontend.NewWitness(witness, field)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ccs.IsSolved(w,
+		solver.OverrideHint(solver.GetHintID(mulE12SZHint), zeroHintOutput),
+		solver.OverrideHint(solver.GetHintID(cs.Bsb22CommitmentComputePlaceholder), commitmentInputCountHint),
+	)
+	if err == nil {
+		t.Fatal("E12.Mul SZ should bind the challenge to multiplication inputs")
 	}
 }
 
@@ -359,7 +394,7 @@ func TestE12MulBy01234SZCorrectness(t *testing.T) {
 
 func TestE12MulSZConstraintCount(t *testing.T) {
 	field := ecc.BW6_761.ScalarField()
-	fmt.Println("=== E12 Multiplication SCS Constraint Counts (Schwartz-Zippel) ===")
+	t.Log("=== E12 Multiplication SCS Constraint Counts (Schwartz-Zippel) ===")
 
 	for _, n := range []int{1, 2, 4, 8, 16} {
 		circuit := newE12MulNCircuit(n)
@@ -369,15 +404,15 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 		}
 		nb := ccs.GetNbConstraints()
 		if n == 1 {
-			fmt.Printf("  N=%2d: total=%d SCS\n", n, nb)
+			t.Logf("  N=%2d: total=%d SCS", n, nb)
 		} else {
 			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, newE12MulNCircuit(1))
 			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
-			fmt.Printf("  N=%2d: total=%d SCS, marginal/mul=%d\n", n, nb, marginal)
+			t.Logf("  N=%2d: total=%d SCS, marginal/mul=%d", n, nb, marginal)
 		}
 	}
 
-	fmt.Println("\n=== E12 MulBy01234 SCS Constraint Counts (Schwartz-Zippel) ===")
+	t.Log("=== E12 MulBy01234 SCS Constraint Counts (Schwartz-Zippel) ===")
 	for _, n := range []int{1, 2, 4} {
 		circuit := &e12MulBy01234NCircuit{N: n, A: make([]E12, n), X: make([][5]E2, n)}
 		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
@@ -386,15 +421,15 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 		}
 		nb := ccs.GetNbConstraints()
 		if n == 1 {
-			fmt.Printf("  N=%2d: total=%d SCS\n", n, nb)
+			t.Logf("  N=%2d: total=%d SCS", n, nb)
 		} else {
 			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, &e12MulBy01234NCircuit{N: 1, A: make([]E12, 1), X: make([][5]E2, 1)})
 			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
-			fmt.Printf("  N=%2d: total=%d SCS, marginal/op=%d\n", n, nb, marginal)
+			t.Logf("  N=%2d: total=%d SCS, marginal/op=%d", n, nb, marginal)
 		}
 	}
 
-	fmt.Println("\n=== E12 MulBy034 SCS Constraint Counts (Schwartz-Zippel) ===")
+	t.Log("=== E12 MulBy034 SCS Constraint Counts (Schwartz-Zippel) ===")
 	for _, n := range []int{1, 2, 4, 8} {
 		circuit := &e12MulBy034NCircuit{N: n, A: make([]E12, n), C3: make([]E2, n), C4: make([]E2, n)}
 		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
@@ -403,15 +438,15 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 		}
 		nb := ccs.GetNbConstraints()
 		if n == 1 {
-			fmt.Printf("  N=%2d: total=%d SCS\n", n, nb)
+			t.Logf("  N=%2d: total=%d SCS", n, nb)
 		} else {
 			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, &e12MulBy034NCircuit{N: 1, A: make([]E12, 1), C3: make([]E2, 1), C4: make([]E2, 1)})
 			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
-			fmt.Printf("  N=%2d: total=%d SCS, marginal/op=%d\n", n, nb, marginal)
+			t.Logf("  N=%2d: total=%d SCS, marginal/op=%d", n, nb, marginal)
 		}
 	}
 
-	fmt.Println("\n=== E12 Square SCS Constraint Counts (Schwartz-Zippel) ===")
+	t.Log("=== E12 Square SCS Constraint Counts (Schwartz-Zippel) ===")
 	for _, n := range []int{1, 2, 4, 8} {
 		circuit := &e12SquareNCircuit{N: n, A: make([]E12, n), C: make([]E12, n)}
 		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
@@ -420,11 +455,11 @@ func TestE12MulSZConstraintCount(t *testing.T) {
 		}
 		nb := ccs.GetNbConstraints()
 		if n == 1 {
-			fmt.Printf("  N=%2d: total=%d SCS\n", n, nb)
+			t.Logf("  N=%2d: total=%d SCS", n, nb)
 		} else {
 			ccs1, _ := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, &e12SquareNCircuit{N: 1, A: make([]E12, 1), C: make([]E12, 1)})
 			marginal := (nb - ccs1.GetNbConstraints()) / (n - 1)
-			fmt.Printf("  N=%2d: total=%d SCS, marginal/sq=%d\n", n, nb, marginal)
+			t.Logf("  N=%2d: total=%d SCS, marginal/sq=%d", n, nb, marginal)
 		}
 	}
 }

--- a/std/algebra/native/fields_bls12377/e6.go
+++ b/std/algebra/native/fields_bls12377/e6.go
@@ -93,10 +93,42 @@ func (e *E6) Mul(api frontend.API, e1, e2 E6) *E6 {
 		case frontendtype.R1CS:
 			return e.mulToom3OverKaratsuba(api, e1, e2)
 		case frontendtype.SCS:
+			if _, ok := api.(frontend.Committer); ok {
+				return e.mulSZ(api, e1, e2)
+			}
 			return e.mulKaratsubaOverKaratsuba(api, e1, e2)
 		}
 	}
 	return e.mulKaratsubaOverKaratsuba(api, e1, e2)
+}
+
+// mulSZ computes e = e1 * e2 using the Schwartz-Zippel technique.
+// P(X) = X^6 + 5. Soundness: 10/p ≈ 2^{-373}.
+func (e *E6) mulSZ(api frontend.API, e1, e2 E6) *E6 {
+	aCoeffs := e6Coeffs(&e1)
+	bCoeffs := e6Coeffs(&e2)
+	in := make([]frontend.Variable, 12)
+	copy(in[:6], aCoeffs[:])
+	copy(in[6:], bCoeffs[:])
+
+	out, err := api.Compiler().NewHint(mulE6SZHint, 11, in...)
+	if err != nil {
+		panic(err)
+	}
+
+	assignE6(e, out[:6])
+
+	var q [5]frontend.Variable
+	copy(q[:], out[6:11])
+
+	aMono := towerToMonomial6(aCoeffs)
+	bMono := towerToMonomial6(bCoeffs)
+	cMono := towerToMonomial6(e6Coeffs(e))
+
+	ch := getE6SZChecker(api)
+	ch.addCheck(aMono, bMono, cMono, q)
+
+	return e
 }
 
 func (e *E6) mulKaratsubaOverKaratsuba(api frontend.API, e1, e2 E6) *E6 {
@@ -268,7 +300,17 @@ func (e *E6) MulByNonResidue(api frontend.API, e1 E6) *E6 {
 
 // Square sets z to the E6 product of x,x, returns e
 func (e *E6) Square(api frontend.API, x E6) *E6 {
+	if ft, ok := api.Compiler().(frontendtype.FrontendTyper); ok {
+		if ft.FrontendType() == frontendtype.SCS {
+			if _, ok := api.(frontend.Committer); ok {
+				return e.squareSZ(api, x)
+			}
+		}
+	}
+	return e.squareKaratsuba(api, x)
+}
 
+func (e *E6) squareKaratsuba(api frontend.API, x E6) *E6 {
 	// Algorithm 16 from https://eprint.iacr.org/2010/354.pdf
 	var c4, c5, c1, c2, c3, c0 E2
 	c4.Mul(api, x.B0, x.B1).Double(api, c4)
@@ -283,6 +325,30 @@ func (e *E6) Square(api frontend.API, x E6) *E6 {
 	e.B2.Add(api, c2, c4).Add(api, e.B2, c5).Sub(api, e.B2, c3)
 	e.B0 = c0
 	e.B1 = c1
+
+	return e
+}
+
+func (e *E6) squareSZ(api frontend.API, x E6) *E6 {
+	aCoeffs := e6Coeffs(&x)
+	in := make([]frontend.Variable, 6)
+	copy(in, aCoeffs[:])
+
+	out, err := api.Compiler().NewHint(squareE6SZHint, 11, in...)
+	if err != nil {
+		panic(err)
+	}
+
+	assignE6(e, out[:6])
+
+	var q [5]frontend.Variable
+	copy(q[:], out[6:11])
+
+	aMono := towerToMonomial6(aCoeffs)
+	cMono := towerToMonomial6(e6Coeffs(e))
+
+	ch := getE6SZChecker(api)
+	ch.addSquareCheck(aMono, cMono, q)
 
 	return e
 }
@@ -366,7 +432,57 @@ func (e *E6) MulByE2(api frontend.API, e1 E6, e2 E2) *E6 {
 
 // MulBy01 multiplication by sparse element (c0,c1,0)
 func (e *E6) MulBy01(api frontend.API, c0, c1 E2) *E6 {
+	if ft, ok := api.Compiler().(frontendtype.FrontendTyper); ok {
+		if ft.FrontendType() == frontendtype.SCS {
+			if _, ok := api.(frontend.Committer); ok {
+				return e.mulBy01SZ(api, c0, c1)
+			}
+		}
+	}
+	return e.mulBy01Karatsuba(api, c0, c1)
+}
 
+// mulBy01SZ computes e = e * sparse(c0, c1, 0) using SZ.
+// Sparse monomial indices: 0, 1, 3, 4 are variable; 2, 5 are zero.
+func (e *E6) mulBy01SZ(api frontend.API, c0, c1 E2) *E6 {
+	aCoeffs := e6Coeffs(e)
+	in := make([]frontend.Variable, 10)
+	copy(in[:6], aCoeffs[:])
+	in[6] = c0.A0
+	in[7] = c0.A1
+	in[8] = c1.A0
+	in[9] = c1.A1
+
+	out, err := api.Compiler().NewHint(mulBy01E6SZHint, 11, in...)
+	if err != nil {
+		panic(err)
+	}
+
+	assignE6(e, out[:6])
+
+	var q [5]frontend.Variable
+	copy(q[:], out[6:11])
+
+	aMono := towerToMonomial6(aCoeffs)
+	cMono := towerToMonomial6(e6Coeffs(e))
+
+	// sparse b: tower = [c0.A0, c0.A1, c1.A0, c1.A1, 0, 0]
+	// monomial = [c0.A0, c1.A0, 0, c0.A1, c1.A1, 0]
+	var bMono [6]frontend.Variable
+	bMono[0] = c0.A0
+	bMono[1] = c1.A0
+	bMono[2] = 0
+	bMono[3] = c0.A1
+	bMono[4] = c1.A1
+	bMono[5] = 0
+
+	ch := getE6SZChecker(api)
+	ch.addSparseCheck(aMono, bMono, cMono, q, []int{0, 1, 3, 4})
+
+	return e
+}
+
+func (e *E6) mulBy01Karatsuba(api frontend.API, c0, c1 E2) *E6 {
 	var a, b, tmp, t0, t1, t2 E2
 
 	a.Mul(api, e.B0, c0)

--- a/std/algebra/native/fields_bls12377/e6.go
+++ b/std/algebra/native/fields_bls12377/e6.go
@@ -125,8 +125,7 @@ func (e *E6) mulSZ(api frontend.API, e1, e2 E6) *E6 {
 	bMono := towerToMonomial6(bCoeffs)
 	cMono := towerToMonomial6(e6Coeffs(e))
 
-	ch := getE6SZChecker(api)
-	ch.addCheck(aMono, bMono, cMono, q)
+	addSZCheck(api, aMono[:], bMono[:], cMono[:], q[:])
 
 	return e
 }
@@ -347,8 +346,7 @@ func (e *E6) squareSZ(api frontend.API, x E6) *E6 {
 	aMono := towerToMonomial6(aCoeffs)
 	cMono := towerToMonomial6(e6Coeffs(e))
 
-	ch := getE6SZChecker(api)
-	ch.addSquareCheck(aMono, cMono, q)
+	addSZSquareCheck(api, aMono[:], cMono[:], q[:])
 
 	return e
 }
@@ -476,8 +474,7 @@ func (e *E6) mulBy01SZ(api frontend.API, c0, c1 E2) *E6 {
 	bMono[4] = c1.A1
 	bMono[5] = 0
 
-	ch := getE6SZChecker(api)
-	ch.addSparseCheck(aMono, bMono, cMono, q, []int{0, 1, 3, 4})
+	addSZCheck(api, aMono[:], bMono[:], cMono[:], q[:])
 
 	return e
 }

--- a/std/algebra/native/fields_bls12377/e6_sz.go
+++ b/std/algebra/native/fields_bls12377/e6_sz.go
@@ -1,0 +1,359 @@
+package fields_bls12377
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+
+	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
+	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/multicommit"
+)
+
+func init() {
+	solver.RegisterHint(mulE6SZHint, squareE6SZHint, mulBy01E6SZHint)
+}
+
+// Schwartz-Zippel based E6 multiplication/squaring for SCS.
+//
+// P(X) = X^6 + 5 is the irreducible polynomial for Fp6 over Fp.
+// Product degree: 10. Soundness: 10/p ≈ 2^{-373}.
+//
+// Gate cost: ~25 SCS per E6.Mul (marginal) vs ~78 for Karatsuba.
+
+// towerToMonomial6 reorders tower-basis E6 coefficients to monomial-basis.
+//
+// Tower basis: {1, u, v, uv, v², uv²} where u²=-5, v³=u.
+// With v=X: u=X³.
+//
+//	tower[0]=1   → X⁰   tower[1]=u   → X³
+//	tower[2]=v   → X¹   tower[3]=uv  → X⁴
+//	tower[4]=v²  → X²   tower[5]=uv² → X⁵
+func towerToMonomial6(t [6]frontend.Variable) [6]frontend.Variable {
+	return [6]frontend.Variable{t[0], t[2], t[4], t[1], t[3], t[5]}
+}
+
+func e6Coeffs(e *E6) [6]frontend.Variable {
+	return [6]frontend.Variable{
+		e.B0.A0, e.B0.A1, e.B1.A0, e.B1.A1, e.B2.A0, e.B2.A1,
+	}
+}
+
+func assignE6(e *E6, v []frontend.Variable) {
+	e.B0.A0, e.B0.A1 = v[0], v[1]
+	e.B1.A0, e.B1.A1 = v[2], v[3]
+	e.B2.A0, e.B2.A1 = v[4], v[5]
+}
+
+// e6MulCheck stores one deferred E6 multiplication check in monomial form.
+type e6MulCheck struct {
+	a, b, c    [6]frontend.Variable // monomial coefficients (degree 5)
+	q          [5]frontend.Variable // quotient monomial coefficients (degree 4)
+	isSquare   bool
+	bSparseIdx []int // if non-nil, only these indices of b are nonzero variables
+}
+
+type e6SZChecker struct {
+	checks []e6MulCheck
+}
+
+var (
+	e6szMu       sync.Mutex
+	e6szCheckers = map[frontend.Compiler]*e6SZChecker{}
+)
+
+func getE6SZChecker(api frontend.API) *e6SZChecker {
+	compiler := api.Compiler()
+
+	e6szMu.Lock()
+	ch, ok := e6szCheckers[compiler]
+	if ok {
+		e6szMu.Unlock()
+		return ch
+	}
+	ch = &e6SZChecker{}
+	e6szCheckers[compiler] = ch
+	e6szMu.Unlock()
+
+	compiler.Defer(func(api frontend.API) error {
+		defer func() {
+			e6szMu.Lock()
+			delete(e6szCheckers, compiler)
+			e6szMu.Unlock()
+		}()
+		return ch.resolve(api)
+	})
+	return ch
+}
+
+func (ch *e6SZChecker) addCheck(a, b, c [6]frontend.Variable, q [5]frontend.Variable) {
+	ch.checks = append(ch.checks, e6MulCheck{a: a, b: b, c: c, q: q})
+}
+
+func (ch *e6SZChecker) addSquareCheck(a, c [6]frontend.Variable, q [5]frontend.Variable) {
+	ch.checks = append(ch.checks, e6MulCheck{a: a, c: c, q: q, isSquare: true})
+}
+
+func (ch *e6SZChecker) addSparseCheck(a, b, c [6]frontend.Variable, q [5]frontend.Variable, sparseIdx []int) {
+	ch.checks = append(ch.checks, e6MulCheck{a: a, b: b, c: c, q: q, bSparseIdx: sparseIdx})
+}
+
+func (ch *e6SZChecker) resolve(api frontend.API) error {
+	if len(ch.checks) == 0 {
+		return nil
+	}
+
+	var toCommit []frontend.Variable
+	for i := range ch.checks {
+		toCommit = append(toCommit, ch.checks[i].c[:]...)
+		toCommit = append(toCommit, ch.checks[i].q[:]...)
+	}
+
+	multicommit.WithCommitment(api, func(api frontend.API, commitment frontend.Variable) error {
+		r := commitment
+
+		// Precompute r², ..., r⁶ (5 gates, shared)
+		rPow := make([]frontend.Variable, 7)
+		rPow[0] = frontend.Variable(1)
+		rPow[1] = r
+		for i := 2; i <= 6; i++ {
+			rPow[i] = api.Mul(rPow[i-1], r)
+		}
+
+		// P(r) = r^6 + 5
+		pEval := api.Add(rPow[6], 5)
+
+		// Batching coefficient
+		alpha := api.Mul(rPow[6], r) // r^7
+
+		lhsAcc := frontend.Variable(0)
+		rhsAcc := frontend.Variable(0)
+		alphaPow := frontend.Variable(1)
+
+		for i := range ch.checks {
+			chk := &ch.checks[i]
+
+			aEval := evalAtPowers6(api, chk.a[:], rPow)
+			var abEval frontend.Variable
+			if chk.isSquare {
+				abEval = api.Mul(aEval, aEval)
+			} else if chk.bSparseIdx != nil {
+				bEval := evalSparse6(api, chk.b[:], rPow, chk.bSparseIdx)
+				abEval = api.Mul(aEval, bEval)
+			} else {
+				bEval := evalAtPowers6(api, chk.b[:], rPow)
+				abEval = api.Mul(aEval, bEval)
+			}
+			cEval := evalAtPowers6(api, chk.c[:], rPow)
+			qEval := evalAtPowers6(api, chk.q[:], rPow)
+
+			qpEval := api.Mul(qEval, pEval)
+			rhs := api.Add(qpEval, cEval)
+
+			lhsAcc = api.Add(lhsAcc, api.Mul(alphaPow, abEval))
+			rhsAcc = api.Add(rhsAcc, api.Mul(alphaPow, rhs))
+
+			if i < len(ch.checks)-1 {
+				alphaPow = api.Mul(alphaPow, alpha)
+			}
+		}
+
+		api.AssertIsEqual(lhsAcc, rhsAcc)
+		return nil
+	}, toCommit...)
+
+	return nil
+}
+
+func evalAtPowers6(api frontend.API, coeffs []frontend.Variable, rPow []frontend.Variable) frontend.Variable {
+	result := coeffs[0]
+	for i := 1; i < len(coeffs); i++ {
+		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
+	}
+	return result
+}
+
+func evalSparse6(api frontend.API, coeffs []frontend.Variable, rPow []frontend.Variable, varIdx []int) frontend.Variable {
+	var result frontend.Variable = 0
+	for _, i := range varIdx {
+		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
+	}
+	return result
+}
+
+// mulBy01E6SZHint computes c = a * sparse(c0, c1, 0) in Fp6.
+// inputs: 10 (6 for a in tower, 2 for c0, 2 for c1)
+// outputs: 11 (6 for c in tower, 5 for q in monomial)
+func mulBy01E6SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	if len(inputs) != 10 {
+		return fmt.Errorf("mulBy01E6SZHint: expected 10 inputs, got %d", len(inputs))
+	}
+	if len(outputs) != 11 {
+		return fmt.Errorf("mulBy01E6SZHint: expected 11 outputs, got %d", len(outputs))
+	}
+
+	var a, b, c bls12377.E6
+	setNativeE6(&a, inputs[:6])
+	b.B0.A0.SetBigInt(inputs[6])
+	b.B0.A1.SetBigInt(inputs[7])
+	b.B1.A0.SetBigInt(inputs[8])
+	b.B1.A1.SetBigInt(inputs[9])
+	// b.B2 = 0
+	c.Mul(&a, &b)
+
+	getNativeE6(&c, outputs[:6])
+
+	aMono := e6TowerToMonomialBigInt(&a)
+	bMono := e6TowerToMonomialBigInt(&b)
+
+	p := bls12377.ID.BaseField()
+	var prod [11]big.Int
+	for i := 0; i < 6; i++ {
+		for j := 0; j < 6; j++ {
+			var t big.Int
+			t.Mul(&aMono[i], &bMono[j])
+			prod[i+j].Add(&prod[i+j], &t)
+			prod[i+j].Mod(&prod[i+j], p)
+		}
+	}
+
+	five := big.NewInt(5)
+	var q [5]big.Int
+	for i := 4; i >= 0; i-- {
+		q[i].Set(&prod[i+6])
+		q[i].Mod(&q[i], p)
+		var t big.Int
+		t.Mul(&q[i], five)
+		prod[i].Sub(&prod[i], &t)
+		prod[i].Mod(&prod[i], p)
+	}
+
+	for i := 0; i < 5; i++ {
+		outputs[6+i].Set(&q[i])
+	}
+	return nil
+}
+
+// mulE6SZHint computes c = a*b in Fp6 and quotient q such that
+// a(X)*b(X) = q(X)*(X^6+5) + c(X).
+func mulE6SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	if len(inputs) != 12 {
+		return fmt.Errorf("mulE6SZHint: expected 12 inputs, got %d", len(inputs))
+	}
+	if len(outputs) != 11 {
+		return fmt.Errorf("mulE6SZHint: expected 11 outputs, got %d", len(outputs))
+	}
+
+	var a, b, c bls12377.E6
+	setNativeE6(&a, inputs[:6])
+	setNativeE6(&b, inputs[6:])
+	c.Mul(&a, &b)
+
+	getNativeE6(&c, outputs[:6])
+
+	aMono := e6TowerToMonomialBigInt(&a)
+	bMono := e6TowerToMonomialBigInt(&b)
+
+	p := bls12377.ID.BaseField()
+	var prod [11]big.Int
+	for i := 0; i < 6; i++ {
+		for j := 0; j < 6; j++ {
+			var t big.Int
+			t.Mul(&aMono[i], &bMono[j])
+			prod[i+j].Add(&prod[i+j], &t)
+			prod[i+j].Mod(&prod[i+j], p)
+		}
+	}
+
+	five := big.NewInt(5)
+	var q [5]big.Int
+	for i := 4; i >= 0; i-- {
+		q[i].Set(&prod[i+6])
+		q[i].Mod(&q[i], p)
+		var t big.Int
+		t.Mul(&q[i], five)
+		prod[i].Sub(&prod[i], &t)
+		prod[i].Mod(&prod[i], p)
+	}
+
+	for i := 0; i < 5; i++ {
+		outputs[6+i].Set(&q[i])
+	}
+	return nil
+}
+
+// squareE6SZHint computes c = a² in Fp6 and quotient q.
+func squareE6SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
+	if len(inputs) != 6 {
+		return fmt.Errorf("squareE6SZHint: expected 6 inputs, got %d", len(inputs))
+	}
+	if len(outputs) != 11 {
+		return fmt.Errorf("squareE6SZHint: expected 11 outputs, got %d", len(outputs))
+	}
+
+	var a, c bls12377.E6
+	setNativeE6(&a, inputs)
+	c.Square(&a)
+
+	getNativeE6(&c, outputs[:6])
+
+	aMono := e6TowerToMonomialBigInt(&a)
+
+	p := bls12377.ID.BaseField()
+	var prod [11]big.Int
+	for i := 0; i < 6; i++ {
+		for j := 0; j < 6; j++ {
+			var t big.Int
+			t.Mul(&aMono[i], &aMono[j])
+			prod[i+j].Add(&prod[i+j], &t)
+			prod[i+j].Mod(&prod[i+j], p)
+		}
+	}
+
+	five := big.NewInt(5)
+	var q [5]big.Int
+	for i := 4; i >= 0; i-- {
+		q[i].Set(&prod[i+6])
+		q[i].Mod(&q[i], p)
+		var t big.Int
+		t.Mul(&q[i], five)
+		prod[i].Sub(&prod[i], &t)
+		prod[i].Mod(&prod[i], p)
+	}
+
+	for i := 0; i < 5; i++ {
+		outputs[6+i].Set(&q[i])
+	}
+	return nil
+}
+
+func setNativeE6(dst *bls12377.E6, inputs []*big.Int) {
+	dst.B0.A0.SetBigInt(inputs[0])
+	dst.B0.A1.SetBigInt(inputs[1])
+	dst.B1.A0.SetBigInt(inputs[2])
+	dst.B1.A1.SetBigInt(inputs[3])
+	dst.B2.A0.SetBigInt(inputs[4])
+	dst.B2.A1.SetBigInt(inputs[5])
+}
+
+func getNativeE6(src *bls12377.E6, outputs []*big.Int) {
+	src.B0.A0.BigInt(outputs[0])
+	src.B0.A1.BigInt(outputs[1])
+	src.B1.A0.BigInt(outputs[2])
+	src.B1.A1.BigInt(outputs[3])
+	src.B2.A0.BigInt(outputs[4])
+	src.B2.A1.BigInt(outputs[5])
+}
+
+func e6TowerToMonomialBigInt(e *bls12377.E6) [6]big.Int {
+	var tower [6]big.Int
+	e.B0.A0.BigInt(&tower[0])
+	e.B0.A1.BigInt(&tower[1])
+	e.B1.A0.BigInt(&tower[2])
+	e.B1.A1.BigInt(&tower[3])
+	e.B2.A0.BigInt(&tower[4])
+	e.B2.A1.BigInt(&tower[5])
+	// permutation: [t[0], t[2], t[4], t[1], t[3], t[5]]
+	return [6]big.Int{tower[0], tower[2], tower[4], tower[1], tower[3], tower[5]}
+}

--- a/std/algebra/native/fields_bls12377/e6_sz.go
+++ b/std/algebra/native/fields_bls12377/e6_sz.go
@@ -3,11 +3,9 @@ package fields_bls12377
 import (
 	"fmt"
 	"math/big"
-	"sync"
 
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/gnark/std/multicommit"
 )
 
 // Schwartz-Zippel based E6 multiplication/squaring for SCS.
@@ -15,7 +13,8 @@ import (
 // P(X) = X^6 + 5 is the irreducible polynomial for Fp6 over Fp.
 // Product degree: 10. Soundness: 10/p ≈ 2^{-373}.
 //
-// Gate cost: ~25 SCS per E6.Mul (marginal) vs ~78 for Karatsuba.
+// The exact SCS cost depends on commitment inputs and batching; see the
+// constraint-count tests for current numbers.
 
 // towerToMonomial6 reorders tower-basis E6 coefficients to monomial-basis.
 //
@@ -39,142 +38,6 @@ func assignE6(e *E6, v []frontend.Variable) {
 	e.B0.A0, e.B0.A1 = v[0], v[1]
 	e.B1.A0, e.B1.A1 = v[2], v[3]
 	e.B2.A0, e.B2.A1 = v[4], v[5]
-}
-
-// e6MulCheck stores one deferred E6 multiplication check in monomial form.
-type e6MulCheck struct {
-	a, b, c    [6]frontend.Variable // monomial coefficients (degree 5)
-	q          [5]frontend.Variable // quotient monomial coefficients (degree 4)
-	isSquare   bool
-	bSparseIdx []int // if non-nil, only these indices of b are nonzero variables
-}
-
-type e6SZChecker struct {
-	checks []e6MulCheck
-}
-
-var (
-	e6szMu       sync.Mutex
-	e6szCheckers = map[frontend.Compiler]*e6SZChecker{}
-)
-
-func getE6SZChecker(api frontend.API) *e6SZChecker {
-	compiler := api.Compiler()
-
-	e6szMu.Lock()
-	ch, ok := e6szCheckers[compiler]
-	if ok {
-		e6szMu.Unlock()
-		return ch
-	}
-	ch = &e6SZChecker{}
-	e6szCheckers[compiler] = ch
-	e6szMu.Unlock()
-
-	compiler.Defer(func(api frontend.API) error {
-		defer func() {
-			e6szMu.Lock()
-			delete(e6szCheckers, compiler)
-			e6szMu.Unlock()
-		}()
-		return ch.resolve(api)
-	})
-	return ch
-}
-
-func (ch *e6SZChecker) addCheck(a, b, c [6]frontend.Variable, q [5]frontend.Variable) {
-	ch.checks = append(ch.checks, e6MulCheck{a: a, b: b, c: c, q: q})
-}
-
-func (ch *e6SZChecker) addSquareCheck(a, c [6]frontend.Variable, q [5]frontend.Variable) {
-	ch.checks = append(ch.checks, e6MulCheck{a: a, c: c, q: q, isSquare: true})
-}
-
-func (ch *e6SZChecker) addSparseCheck(a, b, c [6]frontend.Variable, q [5]frontend.Variable, sparseIdx []int) {
-	ch.checks = append(ch.checks, e6MulCheck{a: a, b: b, c: c, q: q, bSparseIdx: sparseIdx})
-}
-
-func (ch *e6SZChecker) resolve(api frontend.API) error {
-	if len(ch.checks) == 0 {
-		return nil
-	}
-
-	var toCommit []frontend.Variable
-	for i := range ch.checks {
-		toCommit = append(toCommit, ch.checks[i].c[:]...)
-		toCommit = append(toCommit, ch.checks[i].q[:]...)
-	}
-
-	multicommit.WithCommitment(api, func(api frontend.API, commitment frontend.Variable) error {
-		r := commitment
-
-		// Precompute r², ..., r⁶ (5 gates, shared)
-		rPow := make([]frontend.Variable, 7)
-		rPow[0] = frontend.Variable(1)
-		rPow[1] = r
-		for i := 2; i <= 6; i++ {
-			rPow[i] = api.Mul(rPow[i-1], r)
-		}
-
-		// P(r) = r^6 + 5
-		pEval := api.Add(rPow[6], 5)
-
-		// Batching coefficient: r^11 ensures non-overlapping degree ranges (deg(e_i)=10)
-		alpha := api.Mul(rPow[6], rPow[5]) // r^11
-
-		lhsAcc := frontend.Variable(0)
-		rhsAcc := frontend.Variable(0)
-		alphaPow := frontend.Variable(1)
-
-		for i := range ch.checks {
-			chk := &ch.checks[i]
-
-			aEval := evalAtPowers6(api, chk.a[:], rPow)
-			var abEval frontend.Variable
-			if chk.isSquare {
-				abEval = api.Mul(aEval, aEval)
-			} else if chk.bSparseIdx != nil {
-				bEval := evalSparse6(api, chk.b[:], rPow, chk.bSparseIdx)
-				abEval = api.Mul(aEval, bEval)
-			} else {
-				bEval := evalAtPowers6(api, chk.b[:], rPow)
-				abEval = api.Mul(aEval, bEval)
-			}
-			cEval := evalAtPowers6(api, chk.c[:], rPow)
-			qEval := evalAtPowers6(api, chk.q[:], rPow)
-
-			qpEval := api.Mul(qEval, pEval)
-			rhs := api.Add(qpEval, cEval)
-
-			lhsAcc = api.Add(lhsAcc, api.Mul(alphaPow, abEval))
-			rhsAcc = api.Add(rhsAcc, api.Mul(alphaPow, rhs))
-
-			if i < len(ch.checks)-1 {
-				alphaPow = api.Mul(alphaPow, alpha)
-			}
-		}
-
-		api.AssertIsEqual(lhsAcc, rhsAcc)
-		return nil
-	}, toCommit...)
-
-	return nil
-}
-
-func evalAtPowers6(api frontend.API, coeffs []frontend.Variable, rPow []frontend.Variable) frontend.Variable {
-	result := coeffs[0]
-	for i := 1; i < len(coeffs); i++ {
-		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
-	}
-	return result
-}
-
-func evalSparse6(api frontend.API, coeffs []frontend.Variable, rPow []frontend.Variable, varIdx []int) frontend.Variable {
-	var result frontend.Variable = 0
-	for _, i := range varIdx {
-		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
-	}
-	return result
 }
 
 // mulBy01E6SZHint computes c = a * sparse(c0, c1, 0) in Fp6.

--- a/std/algebra/native/fields_bls12377/e6_sz.go
+++ b/std/algebra/native/fields_bls12377/e6_sz.go
@@ -6,14 +6,9 @@ import (
 	"sync"
 
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
-	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/multicommit"
 )
-
-func init() {
-	solver.RegisterHint(mulE6SZHint, squareE6SZHint, mulBy01E6SZHint)
-}
 
 // Schwartz-Zippel based E6 multiplication/squaring for SCS.
 //
@@ -124,8 +119,8 @@ func (ch *e6SZChecker) resolve(api frontend.API) error {
 		// P(r) = r^6 + 5
 		pEval := api.Add(rPow[6], 5)
 
-		// Batching coefficient
-		alpha := api.Mul(rPow[6], r) // r^7
+		// Batching coefficient: r^11 ensures non-overlapping degree ranges (deg(e_i)=10)
+		alpha := api.Mul(rPow[6], rPow[5]) // r^11
 
 		lhsAcc := frontend.Variable(0)
 		rhsAcc := frontend.Variable(0)

--- a/std/algebra/native/fields_bls12377/e6_sz.go
+++ b/std/algebra/native/fields_bls12377/e6_sz.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
+	"github.com/consensys/gnark-crypto/ecc/bls12-377/fp"
 	"github.com/consensys/gnark/frontend"
 )
 
@@ -40,7 +41,8 @@ func assignE6(e *E6, v []frontend.Variable) {
 	e.B2.A0, e.B2.A1 = v[4], v[5]
 }
 
-// mulBy01E6SZHint computes c = a * sparse(c0, c1, 0) in Fp6.
+// mulBy01E6SZHint computes c = a * sparse(c0, c1, 0) in Fp6 and the quotient q
+// such that a(X)*b(X) = q(X)*(X^6+5) + c(X) in Fp[X].
 // inputs: 10 (6 for a in tower, 2 for c0, 2 for c1)
 // outputs: 11 (6 for c in tower, 5 for q in monomial)
 func mulBy01E6SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
@@ -62,33 +64,9 @@ func mulBy01E6SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
 
 	getNativeE6(&c, outputs[:6])
 
-	aMono := e6TowerToMonomialBigInt(&a)
-	bMono := e6TowerToMonomialBigInt(&b)
-
-	p := bls12377.ID.BaseField()
-	var prod [11]big.Int
-	for i := 0; i < 6; i++ {
-		for j := 0; j < 6; j++ {
-			var t big.Int
-			t.Mul(&aMono[i], &bMono[j])
-			prod[i+j].Add(&prod[i+j], &t)
-			prod[i+j].Mod(&prod[i+j], p)
-		}
-	}
-
-	five := big.NewInt(5)
-	var q [5]big.Int
-	for i := 4; i >= 0; i-- {
-		q[i].Set(&prod[i+6])
-		q[i].Mod(&q[i], p)
-		var t big.Int
-		t.Mul(&q[i], five)
-		prod[i].Sub(&prod[i], &t)
-		prod[i].Mod(&prod[i], p)
-	}
-
+	q := e6SZQuotient(e6TowerToMonomialFpElement(&a), e6TowerToMonomialFpElement(&b))
 	for i := 0; i < 5; i++ {
-		outputs[6+i].Set(&q[i])
+		q[i].BigInt(outputs[6+i])
 	}
 	return nil
 }
@@ -110,38 +88,15 @@ func mulE6SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
 
 	getNativeE6(&c, outputs[:6])
 
-	aMono := e6TowerToMonomialBigInt(&a)
-	bMono := e6TowerToMonomialBigInt(&b)
-
-	p := bls12377.ID.BaseField()
-	var prod [11]big.Int
-	for i := 0; i < 6; i++ {
-		for j := 0; j < 6; j++ {
-			var t big.Int
-			t.Mul(&aMono[i], &bMono[j])
-			prod[i+j].Add(&prod[i+j], &t)
-			prod[i+j].Mod(&prod[i+j], p)
-		}
-	}
-
-	five := big.NewInt(5)
-	var q [5]big.Int
-	for i := 4; i >= 0; i-- {
-		q[i].Set(&prod[i+6])
-		q[i].Mod(&q[i], p)
-		var t big.Int
-		t.Mul(&q[i], five)
-		prod[i].Sub(&prod[i], &t)
-		prod[i].Mod(&prod[i], p)
-	}
-
+	q := e6SZQuotient(e6TowerToMonomialFpElement(&a), e6TowerToMonomialFpElement(&b))
 	for i := 0; i < 5; i++ {
-		outputs[6+i].Set(&q[i])
+		q[i].BigInt(outputs[6+i])
 	}
 	return nil
 }
 
-// squareE6SZHint computes c = a² in Fp6 and quotient q.
+// squareE6SZHint computes c = a² in Fp6 and the quotient q such that
+// a(X)² = q(X)*(X^6+5) + c(X) in Fp[X].
 func squareE6SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
 	if len(inputs) != 6 {
 		return fmt.Errorf("squareE6SZHint: expected 6 inputs, got %d", len(inputs))
@@ -156,34 +111,35 @@ func squareE6SZHint(_ *big.Int, inputs []*big.Int, outputs []*big.Int) error {
 
 	getNativeE6(&c, outputs[:6])
 
-	aMono := e6TowerToMonomialBigInt(&a)
+	aMono := e6TowerToMonomialFpElement(&a)
+	q := e6SZQuotient(aMono, aMono)
+	for i := 0; i < 5; i++ {
+		q[i].BigInt(outputs[6+i])
+	}
+	return nil
+}
 
-	p := bls12377.ID.BaseField()
-	var prod [11]big.Int
+func e6SZQuotient(aMono, bMono [6]fp.Element) [5]fp.Element {
+	var prod [11]fp.Element
 	for i := 0; i < 6; i++ {
 		for j := 0; j < 6; j++ {
-			var t big.Int
-			t.Mul(&aMono[i], &aMono[j])
+			var t fp.Element
+			t.Mul(&aMono[i], &bMono[j])
 			prod[i+j].Add(&prod[i+j], &t)
-			prod[i+j].Mod(&prod[i+j], p)
 		}
 	}
 
-	five := big.NewInt(5)
-	var q [5]big.Int
+	var five fp.Element
+	five.SetUint64(5)
+	var q [5]fp.Element
+	// Compute q such that a*b = c + q*(X^6+5).
 	for i := 4; i >= 0; i-- {
 		q[i].Set(&prod[i+6])
-		q[i].Mod(&q[i], p)
-		var t big.Int
-		t.Mul(&q[i], five)
+		var t fp.Element
+		t.Mul(&q[i], &five)
 		prod[i].Sub(&prod[i], &t)
-		prod[i].Mod(&prod[i], p)
 	}
-
-	for i := 0; i < 5; i++ {
-		outputs[6+i].Set(&q[i])
-	}
-	return nil
+	return q
 }
 
 func setNativeE6(dst *bls12377.E6, inputs []*big.Int) {
@@ -204,14 +160,7 @@ func getNativeE6(src *bls12377.E6, outputs []*big.Int) {
 	src.B2.A1.BigInt(outputs[5])
 }
 
-func e6TowerToMonomialBigInt(e *bls12377.E6) [6]big.Int {
-	var tower [6]big.Int
-	e.B0.A0.BigInt(&tower[0])
-	e.B0.A1.BigInt(&tower[1])
-	e.B1.A0.BigInt(&tower[2])
-	e.B1.A1.BigInt(&tower[3])
-	e.B2.A0.BigInt(&tower[4])
-	e.B2.A1.BigInt(&tower[5])
+func e6TowerToMonomialFpElement(e *bls12377.E6) [6]fp.Element {
 	// permutation: [t[0], t[2], t[4], t[1], t[3], t[5]]
-	return [6]big.Int{tower[0], tower[2], tower[4], tower[1], tower[3], tower[5]}
+	return [6]fp.Element{e.B0.A0, e.B1.A0, e.B2.A0, e.B0.A1, e.B1.A1, e.B2.A1}
 }

--- a/std/algebra/native/fields_bls12377/e6_sz_test.go
+++ b/std/algebra/native/fields_bls12377/e6_sz_test.go
@@ -1,0 +1,186 @@
+package fields_bls12377
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
+	"github.com/consensys/gnark/constraint"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/scs"
+)
+
+func randomE6() bls12377.E6 {
+	var e bls12377.E6
+	e.SetRandom()
+	return e
+}
+
+// --- E6.Mul SZ correctness ---
+
+type e6MulSZCircuit struct{ A, B, C E6 }
+
+func (c *e6MulSZCircuit) Define(api frontend.API) error {
+	var r E6
+	r.Mul(api, c.A, c.B)
+	r.AssertIsEqual(api, c.C)
+	return nil
+}
+
+func TestE6MulSZCorrectness(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+	a, b := randomE6(), randomE6()
+	var c bls12377.E6
+	c.Mul(&a, &b)
+
+	circuit := &e6MulSZCircuit{}
+	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witness := &e6MulSZCircuit{}
+	witness.A.Assign(&a)
+	witness.B.Assign(&b)
+	witness.C.Assign(&c)
+	w, _ := frontend.NewWitness(witness, field)
+	if err := ccs.IsSolved(w); err != nil {
+		t.Fatalf("E6.Mul SZ solve failed: %v", err)
+	}
+
+	// wrong result
+	var cWrong bls12377.E6
+	cWrong.SetRandom()
+	bad := &e6MulSZCircuit{}
+	bad.A.Assign(&a)
+	bad.B.Assign(&b)
+	bad.C.Assign(&cWrong)
+	w2, _ := frontend.NewWitness(bad, field)
+	if err := ccs.IsSolved(w2); err == nil {
+		t.Fatal("E6.Mul SZ should reject wrong result")
+	}
+}
+
+// --- E6.Square SZ correctness ---
+
+type e6SquareSZCircuit struct{ A, C E6 }
+
+func (c *e6SquareSZCircuit) Define(api frontend.API) error {
+	var r E6
+	r.Square(api, c.A)
+	r.AssertIsEqual(api, c.C)
+	return nil
+}
+
+func TestE6SquareSZCorrectness(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+	a := randomE6()
+	var c bls12377.E6
+	c.Square(&a)
+
+	circuit := &e6SquareSZCircuit{}
+	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witness := &e6SquareSZCircuit{}
+	witness.A.Assign(&a)
+	witness.C.Assign(&c)
+	w, _ := frontend.NewWitness(witness, field)
+	if err := ccs.IsSolved(w); err != nil {
+		t.Fatalf("E6.Square SZ solve failed: %v", err)
+	}
+
+	var cWrong bls12377.E6
+	cWrong.SetRandom()
+	bad := &e6SquareSZCircuit{}
+	bad.A.Assign(&a)
+	bad.C.Assign(&cWrong)
+	w2, _ := frontend.NewWitness(bad, field)
+	if err := ccs.IsSolved(w2); err == nil {
+		t.Fatal("E6.Square SZ should reject wrong result")
+	}
+}
+
+// --- E6.MulBy01 SZ correctness ---
+
+type e6MulBy01SZCircuit struct {
+	A      E6
+	C0, C1 E2
+	Res    E6
+}
+
+func (c *e6MulBy01SZCircuit) Define(api frontend.API) error {
+	r := c.A
+	r.MulBy01(api, c.C0, c.C1)
+	r.AssertIsEqual(api, c.Res)
+	return nil
+}
+
+func TestE6MulBy01SZCorrectness(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+	a := randomE6()
+	var c0, c1 bls12377.E2
+	c0.SetRandom()
+	c1.SetRandom()
+
+	// compute expected result natively
+	var sparse bls12377.E6
+	sparse.B0 = c0
+	sparse.B1 = c1
+	var res bls12377.E6
+	res.Mul(&a, &sparse)
+
+	circuit := &e6MulBy01SZCircuit{}
+	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	witness := &e6MulBy01SZCircuit{}
+	witness.A.Assign(&a)
+	witness.C0.Assign(&c0)
+	witness.C1.Assign(&c1)
+	witness.Res.Assign(&res)
+	w, _ := frontend.NewWitness(witness, field)
+	if err := ccs.IsSolved(w); err != nil {
+		t.Fatalf("E6.MulBy01 SZ solve failed: %v", err)
+	}
+
+	var resWrong bls12377.E6
+	resWrong.SetRandom()
+	bad := &e6MulBy01SZCircuit{}
+	bad.A.Assign(&a)
+	bad.C0.Assign(&c0)
+	bad.C1.Assign(&c1)
+	bad.Res.Assign(&resWrong)
+	w2, _ := frontend.NewWitness(bad, field)
+	if err := ccs.IsSolved(w2); err == nil {
+		t.Fatal("E6.MulBy01 SZ should reject wrong result")
+	}
+}
+
+// --- E6 SZ constraint counts ---
+
+func TestE6SZConstraintCount(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+
+	fmt.Println("=== E6 SCS Constraint Counts (Schwartz-Zippel) ===")
+
+	for _, tc := range []struct {
+		name    string
+		circuit frontend.Circuit
+	}{
+		{"E6.Mul", &e6MulSZCircuit{}},
+		{"E6.Square", &e6SquareSZCircuit{}},
+		{"E6.MulBy01", &e6MulBy01SZCircuit{}},
+	} {
+		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, tc.circuit)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		fmt.Printf("  %-20s %d SCS\n", tc.name, ccs.GetNbConstraints())
+	}
+}

--- a/std/algebra/native/fields_bls12377/e6_sz_test.go
+++ b/std/algebra/native/fields_bls12377/e6_sz_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
-	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs"
@@ -37,7 +36,7 @@ func TestE6MulSZCorrectness(t *testing.T) {
 	c.Mul(&a, &b)
 
 	circuit := &e6MulSZCircuit{}
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +100,7 @@ func TestE6MulSZRejectsCorruptedQuotientHint(t *testing.T) {
 	c.Mul(&a, &b)
 
 	circuit := &e6MulSZCircuit{}
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +127,7 @@ func TestE6MulSZRejectsForgedInputsWhenCommitted(t *testing.T) {
 	field := ecc.BW6_761.ScalarField()
 
 	circuit := &e6MulSZCircuit{}
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +176,7 @@ func TestE6SquareSZCorrectness(t *testing.T) {
 	c.Square(&a)
 
 	circuit := &e6SquareSZCircuit{}
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +230,7 @@ func TestE6MulBy01SZCorrectness(t *testing.T) {
 	res.Mul(&a, &sparse)
 
 	circuit := &e6MulBy01SZCircuit{}
-	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	ccs, err := frontend.Compile(field, scs.NewBuilder, circuit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +273,7 @@ func TestE6SZConstraintCount(t *testing.T) {
 		{"E6.Square", &e6SquareSZCircuit{}},
 		{"E6.MulBy01", &e6MulBy01SZCircuit{}},
 	} {
-		ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, tc.circuit)
+		ccs, err := frontend.Compile(field, scs.NewBuilder, tc.circuit)
 		if err != nil {
 			t.Fatalf("%s: %v", tc.name, err)
 		}

--- a/std/algebra/native/fields_bls12377/e6_sz_test.go
+++ b/std/algebra/native/fields_bls12377/e6_sz_test.go
@@ -1,7 +1,6 @@
 package fields_bls12377
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/consensys/gnark/constraint"
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs"
 	"github.com/consensys/gnark/frontend/cs/scs"
 )
 
@@ -74,6 +74,26 @@ func corruptHintOutput(h solver.Hint, output int) solver.Hint {
 	}
 }
 
+func zeroHintOutput(_ *big.Int, _ []*big.Int, outputs []*big.Int) error {
+	for i := range outputs {
+		outputs[i].SetUint64(0)
+	}
+	return nil
+}
+
+func commitmentInputCountHint(field *big.Int, inputs, outputs []*big.Int) error {
+	outputs[0].SetInt64(int64(len(inputs)))
+	outputs[0].Mod(outputs[0], field)
+	return nil
+}
+
+func negBLS12377Base(v int64) *big.Int {
+	res := big.NewInt(v)
+	res.Neg(res)
+	res.Mod(res, bls12377.ID.BaseField())
+	return res
+}
+
 func TestE6MulSZRejectsCorruptedQuotientHint(t *testing.T) {
 	field := ecc.BW6_761.ScalarField()
 	a, b := randomE6(), randomE6()
@@ -101,6 +121,41 @@ func TestE6MulSZRejectsCorruptedQuotientHint(t *testing.T) {
 	))
 	if err == nil {
 		t.Fatal("E6.Mul SZ should reject a corrupted quotient hint")
+	}
+}
+
+func TestE6MulSZRejectsForgedInputsWhenCommitted(t *testing.T) {
+	field := ecc.BW6_761.ScalarField()
+
+	circuit := &e6MulSZCircuit{}
+	ccs, err := frontend.CompileGeneric[constraint.U64](field, scs.NewBuilder, circuit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Before committing a and b, the commitment hint sees depth + c + q:
+	// 1 + 6 + 5 inputs. The forged a(X)=X-r, b(X)=1, c=q=0 would pass.
+	const oldChallenge = 12
+	var a, b, c bls12377.E6
+	a.B0.A0.SetBigInt(negBLS12377Base(oldChallenge))
+	a.B1.A0.SetOne()
+	b.SetOne()
+
+	witness := &e6MulSZCircuit{}
+	witness.A.Assign(&a)
+	witness.B.Assign(&b)
+	witness.C.Assign(&c)
+	w, err := frontend.NewWitness(witness, field)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ccs.IsSolved(w,
+		solver.OverrideHint(solver.GetHintID(mulE6SZHint), zeroHintOutput),
+		solver.OverrideHint(solver.GetHintID(cs.Bsb22CommitmentComputePlaceholder), commitmentInputCountHint),
+	)
+	if err == nil {
+		t.Fatal("E6.Mul SZ should bind the challenge to multiplication inputs")
 	}
 }
 
@@ -209,7 +264,7 @@ func TestE6MulBy01SZCorrectness(t *testing.T) {
 func TestE6SZConstraintCount(t *testing.T) {
 	field := ecc.BW6_761.ScalarField()
 
-	fmt.Println("=== E6 SCS Constraint Counts (Schwartz-Zippel) ===")
+	t.Log("=== E6 SCS Constraint Counts (Schwartz-Zippel) ===")
 
 	for _, tc := range []struct {
 		name    string
@@ -223,6 +278,6 @@ func TestE6SZConstraintCount(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", tc.name, err)
 		}
-		fmt.Printf("  %-20s %d SCS\n", tc.name, ccs.GetNbConstraints())
+		t.Logf("  %-20s %d SCS", tc.name, ccs.GetNbConstraints())
 	}
 }

--- a/std/algebra/native/fields_bls12377/hints.go
+++ b/std/algebra/native/fields_bls12377/hints.go
@@ -16,6 +16,12 @@ func GetHints() []solver.Hint {
 		inverseE6Hint,
 		inverseE12Hint,
 		finalExpHint,
+		mulE6SZHint,
+		squareE6SZHint,
+		mulBy01E6SZHint,
+		mulE12SZHint,
+		squareE12SZHint,
+		mulBy034E12SZHint,
 	}
 }
 

--- a/std/algebra/native/fields_bls12377/sz.go
+++ b/std/algebra/native/fields_bls12377/sz.go
@@ -1,0 +1,140 @@
+package fields_bls12377
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/internal/kvstore"
+	"github.com/consensys/gnark/std/multicommit"
+)
+
+type szCheckerKey struct{}
+
+type szMulCheck struct {
+	a, b, c []frontend.Variable
+	q       []frontend.Variable
+	square  bool
+}
+
+type szChecker struct {
+	checks []szMulCheck
+}
+
+func getSZChecker(api frontend.API) *szChecker {
+	kv, ok := api.Compiler().(kvstore.Store)
+	if !ok {
+		panic("compiler does not implement kvstore.Store")
+	}
+	ch := kv.GetKeyValue(szCheckerKey{})
+	if ch != nil {
+		cht, ok := ch.(*szChecker)
+		if !ok {
+			panic("stored Schwartz-Zippel checker has invalid type")
+		}
+		return cht
+	}
+	cht := &szChecker{}
+	kv.SetKeyValue(szCheckerKey{}, cht)
+	api.Compiler().Defer(cht.resolve)
+	return cht
+}
+
+func addSZCheck(api frontend.API, a, b, c, q []frontend.Variable) {
+	getSZChecker(api).addCheck(a, b, c, q, false)
+}
+
+func addSZSquareCheck(api frontend.API, a, c, q []frontend.Variable) {
+	getSZChecker(api).addCheck(a, nil, c, q, true)
+}
+
+func (ch *szChecker) addCheck(a, b, c, q []frontend.Variable, square bool) {
+	ch.checks = append(ch.checks, szMulCheck{
+		a:      append([]frontend.Variable(nil), a...),
+		b:      append([]frontend.Variable(nil), b...),
+		c:      append([]frontend.Variable(nil), c...),
+		q:      append([]frontend.Variable(nil), q...),
+		square: square,
+	})
+}
+
+func (ch *szChecker) resolve(api frontend.API) error {
+	if len(ch.checks) == 0 {
+		return nil
+	}
+
+	maxDegree := 0
+	var toCommit []frontend.Variable
+	for i := range ch.checks {
+		chk := &ch.checks[i]
+		if len(chk.a) != len(chk.c) {
+			panic("Schwartz-Zippel checker: invalid a/c lengths")
+		}
+		if !chk.square && len(chk.b) != len(chk.c) {
+			panic("Schwartz-Zippel checker: invalid b/c lengths")
+		}
+		if len(chk.q) != len(chk.c)-1 {
+			panic("Schwartz-Zippel checker: invalid quotient length")
+		}
+		if len(chk.c) > maxDegree {
+			maxDegree = len(chk.c)
+		}
+		toCommit = append(toCommit, chk.a...)
+		if !chk.square {
+			toCommit = append(toCommit, chk.b...)
+		}
+		toCommit = append(toCommit, chk.c...)
+		toCommit = append(toCommit, chk.q...)
+	}
+
+	multicommit.WithCommitment(api, func(api frontend.API, commitment frontend.Variable) error {
+		r := commitment
+
+		rPow := make([]frontend.Variable, maxDegree+1)
+		rPow[0] = frontend.Variable(1)
+		rPow[1] = r
+		for i := 2; i <= maxDegree; i++ {
+			rPow[i] = api.Mul(rPow[i-1], r)
+		}
+
+		alpha := api.Mul(rPow[maxDegree], rPow[maxDegree-1])
+		lhsAcc := frontend.Variable(0)
+		rhsAcc := frontend.Variable(0)
+		alphaPow := frontend.Variable(1)
+
+		for i := range ch.checks {
+			chk := &ch.checks[i]
+			degree := len(chk.c)
+
+			aEval := evalAtPowers(api, chk.a, rPow)
+			var abEval frontend.Variable
+			if chk.square {
+				abEval = api.Mul(aEval, aEval)
+			} else {
+				bEval := evalAtPowers(api, chk.b, rPow)
+				abEval = api.Mul(aEval, bEval)
+			}
+			cEval := evalAtPowers(api, chk.c, rPow)
+			qEval := evalAtPowers(api, chk.q, rPow)
+			pEval := api.Add(rPow[degree], 5)
+			rhs := api.Add(api.Mul(qEval, pEval), cEval)
+
+			lhsAcc = api.Add(lhsAcc, api.Mul(alphaPow, abEval))
+			rhsAcc = api.Add(rhsAcc, api.Mul(alphaPow, rhs))
+
+			if i < len(ch.checks)-1 {
+				alphaPow = api.Mul(alphaPow, alpha)
+			}
+		}
+
+		api.AssertIsEqual(lhsAcc, rhsAcc)
+		return nil
+	}, toCommit...)
+
+	return nil
+}
+
+func evalAtPowers(api frontend.API, coeffs []frontend.Variable, rPow []frontend.Variable) frontend.Variable {
+	result := coeffs[0]
+	for i := 1; i < len(coeffs); i++ {
+		result = api.Add(result, api.Mul(coeffs[i], rPow[i]))
+	}
+	return result
+}


### PR DESCRIPTION
# Description

This PR adds randomized Schwartz-Zippel (SZ) verification for Fp6 and Fp12 multiplications in the native BLS12-377 field tower, targeting SCS (Plonk) circuits. Instead of computing products via the Karatsuba tower, the prover witnesses the result and a quotient polynomial via a hint, then defers a polynomial identity check at a random Fiat-Shamir challenge point:

```
a(r) · b(r) = q(r) · P(r) + c(r)   in Fp
```

where P(X) = X⁶+5 for Fp6 and P(X) = X¹²+5 for Fp12. Since BLS12-377's base field is ~377 bits, each check provides ~372 bits of soundness — well above the 128-bit requirement.

Multiple checks (across all Fp6 and Fp12 multiplications in the circuit) are batched via random linear combination using a single commitment, amortizing the challenge derivation cost.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes

**Fp12 operations** (`e12.go`, `e12_pairing.go`, `e12_sz.go`):

| Operation | Before (SCS) | After (SCS, marginal) | Reduction |
|---|---:|---:|---|
| E12.Mul | 264 | 128 | 51% |
| E12.Square | 180 | 106 | 41% |
| E12.MulBy034 | 131 | 102 | 22% |
| E12.MulBy01234 | 237 | 112 | 53% |

**Fp6 operations** (`e6.go`, `e6_sz.go`):

| Operation | Before (SCS) | After (SCS) | Reduction |
|---|---:|---:|---|
| E6.Mul | 78 | 67 | 14% |
| E6.Square | 44 | 57 | ❌ regression |
| E6.MulBy01 | 53 | 63 | ❌ regression |

Note: E6.Square and E6.MulBy01 show a standalone regression because the SZ overhead (commitment, power precomputation) isn't amortized. In the pairing circuit where many E6 operations share one commitment, the amortized cost drops significantly:

**Pairing circuits:**

| Circuit | Before (SCS) | After (SCS) | Reduction |
|---|---:|---:|---|
| Torus pairing (default) | 21,273 | 17,830 | **16.2%** |
| Classical pairing (Fp12) | 51,292 | 36,681 | **28.5%** |

**Design:**
- SZ dispatch is gated on `frontendtype.SCS` + `frontend.Committer` — R1CS and SCS without commitment support fall back to Karatsuba (no regression)
- Tower-to-monomial permutations verified with Sage against gnark-crypto native arithmetic
- Sparse multiplications (MulBy034, MulBy01, MulBy01234) exploit zero coefficients in the evaluation to save gates
- Separate E6 and E12 checkers batch independently via `multicommit.WithCommitment`

# How has this been tested?

**SZ correctness tests** (10 tests, all verify against gnark-crypto native arithmetic with random inputs + reject wrong witnesses):
- `TestE12MulSZCorrectness` — E12.Mul
- `TestE12MulSZMultiple` — batched E12.Mul (4 operations, shared commitment)
- `TestE12SquareSZCorrectness` — E12.Square
- `TestE12MulBy034SZCorrectness` — E12.MulBy034 (sparse)
- `TestE12MulBy01234SZCorrectness` — E12.MulBy01234 (sparse)
- `TestE6MulSZCorrectness` — E6.Mul
- `TestE6SquareSZCorrectness` — E6.Square
- `TestE6MulBy01SZCorrectness` — E6.MulBy01 (sparse)

**Karatsuba non-regression** (existing tests via `test.CheckCircuit`, which uses plain SCS without Committer → falls through to Karatsuba):
- `go test -short ./std/algebra/native/fields_bls12377/...` — all pass
- `go test -short ./std/algebra/native/sw_bls12377/...` — all pairing tests pass

# How has this been benchmarked?

Constraint counts measured via `frontend.CompileGeneric[constraint.U64]` with `scs.NewBuilder` on Apple M5.

Per-operation marginal costs (N=8, amortized across shared commitment):

| Operation | Before | After | Marginal |
|---|---:|---:|---:|
| E12.Mul | 264 | — | 128 |
| E12.Square | 180 | — | 106 |
| E12.MulBy034 | 131 | — | 102 |
| E12.MulBy01234 | 237 | — | 112 |
| E6.Mul | 78 | — | 25 (amortized) |

End-to-end pairing benchmarks:

| Circuit | Before | After |
|---|---:|---:|
| BLS12-377 torus pairing check | 21,273 | **17,830** |
| BLS12-377 classical pairing | 51,292 | **36,681** |

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters core BLS12-377 field arithmetic in-circuit by swapping explicit multiplication constraints for hint-based Schwartz-Zippel checks under SCS+commitments; correctness and soundness depend on the new hint implementations and deferred batching logic.
> 
> **Overview**
> Adds a Schwartz-Zippel (hint + deferred polynomial identity) fast path for native BLS12-377 `E6` and `E12` operations when compiling to `frontendtype.SCS` with `frontend.Committer`, falling back to the existing Karatsuba/Toom-Cook implementations otherwise.
> 
> Introduces new SZ hint implementations and a shared, deferred batching checker (`sz.go`) that uses `multicommit.WithCommitment` to derive a Fiat–Shamir challenge and aggregate multiple multiplication/squaring checks into a single constraint.
> 
> Covers the new paths with dedicated correctness/negative tests and updates registered hints; internal pairing constraint stats are updated (notably `pairing_bls12377` on Plonk).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6412569278de75a0b3db367c9fdbc92e8e165f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->