### PR TITLE
fix: do not discard returned value in Miller loop precomputelines

### DIFF
--- a/internal/stats/latest_stats.csv
+++ b/internal/stats/latest_stats.csv
@@ -89,10 +89,10 @@ math/emulated/secp256k1_64,bls12_381,plonk,4025,3923
 math/emulated/secp256k1_64,bw6_761,plonk,4025,3923
 pairing_bls12377,bw6_761,groth16,11876,11876
 pairing_bls12377,bw6_761,plonk,41914,40431
-pairing_bls12381,bn254,groth16,756837,1242260
-pairing_bls12381,bn254,plonk,2529578,2413653
-pairing_bn254,bn254,groth16,506052,823961
-pairing_bn254,bn254,plonk,1646819,1573151
+pairing_bls12381,bn254,groth16,756708,1242087
+pairing_bls12381,bn254,plonk,2529195,2413298
+pairing_bn254,bn254,groth16,505959,823836
+pairing_bn254,bn254,plonk,1646544,1572896
 pairing_bw6761,bn254,groth16,1589471,2646707
 pairing_bw6761,bn254,plonk,5318762,5097941
 scalar_mul_G1_bn254,bn254,groth16,107499,163170

--- a/std/algebra/emulated/sw_bls12381/pairing_test.go
+++ b/std/algebra/emulated/sw_bls12381/pairing_test.go
@@ -158,6 +158,33 @@ func TestMillerLoopSingleTestSolve(t *testing.T) {
 	}, "case=g1-g2-zero")
 }
 
+func TestMillerLoopRejectsOffTwistG2(t *testing.T) {
+	assert := test.NewAssert(t)
+	_, _, p, q := bls12381.Generators()
+
+	// Scaling (x, y) by (s^2, s^3) maps Q to an isomorphic curve with
+	// coefficient s^6*b; for s^6 != 1, the result is off the original twist.
+	var s, s2, s3 bls12381.E2
+	s.A0.SetUint64(2)
+	s.A1.SetZero()
+	s2.Square(&s)
+	s3.Mul(&s2, &s)
+	q.X.Mul(&q.X, &s2)
+	q.Y.Mul(&q.Y, &s3)
+	assert.False(q.IsOnCurve())
+
+	lines := bls12381.PrecomputeLines(q)
+	res, err := bls12381.MillerLoopFixedQ([]bls12381.G1Affine{p}, [][2][len(bls12381.LoopCounter) - 1]bls12381.LineEvaluationAff{lines})
+	assert.NoError(err)
+	witness := MillerLoopSingleCircuit{
+		InG1: NewG1Affine(p),
+		InG2: NewG2Affine(q),
+		Res:  NewGTEl(res),
+	}
+	err = test.IsSolved(&MillerLoopSingleCircuit{}, &witness, ecc.BN254.ScalarField())
+	assert.Error(err, "expected off-twist G2 input to be rejected")
+}
+
 type FinalExponentiationCircuit struct {
 	InGt GTEl
 	Res  GTEl

--- a/std/algebra/emulated/sw_bls12381/precomputations.go
+++ b/std/algebra/emulated/sw_bls12381/precomputations.go
@@ -33,7 +33,7 @@ func (pr *Pairing) computeLines(Q *g2AffP) lineEvaluations {
 
 	// check Q is on curve
 	Qaff := G2Affine{P: *Q, Lines: nil}
-	pr.IsOnTwist(&Qaff)
+	pr.AssertIsOnTwist(&Qaff)
 
 	var cLines lineEvaluations
 	Qacc := Q

--- a/std/algebra/emulated/sw_bn254/pairing_test.go
+++ b/std/algebra/emulated/sw_bn254/pairing_test.go
@@ -157,6 +157,33 @@ func TestMillerLoopSingleTestSolve(t *testing.T) {
 	}, "case=g1-g2-zero")
 }
 
+func TestMillerLoopRejectsOffTwistG2(t *testing.T) {
+	assert := test.NewAssert(t)
+	_, _, p, q := bn254.Generators()
+
+	// Scaling (x, y) by (s^2, s^3) maps Q to an isomorphic curve with
+	// coefficient s^6*b; for s^6 != 1, the result is off the original twist.
+	var s, s2, s3 bn254.E2
+	s.A0.SetUint64(2)
+	s.A1.SetZero()
+	s2.Square(&s)
+	s3.Mul(&s2, &s)
+	q.X.Mul(&q.X, &s2)
+	q.Y.Mul(&q.Y, &s3)
+	assert.False(q.IsOnCurve())
+
+	lines := bn254.PrecomputeLines(q)
+	res, err := bn254.MillerLoopFixedQ([]bn254.G1Affine{p}, [][2][len(bn254.LoopCounter)]bn254.LineEvaluationAff{lines})
+	assert.NoError(err)
+	witness := MillerLoopSingleCircuit{
+		InG1: NewG1Affine(p),
+		InG2: NewG2Affine(q),
+		Res:  NewGTEl(res),
+	}
+	err = test.IsSolved(&MillerLoopSingleCircuit{}, &witness, ecc.BN254.ScalarField())
+	assert.Error(err, "expected off-twist G2 input to be rejected")
+}
+
 type FinalExponentiation struct {
 	InGt GTEl
 	Res  GTEl

--- a/std/algebra/emulated/sw_bn254/precomputations.go
+++ b/std/algebra/emulated/sw_bn254/precomputations.go
@@ -33,7 +33,7 @@ func (pr *Pairing) computeLines(Q *g2AffP) lineEvaluations {
 
 	// check Q is on curve
 	Qaff := G2Affine{P: *Q, Lines: nil}
-	pr.IsOnTwist(&Qaff)
+	pr.AssertIsOnTwist(&Qaff)
 
 	var cLines lineEvaluations
 	Qacc := Q


### PR DESCRIPTION
# Description

Reported issue where the twist check result is discarded during Miller loop line precomputation.

Replace the check with asserting test instead.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestMillerLoopRejectsOffTwistG2 (both BLS12-381 and BN254)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pairing circuit constraints for a security-relevant input validation bug; incorrect enforcement could break valid proofs or still accept bad G2, but scope is localized to precompute paths with new regression tests.
> 
> **Overview**
> **Miller loop line precomputation** for emulated **BLS12-381** and **BN254** pairing now **enforces** that G2 inputs lie on the twist instead of calling `IsOnTwist` and **ignoring** its boolean result.
> 
> `computeLines` switches to **`AssertIsOnTwist`**, so off-twist G2 points fail constraint generation rather than silently proceeding. New **`TestMillerLoopRejectsOffTwistG2`** tests (isomorphic curve scaling) expect the circuit solve to **error** for invalid G2. **`internal/stats/latest_stats.csv`** pairing constraint counts are refreshed slightly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a28c4600246d2edbf94e3cc407b099cedae1be35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->