### PR TITLE
fix: bound GLV hint subscalar bit widths

### DIFF
--- a/std/algebra/emulated/sw_bls12381/g2.go
+++ b/std/algebra/emulated/sw_bls12381/g2.go
@@ -674,6 +674,12 @@ func (g2 *G2) scalarMulGLV(Q *G2Affine, s *Scalar, opts ...algopts.AlgebraOption
 	s1bits := g2.fr.ToBits(s1)
 	s2bits := g2.fr.ToBits(s2)
 
+	nbits := 130
+	for i := nbits; i < len(s1bits); i++ {
+		g2.api.AssertIsEqual(s1bits[i], 0)
+		g2.api.AssertIsEqual(s2bits[i], 0)
+	}
+
 	// precompute -Q, -Φ(Q), Φ(Q)
 	var tableQ, tablePhiQ [3]*G2Affine
 	negQY := g2.Ext2.Neg(&Q.P.Y)
@@ -757,7 +763,6 @@ func (g2 *G2) scalarMulGLV(Q *G2Affine, s *Scalar, opts ...algopts.AlgebraOption
 	// note that half the points are negatives of the other half,
 	// hence have the same X coordinates.
 
-	nbits := 130
 	for i := nbits - 2; i > 0; i -= 2 {
 		// selectorY takes values in [0,15]
 		selectorY := g2.api.Add(

--- a/std/algebra/emulated/sw_bls12381/g2_test.go
+++ b/std/algebra/emulated/sw_bls12381/g2_test.go
@@ -9,6 +9,7 @@ import (
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
 	fr_bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/emulated/fields_bls12381"
 	"github.com/consensys/gnark/std/math/emulated"
@@ -49,6 +50,57 @@ func TestScalarMulG2TestSolve(t *testing.T) {
 	}
 	err := test.IsSolved(&mulG2Circuit{}, &witness, ecc.BN254.ScalarField())
 	assert.NoError(err)
+}
+
+type glvOnlyG2Circuit struct {
+	In, Res G2Affine
+	S       Scalar
+}
+
+func (c *glvOnlyG2Circuit) Define(api frontend.API) error {
+	g2, err := NewG2(api)
+	if err != nil {
+		return fmt.Errorf("new G2 struct: %w", err)
+	}
+	res := g2.scalarMulGLV(&c.In, &c.S)
+	g2.AssertIsEqual(res, &c.Res)
+	return nil
+}
+
+func wideDecomposeScalarG1(mod *big.Int, inputs, outputs []*big.Int) error {
+	return emulated.UnwrapHintContext(mod, inputs, outputs, func(hc emulated.HintContext) error {
+		moduli := hc.EmulatedModuli()
+		_, nativeOutputs := hc.NativeInputsOutputs()
+		_, emuOutputs := hc.InputsOutputs(moduli[0])
+		emuOutputs[0].SetUint64(1)
+		emuOutputs[0].SetBit(emuOutputs[0], 130, 1)
+		emuOutputs[1].SetUint64(0)
+		nativeOutputs[0].SetUint64(1)
+		nativeOutputs[1].SetUint64(0)
+		return nil
+	})
+}
+
+func TestScalarMulG2RejectsWideSubscalars(t *testing.T) {
+	assert := test.NewAssert(t)
+	_, _, _, gen := bls12381.Generators()
+	h := new(big.Int).Lsh(big.NewInt(1), 130)
+	s := new(big.Int).Sub(fr_bls12381.Modulus(), h)
+	s.Sub(s, big.NewInt(1))
+	var r fr_bls12381.Element
+	r.SetBigInt(s)
+	res := gen
+	res.Neg(&res)
+
+	witness := glvOnlyG2Circuit{
+		In:  NewG2Affine(gen),
+		S:   NewScalar(r),
+		Res: NewG2Affine(res),
+	}
+	err := test.IsSolved(&glvOnlyG2Circuit{}, &witness, ecc.BN254.ScalarField(),
+		test.WithReplacementHint(solver.GetHintID(decomposeScalarG1), wideDecomposeScalarG1),
+	)
+	assert.Error(err)
 }
 
 type addG2Circuit struct {

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -712,6 +712,8 @@ func (c *Curve[B, S]) scalarMulGLV(Q *AffinePoint[B], s *emulated.Element[S], op
 	s2bits := c.scalarApi.ToBits(s2)
 	var st S
 	nbits := st.Modulus().BitLen()>>1 + 2
+	c.assertBitLength(s1bits, nbits)
+	c.assertBitLength(s2bits, nbits)
 
 	// precompute -Q, Q, 3Q, -Φ(Q), Φ(Q), 3Φ(Q)
 	var tableQ, tablePhiQ [3]*AffinePoint[B]
@@ -1143,6 +1145,10 @@ func (c *Curve[B, S]) jointScalarMulGLVUnsafe(Q, R *AffinePoint[B], s, t *emulat
 	t2bits := c.scalarApi.ToBits(t2)
 	var st S
 	nbits := st.Modulus().BitLen()>>1 + 2
+	c.assertBitLength(s1bits, nbits)
+	c.assertBitLength(s2bits, nbits)
+	c.assertBitLength(t1bits, nbits)
+	c.assertBitLength(t2bits, nbits)
 
 	// At each iteration we look up the point Bi from:
 	// 		B1  = +Q + R + Φ(Q) + Φ(R)

--- a/std/algebra/emulated/sw_emulated/point.go
+++ b/std/algebra/emulated/sw_emulated/point.go
@@ -90,6 +90,12 @@ func (c *Curve[B, S]) GeneratorMultiples() []AffinePoint[B] {
 	return c.gm
 }
 
+func (c *Curve[B, S]) assertBitLength(bits []frontend.Variable, nbits int) {
+	for i := nbits; i < len(bits); i++ {
+		c.api.AssertIsEqual(bits[i], 0)
+	}
+}
+
 // AffinePoint represents a point on the elliptic curve. We do not check that
 // the point is actually on the curve.
 //
@@ -1413,6 +1419,8 @@ func (c *Curve[B, S]) scalarMulFakeGLV(Q *AffinePoint[B], s *emulated.Element[S]
 	nbits := (st.Modulus().BitLen() + 1) / 2
 	s1bits := c.scalarApi.ToBits(s1)
 	s2bits := c.scalarApi.ToBits(s2)
+	c.assertBitLength(s1bits, nbits)
+	c.assertBitLength(s2bits, nbits)
 
 	// Precomputations:
 	// 		tableQ[0] = -Q
@@ -1808,6 +1816,10 @@ func (c *Curve[B, S]) scalarMulGLVAndFakeGLV(P *AffinePoint[B], s *emulated.Elem
 	u2bits := c.scalarApi.ToBits(u2)
 	v1bits := c.scalarApi.ToBits(v1)
 	v2bits := c.scalarApi.ToBits(v2)
+	c.assertBitLength(u1bits, nbits)
+	c.assertBitLength(u2bits, nbits)
+	c.assertBitLength(v1bits, nbits)
+	c.assertBitLength(v2bits, nbits)
 
 	// At each iteration we look up the point Bi from:
 	// 		B1  = +P + Q + Φ(P) + Φ(Q)

--- a/std/algebra/emulated/sw_emulated/point_test.go
+++ b/std/algebra/emulated/sw_emulated/point_test.go
@@ -2673,6 +2673,34 @@ func zeroRationalReconstructExt(_ *big.Int, _, outputs []*big.Int) error {
 	return nil
 }
 
+func wideRationalReconstructExt(mod *big.Int, inputs, outputs []*big.Int) error {
+	return emulated.UnwrapHintContext(mod, inputs, outputs, func(hc emulated.HintContext) error {
+		moduli := hc.EmulatedModuli()
+		_, nativeOutputs := hc.NativeInputsOutputs()
+		_, emuOutputs := hc.InputsOutputs(moduli[0])
+		emuOutputs[0].SetUint64(1)
+		emuOutputs[0].SetBit(emuOutputs[0], (moduli[0].BitLen()+3)/4+2, 1)
+		emuOutputs[1].SetUint64(0)
+		emuOutputs[2].SetUint64(1)
+		emuOutputs[3].SetUint64(0)
+		for i := range nativeOutputs {
+			nativeOutputs[i].SetUint64(0)
+		}
+		return nil
+	})
+}
+
+func scalarMulMinusOneHint(mod *big.Int, inputs, outputs []*big.Int) error {
+	return emulated.UnwrapHintContext(mod, inputs, outputs, func(hc emulated.HintContext) error {
+		moduli := hc.EmulatedModuli()
+		baseInputs, baseOutputs := hc.InputsOutputs(moduli[0])
+		baseOutputs[0].Set(baseInputs[0])
+		baseOutputs[1].Sub(moduli[0], baseInputs[1])
+		baseOutputs[1].Mod(baseOutputs[1], moduli[0])
+		return nil
+	})
+}
+
 // TestScalarMulGLVAndFakeGLV_TrivialDecompositionRegression: regression for a
 // soundness issue in scalarMulGLVAndFakeGLV. A malicious rationalReconstructExt
 // hint returning the trivial all-zeros decomposition (u1=u2=v1=v2=0) makes
@@ -2708,5 +2736,33 @@ func TestScalarMulGLVAndFakeGLV_TrivialDecompositionRegression(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("malicious all-zeros Eisenstein decomposition was accepted — soundness break")
+	}
+}
+
+func TestScalarMulGLVAndFakeGLVRejectsWideSubscalars(t *testing.T) {
+	_, g := secp256k1.Generators()
+	nbits := (fr_secp.Modulus().BitLen()+3)/4 + 2
+	h := new(big.Int).Lsh(big.NewInt(1), uint(nbits))
+	s := new(big.Int).Sub(fr_secp.Modulus(), h)
+	s.Sub(s, big.NewInt(1))
+
+	p := AffinePoint[emulated.Secp256k1Fp]{
+		X: emulated.ValueOf[emulated.Secp256k1Fp](g.X),
+		Y: emulated.ValueOf[emulated.Secp256k1Fp](g.Y),
+	}
+	r := p
+	r.Y = emulated.ValueOf[emulated.Secp256k1Fp](new(big.Int).Sub(fp_secp.Modulus(), g.Y.BigInt(new(big.Int))))
+	witness := ScalarMulGLVAndFakeGLVEdgeCasesTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
+		S: emulated.ValueOf[emulated.Secp256k1Fr](s),
+		P: p,
+		R: r,
+	}
+
+	err := test.IsSolved(&ScalarMulGLVAndFakeGLVEdgeCasesTest[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{}, &witness, testCurve.ScalarField(),
+		test.WithReplacementHint(solver.GetHintID(rationalReconstructExt), wideRationalReconstructExt),
+		test.WithReplacementHint(solver.GetHintID(scalarMulHint), scalarMulMinusOneHint),
+	)
+	if err == nil {
+		t.Fatal("malicious decomposition with ignored high bits was accepted")
 	}
 }

--- a/std/algebra/emulated/sw_emulated/point_test.go
+++ b/std/algebra/emulated/sw_emulated/point_test.go
@@ -2701,6 +2701,19 @@ func scalarMulMinusOneHint(mod *big.Int, inputs, outputs []*big.Int) error {
 	})
 }
 
+func wideRationalReconstruct(mod *big.Int, inputs, outputs []*big.Int) error {
+	return emulated.UnwrapHintContext(mod, inputs, outputs, func(hc emulated.HintContext) error {
+		moduli := hc.EmulatedModuli()
+		_, nativeOutputs := hc.NativeInputsOutputs()
+		_, emuOutputs := hc.InputsOutputs(moduli[0])
+		emuOutputs[0].SetUint64(1)
+		emuOutputs[0].SetBit(emuOutputs[0], (moduli[0].BitLen()+1)/2, 1)
+		emuOutputs[1].SetUint64(1)
+		nativeOutputs[0].SetUint64(0)
+		return nil
+	})
+}
+
 // TestScalarMulGLVAndFakeGLV_TrivialDecompositionRegression: regression for a
 // soundness issue in scalarMulGLVAndFakeGLV. A malicious rationalReconstructExt
 // hint returning the trivial all-zeros decomposition (u1=u2=v1=v2=0) makes
@@ -2736,6 +2749,34 @@ func TestScalarMulGLVAndFakeGLV_TrivialDecompositionRegression(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("malicious all-zeros Eisenstein decomposition was accepted — soundness break")
+	}
+}
+
+func TestScalarMulFakeGLVRejectsWideSubscalars(t *testing.T) {
+	p256 := elliptic.P256()
+	nbits := (p256.Params().N.BitLen() + 1) / 2
+	h := new(big.Int).Lsh(big.NewInt(1), uint(nbits))
+	s := new(big.Int).Sub(p256.Params().N, h)
+	s.Sub(s, big.NewInt(1))
+
+	q := AffinePoint[emulated.P256Fp]{
+		X: emulated.ValueOf[emulated.P256Fp](p256.Params().Gx),
+		Y: emulated.ValueOf[emulated.P256Fp](p256.Params().Gy),
+	}
+	r := q
+	r.Y = emulated.ValueOf[emulated.P256Fp](new(big.Int).Sub(p256.Params().P, p256.Params().Gy))
+	witness := ScalarMulFakeGLVTest[emulated.P256Fp, emulated.P256Fr]{
+		S: emulated.ValueOf[emulated.P256Fr](s),
+		Q: q,
+		R: r,
+	}
+
+	err := test.IsSolved(&ScalarMulFakeGLVTest[emulated.P256Fp, emulated.P256Fr]{}, &witness, testCurve.ScalarField(),
+		test.WithReplacementHint(solver.GetHintID(rationalReconstruct), wideRationalReconstruct),
+		test.WithReplacementHint(solver.GetHintID(scalarMulHint), scalarMulMinusOneHint),
+	)
+	if err == nil {
+		t.Fatal("malicious fake-GLV decomposition with ignored high bits was accepted")
 	}
 }
 


### PR DESCRIPTION
# Description

Fixes #1767.

This constrains hinted subscalars to the bit windows consumed by the emulated scalar-mul accumulator loops. The fix covers:
- generic GLV
- joint generic GLV
- fake GLV
- GLV + fake GLV
- BLS12-381 G2 GLV

Without these bounds, a malicious hint can satisfy the decomposition relation while placing data above the consumed bit window, so the accumulator checks only the low bits.

The regressions replace decomposition hints with forbidden high-bit outputs and matching forged results. They are rejected after the unused high bits are constrained.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- [x] `go test -run 'TestScalarMulG2RejectsWideSubscalars|TestScalarMulG2TestSolve' ./std/algebra/emulated/sw_bls12381`
- [x] `go test -run 'TestScalarMulFakeGLVRejectsWideSubscalars|TestScalarMulGLVAndFakeGLVRejectsWideSubscalars|TestScalarMulGLVAndFakeGLV_TrivialDecompositionRegression' ./std/algebra/emulated/sw_emulated`
- [x] `go test -short ./std/algebra/emulated/sw_bls12381`
- [x] `go test -short ./std/algebra/emulated/sw_emulated`
- [x] `golangci-lint run -v --timeout=5m ./std/algebra/emulated/sw_bls12381 ./std/algebra/emulated/sw_emulated`
- [x] `git diff --check`

# How has this been benchmarked?

Not run; this adds soundness constraints to enforce existing decomposition bounds rather than changing the scalar-mul algorithm.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds new circuit constraints in multiple scalar-mul implementations to prevent malicious hints from hiding data in unused high bits, which is a security/soundness-critical area and could affect proof validity and constraint counts.
> 
> **Overview**
> Fixes a soundness hole in emulated scalar multiplication by **constraining hinted GLV/fake-GLV subscalars to the bit windows actually consumed by the accumulator loops** (generic `scalarMulGLV`, joint GLV, `scalarMulFakeGLV`, and `scalarMulGLVAndFakeGLV`). This is implemented via a shared `assertBitLength` helper in `sw_emulated/point.go` and an explicit `130`-bit check in `sw_bls12381/g2.go`.
> 
> Adds regression tests that replace decomposition hints with *wide/high-bit* outputs (and forged scalar-mul hint outputs) and assert the circuits now reject them, including a new `TestScalarMulG2RejectsWideSubscalars` and similar tests for fake-GLV and GLV+fake-GLV paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71e2be2dbaa74382acdbccef3f452cb54a428b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->