### PR TITLE
perf: optimize `Lookup2` and `Xor(x,0)`

### DIFF
--- a/frontend/cs/r1cs/api.go
+++ b/frontend/cs/r1cs/api.go
@@ -605,6 +605,19 @@ func (builder *builder[E]) Lookup2(b0, b1 frontend.Variable, i0, i1, i2, i3 fron
 		return in2
 	}
 
+	if b0IsConstant {
+		if builder.isCstOne(c0) {
+			return builder.Select(s1, in3, in1)
+		}
+		return builder.Select(s1, in2, in0)
+	}
+	if b1IsConstant {
+		if builder.isCstOne(c1) {
+			return builder.Select(s0, in3, in2)
+		}
+		return builder.Select(s0, in1, in0)
+	}
+
 	// two-bit lookup for the general case can be done with three constraints as
 	// following:
 	//    (1) (in3 - in2 - in1 + in0) * s1 = tmp1 - in1 + in0

--- a/frontend/cs/r1cs/r1cs_test.go
+++ b/frontend/cs/r1cs/r1cs_test.go
@@ -181,6 +181,61 @@ func TestSubSameNoConstraint(t *testing.T) {
 	}
 }
 
+type lookup2ConstantSelectorCircuit struct {
+	B                    frontend.Variable
+	I0, I1, I2, I3, Want frontend.Variable
+	Mode                 int `gnark:"-"`
+}
+
+func (c *lookup2ConstantSelectorCircuit) Define(api frontend.API) error {
+	api.AssertIsBoolean(c.B)
+	var y frontend.Variable
+	switch c.Mode {
+	case 0:
+		y = api.Lookup2(0, c.B, c.I0, c.I1, c.I2, c.I3)
+	case 1:
+		y = api.Lookup2(1, c.B, c.I0, c.I1, c.I2, c.I3)
+	case 2:
+		y = api.Lookup2(c.B, 0, c.I0, c.I1, c.I2, c.I3)
+	case 3:
+		y = api.Lookup2(c.B, 1, c.I0, c.I1, c.I2, c.I3)
+	default:
+		panic("invalid mode")
+	}
+	api.AssertIsEqual(y, c.Want)
+	return nil
+}
+
+func TestLookup2ConstantSelector(t *testing.T) {
+	for _, tc := range []struct {
+		mode, bit, want int
+	}{
+		{0, 0, 10}, {0, 1, 30},
+		{1, 0, 20}, {1, 1, 40},
+		{2, 0, 10}, {2, 1, 20},
+		{3, 0, 30}, {3, 1, 40},
+	} {
+		ccs, err := frontend.Compile(ecc.BN254.ScalarField(), NewBuilder, &lookup2ConstantSelectorCircuit{Mode: tc.mode})
+		if err != nil {
+			t.Fatal(err)
+		}
+		w, err := frontend.NewWitness(&lookup2ConstantSelectorCircuit{
+			B:    tc.bit,
+			I0:   10,
+			I1:   20,
+			I2:   30,
+			I3:   40,
+			Want: tc.want,
+		}, ecc.BN254.ScalarField())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = ccs.Solve(w); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 type overwriteZeroConstCircuit struct {
 	X frontend.Variable
 	Y frontend.Variable

--- a/frontend/cs/scs/api.go
+++ b/frontend/cs/scs/api.go
@@ -317,9 +317,6 @@ func (builder *builder[E]) Xor(a, b frontend.Variable) frontend.Variable {
 		return b0 ^ b1
 	}
 
-	res := builder.newInternalVariable()
-	builder.MarkBoolean(res)
-
 	// if one input is constant, ensure we put it in b.
 	if aConstant {
 		a, b = b, a
@@ -327,6 +324,12 @@ func (builder *builder[E]) Xor(a, b frontend.Variable) frontend.Variable {
 		_b = _a
 	}
 	if bConstant {
+		if _b.IsZero() {
+			return a
+		}
+
+		res := builder.newInternalVariable()
+		builder.MarkBoolean(res)
 		xa := a.(expr.Term[E])
 		// 1 - 2b
 		qL := builder.tOne
@@ -345,6 +348,9 @@ func (builder *builder[E]) Xor(a, b frontend.Variable) frontend.Variable {
 		// builder.addPlonkConstraint(xa, xb, res, builder.st.CoeffID(oneMinusTwoB), constraint.CoeffIdZero, constraint.CoeffIdZero, constraint.CoeffIdZero, constraint.CoeffIdMinusOne, builder.st.CoeffID(_b))
 		return res
 	}
+
+	res := builder.newInternalVariable()
+	builder.MarkBoolean(res)
 	xa := a.(expr.Term[E])
 	xb := b.(expr.Term[E])
 
@@ -477,6 +483,19 @@ func (builder *builder[E]) Lookup2(b0, b1 frontend.Variable, i0, i1, i2, i3 fron
 			return i3
 		}
 		return i2
+	}
+
+	if b0IsConstant {
+		if builder.cs.IsOne(c0) {
+			return builder.Select(b1, i3, i1)
+		}
+		return builder.Select(b1, i2, i0)
+	}
+	if b1IsConstant {
+		if builder.cs.IsOne(c1) {
+			return builder.Select(b0, i3, i2)
+		}
+		return builder.Select(b0, i1, i0)
 	}
 
 	// two-bit lookup for the general case can be done with three constraints as

--- a/frontend/cs/scs/api_test.go
+++ b/frontend/cs/scs/api_test.go
@@ -365,6 +365,75 @@ func TestRegressionOr(t *testing.T) {
 	}
 }
 
+type regressionXorZero struct {
+	A frontend.Variable
+}
+
+func (c *regressionXorZero) Define(api frontend.API) error {
+	api.AssertIsBoolean(c.A)
+	y := api.Xor(c.A, 0)
+	_ = y
+	return nil
+}
+
+func TestRegressionXorZeroNoConstraint(t *testing.T) {
+	assert := test.NewAssert(t)
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &regressionXorZero{})
+	assert.NoError(err)
+	assert.Equal(1, ccs.GetNbConstraints(), "expected only the boolean assertion")
+}
+
+type regressionLookup2ConstantSelector struct {
+	B                    frontend.Variable
+	I0, I1, I2, I3, Want frontend.Variable
+	Mode                 int `gnark:"-"`
+}
+
+func (c *regressionLookup2ConstantSelector) Define(api frontend.API) error {
+	api.AssertIsBoolean(c.B)
+	var y frontend.Variable
+	switch c.Mode {
+	case 0:
+		y = api.Lookup2(0, c.B, c.I0, c.I1, c.I2, c.I3)
+	case 1:
+		y = api.Lookup2(1, c.B, c.I0, c.I1, c.I2, c.I3)
+	case 2:
+		y = api.Lookup2(c.B, 0, c.I0, c.I1, c.I2, c.I3)
+	case 3:
+		y = api.Lookup2(c.B, 1, c.I0, c.I1, c.I2, c.I3)
+	default:
+		panic("invalid mode")
+	}
+	api.AssertIsEqual(y, c.Want)
+	return nil
+}
+
+func TestRegressionLookup2ConstantSelector(t *testing.T) {
+	assert := test.NewAssert(t)
+	for _, tc := range []struct {
+		mode, bit, want int
+	}{
+		{0, 0, 10}, {0, 1, 30},
+		{1, 0, 20}, {1, 1, 40},
+		{2, 0, 10}, {2, 1, 20},
+		{3, 0, 30}, {3, 1, 40},
+	} {
+		ccs, err := frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &regressionLookup2ConstantSelector{Mode: tc.mode})
+		assert.NoError(err)
+		w, err := frontend.NewWitness(&regressionLookup2ConstantSelector{
+			B:    tc.bit,
+			I0:   10,
+			I1:   20,
+			I2:   30,
+			I3:   40,
+			Want: tc.want,
+		}, ecc.BN254.ScalarField())
+		assert.NoError(err)
+		_, err = ccs.Solve(w)
+		assert.NoError(err)
+	}
+}
+
 type deduplicateCommitmentsCircuit struct {
 	repetitions int
 	A           frontend.Variable


### PR DESCRIPTION
# Description

 - `frontend/cs/r1cs/api.go` and `frontend/cs/scs/api.go`: `Lookup2` now reduces to `Select` when one selector bit is constant. That turns the generic 3-row lookup formula into a 1-row select in the variable-selector case.

 - `frontend/cs/scs/api.go`: SCS `Xor(x, 0)` now returns `x` directly. R1CS already effectively got this through linear expressions.
 
Added regression coverage in `frontend/cs/r1cs/r1cs_test.go` and `frontend/cs/scs/api_test.go`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized frontend compile optimizations with matching solve tests; semantics unchanged for the optimized cases.
> 
> **Overview**
> **Compile-time constraint optimizations** in the R1CS and SCS circuit builders for common bit patterns.
> 
> **`Lookup2`** (R1CS and SCS): when exactly one of the two selector bits is constant (0 or 1), the implementation now delegates to **`Select`** on the remaining variable bit instead of emitting the generic **3-constraint** two-bit lookup. Fully constant selectors were already handled; this covers the mixed constant/variable case.
> 
> **SCS `Xor`**: **`Xor(x, 0)`** (and **`Xor(0, x)`** via constant reordering) now returns **`x`** with no extra XOR constraint; only the existing boolean assertion remains where applicable.
> 
> Regression tests were added for constant-selector **`Lookup2`** modes and for SCS **`Xor`** with zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8acbe626551ec6a7d55381dae72e9da816cf40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->