### PR TITLE
docs: fix typos in comments and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1553,7 +1553,7 @@
 - flatten mpc structure, idomify APIs
 - expose all typed backends in gnark/backend (moved from internal/)
 - compute lagrange basis from scratch
-- dont need nativemod in emulated hint unwrapper
+- don't need nativemod in emulated hint unwrapper
 - solving and compilation in accordance with commitmentInfo struct changes
 - SparceCS.CommitmentConstraint instead of C; more "honest" constraints
 - take api.Commit to api.go

--- a/std/recursion/wrapped_hash.go
+++ b/std/recursion/wrapped_hash.go
@@ -76,7 +76,7 @@ func newShortFromParam(hf hash.Hash, bitBlockSize, outSize int) hash.Hash {
 func (h *shortNativeHash) Write(p []byte) (n int, err error) {
 	// we first write to the buffer. We want to be able to partition the inputs
 	// into smaller parts and buffer is good to keep track of the excess.
-	h.ringBuf.Write(p) // nosec: doesnt fail
+	h.ringBuf.Write(p) // nosec: doesn't fail
 	for h.ringBuf.Len() >= (len(h.buf) - 1) {
 		// the buffer contains now enough bytes so that we can write it to the
 		// underlying hash.


### PR DESCRIPTION
## Description
Fixed spelling errors in code comments and CHANGELOG for better readability.

## Changes
- Fixed `doesnt` → `doesn't` in wrapped_hash.go comment
- Fixed `dont` → `don't` in CHANGELOG.md

## Files Modified
- `std/recursion/wrapped_hash.go`
- `CHANGELOG.md`

## Testing
- Documentation-only changes
- No code logic modified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; no functional code behavior is modified.
> 
> **Overview**
> Fixes two small typos for readability: updates a `CHANGELOG.md` entry from "dont" to "don't", and corrects the `nosec` comment in `std/recursion/wrapped_hash.go` to "doesn't fail".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 711e9bca1cbbb400c668d0529a55e247156f6a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->