### PR TITLE
fix: validate Plonk proof structure according to verifying key

### DIFF
--- a/backend/plonk/bls12-377/verify.go
+++ b/backend/plonk/bls12-377/verify.go
@@ -26,9 +26,11 @@ import (
 )
 
 var (
-	errAlgebraicRelation = errors.New("algebraic relation does not hold")
-	errInvalidWitness    = errors.New("witness length is invalid")
-	errInvalidPoint      = errors.New("point is not on the curve")
+	errAlgebraicRelation   = errors.New("algebraic relation does not hold")
+	errInvalidWitness      = errors.New("witness length is invalid")
+	errInvalidProof        = errors.New("proof length is invalid")
+	errInvalidVerifyingKey = errors.New("verifying key length is invalid")
+	errInvalidPoint        = errors.New("point is not on the curve")
 )
 
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...backend.VerifierOption) error {
@@ -40,8 +42,16 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		return fmt.Errorf("create backend config: %w", err)
 	}
 
+	if len(vk.CommitmentConstraintIndexes) != len(vk.Qcp) {
+		return errInvalidVerifyingKey
+	}
+
 	if len(proof.Bsb22Commitments) != len(vk.Qcp) {
-		return errors.New("BSB22 Commitment number mismatch")
+		return errInvalidProof
+	}
+
+	if len(proof.BatchedProof.ClaimedValues) != 6+len(vk.Qcp) {
+		return errInvalidProof
 	}
 
 	if len(publicWitness) != int(vk.NbPublicVariables) {

--- a/backend/plonk/bls12-381/verify.go
+++ b/backend/plonk/bls12-381/verify.go
@@ -26,9 +26,11 @@ import (
 )
 
 var (
-	errAlgebraicRelation = errors.New("algebraic relation does not hold")
-	errInvalidWitness    = errors.New("witness length is invalid")
-	errInvalidPoint      = errors.New("point is not on the curve")
+	errAlgebraicRelation   = errors.New("algebraic relation does not hold")
+	errInvalidWitness      = errors.New("witness length is invalid")
+	errInvalidProof        = errors.New("proof length is invalid")
+	errInvalidVerifyingKey = errors.New("verifying key length is invalid")
+	errInvalidPoint        = errors.New("point is not on the curve")
 )
 
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...backend.VerifierOption) error {
@@ -40,8 +42,16 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		return fmt.Errorf("create backend config: %w", err)
 	}
 
+	if len(vk.CommitmentConstraintIndexes) != len(vk.Qcp) {
+		return errInvalidVerifyingKey
+	}
+
 	if len(proof.Bsb22Commitments) != len(vk.Qcp) {
-		return errors.New("BSB22 Commitment number mismatch")
+		return errInvalidProof
+	}
+
+	if len(proof.BatchedProof.ClaimedValues) != 6+len(vk.Qcp) {
+		return errInvalidProof
 	}
 
 	if len(publicWitness) != int(vk.NbPublicVariables) {

--- a/backend/plonk/bn254/verify.go
+++ b/backend/plonk/bn254/verify.go
@@ -26,9 +26,11 @@ import (
 )
 
 var (
-	errAlgebraicRelation = errors.New("algebraic relation does not hold")
-	errInvalidWitness    = errors.New("witness length is invalid")
-	errInvalidPoint      = errors.New("point is not on the curve")
+	errAlgebraicRelation   = errors.New("algebraic relation does not hold")
+	errInvalidWitness      = errors.New("witness length is invalid")
+	errInvalidProof        = errors.New("proof length is invalid")
+	errInvalidVerifyingKey = errors.New("verifying key length is invalid")
+	errInvalidPoint        = errors.New("point is not on the curve")
 )
 
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...backend.VerifierOption) error {
@@ -40,8 +42,16 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		return fmt.Errorf("create backend config: %w", err)
 	}
 
+	if len(vk.CommitmentConstraintIndexes) != len(vk.Qcp) {
+		return errInvalidVerifyingKey
+	}
+
 	if len(proof.Bsb22Commitments) != len(vk.Qcp) {
-		return errors.New("BSB22 Commitment number mismatch")
+		return errInvalidProof
+	}
+
+	if len(proof.BatchedProof.ClaimedValues) != 6+len(vk.Qcp) {
+		return errInvalidProof
 	}
 
 	if len(publicWitness) != int(vk.NbPublicVariables) {

--- a/backend/plonk/bw6-761/verify.go
+++ b/backend/plonk/bw6-761/verify.go
@@ -26,9 +26,11 @@ import (
 )
 
 var (
-	errAlgebraicRelation = errors.New("algebraic relation does not hold")
-	errInvalidWitness    = errors.New("witness length is invalid")
-	errInvalidPoint      = errors.New("point is not on the curve")
+	errAlgebraicRelation   = errors.New("algebraic relation does not hold")
+	errInvalidWitness      = errors.New("witness length is invalid")
+	errInvalidProof        = errors.New("proof length is invalid")
+	errInvalidVerifyingKey = errors.New("verifying key length is invalid")
+	errInvalidPoint        = errors.New("point is not on the curve")
 )
 
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...backend.VerifierOption) error {
@@ -40,8 +42,16 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		return fmt.Errorf("create backend config: %w", err)
 	}
 
+	if len(vk.CommitmentConstraintIndexes) != len(vk.Qcp) {
+		return errInvalidVerifyingKey
+	}
+
 	if len(proof.Bsb22Commitments) != len(vk.Qcp) {
-		return errors.New("BSB22 Commitment number mismatch")
+		return errInvalidProof
+	}
+
+	if len(proof.BatchedProof.ClaimedValues) != 6+len(vk.Qcp) {
+		return errInvalidProof
 	}
 
 	if len(publicWitness) != int(vk.NbPublicVariables) {

--- a/internal/generator/backend/template/zkpschemes/plonk/plonk.verify.go.tmpl
+++ b/internal/generator/backend/template/zkpschemes/plonk/plonk.verify.go.tmpl
@@ -23,9 +23,11 @@ import (
 )
 
 var (
-	errAlgebraicRelation = errors.New("algebraic relation does not hold")
-	errInvalidWitness    = errors.New("witness length is invalid")
-	errInvalidPoint      = errors.New("point is not on the curve")
+	errAlgebraicRelation   = errors.New("algebraic relation does not hold")
+	errInvalidWitness      = errors.New("witness length is invalid")
+	errInvalidProof        = errors.New("proof length is invalid")
+	errInvalidVerifyingKey = errors.New("verifying key length is invalid")
+	errInvalidPoint        = errors.New("point is not on the curve")
 )
 
 func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...backend.VerifierOption) error {
@@ -37,8 +39,16 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 		return fmt.Errorf("create backend config: %w", err)
 	}
 
+	if len(vk.CommitmentConstraintIndexes) != len(vk.Qcp) {
+		return errInvalidVerifyingKey
+	}
+
 	if len(proof.Bsb22Commitments) != len(vk.Qcp) {
-		return errors.New("BSB22 Commitment number mismatch")
+		return errInvalidProof
+	}
+
+	if len(proof.BatchedProof.ClaimedValues) != 6+len(vk.Qcp) {
+		return errInvalidProof
 	}
 
 	if len(publicWitness) != int(vk.NbPublicVariables) {

--- a/internal/regression_tests/issue0000/issue0000_test.go
+++ b/internal/regression_tests/issue0000/issue0000_test.go
@@ -1,0 +1,115 @@
+package issue0000
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	fr_bn254 "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/consensys/gnark/backend/plonk"
+	plonk_bn254 "github.com/consensys/gnark/backend/plonk/bn254"
+	"github.com/consensys/gnark/backend/witness"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/scs"
+	"github.com/consensys/gnark/test/unsafekzg"
+	"github.com/stretchr/testify/require"
+)
+
+type squareCircuit struct {
+	X          frontend.Variable `gnark:",public"`
+	Y          frontend.Variable
+	WithCommit bool `gnark:"-"`
+}
+
+func (c *squareCircuit) Define(api frontend.API) error {
+	api.AssertIsEqual(api.Mul(c.Y, c.Y), c.X)
+	if c.WithCommit {
+		commitment, err := api.(frontend.Committer).Commit(c.Y)
+		if err != nil {
+			return err
+		}
+		api.AssertIsDifferent(commitment, c.Y)
+	}
+	return nil
+}
+
+func TestPlonkVerifyClaimedValuesLenMismatch(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		withCommit bool
+		nbQcp      int
+	}{
+		{name: "without_commit", nbQcp: 0},
+		{name: "with_commit", withCommit: true, nbQcp: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proof, vk, publicWitness, expectedClaimedValues := newPlonkProof(t, tc.withCommit, tc.nbQcp)
+
+			runMalformedProof := func(name string, claimedValuesLen int) {
+				t.Run(name, func(t *testing.T) {
+					malformedProof := *proof
+					malformedProof.BatchedProof.ClaimedValues = make([]fr_bn254.Element, claimedValuesLen)
+					copy(malformedProof.BatchedProof.ClaimedValues, proof.BatchedProof.ClaimedValues)
+					var err error
+					require.NotPanics(t, func() {
+						err = plonk.Verify(&malformedProof, vk, publicWitness)
+					})
+					require.Error(t, err)
+
+					var encoded bytes.Buffer
+					_, err = malformedProof.WriteTo(&encoded)
+					require.NoError(t, err)
+
+					var decoded plonk_bn254.Proof
+					if _, err = decoded.ReadFrom(bytes.NewReader(encoded.Bytes())); err != nil {
+						return
+					}
+					require.NotPanics(t, func() {
+						err = plonk.Verify(&decoded, vk, publicWitness)
+					})
+					require.Error(t, err)
+				})
+			}
+
+			runMalformedProof("too_small_base", 5)
+			if tc.withCommit {
+				runMalformedProof("missing_commitment_claimed_value", expectedClaimedValues-1)
+			}
+			runMalformedProof("too_large", expectedClaimedValues+1)
+		})
+	}
+}
+
+func newPlonkProof(t *testing.T, withCommit bool, nbQcp int) (*plonk_bn254.Proof, plonk.VerifyingKey, witness.Witness, int) {
+	t.Helper()
+	assert := require.New(t)
+
+	circuit := &squareCircuit{WithCommit: withCommit}
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, circuit)
+	assert.NoError(err)
+
+	srs, srsLagrange, err := unsafekzg.NewSRS(ccs)
+	assert.NoError(err)
+	pk, vk, err := plonk.Setup(ccs, srs, srsLagrange)
+	assert.NoError(err)
+
+	assignment := &squareCircuit{X: 4, Y: 2, WithCommit: withCommit}
+	fullWitness, err := frontend.NewWitness(assignment, ecc.BN254.ScalarField())
+	assert.NoError(err)
+	publicWitness, err := fullWitness.Public()
+	assert.NoError(err)
+
+	proof, err := plonk.Prove(ccs, pk, fullWitness)
+	assert.NoError(err)
+	assert.NoError(plonk.Verify(proof, vk, publicWitness))
+
+	bn254Proof := proof.(*plonk_bn254.Proof)
+	bn254VK := vk.(*plonk_bn254.VerifyingKey)
+	assert.Len(bn254VK.Qcp, nbQcp)
+
+	expectedClaimedValues := 6 + len(bn254VK.Qcp)
+	assert.Len(bn254Proof.BatchedProof.ClaimedValues, expectedClaimedValues)
+	assert.Len(bn254Proof.Bsb22Commitments, len(bn254VK.Qcp))
+
+	return bn254Proof, vk, publicWitness, expectedClaimedValues
+}

--- a/internal/regression_tests/issue1787/issue1787_test.go
+++ b/internal/regression_tests/issue1787/issue1787_test.go
@@ -1,4 +1,4 @@
-package issue0000
+package issue1787
 
 import (
 	"bytes"


### PR DESCRIPTION
# Description

Check ClaimedValues length according to verifing key.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

<!-- Please describe the tests that you ran or implemented to verify your changes. Provide instructions so we can reproduce. -->

- [x] TestPlonkVerifyClaimedValuesLenMismatch

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] `golangci-lint` does not output errors locally
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the PLONK verifier entry path on all curves; changes are defensive length checks only, but incorrect bounds could reject valid proofs or miss invalid ones.
> 
> **Overview**
> Hardens **PLONK `Verify`** across curves by checking proof and verifying-key shape against `len(vk.Qcp)` **before** the verifier indexes batched openings.
> 
> Early checks now reject mismatched **`CommitmentConstraintIndexes` vs `Qcp`** (`errInvalidVerifyingKey`), **`Bsb22Commitments` count** (replacing the ad-hoc BSB22 error with **`errInvalidProof`**), and **`BatchedProof.ClaimedValues` length** must be **`6 + len(vk.Qcp)`** (`errInvalidProof`) so malformed proofs fail with an error instead of panicking when reading `ClaimedValues[6:]`.
> 
> The same logic is wired through **`plonk.verify.go.tmpl`**; regression test **`issue1787`** covers too-short, too-long, and commitment-missing `ClaimedValues` cases (in-memory and after encode/decode).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a0afd839fec5388e91f7808a49101e74575d147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->