### PR TITLE
chore: pin and update GitHub Actions to latest releases

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: install Go
@@ -54,7 +54,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: install Go
@@ -68,7 +68,7 @@ jobs:
       - staticcheck
     steps:
       - name: checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@1cd598629833fa9fc1694f03abfce8d21b72eb5d # v2.0.6
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@ff5edd492dfd4a70813066fe9f1552a2ac13766f # v2.1.0
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary

Audited all GitHub Workflow files to ensure every third-party action is pinned to a full commit SHA with an accurate version comment, and that each is on its latest release.

All actions were already SHA-pinned with correct comments. Two were behind their latest release and are bumped here:

- `actions/checkout`: `v6.0.2` → `v6.0.3` (in `pr.yml` and `push.yml`)
- `MetaMask/action-security-code-scanner`: `v2.0.6` → `v2.1.0` (in `security-code-scanner.yml`)

Already on latest, left unchanged: `actions/setup-go@v6.4.0`, `golangci/golangci-lint-action@v9.2.1`, `gotesttools/gotestfmt-action@v2.3.0`.

The checkout bump supersedes Dependabot PR #1782.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin updates; no application or runtime code changes.
> 
> **Overview**
> Updates **SHA-pinned** third-party actions in CI workflows to their latest tagged releases, without changing workflow logic or step configuration.
> 
> **`actions/checkout`** moves from **v6.0.2** to **v6.0.3** on all checkout steps in `pr.yml` and `push.yml` (staticcheck and test jobs). **`MetaMask/action-security-code-scanner`** moves from **v2.0.6** to **v2.1.0** in `security-code-scanner.yml`. Other pinned actions in these files are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018ca128f780bfc9f3c5d41545b166245f94e463. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->