### PR TITLE
refactor: enforce least-privilege in GitHub Actions workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,12 +1,11 @@
 on: pull_request
 name: pull_request
 
+permissions: {} # lock everything by default (least-privilege)
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
 
 env:
   ABIGEN_VERSION: v1.14.8
@@ -16,6 +15,8 @@ env:
 jobs:
   staticcheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -52,6 +53,8 @@ jobs:
   test:
     needs: staticcheck
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    permissions:
+      contents: read
     steps:
       - name: checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -88,6 +91,7 @@ jobs:
   notify:
     needs: test
     if: always()
+    permissions: {}
     uses: ./.github/workflows/slack-notifications.yml
     with:
       status: ${{ needs.test.result == 'success' && 'success' || 'failure' }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,12 +4,11 @@ on:
       - "master"
 name: push_master
 
+permissions: {} # lock everything by default (least-privilege)
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
 
 env:
   ABIGEN_VERSION: v1.14.8
@@ -19,6 +18,8 @@ env:
 jobs:
   staticcheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -66,6 +67,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - staticcheck
+    permissions:
+      contents: read
     steps:
       - name: checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -103,6 +106,7 @@ jobs:
   notify:
     needs: test
     if: always()
+    permissions: {}
     uses: ./.github/workflows/slack-notifications.yml
     with:
       status: ${{ needs.test.result == 'success' && 'success' || 'failure' }}

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -15,6 +15,8 @@ on:
         required: false
   workflow_dispatch:
 
+permissions: {} # lock everything by default (least-privilege)
+
 jobs:
   security-scan:
     uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@ff5edd492dfd4a70813066fe9f1552a2ac13766f # v2.1.0

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -27,9 +27,12 @@ on:
         required: true
         type: string
 
+permissions: {} # lock everything by default (least-privilege)
+
 jobs:
   notify_slack:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Post to Slack
         env:


### PR DESCRIPTION
## Overview
This PR enforces least-privilege permissions across the repository GitHub Actions workflows.

## Changes
- Set permissions: {} at the workflow level in every workflow to lock permissions by default
- Grant only the minimum job-level permissions required for each workflow to run:
  - staticcheck and test jobs: contents: read
  - security-scan job: actions: read, contents: read, security-events: write
  - Slack notification jobs: no GitHub permissions

## Security Impact
This change addresses the following code scanning alerts:
- https://github.com/Consensys/gnark/security/code-scanning/38
- https://github.com/Consensys/gnark/security/code-scanning/39
- https://github.com/Consensys/gnark/security/code-scanning/40

It also reduces the GitHub Actions attack surface by ensuring jobs receive only the permissions they actually need.

## Files Modified
- .github/workflows/pr.yml
- .github/workflows/push.yml
- .github/workflows/security-code-scanner.yml
- .github/workflows/slack-notifications.yml

## Validation
These changes are configuration-only and preserve existing workflow behavior while tightening permissions.